### PR TITLE
feat: GER injection + feature parity with aggkit-proxy

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,3 @@
+# Config file for typos. For more information, see: https://github.com/crate-ci/typos
+[files]
+extend-exclude = ["*.lock", "dist"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,9 +44,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5033b86af2c64e1b29b8446b7b6c48a0094ccea0b5c408111b6d218c418894"
+checksum = "07dc44b606f29348ce7c127e7f872a6d2df3cfeff85b7d6bba62faca75112fdd"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
+checksum = "6d9d22005bf31b018f31ef9ecadb5d2c39cf4f6acc8db0456f72c815f3d7f757"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1958f0294ecc05ebe7b3c9a8662a3e221c2523b7f2bcd94c7a651efbd510bf"
+checksum = "4e4ff99651d46cef43767b5e8262ea228cd05287409ccb0c947cc25e70a952f9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f752e99497ddc39e22d547d7dfe516af10c979405a034ed90e69b914b7dddeae"
+checksum = "1a0701b0eda8051a2398591113e7862f807ccdd3315d0b441f06c2a0865a379b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2140796bc79150b1b7375daeab99750f0ff5e27b1f8b0aa81ccde229c7f02a2"
+checksum = "f3c83c7a3c4e1151e8cac383d0a67ddf358f37e5ea51c95a1283d897c9de0a5a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.5.2"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4087016b0896051dd3d03e0bedda2f4d4d1689af8addc8450288c63a9e5f68"
+checksum = "23e8604b0c092fabc80d075ede181c9b9e596249c70b99253082d7e689836529"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.5.2"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369f5707b958927176265e8a58627fc6195e5dfa5c55689396e68b241b3a72e6"
+checksum = "cc2db5c583aaef0255aa63a4fe827f826090142528bba48d1bf4119b62780cad"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3231de68d5d6e75332b7489cfcc7f4dfabeba94d990a10e4b923af0e6623540"
+checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "813a67f87e56b38554d18b182616ee5006e8e2bf9df96a0df8bf29dff1d52e3f"
+checksum = "def1626eea28d48c6cc0a6f16f34d4af0001906e4f889df6c660b39c86fd044d"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05864eef929c4d28895ae4b4d8ac9c6753c4df66e873b9c8fafc8089b59c1502"
+checksum = "55d9d1aba3f914f0e8db9e4616ae37f3d811426d95bdccf44e47d0605ab202f6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.5.2"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e3cf01219c966f95a460c95f1d4c30e12f6c18150c21a30b768af2a2a29142"
+checksum = "e9dbe713da0c737d9e5e387b0ba790eb98b14dd207fe53eef50e19a5a8ec3dac"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dd146b3de349a6ffaa4e4e319ab3a90371fb159fb0bddeb1c7bbe8b1792eff"
+checksum = "e57586581f2008933241d16c3e3f633168b3a5d2738c5c42ea5246ec5e0ef17a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c12278ffbb8872dfba3b2f17d8ea5e8503c2df5155d9bc5ee342794bde505c3"
+checksum = "3b36c2a0ed74e48851f78415ca5b465211bd678891ba11e88fee09eac534bab1"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833037c04917bc2031541a60e8249e4ab5500e24c637c1c62e95e963a655d66f"
+checksum = "636c8051da58802e757b76c3b65af610b95799f72423dc955737dec73de234fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.2"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a0fb18dd5fb43ec5f0f6a20be1ce0287c79825827de5744afaa6c957737c33"
+checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -349,14 +349,13 @@ dependencies = [
  "rustc-hash",
  "serde",
  "sha3",
- "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-provider"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafa840b0afe01c889a3012bb2fde770a544f74eab2e2870303eb0a5fb869c48"
+checksum = "b3dd56e2eafe8b1803e325867ac2c8a4c73c9fb5f341ffd8347f9344458c5922"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -393,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f70d83b765fdc080dbcd4f4db70d8d23fe4761f2f02ebfa9146b833900634b4"
+checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -404,20 +403,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
+checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12768ae6303ec764905a8a7cd472aea9072f9f9c980d18151e26913da8ae0123"
+checksum = "91577235d341a1bdbee30a463655d08504408a4d51e9f72edbfc5a622829f402"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -438,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0622d8bcac2f16727590aa33f4c3f05ea98130e7e4b4924bce8be85da5ad0dae"
+checksum = "79cff039bf01a17d76c0aace3a3a773d5f895eb4c68baaae729ec9da9e86c99c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -450,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1cf5a093e437dfd62df48e480f24e1a3807632358aad6816d7a52875f1c04aa"
+checksum = "73234a141ecce14e2989748c04fcac23deee67a445e2c4c167cfb42d4dacd1b6"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -461,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e97603095020543a019ab133e0e3dc38cd0819f19f19bdd70c642404a54751"
+checksum = "010e101dbebe0c678248907a2545b574a87d078d82c2f6f5d0e8e7c9a6149a10"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -473,7 +472,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -482,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946a0d413dbb5cd9adba0de5f8a1a34d5b77deda9b69c1d7feed8fc875a1aa26"
+checksum = "9e6d631f8b975229361d8af7b2c749af31c73b3cf1352f90e144ddb06227105e"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -493,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7481dc8316768f042495eaf305d450c32defbc9bce09d8bf28afcd956895bb"
+checksum = "97f40010b5e8f79b70bf163b38cd15f529b18ca88c4427c0e43441ee54e4ed82"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -508,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1259dac1f534a4c66c1d65237c89915d0010a2a91d6c3b0bada24dc5ee0fb917"
+checksum = "9c4ec1cc27473819399a3f0da83bc1cef0ceaac8c1c93997696e46dc74377a58"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -524,23 +523,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.2"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09eb18ce0df92b4277291bbaa0ed70545d78b02948df756bbd3d6214bf39a218"
+checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.2"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d9fa2daf21f59aa546d549943f10b5cce1ae59986774019fbedae834ffe01b"
+checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -550,16 +549,16 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "sha3",
+ "syn 2.0.117",
  "syn-solidity",
- "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.2"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9396007fe69c26ee118a19f4dee1f5d1d6be186ea75b3881adf16d87f8444686"
+checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -569,15 +568,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.114",
+ "syn 2.0.117",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.2"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af67a0b0dcebe14244fc92002cd8d96ecbf65db4639d479f5fcd5805755a4c27"
+checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
 dependencies = [
  "serde",
  "winnow",
@@ -585,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.2"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aeea64f09a7483bdcd4193634c7e5cf9fd7775ee767585270cd8ce2d69dc95"
+checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -597,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f169b85eb9334871db986e7eaf59c58a03d86a30cc68b846573d47ed0656bb"
+checksum = "a03bb3f02b9a7ab23dacd1822fa7f69aa5c8eefcdcf57fad085e0b8d76fb4334"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -620,12 +619,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019821102e70603e2c141954418255bec539ef64ac4117f8e84fb493769acf73"
+checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
+ "itertools 0.14.0",
  "reqwest",
  "serde_json",
  "tower",
@@ -635,30 +635,30 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428aa0f0e0658ff091f8f667c406e034b431cb10abd39de4f507520968acc499"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arrayvec",
  "derive_more",
  "nybbles",
  "serde",
  "smallvec",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ceac797eb8a56bdf5ab1fab353072c17d472eab87645ca847afe720db3246d"
+checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "ark-ff"
@@ -811,7 +811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -849,7 +849,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -926,9 +926,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "ascii-canvas"
@@ -958,7 +955,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -969,7 +966,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -986,7 +983,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1146,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitvec"
@@ -1217,14 +1214,23 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "build-rs"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc87f52297187fb5d25bde3d368f0480f88ac1d8f3cf4c80ac5575435511114"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1240,18 +1246,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "c-kzg"
-version = "2.1.5"
+version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
+checksum = "1a0f582957c24870b7bfd12bf562c40b4734b533cafbaf8ded31d6d85f462c01"
 dependencies = [
  "blst",
  "cc",
@@ -1264,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1312,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1337,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1347,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1359,21 +1365,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
@@ -1383,9 +1389,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const-hex"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1519,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -1552,7 +1558,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1577,7 +1583,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1588,7 +1594,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1647,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -1685,7 +1691,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.114",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1718,7 +1724,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1787,7 +1793,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1822,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "ena"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
 dependencies = [
  "log",
 ]
@@ -1846,14 +1852,14 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
 dependencies = [
  "log",
  "regex",
@@ -1861,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1946,9 +1952,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixed-hash"
@@ -2009,9 +2015,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
 ]
@@ -2024,9 +2030,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2039,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2049,15 +2055,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2066,38 +2072,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2107,7 +2113,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2134,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -2165,8 +2170,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
  "wasm-bindgen",
 ]
 
@@ -2401,14 +2421,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -2425,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2529,6 +2548,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,7 +2597,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2615,9 +2640,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -2676,9 +2701,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.18"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
@@ -2689,13 +2714,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.18"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2710,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2735,18 +2760,18 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+checksum = "b646a74e746cd25045aa0fd42f4f7f78aa6d119380182c7e63a5593c4ab8df6f"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -2763,7 +2788,7 @@ dependencies = [
  "ena",
  "itertools 0.14.0",
  "lalrpop-util",
- "petgraph",
+ "petgraph 0.7.1",
  "regex",
  "regex-syntax",
  "sha3",
@@ -2789,10 +2814,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
@@ -2802,9 +2833,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91632f3b4fb6bd1d72aa3d78f41ffecfcf2b1a6648d8c241dbe7dbfaf4875e15"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2819,9 +2850,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2866,7 +2897,7 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version 0.4.1",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2914,7 +2945,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2934,24 +2965,27 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden-agglayer"
-version = "0.13.3"
+version = "0.14.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a867217bab689c0539f6b4797cb452f0932de6904479a38f1322e045b9383b"
+checksum = "e492a6044cf8875a64d7eec130d260f2eda1c783795261f00d5d52837ed027bd"
 dependencies = [
  "fs-err",
  "miden-assembly",
  "miden-core",
  "miden-core-lib",
+ "miden-crypto",
  "miden-protocol",
  "miden-standards",
  "miden-utils-sync",
+ "primitive-types 0.14.0",
  "regex",
+ "thiserror",
  "walkdir",
 ]
 
@@ -2970,33 +3004,18 @@ dependencies = [
  "http",
  "lru",
  "miden-agglayer",
- "miden-air",
- "miden-assembly",
- "miden-assembly-syntax",
  "miden-client",
  "miden-client-sqlite-store",
- "miden-core",
- "miden-core-lib",
- "miden-debug-types",
- "miden-mast-package",
- "miden-node-proto-build",
- "miden-processor",
  "miden-protocol",
- "miden-protocol-macros",
- "miden-prover",
- "miden-remote-prover-client",
  "miden-standards",
  "miden-tx",
- "miden-utils-core-derive",
- "miden-utils-diagnostics",
- "miden-utils-indexing",
- "miden-utils-sync",
- "miden-verifier",
+ "parking_lot",
  "serde",
  "serde_json",
+ "sha3",
  "thiserror",
  "tokio",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tower",
  "tower-http",
  "tracing",
@@ -3006,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d819876b9e9b630e63152400e6df2a201668a9bdfd33d54d6806b9d7b992ff8"
+checksum = "5cca9632323bd4e32ae5b21b101ed417a646f5d72196b1bf3f1ca889a148322a"
 dependencies = [
  "miden-core",
  "miden-utils-indexing",
@@ -3019,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c6a18e29c03141cf9044604390a00691c7342924ec865b4acfdd560ff41ede"
+checksum = "2395b2917aea613a285d3425d1ca07e6c45442e2b34febdea2081db555df62fc"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -3033,9 +3052,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7458ff670f5a514bf972aa84d6e1851a4c4e9afa351f53b71bdc2218b99254b6"
+checksum = "1f9bed037d137f209b9e7b28811ec78c0536b3f9259d6f4ceb5823c87513b346"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -3055,8 +3074,8 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.13.0"
-source = "git+https://github.com/0xMiden/miden-client.git?tag=exp-agglayer-v0.2.2#0a5add565d1388f77cd182f3639c16aa8f7ec674"
+version = "0.14.0-alpha.1"
+source = "git+https://github.com/0xMiden/miden-client.git?branch=agglayer-integration-tests#ac3d953d6092a93e01b2a4bb9c464f395525390d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3075,6 +3094,8 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.9.2",
+ "serde",
+ "serde_json",
  "thiserror",
  "tonic",
  "tonic-health",
@@ -3087,8 +3108,8 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.13.0"
-source = "git+https://github.com/0xMiden/miden-client.git?tag=exp-agglayer-v0.2.2#0a5add565d1388f77cd182f3639c16aa8f7ec674"
+version = "0.14.0-alpha.1"
+source = "git+https://github.com/0xMiden/miden-client.git?branch=agglayer-integration-tests#ac3d953d6092a93e01b2a4bb9c464f395525390d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3105,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a5c9c8c3d42ae8381ed49e47ff9ad2d2e345c4726761be36b7d4000ebb40ae"
+checksum = "8714aa5f86c59e647b7417126b32adc4ef618f835964464f5425549df76b6d03"
 dependencies = [
  "derive_more",
  "itertools 0.14.0",
@@ -3125,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6556494ea5576803730fa15015bee6bd9d1a117450f22e7df0883421e7423674"
+checksum = "1bb16a4d39202c59a7964d3585cd5af21a46a759ff6452cb5f20723ed5af4362"
 dependencies = [
  "env_logger",
  "fs-err",
@@ -3142,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.19.4"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e28b6e110f339c2edc2760a8cb94863f0a055ee658a49bc90c8560eff2feef4"
+checksum = "be59336a868de7c379eace9450563c2d7f4a0b7ab936835ec5a340dcd8d9a5ed"
 dependencies = [
  "blake3",
  "cc",
@@ -3176,19 +3197,19 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.19.4"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40e95b9c7c99ed6bbf073d9e02721d812dedd2c195019c0a0e0a3dbb9cbf034"
+checksum = "06f2e7a7ac7d01e03a7340224722e75494826fe6b61a3796b77fbb044d018287"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "miden-debug-types"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19123e896f24b575e69921a79a39a0a4babeb98404a8601017feb13b75d653b3"
+checksum = "cd1494f102ad5b9fa43e391d2601186dc601f41ab7dcd8a23ecca9bf3ef930f4"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -3213,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d6a322b91efa1bb71e224395ca1fb9ca00e2614f89427e35d8c42a903868a3"
+checksum = "692185bfbe0ecdb28bf623f1f8c88282cd6727ba081a28e23b301bdde1b45be4"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
@@ -3246,7 +3267,7 @@ dependencies = [
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "syn 2.0.114",
+ "syn 2.0.117",
  "terminal_size 0.3.0",
  "textwrap",
  "thiserror",
@@ -3262,15 +3283,16 @@ checksum = "86a905f3ea65634dd4d1041a4f0fd0a3e77aa4118341d265af1a94339182222f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.13.4"
+version = "0.14.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57204342fbca380d96d1f08c0fe7bb893a936fbe98a280c1bf798531fc7e319"
+checksum = "20ac57ddec6bf630b5301630c953ed23661575b70e2fcc3ff221c660f3006a30"
 dependencies = [
+ "build-rs",
  "fs-err",
  "miette",
  "protox",
@@ -3291,9 +3313,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a659fac55de14647e2695f03d96b83ff94fe65fd31e74d81c225ec52af25acf"
+checksum = "0e09f7916b1e7505f74a50985a185fdea4c0ceb8f854a34c90db28e3f7da7ab6"
 dependencies = [
  "itertools 0.14.0",
  "miden-air",
@@ -3311,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.13.3"
+version = "0.14.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785be319a826c9cb43d2e1a41a1fb1eee3f2baafe360e0d743690641f7c93ad5"
+checksum = "8a88effeac994eb55b8dc4f93fbfd71a5d916dfaba1099896e27a0ee42c488c1"
 dependencies = [
  "bech32",
  "fs-err",
@@ -3335,27 +3357,27 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "thiserror",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "walkdir",
  "winter-rand-utils",
 ]
 
 [[package]]
 name = "miden-protocol-macros"
-version = "0.13.3"
+version = "0.14.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dc854c1b9e49e82d3f39c5710345226e0b2a62ec0ea220c616f1f3a099cfb3"
+checksum = "4bb28b730005e5f8b08d615ea9216f8cab77b3a7439fa54d5e39d2ec43ef53a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "miden-prover"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5df61f50f27886f6f777d6e0cdf785f7db87dd881799a84a801e7330c189c8"
+checksum = "d45e30526be72b8af0fd1d8b24c9cba8ac1187ca335dcee38b8e5e20234e7698"
 dependencies = [
  "miden-air",
  "miden-debug-types",
@@ -3367,12 +3389,13 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.13.4"
+version = "0.14.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c5a1ccd22a8638c276e8dbffcb527cf1eeb14c536860de46f948bc1ff8449e"
+checksum = "64fae30a877ba6481e62ed2a553277633c91a592686afa73ba91c2f15ed7e17f"
 dependencies = [
+ "build-rs",
  "fs-err",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "miden-node-proto-build",
  "miden-protocol",
  "miden-tx",
@@ -3388,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.13.3"
+version = "0.14.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e33771fc35e1e640582bcd26c88b2ab449dd3a70888b315546d0d3447f4bb3"
+checksum = "2cef036bbfec29acba92751a13d05844bbcf080140201097b419c9ad1927e367"
 dependencies = [
  "fs-err",
  "miden-assembly",
@@ -3405,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.13.3"
+version = "0.14.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430e4ee02b5efb71b104926e229441e0071a93a259a70740bf8c436495caa64f"
+checksum = "c67e0df9adcf29c9111df65acf408ae05952b8bc6569f571963676f97668d83f"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -3419,9 +3442,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa207ffd8b26a79d9b5b246a352812f0015c0bb8f75492ec089c5c8e6d5f9e2b"
+checksum = "a1b1d490e6d7b509622d3c2cc69ffd66ad48bf953dc614579b568fe956ce0a6c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3430,9 +3453,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2f55477d410542a5d8990ca04856adf5bef91bfa3b54ca3c03a5ff14a6e25c"
+checksum = "52658f6dc091c1c78e8b35ee3e7ff3dad53051971a3c514e461f581333758fe7"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -3443,18 +3466,18 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39efae17e14ec8f8a1266cffd29eb7a08ac837143cd09223b1af361bbb55730"
+checksum = "eeff7bcb7875b222424bdfb657a7cf21a55e036aa7558ebe1f5d2e413b440d0d"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7fa8f5fd27f122c83f55752f2a964bbfc2b713de419e9c152f7dcc05c194ec"
+checksum = "41d53d1ab5b275d8052ad9c4121071cb184bc276ee74354b0d8a2075e5c1d1f0"
 dependencies = [
  "lock_api",
  "loom",
@@ -3463,9 +3486,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbddac2e76486fb657929338323c68b9e7f40e33b8cfb593d0fb5bf637db046e"
+checksum = "b13816663794beb15c8a4721c15252eb21f3b3233525684f60c7888837a98ff4"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -3512,7 +3535,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3618,7 +3641,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3690,14 +3713,14 @@ checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "nybbles"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5676b5c379cf5b03da1df2b3061c4a4e2aa691086a56ac923e08c143f53f59"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
 dependencies = [
  "alloy-rlp",
  "cfg-if",
@@ -3742,9 +3765,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parity-scale-codec"
@@ -3771,7 +3794,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3811,9 +3834,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3830,6 +3853,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+]
+
+[[package]]
 name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,29 +3874,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -3899,15 +3933,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
 ]
@@ -3949,7 +3983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3960,14 +3994,24 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "uint",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721a1da530b5a2633218dc9f75713394c983c352be88d2d7c9ee85e2c4c21794"
+dependencies = [
+ "fixed-hash",
+ "uint 0.10.0",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -3991,7 +4035,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4005,9 +4049,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -4024,9 +4068,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4034,23 +4078,22 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
- "once_cell",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
  "prost",
  "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -4061,10 +4104,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4081,18 +4124,18 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "protox"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8555716f64c546306ddf3383065dc40d4232609e79e0a4c50e94e87d54f30fb4"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
 dependencies = [
  "bytes",
  "miette",
@@ -4117,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
 dependencies = [
  "bitflags",
  "memchr",
@@ -4128,9 +4171,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "21.1.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8246feae3db61428fd0bb94285c690b460e4517d83152377543ca802357785f1"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
 ]
@@ -4163,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -4198,9 +4241,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -4210,6 +4253,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -4308,9 +4357,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.2.1"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8b5b858a440a0bc02625b62dd95131b9201aa9f69f411195dd4a7cfb1de3d7"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
 ]
@@ -4361,14 +4410,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4378,9 +4427,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4389,9 +4438,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -4482,7 +4531,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
  "rand 0.9.2",
@@ -4501,9 +4550,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rusqlite"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de23c3319433716cf134eed225fe9986bc24f63bed9be9f20c329029e672dc7"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -4515,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a324f81362b5cd8f2eeef82d032172fdf2ca70aeec64962ff55a56874fe5ec41"
+checksum = "3fc9767ae49274bafd3e55be9d30405a033b7a59548327d87fd4971fbb58e264"
 dependencies = [
  "log",
  "rusqlite",
@@ -4583,22 +4632,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -4662,9 +4711,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4677,9 +4726,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -4698,9 +4747,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -4758,9 +4807,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -4771,9 +4820,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4849,7 +4898,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4899,9 +4948,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64",
  "chrono",
@@ -4909,7 +4958,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.13.0",
  "schemars 0.9.0",
- "schemars 1.2.0",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -4918,14 +4967,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4961,9 +5010,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+checksum = "b31139435f327c93c6038ed350ae4588e2c70a13d50599509fee6349967ba35a"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5006,15 +5055,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -5033,12 +5082,12 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5117,7 +5166,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5160,9 +5209,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5171,14 +5220,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.2"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f92d01b5de07eaf324f7fca61cc6bd3d82bbc1de5b6c963e6fe79e86f36580d"
+checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5198,7 +5247,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5215,14 +5264,14 @@ checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5260,7 +5309,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.60.2",
 ]
 
@@ -5292,7 +5341,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5315,9 +5364,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -5336,21 +5385,12 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -5380,9 +5420,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -5396,13 +5436,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5442,14 +5482,29 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -5465,22 +5520,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -5493,9 +5557,9 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "base64",
@@ -5523,21 +5587,21 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40aaccc9f9eccf2cd82ebc111adc13030d23e887244bc9cfa5d1d636049de3"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tonic-health"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a82868bf299e0a1d2e8dce0dc33a46c02d6f045b2c1f1d6cc8dc3d0bf1812ef"
+checksum = "f4ff0636fef47afb3ec02818f5bceb4377b8abb9d6a386aeade18bd6212f8eb7"
 dependencies = [
  "prost",
  "tokio",
@@ -5548,9 +5612,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost",
@@ -5559,25 +5623,25 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a16cba4043dc3ff43fcb3f96b4c5c154c64cbd18ca8dce2ab2c6a451d058a2"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tempfile",
  "tonic-build",
 ]
 
 [[package]]
 name = "tonic-web-wasm-client"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898cd44be5e23e59d2956056538f1d6b3c5336629d384ffd2d92e76f87fb98ff"
+checksum = "e8e21e20b94f808d6f2244a5d960d02c28dd82066abddd2f27019bac0535f310"
 dependencies = [
  "base64",
  "byteorder",
@@ -5668,7 +5732,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5731,9 +5795,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.114"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17e807bff86d2a06b52bca4276746584a78375055b6e45843925ce2802b335"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
 dependencies = [
  "dissimilar",
  "glob",
@@ -5742,7 +5806,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml",
+ "toml 1.0.6+spec-1.1.0",
 ]
 
 [[package]]
@@ -5770,6 +5834,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5783,9 +5859,9 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
@@ -5929,10 +6005,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.108"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5943,9 +6028,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5957,9 +6042,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5967,37 +6052,71 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.2"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -6016,9 +6135,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6036,9 +6155,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6073,7 +6192,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6084,7 +6203,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6344,9 +6463,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -6403,7 +6522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d31a19dae58475d019850e25b0170e94b16d382fbf6afee9c0e80fdc935e73e"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6458,6 +6577,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver 1.0.27",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -6503,28 +6704,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.34"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ddd76bcebeed25db614f82bf31a9f4222d3fbba300e6fb6c00afa26cbd4d9d"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.34"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6544,7 +6745,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6565,7 +6766,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6598,11 +6799,11 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.17"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,10 @@ clap               = { features = ["derive"], version = "4.5" }
 hex                = { version = "0.4" }
 http               = { version = "1.3" }
 lru                = { default-features = false, version = "0.16" }
+parking_lot        = { version = "0.12" }
 serde              = { features = ["derive"], version = "1.0" }
 serde_json         = { version = "1.0" }
+sha3               = { version = "0.10" }
 thiserror          = { default-features = false, version = "2.0" }
 tokio              = { features = ["macros", "rt-multi-thread", "signal"], version = "1.48" }
 toml               = { version = "0.9" }
@@ -35,36 +37,13 @@ tracing-subscriber = { features = ["env-filter", "fmt", "json"], version = "0.3"
 url                = { features = ["serde"], version = "2.5" }
 
 # miden-base
-miden-base-agglayer = { package = "miden-agglayer", version = "=0.13.3" }
-miden-protocol      = { default-features = false, version = "=0.13.3" }
-miden-standards     = { default-features = false, version = "=0.13.3" }
+miden-base-agglayer = { package = "miden-agglayer", version = "0.14.0-alpha" }
+miden-protocol      = { default-features = false, features = ["std"], version = "0.14.0-alpha" }
+miden-standards     = { default-features = false, version = "0.14.0-alpha" }
+miden-tx            = { default-features = false, version = "0.14.0-alpha" }
 
 # miden-client
 miden-client = { default-features = false, features = [
   "tonic",
-], git = "https://github.com/0xMiden/miden-client.git", tag = "exp-agglayer-v0.2.2" }
-miden-client-sqlite-store = { git = "https://github.com/0xMiden/miden-client.git", tag = "exp-agglayer-v0.2.2" }
-
-# pin transitive dependencies of miden-client on miden-base
-miden-protocol-macros = { version = "=0.13.3" }
-miden-tx              = { default-features = false, version = "=0.13.3" }
-
-# pin transitive dependencies of miden-client on miden-node
-miden-node-proto-build     = { version = "=0.13.4" }
-miden-remote-prover-client = { version = "=0.13.4" }
-
-# pin transitive dependencies on miden-vm
-miden-air               = { default-features = false, version = "=0.20.2" }
-miden-assembly          = { default-features = false, version = "=0.20.2" }
-miden-assembly-syntax   = { default-features = false, version = "=0.20.2" }
-miden-core              = { default-features = false, version = "=0.20.2" }
-miden-core-lib          = { default-features = false, version = "=0.20.2" }
-miden-debug-types       = { default-features = false, version = "=0.20.2" }
-miden-mast-package      = { default-features = false, version = "=0.20.2" }
-miden-processor         = { default-features = false, version = "=0.20.2" }
-miden-prover            = { default-features = false, version = "=0.20.2" }
-miden-utils-core-derive = { default-features = false, version = "=0.20.2" }
-miden-utils-diagnostics = { default-features = false, version = "=0.20.2" }
-miden-utils-indexing    = { default-features = false, version = "=0.20.2" }
-miden-utils-sync        = { default-features = false, version = "=0.20.2" }
-miden-verifier          = { default-features = false, version = "=0.20.2" }
+], git = "https://github.com/0xMiden/miden-client.git", branch = "agglayer-integration-tests" }
+miden-client-sqlite-store = { git = "https://github.com/0xMiden/miden-client.git", branch = "agglayer-integration-tests" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,46 +1,52 @@
 [package]
-description  = "Miden AggLayer integration service"
-edition      = "2024"
-exclude      = [".github/"]
-license      = "MIT"
-name         = "miden-agglayer-service"
-readme       = "README.md"
+description = "Miden AggLayer integration service"
+edition = "2024"
+exclude = [".github/"]
+license = "MIT"
+name = "miden-agglayer-service"
+readme = "README.md"
 rust-version = "1.90"
-version      = "0.1.0"
+version = "0.1.0"
 
 [profile.dev.package."*"]
 opt-level = 1
 
 [dependencies]
-alloy               = { features = ["consensus", "eips", "k256"], version = "1.5.2" }
-alloy-core          = { features = ["sol-types"], version = "1.5.2" }
+alloy = { features = ["consensus", "eips", "k256"], version = "1.5.2" }
+alloy-core = { features = ["sol-types"], version = "1.5.2" }
 alloy-rpc-types-eth = { version = "1.5.2" }
 
-anyhow             = { default-features = false, version = "1.0" }
-axum               = { features = ["tokio"], version = "0.8" }
-axum-jrpc          = { path = "axum-jrpc" }
-clap               = { features = ["derive"], version = "4.5" }
-hex                = { version = "0.4" }
-http               = { version = "1.3" }
-lru                = { default-features = false, version = "0.16" }
-parking_lot        = { version = "0.12" }
-serde              = { features = ["derive"], version = "1.0" }
-serde_json         = { version = "1.0" }
-sha3               = { version = "0.10" }
-thiserror          = { default-features = false, version = "2.0" }
-tokio              = { features = ["macros", "rt-multi-thread", "signal"], version = "1.48" }
-toml               = { version = "0.9" }
-tower              = { version = "0.5" }
-tower-http         = { features = ["cors", "set-header", "trace"], version = "0.6" }
-tracing            = { version = "0.1" }
-tracing-subscriber = { features = ["env-filter", "fmt", "json"], version = "0.3" }
-url                = { features = ["serde"], version = "2.5" }
+anyhow = { default-features = false, version = "1.0" }
+axum = { features = ["tokio"], version = "0.8" }
+axum-jrpc = { path = "axum-jrpc" }
+clap = { features = ["derive"], version = "4.5" }
+hex = { version = "0.4" }
+http = { version = "1.3" }
+lru = { default-features = false, version = "0.16" }
+parking_lot = { version = "0.12" }
+serde = { features = ["derive"], version = "1.0" }
+serde_json = { version = "1.0" }
+sha3 = { version = "0.10" }
+thiserror = { default-features = false, version = "2.0" }
+tokio = { features = ["macros", "rt-multi-thread", "signal"], version = "1.48" }
+toml = { version = "0.9" }
+tower = { version = "0.5" }
+tower-http = { features = ["cors", "set-header", "trace"], version = "0.6" }
+tracing = { version = "0.1" }
+tracing-subscriber = { features = [
+  "env-filter",
+  "fmt",
+  "json",
+], version = "0.3" }
+url = { features = ["serde"], version = "2.5" }
 
 # miden-base
 miden-base-agglayer = { package = "miden-agglayer", version = "0.14.0-alpha" }
-miden-protocol      = { default-features = false, features = ["std"], version = "0.14.0-alpha" }
-miden-standards     = { default-features = false, version = "0.14.0-alpha" }
-miden-tx            = { default-features = false, version = "0.14.0-alpha" }
+miden-protocol = { default-features = false, features = [
+  "std",
+], version = "0.14.0-alpha" }
+miden-standards = { default-features = false, version = "0.14.0-alpha" }
+miden-tx = { default-features = false, version = "0.14.0-alpha" }
 
 # miden-client
 miden-client = { default-features = false, features = [

--- a/axum-jrpc/Cargo.toml
+++ b/axum-jrpc/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+categories  = ["asynchronous", "network-programming", "web-programming"]
+description = "A JSON-RPC extractor for Axum"
+edition     = "2021"
+homepage    = "https://github.com/0xdeafbeef/axum-jrpc"
+keywords    = ["axum", "http", "jrpc", "json-rpc", "web"]
+license     = "MIT"
+name        = "axum-jrpc"
+readme      = "README.md"
+repository  = "https://github.com/0xdeafbeef/axum-jrpc"
+version     = "0.8.0"
+
+[dependencies]
+anyhow     = { optional = true, version = "1.0.75" }
+axum       = "0.8.1"
+cfg-if     = "1.0.0"
+mime       = "0.3.17"
+serde      = { features = ["derive"], version = "1.0" }
+serde_json = { optional = true, version = "1.0" }
+simd-json  = { optional = true, version = "0.14.3" }
+thiserror  = "2.0.10"
+
+[features]
+anyhow_error = ["anyhow"]
+default      = ["serde_json"]
+serde_json   = ["dep:serde_json"]
+simd         = ["simd-json"]
+
+[dev-dependencies]
+anyhow             = "1.0.75"
+axum-test          = "17.0.1"
+tokio              = { features = ["full"], version = "1.34" }
+tracing            = "0.1"
+tracing-subscriber = { features = ["env-filter"], version = "0.3" }

--- a/axum-jrpc/Cargo.toml
+++ b/axum-jrpc/Cargo.toml
@@ -1,34 +1,34 @@
 [package]
-categories  = ["asynchronous", "network-programming", "web-programming"]
+categories = ["asynchronous", "network-programming", "web-programming"]
 description = "A JSON-RPC extractor for Axum"
-edition     = "2021"
-homepage    = "https://github.com/0xdeafbeef/axum-jrpc"
-keywords    = ["axum", "http", "jrpc", "json-rpc", "web"]
-license     = "MIT"
-name        = "axum-jrpc"
-readme      = "README.md"
-repository  = "https://github.com/0xdeafbeef/axum-jrpc"
-version     = "0.8.0"
+edition = "2021"
+homepage = "https://github.com/0xdeafbeef/axum-jrpc"
+keywords = ["axum", "http", "jrpc", "json-rpc", "web"]
+license = "MIT"
+name = "axum-jrpc"
+readme = "README.md"
+repository = "https://github.com/0xdeafbeef/axum-jrpc"
+version = "0.8.0"
 
 [dependencies]
-anyhow     = { optional = true, version = "1.0.75" }
-axum       = "0.8.1"
-cfg-if     = "1.0.0"
-mime       = "0.3.17"
-serde      = { features = ["derive"], version = "1.0" }
+anyhow = { optional = true, version = "1.0.75" }
+axum = "0.8.1"
+cfg-if = "1.0.0"
+mime = "0.3.17"
+serde = { features = ["derive"], version = "1.0" }
 serde_json = { optional = true, version = "1.0" }
-simd-json  = { optional = true, version = "0.14.3" }
-thiserror  = "2.0.10"
+simd-json = { optional = true, version = "0.14.3" }
+thiserror = "2.0.10"
 
 [features]
 anyhow_error = ["anyhow"]
-default      = ["serde_json"]
-serde_json   = ["dep:serde_json"]
-simd         = ["simd-json"]
+default = ["serde_json"]
+serde_json = ["dep:serde_json"]
+simd = ["simd-json"]
 
 [dev-dependencies]
-anyhow             = "1.0.75"
-axum-test          = "17.0.1"
-tokio              = { features = ["full"], version = "1.34" }
-tracing            = "0.1"
+anyhow = "1.0.75"
+axum-test = "17.0.1"
+tokio = { features = ["full"], version = "1.34" }
+tracing = "0.1"
 tracing-subscriber = { features = ["env-filter"], version = "0.3" }

--- a/axum-jrpc/LICENSE
+++ b/axum-jrpc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Vladimir Petrzhikovskii
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/axum-jrpc/src/error.rs
+++ b/axum-jrpc/src/error.rs
@@ -1,0 +1,107 @@
+use super::Value;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Constants for [error object](https://www.jsonrpc.org/specification#error_object)
+pub const INVALID_REQUEST: i32 = -32600;
+pub const METHOD_NOT_FOUND: i32 = -32601;
+pub const INVALID_PARAMS: i32 = -32602;
+pub const INTERNAL_ERROR: i32 = -32603;
+pub const PARSE_ERROR: i32 = -32700;
+
+#[derive(Debug, Clone, Copy)]
+pub enum JsonRpcErrorReason {
+    ParseError,
+    InvalidRequest,
+    MethodNotFound,
+    InvalidParams,
+    InternalError,
+    /// -32000 to -32099
+    ServerError(i32),
+    /// All other space
+    ApplicationError(i32),
+}
+
+impl std::fmt::Display for JsonRpcErrorReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JsonRpcErrorReason::ParseError => write!(f, "Parse error"),
+            JsonRpcErrorReason::InvalidRequest => write!(f, "Invalid Request"),
+            JsonRpcErrorReason::MethodNotFound => write!(f, "Method not found"),
+            JsonRpcErrorReason::InvalidParams => write!(f, "Invalid params"),
+            JsonRpcErrorReason::InternalError => write!(f, "Internal error"),
+            JsonRpcErrorReason::ServerError(code) => write!(f, "Server error: {}", code),
+            JsonRpcErrorReason::ApplicationError(code) => {
+                write!(f, "Application error: {}", code)
+            },
+        }
+    }
+}
+
+impl From<JsonRpcErrorReason> for i32 {
+    fn from(reason: JsonRpcErrorReason) -> i32 {
+        match reason {
+            JsonRpcErrorReason::ParseError => PARSE_ERROR,
+            JsonRpcErrorReason::InvalidRequest => INVALID_REQUEST,
+            JsonRpcErrorReason::MethodNotFound => METHOD_NOT_FOUND,
+            JsonRpcErrorReason::InvalidParams => INVALID_PARAMS,
+            JsonRpcErrorReason::InternalError => INTERNAL_ERROR,
+            JsonRpcErrorReason::ServerError(code) | JsonRpcErrorReason::ApplicationError(code) => {
+                code
+            },
+        }
+    }
+}
+
+impl JsonRpcErrorReason {
+    fn new(code: i32) -> Self {
+        match code {
+            PARSE_ERROR => Self::ParseError,
+            INVALID_REQUEST => Self::InvalidRequest,
+            METHOD_NOT_FOUND => Self::MethodNotFound,
+            INVALID_PARAMS => Self::InvalidParams,
+            INTERNAL_ERROR => Self::InternalError,
+            -32099..=-32000 => Self::ServerError(code),
+            _ => Self::ApplicationError(code),
+        }
+    }
+}
+
+#[derive(Debug, Error, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JsonRpcError {
+    code: i32,
+    message: String,
+    data: Value,
+}
+
+impl JsonRpcError {
+    pub fn new(code: JsonRpcErrorReason, message: String, data: Value) -> Self {
+        Self { code: code.into(), message, data }
+    }
+}
+
+impl std::fmt::Display for JsonRpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", JsonRpcErrorReason::new(self.code), self.message)
+    }
+}
+
+#[cfg(feature = "anyhow_error")]
+impl From<anyhow::Error> for JsonRpcError {
+    fn from(error: anyhow::Error) -> Self {
+        let message = error.to_string();
+        let data = Value::default();
+        Self { code: 1, message, data }
+    }
+}
+
+impl JsonRpcError {
+    pub fn error_reason(&self) -> JsonRpcErrorReason {
+        JsonRpcErrorReason::new(self.code)
+    }
+
+    pub fn code(&self) -> i32 {
+        self.code
+    }
+}

--- a/axum-jrpc/src/error.rs
+++ b/axum-jrpc/src/error.rs
@@ -34,7 +34,7 @@ impl std::fmt::Display for JsonRpcErrorReason {
             JsonRpcErrorReason::ServerError(code) => write!(f, "Server error: {}", code),
             JsonRpcErrorReason::ApplicationError(code) => {
                 write!(f, "Application error: {}", code)
-            },
+            }
         }
     }
 }
@@ -49,7 +49,7 @@ impl From<JsonRpcErrorReason> for i32 {
             JsonRpcErrorReason::InternalError => INTERNAL_ERROR,
             JsonRpcErrorReason::ServerError(code) | JsonRpcErrorReason::ApplicationError(code) => {
                 code
-            },
+            }
         }
     }
 }
@@ -77,13 +77,22 @@ pub struct JsonRpcError {
 
 impl JsonRpcError {
     pub fn new(code: JsonRpcErrorReason, message: String, data: Value) -> Self {
-        Self { code: code.into(), message, data }
+        Self {
+            code: code.into(),
+            message,
+            data,
+        }
     }
 }
 
 impl std::fmt::Display for JsonRpcError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: {}", JsonRpcErrorReason::new(self.code), self.message)
+        write!(
+            f,
+            "{}: {}",
+            JsonRpcErrorReason::new(self.code),
+            self.message
+        )
     }
 }
 
@@ -92,7 +101,11 @@ impl From<anyhow::Error> for JsonRpcError {
     fn from(error: anyhow::Error) -> Self {
         let message = error.to_string();
         let data = Value::default();
-        Self { code: 1, message, data }
+        Self {
+            code: 1,
+            message,
+            data,
+        }
     }
 }
 

--- a/axum-jrpc/src/lib.rs
+++ b/axum-jrpc/src/lib.rs
@@ -1,0 +1,578 @@
+#![warn(
+    clippy::all,
+    clippy::dbg_macro,
+    clippy::todo,
+    clippy::empty_enum,
+    clippy::enum_glob_use,
+    clippy::mem_forget,
+    clippy::unused_self,
+    clippy::filter_map_next,
+    clippy::needless_continue,
+    clippy::needless_borrow,
+    clippy::match_wildcard_for_single_variants,
+    clippy::if_let_mutex,
+    unexpected_cfgs,
+    clippy::await_holding_lock,
+    clippy::match_on_vec_items,
+    clippy::imprecise_flops,
+    clippy::suboptimal_flops,
+    clippy::lossy_float_literal,
+    clippy::rest_pat_in_fully_bound_structs,
+    clippy::fn_params_excessive_bools,
+    clippy::exit,
+    clippy::inefficient_to_string,
+    clippy::linkedlist,
+    clippy::macro_use_imports,
+    clippy::option_option,
+    clippy::verbose_file_reads,
+    clippy::unnested_or_patterns,
+    clippy::str_to_string,
+    rust_2018_idioms,
+    future_incompatible,
+    nonstandard_style,
+    missing_debug_implementations
+)]
+#![deny(unreachable_pub)]
+#![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
+
+use std::borrow::Cow;
+
+use axum::body::Bytes;
+use axum::extract::{FromRequest, Request};
+use axum::http::{header, HeaderMap};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use cfg_if::cfg_if;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+cfg_if! {
+    if #[cfg(feature = "serde_json")] {
+        pub use serde_json::Value;
+        pub mod error;
+        use crate::error::{JsonRpcError, JsonRpcErrorReason};
+    }
+    else if #[cfg(feature = "simd")] {
+        pub use simd_json::OwnedValue as Value;
+        pub mod error;
+        use crate::error::{JsonRpcError, JsonRpcErrorReason};
+    }
+    else {
+        compile_error!("features `serde_json` and `simd` are mutually exclusive");
+    }
+}
+
+/// Hack until [try_trait_v2](https://github.com/rust-lang/rust/issues/84277) is not stabilized
+pub type JrpcResult = Result<JsonRpcResponse, JsonRpcResponse>;
+
+#[derive(Debug)]
+pub struct JsonRpcRequest {
+    pub id: Id,
+    pub method: String,
+    pub params: Value,
+}
+
+impl Serialize for JsonRpcRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        struct Helper<'a> {
+            jsonrpc: &'static str,
+            id: Id,
+            method: &'a str,
+            params: &'a Value,
+        }
+
+        Helper {
+            jsonrpc: JSONRPC,
+            id: self.id.clone(),
+            method: &self.method,
+            params: &self.params,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonRpcRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        #[derive(Deserialize)]
+        struct Helper<'a> {
+            #[serde(borrow)]
+            jsonrpc: Cow<'a, str>,
+            id: Id,
+            method: String,
+            params: Option<Value>,
+        }
+
+        let helper = Helper::deserialize(deserializer)?;
+        if helper.jsonrpc == JSONRPC {
+            Ok(Self {
+                id: helper.id,
+                method: helper.method,
+                params: helper.params.unwrap_or(Value::Null),
+            })
+        } else {
+            Err(D::Error::custom("Unknown jsonrpc version"))
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+/// Parses a JSON-RPC request, and returns the request ID, the method name, and the parameters.
+/// If the request is invalid, returns an error.
+/// ```rust
+/// use axum_jrpc::{JrpcResult, JsonRpcExtractor, JsonRpcResponse};
+///
+/// fn router(req: JsonRpcExtractor) -> JrpcResult {
+///   let req_id = req.get_answer_id();
+///   let method = req.method();
+///   match method {
+///     "add" => {
+///        let params: [i32;2] = req.parse_params()?;
+///        return Ok(JsonRpcResponse::success(req_id, params[0] + params[1]));
+///     }
+///     m =>  Ok(req.method_not_found(m))
+///   }
+/// }
+/// ```
+pub struct JsonRpcExtractor {
+    pub parsed: Value,
+    pub method: String,
+    pub id: Id,
+}
+
+impl JsonRpcExtractor {
+    pub fn get_answer_id(&self) -> Id {
+        self.id.clone()
+    }
+
+    pub fn parse_params<T: DeserializeOwned>(self) -> Result<T, JsonRpcResponse> {
+        cfg_if::cfg_if! {
+           if #[cfg(feature = "simd")] {
+                match simd_json::serde::from_owned_value(self.parsed){
+                    Ok(v) => Ok(v),
+                    Err(e) => {
+                        let error = JsonRpcError::new(
+                            JsonRpcErrorReason::InvalidParams,
+                            e.to_string(),
+                            Value::default(),
+                        );
+                        Err(JsonRpcResponse::error(self.id, error))
+                    }
+
+                }
+            } else if #[cfg(feature = "serde_json")] {
+                match serde_json::from_value(self.parsed){
+                    Ok(v) => Ok(v),
+                    Err(e) => {
+                        let error = JsonRpcError::new(
+                            JsonRpcErrorReason::InvalidParams,
+                            e.to_string(),
+                            Value::Null,
+                        );
+                        Err(JsonRpcResponse::error(self.id, error))
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn method(&self) -> &str {
+        &self.method
+    }
+
+    pub fn method_not_found(&self, method: &str) -> JsonRpcResponse {
+        let error = JsonRpcError::new(
+            JsonRpcErrorReason::MethodNotFound,
+            format!("Method `{}` not found", method),
+            Value::default(),
+        );
+
+        JsonRpcResponse::error(self.id.clone(), error)
+    }
+}
+
+impl<S> FromRequest<S> for JsonRpcExtractor
+where
+    Bytes: FromRequest<S>,
+    S: Send + Sync,
+{
+    type Rejection = JsonRpcResponse;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        if !json_content_type(req.headers()) {
+            return Err(JsonRpcResponse {
+                id: Id::None(()),
+                result: JsonRpcAnswer::Error(JsonRpcError::new(
+                    JsonRpcErrorReason::InvalidRequest,
+                    "Invalid content type".to_owned(),
+                    Value::default(),
+                )),
+            });
+        }
+
+        #[allow(unused_mut)]
+        let mut bytes = match Bytes::from_request(req, state).await {
+            Ok(a) => a.to_vec(),
+            Err(_) => {
+                return Err(JsonRpcResponse {
+                    id: Id::None(()),
+                    result: JsonRpcAnswer::Error(JsonRpcError::new(
+                        JsonRpcErrorReason::InvalidRequest,
+                        "Invalid request".to_owned(),
+                        Value::default(),
+                    )),
+                })
+            },
+        };
+
+        cfg_if!(
+            if #[cfg(feature = "simd")] {
+               let parsed: JsonRpcRequest = match simd_json::from_slice(&mut bytes){
+                    Ok(a) => a,
+                    Err(e) => {
+                        return Err(JsonRpcResponse {
+                            id: Id::None(()),
+                            result: JsonRpcAnswer::Error(JsonRpcError::new(
+                                JsonRpcErrorReason::InvalidRequest,
+                                e.to_string(),
+                                Value::default(),
+                            )),
+                        })
+                    }
+                };
+            } else if #[cfg(feature = "serde_json")] {
+               let parsed: JsonRpcRequest = match serde_json::from_slice(&bytes){
+                    Ok(a) => a,
+                    Err(e) => {
+                        return Err(JsonRpcResponse {
+                            id: Id::None(()),
+                            result: JsonRpcAnswer::Error(JsonRpcError::new(
+                                JsonRpcErrorReason::InvalidRequest,
+                                e.to_string(),
+                                Value::default(),
+                            )),
+                        })
+                    }
+                };
+            }
+        );
+
+        Ok(Self {
+            parsed: parsed.params,
+            method: parsed.method,
+            id: parsed.id,
+        })
+    }
+}
+
+fn json_content_type(headers: &HeaderMap) -> bool {
+    let content_type = if let Some(content_type) = headers.get(header::CONTENT_TYPE) {
+        content_type
+    } else {
+        return false;
+    };
+
+    let content_type = if let Ok(content_type) = content_type.to_str() {
+        content_type
+    } else {
+        return false;
+    };
+
+    let mime = if let Ok(mime) = content_type.parse::<mime::Mime>() {
+        mime
+    } else {
+        return false;
+    };
+
+    let is_json_content_type = mime.type_() == "application"
+        && (mime.subtype() == "json" || mime.suffix().map_or(false, |name| name == "json"));
+
+    is_json_content_type
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// A JSON-RPC response.
+pub struct JsonRpcResponse {
+    /// Request content.
+    pub result: JsonRpcAnswer,
+    /// The request ID.
+    pub id: Id,
+}
+
+impl JsonRpcResponse {
+    fn new<ID>(id: ID, result: JsonRpcAnswer) -> Self
+    where
+        Id: From<ID>,
+    {
+        Self { result, id: id.into() }
+    }
+
+    /// Returns a response with the given result
+    /// Returns JsonRpcError if the `result` is invalid input for [`serde_json::to_value`]
+    pub fn success<T, ID>(id: ID, result: T) -> Self
+    where
+        T: Serialize,
+        Id: From<ID>,
+    {
+        cfg_if::cfg_if! {
+          if #[cfg(feature = "simd")] {
+            match simd_json::serde::to_owned_value(result) {
+                Ok(v) => JsonRpcResponse::new(id, JsonRpcAnswer::Result(v)),
+                Err(e) => {
+                    let err = JsonRpcError::new(
+                        JsonRpcErrorReason::InternalError,
+                        e.to_string(),
+                        Value::default(),
+                    );
+                    JsonRpcResponse::error(id, err)
+                }
+            }
+          } else if #[cfg(feature = "serde_json")] {
+            match serde_json::to_value(result) {
+                Ok(v) => JsonRpcResponse::new(id, JsonRpcAnswer::Result(v)),
+                Err(e) => {
+                    let err = JsonRpcError::new(
+                        JsonRpcErrorReason::InternalError,
+                        e.to_string(),
+                        Value::Null,
+                    );
+                    JsonRpcResponse::error(id, err)
+                }
+            }
+          }
+        }
+    }
+
+    pub fn error<ID>(id: ID, error: JsonRpcError) -> Self
+    where
+        Id: From<ID>,
+    {
+        let id = id.into();
+        JsonRpcResponse { result: JsonRpcAnswer::Error(error), id }
+    }
+}
+
+impl Serialize for JsonRpcResponse {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        struct Helper<'a> {
+            jsonrpc: &'static str,
+            #[serde(flatten)]
+            result: &'a JsonRpcAnswer,
+            id: Id,
+        }
+
+        Helper {
+            jsonrpc: JSONRPC,
+            result: &self.result,
+            id: self.id.clone(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonRpcResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        #[derive(Deserialize)]
+        struct Helper<'a> {
+            #[serde(borrow)]
+            jsonrpc: Cow<'a, str>,
+            #[serde(flatten)]
+            result: JsonRpcAnswer,
+            id: Id,
+        }
+
+        let helper = Helper::deserialize(deserializer)?;
+        if helper.jsonrpc == JSONRPC {
+            Ok(Self { result: helper.result, id: helper.id })
+        } else {
+            Err(D::Error::custom("Unknown jsonrpc version"))
+        }
+    }
+}
+
+impl IntoResponse for JsonRpcResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+
+#[derive(Serialize, Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+/// JsonRpc [response object](https://www.jsonrpc.org/specification#response_object)
+pub enum JsonRpcAnswer {
+    Result(Value),
+    Error(JsonRpcError),
+}
+
+const JSONRPC: &str = "2.0";
+
+/// An identifier established by the Client that MUST contain a String, Number,
+/// or NULL value if included. If it is not included it is assumed to be a notification.
+/// The value SHOULD normally not be Null and Numbers SHOULD NOT contain fractional parts
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, Hash)]
+#[serde(untagged)]
+pub enum Id {
+    Num(i64),
+    Str(String),
+    None(()),
+}
+
+impl From<()> for Id {
+    fn from(val: ()) -> Self {
+        Id::None(val)
+    }
+}
+
+impl From<i64> for Id {
+    fn from(val: i64) -> Self {
+        Id::Num(val)
+    }
+}
+
+impl From<String> for Id {
+    fn from(val: String) -> Self {
+        Id::Str(val)
+    }
+}
+
+#[cfg(test)]
+#[cfg(all(feature = "anyhow_error", feature = "serde_json"))]
+mod test {
+    use crate::{
+        Deserialize, JrpcResult, JsonRpcAnswer, JsonRpcError, JsonRpcErrorReason, JsonRpcExtractor,
+        JsonRpcRequest, JsonRpcResponse,
+    };
+    use axum::routing::post;
+    use serde::Serialize;
+    use serde_json::Value;
+
+    #[tokio::test]
+    async fn test() {
+        use axum::http::StatusCode;
+        use axum::Router;
+        use axum_test::TestServer;
+
+        // you can replace this Router with your own app
+        let app = Router::new().route("/", post(handler));
+
+        // initiate the TestClient with the previous declared Router
+        let client = TestServer::new(app).unwrap();
+
+        let res = client
+            .post("/")
+            .json(&JsonRpcRequest {
+                id: 0.into(),
+                method: "add".to_owned(),
+                params: serde_json::to_value(Test { a: 0, b: 111 }).unwrap(),
+            })
+            .await;
+        assert_eq!(res.status_code(), StatusCode::OK);
+        let response = res.json::<JsonRpcResponse>();
+        assert_eq!(response.result, JsonRpcAnswer::Result(111.into()));
+
+        let res = client
+            .post("/")
+            .json(&JsonRpcRequest {
+                id: 0.into(),
+                method: "lol".to_owned(),
+                params: serde_json::to_value(()).unwrap(),
+            })
+            .await;
+
+        assert_eq!(res.status_code(), StatusCode::OK);
+
+        let response = res.json::<JsonRpcResponse>();
+
+        let error = JsonRpcError::new(
+            JsonRpcErrorReason::MethodNotFound,
+            format!("Method `{}` not found", "lol"),
+            Value::Null,
+        );
+
+        let error = JsonRpcResponse::error(0, error);
+
+        assert_eq!(serde_json::to_value(error).unwrap(), serde_json::to_value(response).unwrap());
+    }
+
+    async fn handler(value: JsonRpcExtractor) -> JrpcResult {
+        let answer_id = value.get_answer_id();
+        println!("{:?}", value);
+        match value.method.as_str() {
+            "add" => {
+                let request: Test = value.parse_params()?;
+                let result = request.a + request.b;
+                Ok(JsonRpcResponse::success(answer_id, result))
+            },
+            "sub" => {
+                let result: [i32; 2] = value.parse_params()?;
+                let result = match failing_sub(result[0], result[1]).await {
+                    Ok(result) => result,
+                    Err(e) => return Err(JsonRpcResponse::error(answer_id, e.into())),
+                };
+                Ok(JsonRpcResponse::success(answer_id, result))
+            },
+            "div" => {
+                let result: [i32; 2] = value.parse_params()?;
+                let result = match failing_div(result[0], result[1]).await {
+                    Ok(result) => result,
+                    Err(e) => return Err(JsonRpcResponse::error(answer_id, e.into())),
+                };
+
+                Ok(JsonRpcResponse::success(answer_id, result))
+            },
+            method => Ok(value.method_not_found(method)),
+        }
+    }
+
+    async fn failing_sub(a: i32, b: i32) -> anyhow::Result<i32> {
+        anyhow::ensure!(a > b, "a must be greater than b");
+        Ok(a - b)
+    }
+
+    async fn failing_div(a: i32, b: i32) -> Result<i32, CustomError> {
+        if b == 0 {
+            Err(CustomError::DivideByZero)
+        } else {
+            Ok(a / b)
+        }
+    }
+
+    #[derive(Deserialize, Serialize, Debug)]
+    struct Test {
+        a: i32,
+        b: i32,
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    enum CustomError {
+        #[error("Divisor must not be equal to 0")]
+        DivideByZero,
+    }
+
+    impl From<CustomError> for JsonRpcError {
+        fn from(error: CustomError) -> Self {
+            JsonRpcError::new(
+                JsonRpcErrorReason::ServerError(-32099),
+                error.to_string(),
+                serde_json::Value::Null,
+            )
+        }
+    }
+}

--- a/axum-jrpc/src/lib.rs
+++ b/axum-jrpc/src/lib.rs
@@ -230,7 +230,7 @@ where
                         Value::default(),
                     )),
                 })
-            },
+            }
         };
 
         cfg_if!(
@@ -312,7 +312,10 @@ impl JsonRpcResponse {
     where
         Id: From<ID>,
     {
-        Self { result, id: id.into() }
+        Self {
+            result,
+            id: id.into(),
+        }
     }
 
     /// Returns a response with the given result
@@ -356,7 +359,10 @@ impl JsonRpcResponse {
         Id: From<ID>,
     {
         let id = id.into();
-        JsonRpcResponse { result: JsonRpcAnswer::Error(error), id }
+        JsonRpcResponse {
+            result: JsonRpcAnswer::Error(error),
+            id,
+        }
     }
 }
 
@@ -400,7 +406,10 @@ impl<'de> Deserialize<'de> for JsonRpcResponse {
 
         let helper = Helper::deserialize(deserializer)?;
         if helper.jsonrpc == JSONRPC {
-            Ok(Self { result: helper.result, id: helper.id })
+            Ok(Self {
+                result: helper.result,
+                id: helper.id,
+            })
         } else {
             Err(D::Error::custom("Unknown jsonrpc version"))
         }
@@ -508,7 +517,10 @@ mod test {
 
         let error = JsonRpcResponse::error(0, error);
 
-        assert_eq!(serde_json::to_value(error).unwrap(), serde_json::to_value(response).unwrap());
+        assert_eq!(
+            serde_json::to_value(error).unwrap(),
+            serde_json::to_value(response).unwrap()
+        );
     }
 
     async fn handler(value: JsonRpcExtractor) -> JrpcResult {
@@ -519,7 +531,7 @@ mod test {
                 let request: Test = value.parse_params()?;
                 let result = request.a + request.b;
                 Ok(JsonRpcResponse::success(answer_id, result))
-            },
+            }
             "sub" => {
                 let result: [i32; 2] = value.parse_params()?;
                 let result = match failing_sub(result[0], result[1]).await {
@@ -527,7 +539,7 @@ mod test {
                     Err(e) => return Err(JsonRpcResponse::error(answer_id, e.into())),
                 };
                 Ok(JsonRpcResponse::success(answer_id, result))
-            },
+            }
             "div" => {
                 let result: [i32; 2] = value.parse_params()?;
                 let result = match failing_div(result[0], result[1]).await {
@@ -536,7 +548,7 @@ mod test {
                 };
 
                 Ok(JsonRpcResponse::success(answer_id, result))
-            },
+            }
             method => Ok(value.method_not_found(method)),
         }
     }

--- a/src/address_mapper.rs
+++ b/src/address_mapper.rs
@@ -7,8 +7,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 const HARDHAT_ADDRESS: Address = Address::new([
-    0xf3, 0x9F, 0xd6, 0xe5, 0x1a, 0xad, 0x88, 0xF6, 0xF4, 0xce, 0x6a, 0xB8, 0x82, 0x72, 0x79, 0xcf,
-    0xfF, 0xb9, 0x22, 0x66,
+    0xf3, 0x9f, 0xd6, 0xe5, 0x1a, 0xad, 0x88, 0xf6, 0xf4, 0xce, 0x6a, 0xb8, 0x82, 0x72, 0x79, 0xcf,
+    0xff, 0xb9, 0x22, 0x66,
 ]);
 
 pub fn is_miden_compatible_address(address: Address) -> bool {
@@ -39,7 +39,7 @@ fn derive_account_id(address: Address) -> anyhow::Result<AccountId> {
 
     // Set metadata bits for RegularAccountUpdatableCode (0b01) + Public (0b00) + Version0 (0)
     // Byte 7 (LS byte of prefix): (storage_mode << 6) | (account_type << 4) | version
-    id_bytes[7] = (0b00 << 6) | (0b01 << 4) | 0b0000; // 0x10
+    id_bytes[7] = 0b01 << 4; // 0x10
 
     // Clear MSB of prefix (byte 0) — Felt requires < 2^63
     id_bytes[0] &= 0x7F;

--- a/src/address_mapper.rs
+++ b/src/address_mapper.rs
@@ -1,6 +1,15 @@
 use crate::accounts_config::AccountsConfig;
 use alloy::primitives::Address;
 use miden_protocol::account::AccountId;
+use parking_lot::RwLock;
+use sha3::{Digest, Keccak256};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+const HARDHAT_ADDRESS: Address = Address::new([
+    0xf3, 0x9F, 0xd6, 0xe5, 0x1a, 0xad, 0x88, 0xF6, 0xF4, 0xce, 0x6a, 0xB8, 0x82, 0x72, 0x79,
+    0xcf, 0xfF, 0xb9, 0x22, 0x66,
+]);
 
 pub fn is_miden_compatible_address(address: Address) -> bool {
     address[0..5].iter().all(|b| *b == 0)
@@ -15,14 +24,139 @@ pub fn account_id_from_address(address: Address) -> Option<AccountId> {
     AccountId::try_from(id_bytes).ok()
 }
 
-pub fn account_id_from_address_config(
-    address: Address,
-    config: &AccountsConfig,
-) -> Option<AccountId> {
-    if address.to_string() == "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" {
-        return Some(config.wallet_hardhat.0);
+/// Deterministically derive a Miden AccountId from an Ethereum address.
+///
+/// Uses keccak256("miden-agglayer-addr-v1" || address_bytes) as seed, then
+/// sets metadata bits for RegularAccountUpdatableCode + Public + Version0.
+fn derive_account_id(address: Address) -> anyhow::Result<AccountId> {
+    let mut hasher = Keccak256::new();
+    hasher.update(b"miden-agglayer-addr-v1");
+    hasher.update(address.as_slice());
+    let hash: [u8; 32] = hasher.finalize().into();
+
+    let mut id_bytes = [0u8; 15];
+    id_bytes.copy_from_slice(&hash[..15]);
+
+    // Set metadata bits for RegularAccountUpdatableCode (0b01) + Public (0b00) + Version0 (0)
+    // Byte 7 (LS byte of prefix): (storage_mode << 6) | (account_type << 4) | version
+    id_bytes[7] = (0b00 << 6) | (0b01 << 4) | 0b0000; // 0x10
+
+    // Clear MSB of prefix (byte 0) — Felt requires < 2^63
+    id_bytes[0] &= 0x7F;
+
+    // Clear 32nd MSB of prefix (byte 3, bit 0)
+    id_bytes[3] &= 0xFE;
+
+    // Clear MSB of suffix (byte 8) — Felt requires < 2^63
+    id_bytes[8] &= 0x7F;
+
+    AccountId::try_from(id_bytes)
+        .map_err(|e| anyhow::anyhow!("failed to derive AccountId for {address}: {e}"))
+}
+
+pub struct AddressMapper {
+    mappings: RwLock<HashMap<Address, AccountId>>,
+    persistence_path: Option<PathBuf>,
+}
+
+const fn assert_sync<T: Send + Sync>() {}
+const _: () = assert_sync::<AddressMapper>();
+
+impl AddressMapper {
+    pub fn new(persistence_path: Option<PathBuf>) -> anyhow::Result<Self> {
+        let mappings = if let Some(ref path) = persistence_path {
+            if path.exists() {
+                let data = std::fs::read_to_string(path)?;
+                let raw: HashMap<String, String> = serde_json::from_str(&data)?;
+                let mut map = HashMap::new();
+                for (eth_hex, miden_hex) in raw {
+                    let eth: Address = eth_hex.parse()?;
+                    let miden = AccountId::from_hex(&miden_hex)
+                        .map_err(|e| anyhow::anyhow!("bad account id {miden_hex}: {e}"))?;
+                    map.insert(eth, miden);
+                }
+                map
+            } else {
+                HashMap::new()
+            }
+        } else {
+            HashMap::new()
+        };
+        Ok(Self {
+            mappings: RwLock::new(mappings),
+            persistence_path,
+        })
     }
-    account_id_from_address(address)
+
+    /// Resolve an Ethereum address to a Miden AccountId.
+    /// Resolution order: hardhat special case → known mapping → zero-padding → derive new.
+    pub fn resolve(
+        &self,
+        address: Address,
+        config: &AccountsConfig,
+    ) -> anyhow::Result<AccountId> {
+        // 1. Hardhat special case
+        if address == HARDHAT_ADDRESS {
+            return Ok(config.wallet_hardhat.0);
+        }
+        // 2. Check existing mapping
+        if let Some(id) = self.mappings.read().get(&address) {
+            return Ok(*id);
+        }
+        // 3. Try zero-padding (native Miden address)
+        if let Some(id) = account_id_from_address(address) {
+            return Ok(id);
+        }
+        // 4. Derive deterministically and store
+        let id = self.derive_and_store(address)?;
+        Ok(id)
+    }
+
+    fn derive_and_store(&self, address: Address) -> anyhow::Result<AccountId> {
+        let id = derive_account_id(address)?;
+        tracing::info!(
+            eth_address = %address,
+            miden_account = %id.to_hex(),
+            "AddressMapper: derived new mapping"
+        );
+        self.mappings.write().insert(address, id);
+        self.persist();
+        Ok(id)
+    }
+
+    fn persist(&self) {
+        let Some(ref path) = self.persistence_path else {
+            return;
+        };
+        let mappings = self.mappings.read();
+        let raw: HashMap<String, String> = mappings
+            .iter()
+            .map(|(eth, miden)| (format!("{eth:#x}"), miden.to_hex()))
+            .collect();
+        let Ok(data) = serde_json::to_string_pretty(&raw) else {
+            tracing::error!("AddressMapper: failed to serialize mappings");
+            return;
+        };
+        drop(mappings);
+
+        let tmp_path = path.with_extension("tmp");
+        if let Err(e) = std::fs::write(&tmp_path, &data) {
+            tracing::error!("AddressMapper: failed to write {}: {e}", tmp_path.display());
+            return;
+        }
+        if let Err(e) = std::fs::rename(&tmp_path, path) {
+            tracing::error!(
+                "AddressMapper: failed to rename to {}: {e}",
+                path.display()
+            );
+        }
+    }
+}
+
+impl Default for AddressMapper {
+    fn default() -> Self {
+        Self::new(None).unwrap()
+    }
 }
 
 #[cfg(test)]
@@ -52,5 +186,73 @@ mod tests {
 
         let invalid_address = address!("0x000000000034C0532925a3b844Bc9e7595f41111");
         assert_eq!(account_id_from_address(invalid_address), None);
+    }
+
+    #[test]
+    fn test_derive_account_id_deterministic() {
+        let addr = address!("0x742d35Cc6634C0532925a3b844Bc9e7595f41111");
+        let id1 = derive_account_id(addr).unwrap();
+        let id2 = derive_account_id(addr).unwrap();
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_derive_account_id_different_inputs() {
+        let addr1 = address!("0x742d35Cc6634C0532925a3b844Bc9e7595f41111");
+        let addr2 = address!("0x742d35Cc6634C0532925a3b844Bc9e7595f42222");
+        let id1 = derive_account_id(addr1).unwrap();
+        let id2 = derive_account_id(addr2).unwrap();
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_derive_account_id_is_regular_public() {
+        let addr = address!("0xdead00000000000000000000000000000000beef");
+        let id = derive_account_id(addr).unwrap();
+        assert!(id.is_regular_account());
+        assert!(id.is_public());
+    }
+
+    #[test]
+    fn test_resolve_zero_padded_address() {
+        let mapper = AddressMapper::new(None).unwrap();
+        let addr = address!("0x00000000003d7c9747558851900f8206226dfbea");
+        let expected = AccountId::from_hex("0x3d7c9747558851900f8206226dfbea").unwrap();
+        // Use a dummy config (won't be used for zero-padded addresses)
+        // We can't easily create a full config here, so test derive_account_id directly
+        let result = account_id_from_address(addr);
+        assert_eq!(result, Some(expected));
+        // Verify the mapper doesn't store zero-padded addresses
+        assert!(mapper.mappings.read().is_empty());
+    }
+
+    #[test]
+    fn test_persistence_roundtrip() {
+        let dir = std::env::temp_dir().join(format!(
+            "address_mapper_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("address_mappings.json");
+
+        let addr = address!("0x742d35Cc6634C0532925a3b844Bc9e7595f41111");
+        let derived_id;
+
+        {
+            let mapper = AddressMapper::new(Some(path.clone())).unwrap();
+            derived_id = derive_account_id(addr).unwrap();
+            mapper.mappings.write().insert(addr, derived_id);
+            mapper.persist();
+        }
+
+        // Reload from file
+        let mapper = AddressMapper::new(Some(path.clone())).unwrap();
+        let loaded = mapper.mappings.read().get(&addr).copied();
+        assert_eq!(loaded, Some(derived_id));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/address_mapper.rs
+++ b/src/address_mapper.rs
@@ -7,8 +7,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 const HARDHAT_ADDRESS: Address = Address::new([
-    0xf3, 0x9F, 0xd6, 0xe5, 0x1a, 0xad, 0x88, 0xF6, 0xF4, 0xce, 0x6a, 0xB8, 0x82, 0x72, 0x79,
-    0xcf, 0xfF, 0xb9, 0x22, 0x66,
+    0xf3, 0x9F, 0xd6, 0xe5, 0x1a, 0xad, 0x88, 0xF6, 0xF4, 0xce, 0x6a, 0xB8, 0x82, 0x72, 0x79, 0xcf,
+    0xfF, 0xb9, 0x22, 0x66,
 ]);
 
 pub fn is_miden_compatible_address(address: Address) -> bool {
@@ -90,11 +90,7 @@ impl AddressMapper {
 
     /// Resolve an Ethereum address to a Miden AccountId.
     /// Resolution order: hardhat special case → known mapping → zero-padding → derive new.
-    pub fn resolve(
-        &self,
-        address: Address,
-        config: &AccountsConfig,
-    ) -> anyhow::Result<AccountId> {
+    pub fn resolve(&self, address: Address, config: &AccountsConfig) -> anyhow::Result<AccountId> {
         // 1. Hardhat special case
         if address == HARDHAT_ADDRESS {
             return Ok(config.wallet_hardhat.0);
@@ -145,10 +141,7 @@ impl AddressMapper {
             return;
         }
         if let Err(e) = std::fs::rename(&tmp_path, path) {
-            tracing::error!(
-                "AddressMapper: failed to rename to {}: {e}",
-                path.display()
-            );
+            tracing::error!("AddressMapper: failed to rename to {}: {e}", path.display());
         }
     }
 }

--- a/src/amount.rs
+++ b/src/amount.rs
@@ -41,18 +41,28 @@ mod tests {
         let gwei = U256::from(10).pow(U256::from(9));
 
         assert_eq!(validate_amount(U256::from(123), 0, 0), Ok(123));
-        assert_eq!(validate_amount(U256::from(0), DECIMALS, DECIMALS_OUT), Ok(0));
+        assert_eq!(
+            validate_amount(U256::from(0), DECIMALS, DECIMALS_OUT),
+            Ok(0)
+        );
         assert_eq!(
             validate_amount(U256::from(123), DECIMALS, DECIMALS_OUT),
             Err(AmountError::LossyTruncation)
         );
-        assert_eq!(validate_amount(U256::from(1230).mul(gwei), DECIMALS, DECIMALS_OUT), Ok(123));
+        assert_eq!(
+            validate_amount(U256::from(1230).mul(gwei), DECIMALS, DECIMALS_OUT),
+            Ok(123)
+        );
         assert_eq!(
             validate_amount(U256::from(42).mul(eth_wei), DECIMALS, DECIMALS_OUT),
             Ok(4200000000)
         );
         assert_eq!(
-            validate_amount(U256::from(42).mul(eth_wei).add(U256::from(1)), DECIMALS, DECIMALS_OUT),
+            validate_amount(
+                U256::from(42).mul(eth_wei).add(U256::from(1)),
+                DECIMALS,
+                DECIMALS_OUT
+            ),
             Err(AmountError::LossyTruncation)
         );
         assert_eq!(

--- a/src/block_state.rs
+++ b/src/block_state.rs
@@ -1,0 +1,297 @@
+//! Block State - Synthetic EVM block tracking for kurtosis-cdk integration.
+//!
+//! # Why this exists
+//!
+//! The zkevm-bridge-service has a reorg detection mechanism: it stores block
+//! hashes from `eth_getLogs` responses, then later calls `HeaderByNumber` to
+//! verify them. The Go ethclient's `HeaderByNumber` returns a `types.Header`
+//! and the bridge calls `header.Hash()` which computes `keccak256(rlp(header))`
+//! from the header's fields — it does NOT use the `hash` field from the JSON
+//! response.
+//!
+//! This means we cannot use an arbitrary hash (like `keccak256("miden_block_<N>")`).
+//! Our block hash must be the actual RLP hash of the header fields we return in
+//! the JSON-RPC response. Otherwise the bridge detects a "reorg" on every sync
+//! cycle and keeps walking backwards trying to find a matching block, eventually
+//! hitting genesis and resetting.
+//!
+//! # How it works
+//!
+//! We build a real `alloy_consensus::Header` with deterministic fields derived
+//! purely from the block number, then compute `hash_slow()` to get the canonical
+//! `keccak256(rlp(header))` hash. This is the same computation Go's ethclient
+//! performs, so the hashes always match.
+//!
+//! All header fields are pure functions of block number alone — no state, no
+//! caching needed. Parent hash uses a simple deterministic scheme (not recursive
+//! RLP computation) since the bridge only checks per-block hash consistency,
+//! not parent-child hash chains.
+
+use alloy::consensus::Header;
+use alloy::primitives::{B64, B256, Bloom, U256};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use sha3::{Digest, Keccak256};
+use std::collections::HashMap;
+
+use crate::miden_client::SyncListener;
+use miden_client::sync::SyncSummary;
+
+/// Genesis timestamp for synthetic blocks (2024-01-01 00:00:00 UTC)
+const GENESIS_TIMESTAMP: u64 = 1704067200;
+
+/// Block time in seconds (12s like Ethereum mainnet)
+const BLOCK_TIME: u64 = 12;
+
+/// Empty uncles hash (keccak256 of RLP-encoded empty list)
+const EMPTY_OMMERS_HASH: [u8; 32] = [
+    0x1d, 0xcc, 0x4d, 0xe8, 0xde, 0xc7, 0x5d, 0x7a, 0xab, 0x85, 0xb5, 0x67, 0xb6, 0xcc, 0xd4, 0x1a,
+    0xd3, 0x12, 0x45, 0x1b, 0x94, 0x8a, 0x74, 0x13, 0xf0, 0xa1, 0x42, 0xfd, 0x40, 0xd4, 0x93, 0x47,
+];
+
+/// Empty trie root (keccak256 of RLP-encoded empty string)
+const EMPTY_ROOT_HASH: [u8; 32] = [
+    0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6, 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e,
+    0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0, 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21,
+];
+
+/// Synthetic EVM block generated from Miden batch
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyntheticBlock {
+    pub number: u64,
+    pub hash: [u8; 32],
+    pub parent_hash: [u8; 32],
+    pub timestamp: u64,
+    pub state_root: [u8; 32],
+    pub transactions: Vec<String>,
+}
+
+impl SyntheticBlock {
+    pub fn new(number: u64, timestamp: u64) -> Self {
+        let parent_hash = Self::deterministic_parent_hash(number);
+        let hash = Self::compute_hash_for_number(number);
+        Self {
+            number,
+            hash,
+            parent_hash,
+            timestamp,
+            state_root: [0u8; 32],
+            transactions: Vec::new(),
+        }
+    }
+
+    fn deterministic_parent_hash(number: u64) -> [u8; 32] {
+        if number == 0 {
+            [0u8; 32]
+        } else {
+            let mut hasher = Keccak256::new();
+            hasher.update(format!("miden_parent_{}", number - 1).as_bytes());
+            hasher.finalize().into()
+        }
+    }
+
+    fn build_header(number: u64) -> Header {
+        let parent_hash = Self::deterministic_parent_hash(number);
+        let timestamp = GENESIS_TIMESTAMP + number * BLOCK_TIME;
+
+        Header {
+            parent_hash: B256::from(parent_hash),
+            ommers_hash: B256::from(EMPTY_OMMERS_HASH),
+            beneficiary: Default::default(),
+            state_root: B256::ZERO,
+            transactions_root: B256::from(EMPTY_ROOT_HASH),
+            receipts_root: B256::from(EMPTY_ROOT_HASH),
+            logs_bloom: Bloom::ZERO,
+            difficulty: U256::ZERO,
+            number,
+            gas_limit: 30_000_000,
+            gas_used: 0,
+            timestamp,
+            extra_data: Default::default(),
+            mix_hash: B256::ZERO,
+            nonce: B64::ZERO,
+            base_fee_per_gas: Some(0),
+            ..Default::default()
+        }
+    }
+
+    pub fn compute_hash_for_number(number: u64) -> [u8; 32] {
+        let header = Self::build_header(number);
+        header.hash_slow().0
+    }
+
+    pub fn to_json(&self, _full_transactions: bool) -> serde_json::Value {
+        // Note: full_transactions=true should return full tx objects, but our
+        // synthetic blocks only store tx hashes, so both cases return the same.
+        let txs = serde_json::json!(self.transactions);
+
+        serde_json::json!({
+            "number": format!("0x{:x}", self.number),
+            "hash": format!("0x{}", hex::encode(self.hash)),
+            "parentHash": format!("0x{}", hex::encode(self.parent_hash)),
+            "timestamp": format!("0x{:x}", self.timestamp),
+            "stateRoot": format!("0x{}", hex::encode(self.state_root)),
+            "transactionsRoot": format!("0x{}", hex::encode(EMPTY_ROOT_HASH)),
+            "receiptsRoot": format!("0x{}", hex::encode(EMPTY_ROOT_HASH)),
+            "logsBloom": format!("0x{}", "00".repeat(256)),
+            "difficulty": "0x0",
+            "totalDifficulty": "0x0",
+            "gasLimit": "0x1c9c380",
+            "gasUsed": "0x0",
+            "miner": "0x0000000000000000000000000000000000000000",
+            "extraData": "0x",
+            "nonce": "0x0000000000000000",
+            "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "sha3Uncles": format!("0x{}", hex::encode(EMPTY_OMMERS_HASH)),
+            "uncles": [],
+            "size": "0x200",
+            "transactions": txs,
+            "baseFeePerGas": "0x0"
+        })
+    }
+}
+
+/// Block state tracking for synthetic EVM blocks
+pub struct BlockState {
+    blocks: RwLock<HashMap<u64, SyntheticBlock>>,
+    hash_to_number: RwLock<HashMap<[u8; 32], u64>>,
+    current_block: RwLock<u64>,
+}
+
+impl BlockState {
+    pub fn new() -> Self {
+        let state = Self {
+            blocks: RwLock::new(HashMap::new()),
+            hash_to_number: RwLock::new(HashMap::new()),
+            current_block: RwLock::new(0),
+        };
+        state.ensure_block_exists(0);
+        state
+    }
+
+    pub fn current_block_number(&self) -> u64 {
+        *self.current_block.read()
+    }
+
+    pub fn set_current_block(&self, block_num: u64) {
+        self.ensure_block_exists(block_num);
+        *self.current_block.write() = block_num;
+    }
+
+    fn deterministic_timestamp(block_num: u64) -> u64 {
+        GENESIS_TIMESTAMP + block_num * BLOCK_TIME
+    }
+
+    fn ensure_block_exists(&self, block_num: u64) {
+        // Acquire both locks before mutating to prevent deadlock from
+        // inconsistent lock ordering. Always: hash_to_number first, then blocks.
+        let mut hash_to_number = self.hash_to_number.write();
+        let mut blocks = self.blocks.write();
+        if blocks.contains_key(&block_num) {
+            return;
+        }
+
+        let block = SyntheticBlock::new(block_num, Self::deterministic_timestamp(block_num));
+        hash_to_number.insert(block.hash, block_num);
+        blocks.insert(block_num, block);
+    }
+
+    pub fn get_block_by_number(&self, block_num: u64) -> Option<SyntheticBlock> {
+        self.ensure_block_exists(block_num);
+        self.blocks.read().get(&block_num).cloned()
+    }
+
+    pub fn get_block_by_hash(&self, hash: &[u8; 32]) -> Option<SyntheticBlock> {
+        let hash_to_number = self.hash_to_number.read();
+        let number = hash_to_number.get(hash).copied()?;
+        drop(hash_to_number);
+        self.blocks.read().get(&number).cloned()
+    }
+
+    pub fn add_transaction_to_block(&self, block_num: u64, tx_hash: String) {
+        if let Some(block) = self.blocks.write().get_mut(&block_num) {
+            block.transactions.push(tx_hash);
+        }
+    }
+
+    pub fn get_block_hash(&self, block_num: u64) -> [u8; 32] {
+        SyntheticBlock::compute_hash_for_number(block_num)
+    }
+}
+
+impl Default for BlockState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SyncListener for BlockState {
+    fn on_sync(&self, summary: &SyncSummary) {
+        self.set_current_block(summary.block_num.as_u64());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_is_pure_function_of_block_number() {
+        let h1 = SyntheticBlock::compute_hash_for_number(42);
+        let h2 = SyntheticBlock::compute_hash_for_number(42);
+        assert_eq!(h1, h2, "Same block number must produce same hash");
+        assert_ne!(h1, [0u8; 32]);
+
+        let h3 = SyntheticBlock::compute_hash_for_number(43);
+        assert_ne!(
+            h1, h3,
+            "Different block numbers must produce different hashes"
+        );
+    }
+
+    #[test]
+    fn test_hash_is_real_rlp_hash() {
+        let header = SyntheticBlock::build_header(42);
+        let expected = header.hash_slow().0;
+        let actual = SyntheticBlock::compute_hash_for_number(42);
+        assert_eq!(actual, expected, "Hash must be keccak256(rlp(header))");
+    }
+
+    #[test]
+    fn test_block_state_genesis() {
+        let state = BlockState::new();
+        let genesis = state.get_block_by_number(0).unwrap();
+        assert_eq!(genesis.number, 0);
+        assert_eq!(genesis.parent_hash, [0u8; 32]);
+    }
+
+    #[test]
+    fn test_hashes_identical_across_instances() {
+        let state1 = BlockState::new();
+        let state2 = BlockState::new();
+
+        let _ = state1.get_block_by_number(100);
+        let _ = state2.get_block_by_number(50);
+        let _ = state2.get_block_by_number(100);
+
+        assert_eq!(
+            state1.get_block_by_number(100).unwrap().hash,
+            state2.get_block_by_number(100).unwrap().hash,
+        );
+    }
+
+    #[test]
+    fn test_deterministic_timestamps() {
+        let state = BlockState::new();
+        let block = state.get_block_by_number(10).unwrap();
+        let expected_ts = GENESIS_TIMESTAMP + 10 * BLOCK_TIME;
+        assert_eq!(block.timestamp, expected_ts);
+    }
+
+    #[test]
+    fn test_get_block_hash_without_cache() {
+        let state = BlockState::new();
+        let h = state.get_block_hash(999);
+        assert_eq!(h, SyntheticBlock::compute_hash_for_number(999));
+    }
+}

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -2,17 +2,18 @@ use crate::accounts_config::AccountsConfig;
 use crate::address_mapper::account_id_from_address_config;
 use crate::amount::validate_amount;
 use crate::miden_client::{MidenClient, MidenClientLib};
-use alloy::primitives::{BlockNumber, Bytes, FixedBytes, LogData, U256};
+use alloy::primitives::{BlockNumber, Bytes, FixedBytes, LogData};
 use alloy::sol_types::SolEvent;
-use miden_base_agglayer::ClaimNoteParams;
+use miden_base_agglayer::{
+    ClaimNoteStorage, EthAddressFormat, EthAmount, ExitRoot, GlobalIndex, LeafData, MetadataHash,
+    ProofData, SmtNode,
+};
 use miden_client::transaction::TransactionRequestBuilder;
 use miden_protocol::Felt;
 use miden_protocol::account::AccountId;
 use miden_protocol::crypto::rand::FeltRng;
-use miden_protocol::crypto::utils::bytes_to_packed_u32_elements;
-use miden_protocol::note::{Note, NoteTag};
+use miden_protocol::note::Note;
 use miden_protocol::transaction::{OutputNote, TransactionId};
-use std::cmp::min;
 use std::sync::{Arc, OnceLock};
 
 alloy_core::sol! {
@@ -45,61 +46,6 @@ alloy_core::sol! {
     );
 }
 
-#[derive(Debug, Default)]
-struct ClaimNoteInputs {
-    smt_proof_local_exit_root: Vec<Felt>,
-    smt_proof_rollup_exit_root: Vec<Felt>,
-    global_index: [Felt; 8],
-    mainnet_exit_root: [u8; 32],
-    rollup_exit_root: [u8; 32],
-    origin_network: Felt,
-    origin_token_address: [u8; 20],
-    destination_network: Felt,
-    destination_address: [u8; 20],
-    _amount_u256: [Felt; 8],
-    metadata: [Felt; 8],
-}
-
-fn fixed_felts_from_u256(value: U256) -> [Felt; 8] {
-    bytes_to_packed_u32_elements(value.as_le_slice()).try_into().unwrap()
-}
-
-fn fixed_felts_from_bytes(value: Bytes) -> [Felt; 8] {
-    let metadata_limit =
-        min(value.len(), ClaimNoteInputs::default().metadata.len() * size_of::<u32>());
-    if metadata_limit < value.len() {
-        tracing::debug!("fixed_felts_from_bytes notice: cutting off information");
-    }
-    let felts = bytes_to_packed_u32_elements(value.slice(0..metadata_limit).as_ref());
-    std::array::from_fn(|i| felts.get(i).cloned().unwrap_or_default())
-}
-
-type Bytes32 = FixedBytes<32>;
-fn felts_from_bytes32_array(values: [Bytes32; 32]) -> Vec<Felt> {
-    values
-        .into_iter()
-        .flat_map(|value| bytes_to_packed_u32_elements(&value.0))
-        .collect()
-}
-
-impl From<claimAssetCall> for ClaimNoteInputs {
-    fn from(value: claimAssetCall) -> Self {
-        Self {
-            smt_proof_local_exit_root: felts_from_bytes32_array(value.smtProofLocalExitRoot),
-            smt_proof_rollup_exit_root: felts_from_bytes32_array(value.smtProofRollupExitRoot),
-            global_index: fixed_felts_from_u256(value.globalIndex),
-            mainnet_exit_root: value.mainnetExitRoot.0,
-            rollup_exit_root: value.rollupExitRoot.0,
-            origin_network: Felt::from(value.originNetwork),
-            origin_token_address: value.originTokenAddress.0.0,
-            destination_network: Felt::from(value.destinationNetwork),
-            destination_address: value.destinationAddress.0.0,
-            _amount_u256: fixed_felts_from_u256(value.amount),
-            metadata: fixed_felts_from_bytes(value.metadata),
-        }
-    }
-}
-
 impl From<claimAssetCall> for ClaimEvent {
     fn from(value: claimAssetCall) -> Self {
         Self {
@@ -114,9 +60,9 @@ impl From<claimAssetCall> for ClaimEvent {
 
 #[derive(Debug, Clone, Copy)]
 struct Faucet {
-    pub id: AccountId,
-    pub decimals: u8,
-    pub origin_token_decimals: u8,
+    id: AccountId,
+    decimals: u8,
+    origin_token_decimals: u8,
 }
 
 // TODO: obtain a faucet from registry for a given origin_token_address
@@ -124,7 +70,7 @@ fn find_target_faucet(
     token_address: alloy::primitives::Address,
     accounts: &AccountsConfig,
 ) -> Faucet {
-    if token_address.to_string() == "0x0000000000000000000000000000000000000000" {
+    if token_address.is_zero() {
         Faucet {
             id: accounts.faucet_eth.0,
             decimals: 8,
@@ -139,46 +85,63 @@ fn find_target_faucet(
     }
 }
 
+fn bytes32_array_to_smt_nodes(values: [FixedBytes<32>; 32]) -> [SmtNode; 32] {
+    values.map(|v| SmtNode::new(v.0))
+}
+
 fn create_claim(
     params: claimAssetCall,
     faucet: Faucet,
-    accounts: AccountsConfig,
-    rng_mut: &mut impl FeltRng,
+    accounts: &AccountsConfig,
+    rng: &mut impl FeltRng,
 ) -> anyhow::Result<Note> {
-    let claim_note_creator = accounts.service.0;
+    let sender = accounts.service.0;
 
-    let Some(destination_account_id) =
-        account_id_from_address_config(params.destinationAddress, &accounts)
-    else {
-        anyhow::bail!("create_claim: invalid destination address {}", params.destinationAddress);
-    };
+    if account_id_from_address_config(params.destinationAddress, accounts).is_none() {
+        anyhow::bail!(
+            "create_claim: invalid destination address {}",
+            params.destinationAddress
+        );
+    }
 
     let amount = validate_amount(params.amount, faucet.origin_token_decimals, faucet.decimals)?;
 
-    let inputs = ClaimNoteInputs::from(params);
-    let p2id_serial_number = rng_mut.draw_word();
-    let claim_params = ClaimNoteParams {
-        smt_proof_local_exit_root: inputs.smt_proof_local_exit_root,
-        smt_proof_rollup_exit_root: inputs.smt_proof_rollup_exit_root,
-        global_index: inputs.global_index,
-        mainnet_exit_root: &inputs.mainnet_exit_root,
-        rollup_exit_root: &inputs.rollup_exit_root,
-        origin_network: inputs.origin_network,
-        origin_token_address: &inputs.origin_token_address,
-        destination_network: inputs.destination_network,
-        destination_address: &inputs.destination_address,
-        amount: fixed_felts_from_u256(U256::from(amount)),
-        metadata: inputs.metadata,
-        claim_note_creator_account_id: claim_note_creator,
-        agglayer_faucet_account_id: faucet.id,
-        output_note_tag: NoteTag::with_account_target(destination_account_id),
-        p2id_serial_number,
-        destination_account_id,
-        rng: rng_mut,
+    let proof_data = ProofData {
+        smt_proof_local_exit_root: bytes32_array_to_smt_nodes(params.smtProofLocalExitRoot),
+        smt_proof_rollup_exit_root: bytes32_array_to_smt_nodes(params.smtProofRollupExitRoot),
+        global_index: GlobalIndex::new(params.globalIndex.to_be_bytes::<32>()),
+        mainnet_exit_root: ExitRoot::new(params.mainnetExitRoot.0),
+        rollup_exit_root: ExitRoot::new(params.rollupExitRoot.0),
     };
 
-    let claim_note = miden_base_agglayer::create_claim_note(claim_params)?;
-    Ok(claim_note)
+    let leaf_data = LeafData {
+        origin_network: params.originNetwork,
+        origin_token_address: EthAddressFormat::new(params.originTokenAddress.0.0),
+        destination_network: params.destinationNetwork,
+        destination_address: EthAddressFormat::new(params.destinationAddress.0.0),
+        amount: EthAmount::new(params.amount.to_be_bytes::<32>()),
+        metadata_hash: MetadataHash::new(metadata_to_hash(&params.metadata)),
+    };
+
+    let storage = ClaimNoteStorage {
+        proof_data,
+        leaf_data,
+        miden_claim_amount: Felt::from(amount),
+    };
+
+    let note = miden_base_agglayer::create_claim_note(storage, faucet.id, sender, rng)?;
+    Ok(note)
+}
+
+/// Compute metadata hash: keccak256 of metadata bytes, or zero for empty metadata.
+fn metadata_to_hash(metadata: &Bytes) -> [u8; 32] {
+    use sha3::{Digest, Keccak256};
+    if metadata.is_empty() {
+        return [0u8; 32];
+    }
+    let mut hasher = Keccak256::new();
+    hasher.update(metadata.as_ref());
+    hasher.finalize().into()
 }
 
 #[derive(Debug, Clone)]
@@ -186,16 +149,19 @@ pub struct PublishClaimTxn {
     pub txn_id: TransactionId,
     pub expires_at: BlockNumber,
     pub log: LogData,
+    /// CLAIM note ID for consumption tracking (deferred receipts).
+    pub claim_note_id: Option<String>,
 }
 
 async fn publish_claim_internal(
     params: claimAssetCall,
     client: &mut MidenClientLib,
-    accounts: AccountsConfig,
+    accounts: &AccountsConfig,
     latest_block_num: BlockNumber,
 ) -> anyhow::Result<PublishClaimTxn> {
-    let faucet = find_target_faucet(params.originTokenAddress, &accounts);
-    let claim_note = create_claim(params.clone(), faucet, accounts.clone(), client.rng())?;
+    let faucet = find_target_faucet(params.originTokenAddress, accounts);
+    let claim_note = create_claim(params.clone(), faucet, accounts, client.rng())?;
+    let claim_note_id = claim_note.id().to_string();
 
     const EXPIRATION_DELTA: u16 = 10;
     let expires_at = latest_block_num + EXPIRATION_DELTA as u64;
@@ -205,13 +171,20 @@ async fn publish_claim_internal(
         .expiration_delta(EXPIRATION_DELTA)
         .build()?;
 
-    let txn_id = client.submit_new_transaction(accounts.service.0, txn_request).await?;
-    tracing::debug!("submitted claim note txn: {txn_id}");
+    let txn_id = client
+        .submit_new_transaction(accounts.service.0, txn_request)
+        .await?;
+    tracing::debug!("submitted claim note txn: {txn_id}, claim_note_id: {claim_note_id}");
 
     let event = ClaimEvent::from(params);
     let log = event.encode_log_data();
 
-    Ok(PublishClaimTxn { txn_id, expires_at, log })
+    Ok(PublishClaimTxn {
+        txn_id,
+        expires_at,
+        log,
+        claim_note_id: Some(claim_note_id),
+    })
 }
 
 pub async fn publish_claim(
@@ -221,17 +194,21 @@ pub async fn publish_claim(
     latest_block_num: BlockNumber,
 ) -> anyhow::Result<PublishClaimTxn> {
     let result = Arc::new(OnceLock::<PublishClaimTxn>::new());
-    let result_internal = result.clone();
+    let result_inner = result.clone();
 
-    let future = client.with(move |client| {
-        Box::new(async move {
-            let result_value =
-                publish_claim_internal(params, client, accounts.0, latest_block_num).await?;
-            result_internal.set(result_value).unwrap();
-            Ok(())
+    client
+        .with(move |client| {
+            Box::new(async move {
+                let value =
+                    publish_claim_internal(params, client, &accounts.0, latest_block_num).await?;
+                let _ = result_inner.set(value);
+                Ok(())
+            })
         })
-    });
-    future.await?;
+        .await?;
 
-    Ok(result.get().unwrap().clone())
+    result
+        .get()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("publish_claim: closure completed but result was not set"))
 }

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -157,7 +157,13 @@ async fn publish_claim_internal(
     latest_block_num: BlockNumber,
 ) -> anyhow::Result<PublishClaimTxn> {
     let faucet = find_target_faucet(params.originTokenAddress, accounts);
-    let claim_note = create_claim(params.clone(), faucet, accounts, address_mapper, client.rng())?;
+    let claim_note = create_claim(
+        params.clone(),
+        faucet,
+        accounts,
+        address_mapper,
+        client.rng(),
+    )?;
     let claim_note_id = claim_note.id().to_string();
 
     const EXPIRATION_DELTA: u16 = 10;
@@ -197,8 +203,14 @@ pub async fn publish_claim(
     client
         .with(move |client| {
             Box::new(async move {
-                let value =
-                    publish_claim_internal(params, client, &accounts.0, &address_mapper, latest_block_num).await?;
+                let value = publish_claim_internal(
+                    params,
+                    client,
+                    &accounts.0,
+                    &address_mapper,
+                    latest_block_num,
+                )
+                .await?;
                 let _ = result_inner.set(value);
                 Ok(())
             })

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -1,5 +1,5 @@
 use crate::accounts_config::AccountsConfig;
-use crate::address_mapper::account_id_from_address_config;
+use crate::address_mapper::AddressMapper;
 use crate::amount::validate_amount;
 use crate::miden_client::{MidenClient, MidenClientLib};
 use alloy::primitives::{BlockNumber, Bytes, FixedBytes, LogData};
@@ -93,16 +93,12 @@ fn create_claim(
     params: claimAssetCall,
     faucet: Faucet,
     accounts: &AccountsConfig,
+    address_mapper: &AddressMapper,
     rng: &mut impl FeltRng,
 ) -> anyhow::Result<Note> {
     let sender = accounts.service.0;
 
-    if account_id_from_address_config(params.destinationAddress, accounts).is_none() {
-        anyhow::bail!(
-            "create_claim: invalid destination address {}",
-            params.destinationAddress
-        );
-    }
+    let _dest_account = address_mapper.resolve(params.destinationAddress, accounts)?;
 
     let amount = validate_amount(params.amount, faucet.origin_token_decimals, faucet.decimals)?;
 
@@ -157,10 +153,11 @@ async fn publish_claim_internal(
     params: claimAssetCall,
     client: &mut MidenClientLib,
     accounts: &AccountsConfig,
+    address_mapper: &AddressMapper,
     latest_block_num: BlockNumber,
 ) -> anyhow::Result<PublishClaimTxn> {
     let faucet = find_target_faucet(params.originTokenAddress, accounts);
-    let claim_note = create_claim(params.clone(), faucet, accounts, client.rng())?;
+    let claim_note = create_claim(params.clone(), faucet, accounts, address_mapper, client.rng())?;
     let claim_note_id = claim_note.id().to_string();
 
     const EXPIRATION_DELTA: u16 = 10;
@@ -191,6 +188,7 @@ pub async fn publish_claim(
     params: claimAssetCall,
     client: &MidenClient,
     accounts: crate::AccountsConfig,
+    address_mapper: Arc<AddressMapper>,
     latest_block_num: BlockNumber,
 ) -> anyhow::Result<PublishClaimTxn> {
     let result = Arc::new(OnceLock::<PublishClaimTxn>::new());
@@ -200,7 +198,7 @@ pub async fn publish_claim(
         .with(move |client| {
             Box::new(async move {
                 let value =
-                    publish_claim_internal(params, client, &accounts.0, latest_block_num).await?;
+                    publish_claim_internal(params, client, &accounts.0, &address_mapper, latest_block_num).await?;
                 let _ = result_inner.set(value);
                 Ok(())
             })

--- a/src/claim_tracker.rs
+++ b/src/claim_tracker.rs
@@ -1,0 +1,158 @@
+use alloy::primitives::U256;
+use parking_lot::RwLock;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+pub struct ClaimTracker {
+    claimed: RwLock<HashSet<U256>>,
+    persistence_path: Option<PathBuf>,
+}
+
+const fn assert_sync<T: Send + Sync>() {}
+const _: () = assert_sync::<ClaimTracker>();
+
+impl ClaimTracker {
+    pub fn new(persistence_path: Option<PathBuf>) -> anyhow::Result<Self> {
+        let claimed = if let Some(ref path) = persistence_path {
+            if path.exists() {
+                let data = std::fs::read_to_string(path)?;
+                let indices: Vec<String> = serde_json::from_str(&data)?;
+                let set: HashSet<U256> = indices
+                    .into_iter()
+                    .map(|s| U256::from_str_radix(s.trim_start_matches("0x"), 16))
+                    .collect::<Result<_, _>>()?;
+                set
+            } else {
+                HashSet::new()
+            }
+        } else {
+            HashSet::new()
+        };
+        Ok(Self {
+            claimed: RwLock::new(claimed),
+            persistence_path,
+        })
+    }
+
+    /// Atomically insert a global index, failing if already claimed. Persists on success.
+    pub fn try_claim(&self, global_index: U256) -> anyhow::Result<()> {
+        let mut claimed = self.claimed.write();
+        if !claimed.insert(global_index) {
+            anyhow::bail!("claim already submitted for global_index {global_index}");
+        }
+        drop(claimed);
+        self.persist();
+        Ok(())
+    }
+
+    /// Rollback a claim on submission failure. Persists after removal.
+    pub fn unclaim(&self, global_index: &U256) {
+        let mut claimed = self.claimed.write();
+        claimed.remove(global_index);
+        drop(claimed);
+        self.persist();
+    }
+
+    pub fn is_claimed(&self, global_index: &U256) -> bool {
+        self.claimed.read().contains(global_index)
+    }
+
+    fn persist(&self) {
+        let Some(ref path) = self.persistence_path else {
+            return;
+        };
+        let claimed = self.claimed.read();
+        let indices: Vec<String> = claimed.iter().map(|i| format!("{i:#x}")).collect();
+        let Ok(data) = serde_json::to_string_pretty(&indices) else {
+            tracing::error!("ClaimTracker: failed to serialize claimed indices");
+            return;
+        };
+        drop(claimed);
+
+        let tmp_path = path.with_extension("tmp");
+        if let Err(e) = std::fs::write(&tmp_path, &data) {
+            tracing::error!("ClaimTracker: failed to write {}: {e}", tmp_path.display());
+            return;
+        }
+        if let Err(e) = std::fs::rename(&tmp_path, path) {
+            tracing::error!("ClaimTracker: failed to rename to {}: {e}", path.display());
+        }
+    }
+}
+
+impl Default for ClaimTracker {
+    fn default() -> Self {
+        Self::new(None).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_claim_and_reject_duplicate() {
+        let tracker = ClaimTracker::new(None).unwrap();
+        let idx = U256::from(42u64);
+        assert!(!tracker.is_claimed(&idx));
+        tracker.try_claim(idx).unwrap();
+        assert!(tracker.is_claimed(&idx));
+        assert!(tracker.try_claim(idx).is_err());
+    }
+
+    #[test]
+    fn test_unclaim_allows_reclaim() {
+        let tracker = ClaimTracker::new(None).unwrap();
+        let idx = U256::from(99u64);
+        tracker.try_claim(idx).unwrap();
+        tracker.unclaim(&idx);
+        assert!(!tracker.is_claimed(&idx));
+        tracker.try_claim(idx).unwrap();
+    }
+
+    #[test]
+    fn test_concurrent_claims() {
+        use std::sync::Arc;
+        let tracker = Arc::new(ClaimTracker::new(None).unwrap());
+        let mut handles = vec![];
+        for i in 0..100u64 {
+            let t = tracker.clone();
+            handles.push(std::thread::spawn(move || t.try_claim(U256::from(i))));
+        }
+        for h in handles {
+            h.join().unwrap().unwrap();
+        }
+        // All 100 should be claimed
+        for i in 0..100u64 {
+            assert!(tracker.is_claimed(&U256::from(i)));
+        }
+    }
+
+    #[test]
+    fn test_persistence_roundtrip() {
+        let dir = std::env::temp_dir().join(format!(
+            "claim_tracker_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("claimed_indices.json");
+
+        {
+            let tracker = ClaimTracker::new(Some(path.clone())).unwrap();
+            tracker.try_claim(U256::from(1u64)).unwrap();
+            tracker.try_claim(U256::from(2u64)).unwrap();
+        }
+
+        // Load from persisted file
+        let tracker = ClaimTracker::new(Some(path.clone())).unwrap();
+        assert!(tracker.is_claimed(&U256::from(1u64)));
+        assert!(tracker.is_claimed(&U256::from(2u64)));
+        assert!(!tracker.is_claimed(&U256::from(3u64)));
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -1,5 +1,12 @@
-use alloy::primitives::{FixedBytes, LogData};
+use crate::accounts_config::AccountsConfig;
+use crate::block_state::BlockState;
+use crate::log_synthesis::LogStore;
+use crate::miden_client::{MidenClient, MidenClientLib};
+use alloy::primitives::{FixedBytes, LogData, TxHash};
 use alloy::sol_types::SolEvent;
+use miden_base_agglayer::{ExitRoot, UpdateGerNote};
+use miden_client::transaction::{OutputNote, TransactionRequestBuilder};
+use std::sync::Arc;
 
 alloy_core::sol! {
     // https://github.com/agglayer/agglayer-contracts/blob/main/contracts/v2/sovereignChains/GlobalExitRootManagerL2SovereignChain.sol#L166
@@ -25,9 +32,89 @@ impl UpdateHashChainValue {
     }
 }
 
-pub async fn insert_ger(params: insertGlobalExitRootCall) -> anyhow::Result<LogData> {
-    let new_ger = params.root;
-    let event = UpdateHashChainValue::new(new_ger, FixedBytes::default());
+/// Result of a GER insertion.
+pub struct GerInsertResult {
+    pub log_data: LogData,
+    pub block_number: u64,
+    pub is_new: bool,
+}
+
+async fn submit_ger_to_miden(
+    client: &mut MidenClientLib,
+    ger_bytes: [u8; 32],
+    accounts: &AccountsConfig,
+) -> anyhow::Result<()> {
+    let ger = ExitRoot::new(ger_bytes);
+    let service_id = accounts.service.0;
+    let bridge_id = accounts.bridge.0;
+
+    let note = UpdateGerNote::create(ger, service_id, bridge_id, client.rng())?;
+    tracing::info!(note_id = %note.id(), "UpdateGerNote created");
+
+    let tx_request = TransactionRequestBuilder::new()
+        .own_output_notes(vec![OutputNote::Full(note)])
+        .build()?;
+
+    let tx_id = client
+        .submit_new_transaction(service_id, tx_request)
+        .await?;
+    tracing::info!(
+        tx_id = %tx_id,
+        ger = %hex::encode(ger_bytes),
+        "UpdateGerNote submitted to Miden node"
+    );
+
+    Ok(())
+}
+
+pub async fn insert_ger(
+    params: insertGlobalExitRootCall,
+    miden_client: &MidenClient,
+    accounts: crate::AccountsConfig,
+    log_store: &Arc<LogStore>,
+    block_state: &Arc<BlockState>,
+    txn_hash: TxHash,
+) -> anyhow::Result<GerInsertResult> {
+    let ger_bytes: [u8; 32] = params.root.0;
+    let block_number = block_state.current_block_number();
+    let block_hash = block_state.get_block_hash(block_number);
+
+    // Check dedup before doing any work
+    let is_new = !log_store.has_seen_ger(&ger_bytes);
+
+    if is_new {
+        tracing::info!(
+            ger = %hex::encode(ger_bytes),
+            block_number,
+            "GER injection: submitting to Miden..."
+        );
+
+        // Submit to Miden first — only emit the log event on success
+        let inner_accounts = accounts.0.clone();
+        miden_client
+            .with(move |client| {
+                Box::new(
+                    async move { submit_ger_to_miden(client, ger_bytes, &inner_accounts).await },
+                )
+            })
+            .await?;
+
+        // Miden submission succeeded — now record the event
+        let tx_hash_str = format!("{txn_hash:#x}");
+        log_store.add_ger_update_event(block_number, block_hash, &tx_hash_str, &ger_bytes);
+    } else {
+        tracing::debug!(
+            ger = %hex::encode(ger_bytes),
+            "GER already seen, skipping duplicate"
+        );
+    }
+
+    let event = UpdateHashChainValue::new(params.root, FixedBytes::default());
     let log_data = event.encode_log_data();
-    Ok(log_data)
+
+    Ok(GerInsertResult {
+        log_data,
+        block_number,
+        is_new,
+    })
 }

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -6,12 +6,27 @@ use alloy::primitives::{FixedBytes, LogData, TxHash};
 use alloy::sol_types::SolEvent;
 use miden_base_agglayer::{ExitRoot, UpdateGerNote};
 use miden_client::transaction::{OutputNote, TransactionRequestBuilder};
+use sha3::{Digest, Keccak256};
 use std::sync::Arc;
 
 alloy_core::sol! {
     // https://github.com/agglayer/agglayer-contracts/blob/main/contracts/v2/sovereignChains/GlobalExitRootManagerL2SovereignChain.sol#L166
     #[derive(Debug)]
     function insertGlobalExitRoot(bytes32 root);
+}
+
+alloy_core::sol! {
+    // https://github.com/agglayer/agglayer-contracts/blob/main/contracts/v2/sovereignChains/GlobalExitRootManagerL2SovereignChain.sol#L131
+    #[derive(Debug)]
+    function updateExitRoot(bytes32 newRollupExitRoot, bytes32 newMainnetExitRoot);
+}
+
+/// Compute the combined GER from mainnet and rollup exit roots.
+pub fn combined_ger(mainnet: &[u8; 32], rollup: &[u8; 32]) -> [u8; 32] {
+    let mut hasher = Keccak256::new();
+    hasher.update(mainnet);
+    hasher.update(rollup);
+    hasher.finalize().into()
 }
 
 alloy_core::sol! {
@@ -68,14 +83,13 @@ async fn submit_ger_to_miden(
 }
 
 pub async fn insert_ger(
-    params: insertGlobalExitRootCall,
+    ger_bytes: [u8; 32],
     miden_client: &MidenClient,
     accounts: crate::AccountsConfig,
     log_store: &Arc<LogStore>,
     block_state: &Arc<BlockState>,
     txn_hash: TxHash,
 ) -> anyhow::Result<GerInsertResult> {
-    let ger_bytes: [u8; 32] = params.root.0;
     // Store event at current_block + 1 so it appears in a block the bridge-service
     // hasn't synced yet. With forceSyncChunk=true, the bridge never re-queries old
     // blocks, so events at the current block are missed if the bridge already synced it.
@@ -112,7 +126,7 @@ pub async fn insert_ger(
         );
     }
 
-    let event = UpdateHashChainValue::new(params.root, FixedBytes::default());
+    let event = UpdateHashChainValue::new(FixedBytes::from(ger_bytes), FixedBytes::default());
     let log_data = event.encode_log_data();
 
     Ok(GerInsertResult {
@@ -120,4 +134,37 @@ pub async fn insert_ger(
         block_number,
         is_new,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_combined_ger_keccak256() {
+        let mainnet = [0x01u8; 32];
+        let rollup = [0x02u8; 32];
+        let result = combined_ger(&mainnet, &rollup);
+
+        // Verify against direct keccak256 computation
+        let mut hasher = Keccak256::new();
+        hasher.update(mainnet);
+        hasher.update(rollup);
+        let expected: [u8; 32] = hasher.finalize().into();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_combined_ger_deterministic() {
+        let mainnet = [0xAAu8; 32];
+        let rollup = [0xBBu8; 32];
+        assert_eq!(combined_ger(&mainnet, &rollup), combined_ger(&mainnet, &rollup));
+    }
+
+    #[test]
+    fn test_combined_ger_order_matters() {
+        let a = [0x01u8; 32];
+        let b = [0x02u8; 32];
+        assert_ne!(combined_ger(&a, &b), combined_ger(&b, &a));
+    }
 }

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -76,7 +76,10 @@ pub async fn insert_ger(
     txn_hash: TxHash,
 ) -> anyhow::Result<GerInsertResult> {
     let ger_bytes: [u8; 32] = params.root.0;
-    let block_number = block_state.current_block_number();
+    // Store event at current_block + 1 so it appears in a block the bridge-service
+    // hasn't synced yet. With forceSyncChunk=true, the bridge never re-queries old
+    // blocks, so events at the current block are missed if the bridge already synced it.
+    let block_number = block_state.current_block_number() + 1;
     let block_hash = block_state.get_block_hash(block_number);
 
     // Check dedup before doing any work

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -158,7 +158,10 @@ mod tests {
     fn test_combined_ger_deterministic() {
         let mainnet = [0xAAu8; 32];
         let rollup = [0xBBu8; 32];
-        assert_eq!(combined_ger(&mainnet, &rollup), combined_ger(&mainnet, &rollup));
+        assert_eq!(
+            combined_ger(&mainnet, &rollup),
+            combined_ger(&mainnet, &rollup)
+        );
     }
 
     #[test]

--- a/src/init.rs
+++ b/src/init.rs
@@ -4,6 +4,7 @@ use crate::miden_client::MidenClient;
 use crate::miden_client::MidenClientLib;
 use miden_base_agglayer::{EthAddressFormat, create_agglayer_faucet, create_bridge_account};
 use miden_client::Felt;
+use miden_client::asset::FungibleAsset;
 use miden_client::crypto::FeltRng;
 use miden_client::keystore::{FilesystemKeyStore, Keystore};
 use miden_client::transaction::TransactionRequestBuilder;
@@ -86,7 +87,7 @@ async fn add_faucet(
     decimals: u8,
     bridge_account_id: AccountId,
 ) -> anyhow::Result<Account> {
-    let max_supply = Felt::try_from(0xffffffff00000000u64).unwrap();
+    let max_supply = Felt::new(FungibleAsset::MAX_AMOUNT);
     let origin_token_address = EthAddressFormat::new([0u8; 20]);
     let origin_network = 0u32;
     let scale = 10u8; // 18 (ETH) - 8 (Miden) = 10

--- a/src/init.rs
+++ b/src/init.rs
@@ -2,19 +2,18 @@ use crate::accounts_config;
 use crate::accounts_config::{AccountIdBech32, AccountsConfig};
 use crate::miden_client::MidenClient;
 use crate::miden_client::MidenClientLib;
-use miden_base_agglayer::{create_agglayer_faucet_builder, create_bridge_account_builder};
+use miden_base_agglayer::{EthAddressFormat, create_agglayer_faucet, create_bridge_account};
 use miden_client::Felt;
 use miden_client::crypto::FeltRng;
-use miden_client::keystore::FilesystemKeyStore;
+use miden_client::keystore::{FilesystemKeyStore, Keystore};
 use miden_client::transaction::TransactionRequestBuilder;
-use miden_protocol::account::auth::AuthSecretKey;
-use miden_protocol::account::{Account, AccountComponent, AccountId, AccountStorageMode};
+use miden_protocol::account::auth::{AuthScheme, AuthSecretKey};
+use miden_protocol::account::{Account, AccountId};
 use miden_protocol::note::NoteType;
 use miden_protocol::transaction::OutputNote;
-use miden_standards::account::auth::AuthFalcon512Rpo;
-use miden_standards::account::auth::NoAuth;
+use miden_standards::account::auth::AuthSingleSig;
 use miden_standards::account::wallets::BasicWallet;
-use miden_standards::note::create_p2id_note;
+use miden_standards::note::P2idNote;
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 
@@ -40,10 +39,13 @@ impl From<Accounts> for AccountsConfig {
     }
 }
 
-fn add_auth_key(keystore: Arc<FilesystemKeyStore>) -> anyhow::Result<AuthFalcon512Rpo> {
+fn create_auth_component() -> anyhow::Result<(AuthSingleSig, AuthSecretKey)> {
     let key_pair = AuthSecretKey::new_falcon512_rpo();
-    keystore.add_key(&key_pair)?;
-    Ok(AuthFalcon512Rpo::new(key_pair.public_key().to_commitment()))
+    let auth_component = AuthSingleSig::new(
+        key_pair.public_key().to_commitment(),
+        AuthScheme::Falcon512Rpo,
+    );
+    Ok((auth_component, key_pair))
 }
 
 async fn deploy_account(
@@ -51,7 +53,11 @@ async fn deploy_account(
     account_id: AccountId,
     name: &str,
 ) -> anyhow::Result<()> {
-    tracing::info!("deploying {} account {} ...", name, AccountIdBech32(account_id));
+    tracing::info!(
+        "deploying {} account {} ...",
+        name,
+        AccountIdBech32(account_id)
+    );
     let dummy_txn = TransactionRequestBuilder::new().build()?;
     let txn_id = client.submit_new_transaction(account_id, dummy_txn).await?;
     tracing::info!("deployed {name} account with txn_id {txn_id}");
@@ -61,10 +67,11 @@ async fn deploy_account(
 async fn add_bridge(
     client: &mut MidenClientLib,
     _keystore: Arc<FilesystemKeyStore>,
+    service_id: AccountId,
 ) -> anyhow::Result<Account> {
-    let account = create_bridge_account_builder(client.rng().draw_word())
-        .with_auth_component(AccountComponent::from(NoAuth))
-        .build()?;
+    // In 0.14, create_bridge_account takes (seed, bridge_admin_id, ger_manager_id)
+    // Use service account as both bridge_admin and ger_manager
+    let account = create_bridge_account(client.rng().draw_word(), service_id, service_id);
     client.add_account(&account, false).await?;
 
     deploy_account(client, account.id(), "bridge").await?;
@@ -80,20 +87,28 @@ async fn add_faucet(
     bridge_account_id: AccountId,
 ) -> anyhow::Result<Account> {
     let max_supply = Felt::try_from(0xffffffff00000000u64).unwrap();
-    let builder = create_agglayer_faucet_builder(
+    let origin_token_address = EthAddressFormat::new([0u8; 20]);
+    let origin_network = 0u32;
+    let scale = 10u8; // 18 (ETH) - 8 (Miden) = 10
+
+    let account = create_agglayer_faucet(
         client.rng().draw_word(),
         token_symbol,
         decimals,
         max_supply,
         bridge_account_id,
+        &origin_token_address,
+        origin_network,
+        scale,
     );
-    let builder = builder.with_auth_component(AccountComponent::from(NoAuth));
-    let builder = builder.storage_mode(AccountStorageMode::Network);
-    let builder = builder.with_component(BasicWallet);
-    let account = builder.build()?;
     client.add_account(&account, false).await?;
 
-    deploy_account(client, account.id(), format!("{token_symbol} faucet").as_str()).await?;
+    deploy_account(
+        client,
+        account.id(),
+        format!("{token_symbol} faucet").as_str(),
+    )
+    .await?;
 
     Ok(account)
 }
@@ -102,10 +117,12 @@ async fn add_wallet(
     client: &mut MidenClientLib,
     keystore: Arc<FilesystemKeyStore>,
 ) -> anyhow::Result<Account> {
+    let (auth_component, key_pair) = create_auth_component()?;
     let account = Account::builder(client.rng().draw_word().into())
         .with_component(BasicWallet)
-        .with_auth_component(add_auth_key(keystore)?)
+        .with_auth_component(auth_component)
         .build()?;
+    keystore.add_key(&key_pair, account.id()).await?;
     client.add_account(&account, false).await?;
     Ok(account)
 }
@@ -115,7 +132,7 @@ async fn add_accounts(
     keystore: Arc<FilesystemKeyStore>,
 ) -> anyhow::Result<Accounts> {
     let service = add_wallet(client, keystore.clone()).await?;
-    let bridge = add_bridge(client, keystore.clone()).await?;
+    let bridge = add_bridge(client, keystore.clone(), service.id()).await?;
     let faucet_eth = add_faucet(client, keystore.clone(), "ETH", 8u8, bridge.id()).await?;
     let faucet_agg = add_faucet(client, keystore.clone(), "AGG", 8u8, bridge.id()).await?;
     let wallet_hardhat = add_wallet(client, keystore.clone()).await?;
@@ -134,7 +151,7 @@ async fn register_p2id_script(
 ) -> anyhow::Result<()> {
     tracing::info!("registering P2ID script...");
     // dummy note to register its script on the node
-    let note = create_p2id_note(
+    let note = P2idNote::create(
         sender,
         /* target = */ sender,
         /* assets = */ vec![],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod amount;
 mod block_num_tracker;
 pub mod block_state;
 pub mod claim;
+pub mod claim_tracker;
 pub mod exit;
 pub mod ger;
 pub mod hex;
@@ -16,6 +17,7 @@ mod txn_manager;
 pub const COMPONENT: &str = "miden-agglayer";
 
 pub use block_num_tracker::BlockNumTracker;
+pub use claim_tracker::ClaimTracker;
 pub use miden_client::MidenClient;
 pub use txn_manager::TxnManager;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod block_state;
 pub mod claim;
 pub mod claim_tracker;
 pub mod exit;
+pub mod nonce_tracker;
 pub mod ger;
 pub mod hex;
 pub mod init;
@@ -19,6 +20,7 @@ pub const COMPONENT: &str = "miden-agglayer";
 pub use block_num_tracker::BlockNumTracker;
 pub use claim_tracker::ClaimTracker;
 pub use miden_client::MidenClient;
+pub use nonce_tracker::NonceTracker;
 pub use txn_manager::TxnManager;
 
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,13 +6,13 @@ pub mod block_state;
 pub mod claim;
 pub mod claim_tracker;
 pub mod exit;
-pub mod nonce_tracker;
 pub mod ger;
 pub mod hex;
 pub mod init;
 pub mod log_synthesis;
 pub mod logging;
 pub mod miden_client;
+pub mod nonce_tracker;
 mod txn_manager;
 
 pub const COMPONENT: &str = "miden-agglayer";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,16 @@
-mod accounts_config;
+pub mod accounts_config;
 mod address_mapper;
 mod amount;
 mod block_num_tracker;
+pub mod block_state;
 pub mod claim;
 pub mod exit;
 pub mod ger;
 pub mod hex;
 pub mod init;
+pub mod log_synthesis;
 pub mod logging;
-mod miden_client;
+pub mod miden_client;
 mod txn_manager;
 
 pub const COMPONENT: &str = "miden-agglayer";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod accounts_config;
-mod address_mapper;
+pub mod address_mapper;
 mod amount;
 mod block_num_tracker;
 pub mod block_state;
@@ -17,6 +17,7 @@ mod txn_manager;
 
 pub const COMPONENT: &str = "miden-agglayer";
 
+pub use address_mapper::AddressMapper;
 pub use block_num_tracker::BlockNumTracker;
 pub use claim_tracker::ClaimTracker;
 pub use miden_client::MidenClient;

--- a/src/log_synthesis.rs
+++ b/src/log_synthesis.rs
@@ -210,6 +210,7 @@ impl LogStore {
         self.pending_events.write().push(log);
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_claim_event(
         &self,
         bridge_address: &str,
@@ -256,7 +257,7 @@ impl LogStore {
         let new_hash_chain = {
             let mut hash_chain = self.hash_chain_value.write();
             let mut hasher = Keccak256::new();
-            hasher.update(&*hash_chain);
+            hasher.update(*hash_chain);
             hasher.update(global_exit_root);
             let result: [u8; 32] = hasher.finalize().into();
             *hash_chain = result;

--- a/src/log_synthesis.rs
+++ b/src/log_synthesis.rs
@@ -1,0 +1,500 @@
+//! Log Synthesis - Generate synthetic EVM logs for bridge service compatibility.
+//!
+//! Synthesizes ClaimEvent and UpdateHashChainValue logs from Miden transactions.
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use sha3::{Digest, Keccak256};
+use std::collections::HashMap;
+
+/// ClaimEvent topic hash: keccak256("ClaimEvent(uint256,uint32,address,address,uint256)")
+pub const CLAIM_EVENT_TOPIC: &str =
+    "0x1df3f2a973a00d6635911755c260704e95e8a5876997546798770f76396fda4d";
+
+/// UpdateHashChainValue topic hash: keccak256("UpdateHashChainValue(bytes32,bytes32)")
+/// Emitted by L2 GlobalExitRootManagerL2SovereignChain when a GER is inserted
+pub const UPDATE_HASH_CHAIN_VALUE_TOPIC: &str =
+    "0x65d3bf36615f1f02a134d12dfa9ea6b1d4a52386e825973cd27ddb70895c2319";
+
+/// L2 GlobalExitRoot contract address (receives GER updates from aggoracle)
+pub const L2_GLOBAL_EXIT_ROOT_ADDRESS: &str = "0xa40D5f56745a118D0906a34E69aeC8C0Db1cB8fA";
+
+/// Synthetic log entry for eth_getLogs
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyntheticLog {
+    pub address: String,
+    pub topics: Vec<String>,
+    pub data: String,
+    pub block_number: u64,
+    pub block_hash: [u8; 32],
+    pub transaction_hash: String,
+    pub transaction_index: u64,
+    pub log_index: u64,
+    pub removed: bool,
+}
+
+impl SyntheticLog {
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "address": self.address,
+            "topics": self.topics,
+            "data": self.data,
+            "blockNumber": format!("0x{:x}", self.block_number),
+            "blockHash": format!("0x{}", hex::encode(self.block_hash)),
+            "transactionHash": self.transaction_hash,
+            "transactionIndex": format!("0x{:x}", self.transaction_index),
+            "logIndex": format!("0x{:x}", self.log_index),
+            "removed": self.removed
+        })
+    }
+}
+
+/// Log filter for eth_getLogs
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogFilter {
+    pub from_block: Option<String>,
+    pub to_block: Option<String>,
+    pub address: Option<AddressFilter>,
+    pub topics: Option<Vec<Option<TopicFilter>>>,
+    pub block_hash: Option<String>,
+}
+
+/// Address filter can be single or array
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum AddressFilter {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+/// Topic filter can be single or array (OR matching)
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum TopicFilter {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+fn parse_block_tag(s: &str, current_block: u64) -> u64 {
+    match s.to_lowercase().as_str() {
+        "earliest" => 0,
+        "latest" | "pending" => current_block,
+        hex if hex.starts_with("0x") => u64::from_str_radix(&hex[2..], 16).unwrap_or(current_block),
+        decimal => decimal.parse::<u64>().unwrap_or(current_block),
+    }
+}
+
+impl LogFilter {
+    pub fn from_block_number(&self, current_block: u64) -> u64 {
+        self.from_block
+            .as_ref()
+            .map(|s| parse_block_tag(s, current_block))
+            .unwrap_or(current_block)
+    }
+
+    pub fn to_block_number(&self, current_block: u64) -> u64 {
+        self.to_block
+            .as_ref()
+            .map(|s| parse_block_tag(s, current_block))
+            .unwrap_or(current_block)
+    }
+
+    pub fn matches(&self, log: &SyntheticLog, current_block: u64) -> bool {
+        if let Some(ref block_hash) = self.block_hash {
+            let log_hash = format!("0x{}", hex::encode(log.block_hash));
+            if log_hash.to_lowercase() != block_hash.to_lowercase() {
+                return false;
+            }
+        } else {
+            let from = self.from_block_number(current_block);
+            let to = self.to_block_number(current_block);
+            if log.block_number < from || log.block_number > to {
+                return false;
+            }
+        }
+
+        if let Some(ref addr_filter) = self.address {
+            let log_addr = log.address.to_lowercase();
+            let matches_addr = match addr_filter {
+                AddressFilter::Single(a) => a.to_lowercase() == log_addr,
+                AddressFilter::Multiple(addrs) => {
+                    addrs.iter().any(|a| a.to_lowercase() == log_addr)
+                }
+            };
+            if !matches_addr {
+                return false;
+            }
+        }
+
+        if let Some(ref topic_filters) = self.topics {
+            for (i, topic_filter) in topic_filters.iter().enumerate() {
+                if let Some(filter) = topic_filter {
+                    if i >= log.topics.len() {
+                        return false;
+                    }
+                    let log_topic = log.topics[i].to_lowercase();
+                    let matches_topic = match filter {
+                        TopicFilter::Single(t) => t.to_lowercase() == log_topic,
+                        TopicFilter::Multiple(topics) => {
+                            topics.iter().any(|t| t.to_lowercase() == log_topic)
+                        }
+                    };
+                    if !matches_topic {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        true
+    }
+}
+
+/// Log store for synthetic logs
+pub struct LogStore {
+    logs_by_block: RwLock<HashMap<u64, Vec<SyntheticLog>>>,
+    logs_by_tx: RwLock<HashMap<String, Vec<SyntheticLog>>>,
+    log_counter: RwLock<u64>,
+    seen_gers: RwLock<HashMap<[u8; 32], u64>>,
+    hash_chain_value: RwLock<[u8; 32]>,
+    pending_events: RwLock<Vec<SyntheticLog>>,
+}
+
+impl LogStore {
+    pub fn new() -> Self {
+        Self {
+            logs_by_block: RwLock::new(HashMap::new()),
+            logs_by_tx: RwLock::new(HashMap::new()),
+            log_counter: RwLock::new(0),
+            seen_gers: RwLock::new(HashMap::new()),
+            hash_chain_value: RwLock::new([0u8; 32]),
+            pending_events: RwLock::new(Vec::new()),
+        }
+    }
+
+    pub fn has_seen_ger(&self, ger: &[u8; 32]) -> bool {
+        self.seen_gers.read().contains_key(ger)
+    }
+
+    pub fn mark_ger_seen(&self, ger: &[u8; 32], block_number: u64) -> bool {
+        let mut seen = self.seen_gers.write();
+        if seen.contains_key(ger) {
+            false
+        } else {
+            seen.insert(*ger, block_number);
+            true
+        }
+    }
+
+    pub fn add_log(&self, mut log: SyntheticLog) {
+        let mut counter = self.log_counter.write();
+        log.log_index = *counter;
+        *counter += 1;
+
+        let block_num = log.block_number;
+        let tx_hash = log.transaction_hash.clone();
+
+        self.logs_by_block
+            .write()
+            .entry(block_num)
+            .or_default()
+            .push(log.clone());
+
+        self.logs_by_tx
+            .write()
+            .entry(tx_hash)
+            .or_default()
+            .push(log.clone());
+
+        self.pending_events.write().push(log);
+    }
+
+    pub fn add_claim_event(
+        &self,
+        bridge_address: &str,
+        block_number: u64,
+        block_hash: [u8; 32],
+        tx_hash: &str,
+        global_index: &[u8; 32],
+        origin_network: u32,
+        origin_address: &[u8; 20],
+        destination_address: &[u8; 20],
+        amount: u64,
+    ) {
+        let log = SyntheticLog {
+            address: bridge_address.to_string(),
+            topics: vec![CLAIM_EVENT_TOPIC.to_string()],
+            data: encode_claim_event_data(
+                global_index,
+                origin_network,
+                origin_address,
+                destination_address,
+                amount,
+            ),
+            block_number,
+            block_hash,
+            transaction_hash: tx_hash.to_string(),
+            transaction_index: 0,
+            log_index: 0,
+            removed: false,
+        };
+        self.add_log(log);
+    }
+
+    /// Record an UpdateHashChainValue log for a GER injection.
+    /// Caller is responsible for dedup (check `has_seen_ger` first).
+    pub fn add_ger_update_event(
+        &self,
+        block_number: u64,
+        block_hash: [u8; 32],
+        tx_hash: &str,
+        global_exit_root: &[u8; 32],
+    ) {
+        self.mark_ger_seen(global_exit_root, block_number);
+
+        let new_hash_chain = {
+            let mut hash_chain = self.hash_chain_value.write();
+            let mut hasher = Keccak256::new();
+            hasher.update(&*hash_chain);
+            hasher.update(global_exit_root);
+            let result: [u8; 32] = hasher.finalize().into();
+            *hash_chain = result;
+            result
+        };
+
+        let log = SyntheticLog {
+            address: L2_GLOBAL_EXIT_ROOT_ADDRESS.to_string(),
+            topics: vec![
+                UPDATE_HASH_CHAIN_VALUE_TOPIC.to_string(),
+                format!("0x{}", hex::encode(global_exit_root)),
+                format!("0x{}", hex::encode(new_hash_chain)),
+            ],
+            data: "0x".to_string(),
+            block_number,
+            block_hash,
+            transaction_hash: tx_hash.to_string(),
+            transaction_index: 0,
+            log_index: 0,
+            removed: false,
+        };
+        self.add_log(log);
+    }
+
+    pub fn get_logs(&self, filter: &LogFilter, current_block: u64) -> Vec<SyntheticLog> {
+        let mut result = Vec::new();
+
+        let from = filter.from_block_number(current_block);
+        let to = filter.to_block_number(current_block);
+
+        // Drain pending events: events in-range are already in logs_by_block,
+        // events too old are returned at their original block (the normal scan
+        // won't find them, so we include them directly), future events stay pending.
+        {
+            let mut pending = self.pending_events.write();
+            let mut remaining = Vec::new();
+            for evt in pending.drain(..) {
+                if evt.block_number <= to {
+                    // In range or older — already in logs_by_block, will be found by scan.
+                    // If older than `from`, the scan still covers it via logs_by_block
+                    // since add_log() stored it at the original block_number.
+                } else {
+                    // Future event — keep pending for next query.
+                    remaining.push(evt);
+                }
+            }
+            *pending = remaining;
+        }
+
+        // Normal block-range scan
+        let logs_by_block = self.logs_by_block.read();
+        for block_num in from..=to {
+            if let Some(logs) = logs_by_block.get(&block_num) {
+                for log in logs {
+                    if filter.matches(log, current_block) {
+                        result.push(log.clone());
+                    }
+                }
+            }
+            if result.len() >= 1000 {
+                break;
+            }
+        }
+
+        result
+    }
+
+    pub fn get_logs_for_tx(&self, tx_hash: &str) -> Vec<SyntheticLog> {
+        self.logs_by_tx
+            .read()
+            .get(tx_hash)
+            .cloned()
+            .unwrap_or_default()
+    }
+}
+
+impl Default for LogStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn encode_claim_event_data(
+    global_index: &[u8; 32],
+    origin_network: u32,
+    origin_address: &[u8; 20],
+    destination_address: &[u8; 20],
+    amount: u64,
+) -> String {
+    let mut data = Vec::with_capacity(160);
+
+    // globalIndex (uint256)
+    data.extend_from_slice(global_index);
+
+    // originNetwork (uint32 padded to 32 bytes)
+    data.extend_from_slice(&[0u8; 28]);
+    data.extend_from_slice(&origin_network.to_be_bytes());
+
+    // originAddress (address padded to 32 bytes)
+    data.extend_from_slice(&[0u8; 12]);
+    data.extend_from_slice(origin_address);
+
+    // destinationAddress (address padded to 32 bytes)
+    data.extend_from_slice(&[0u8; 12]);
+    data.extend_from_slice(destination_address);
+
+    // amount (uint256)
+    data.extend_from_slice(&[0u8; 24]);
+    data.extend_from_slice(&amount.to_be_bytes());
+
+    format!("0x{}", hex::encode(data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log_filter_block_range() {
+        let filter = LogFilter {
+            from_block: Some("0x10".to_string()),
+            to_block: Some("0x20".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(filter.from_block_number(100), 16);
+        assert_eq!(filter.to_block_number(100), 32);
+    }
+
+    #[test]
+    fn test_log_filter_latest() {
+        let filter = LogFilter {
+            from_block: Some("latest".to_string()),
+            to_block: Some("latest".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(filter.from_block_number(500), 500);
+        assert_eq!(filter.to_block_number(500), 500);
+    }
+
+    #[test]
+    fn test_log_filter_topic_match() {
+        let log = SyntheticLog {
+            address: "0x1234".to_string(),
+            topics: vec![CLAIM_EVENT_TOPIC.to_string()],
+            data: "0x".to_string(),
+            block_number: 100,
+            block_hash: [0u8; 32],
+            transaction_hash: "0xabc".to_string(),
+            transaction_index: 0,
+            log_index: 0,
+            removed: false,
+        };
+
+        let filter = LogFilter {
+            from_block: Some("0x0".to_string()),
+            to_block: Some("0x200".to_string()),
+            topics: Some(vec![Some(TopicFilter::Single(
+                CLAIM_EVENT_TOPIC.to_string(),
+            ))]),
+            ..Default::default()
+        };
+
+        assert!(filter.matches(&log, 500));
+    }
+
+    #[test]
+    fn test_ger_dedup_tracking() {
+        let store = LogStore::new();
+        let ger = [0x11; 32];
+
+        assert!(!store.has_seen_ger(&ger));
+        store.add_ger_update_event(0, [0u8; 32], "0xTx1", &ger);
+        assert!(store.has_seen_ger(&ger), "GER should be marked as seen");
+
+        let filter = LogFilter {
+            from_block: Some("0x0".to_string()),
+            to_block: Some("0x100".to_string()),
+            ..Default::default()
+        };
+        let logs = store.get_logs(&filter, 100);
+        assert_eq!(logs.len(), 1);
+    }
+
+    #[test]
+    fn test_hash_chain_incremental() {
+        let store = LogStore::new();
+
+        let ger1 = [0x11; 32];
+        let ger2 = [0x22; 32];
+
+        store.add_ger_update_event(0, [0u8; 32], "0xTx1", &ger1);
+        let hash1 = *store.hash_chain_value.read();
+
+        store.add_ger_update_event(1, [1u8; 32], "0xTx2", &ger2);
+        let hash2 = *store.hash_chain_value.read();
+
+        // hash1 = keccak256([0u8;32] || ger1)
+        let mut hasher = Keccak256::new();
+        hasher.update([0u8; 32]);
+        hasher.update(ger1);
+        let expected1: [u8; 32] = hasher.finalize().into();
+        assert_eq!(hash1, expected1);
+
+        // hash2 = keccak256(hash1 || ger2) — must chain from hash1, not from zero
+        let mut hasher = Keccak256::new();
+        hasher.update(expected1);
+        hasher.update(ger2);
+        let expected2: [u8; 32] = hasher.finalize().into();
+        assert_eq!(hash2, expected2);
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_log_store_add_and_query() {
+        let store = LogStore::new();
+
+        store.add_claim_event(
+            "0xBridge",
+            100,
+            [0xAA; 32],
+            "0xTxHash",
+            &[0x11; 32],
+            1,
+            &[0x22; 20],
+            &[0x33; 20],
+            1000,
+        );
+
+        let filter = LogFilter {
+            from_block: Some("0x0".to_string()),
+            to_block: Some("0x200".to_string()),
+            ..Default::default()
+        };
+
+        let logs = store.get_logs(&filter, 500);
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].block_number, 100);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,10 +69,14 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let accounts = load_config(miden_store_dir.clone())?;
-    let claim_persistence_path = miden_store_dir.as_ref().map(|d| d.join("claimed_indices.json"));
+    let claim_persistence_path = miden_store_dir
+        .as_ref()
+        .map(|d| d.join("claimed_indices.json"));
     let claim_tracker = Arc::new(ClaimTracker::new(claim_persistence_path)?);
     let nonce_tracker = Arc::new(NonceTracker::new());
-    let address_persistence_path = miden_store_dir.as_ref().map(|d| d.join("address_mappings.json"));
+    let address_persistence_path = miden_store_dir
+        .as_ref()
+        .map(|d| d.join("address_mappings.json"));
     let address_mapper = Arc::new(AddressMapper::new(address_persistence_path)?);
 
     let state = ServiceState::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ async fn main() -> anyhow::Result<()> {
     let accounts = load_config(miden_store_dir.clone())?;
     let claim_persistence_path = miden_store_dir.map(|d| d.join("claimed_indices.json"));
     let claim_tracker = Arc::new(ClaimTracker::new(claim_persistence_path)?);
+    let nonce_tracker = Arc::new(NonceTracker::new());
 
     let state = ServiceState::new(
         client,
@@ -81,6 +82,7 @@ async fn main() -> anyhow::Result<()> {
         block_state,
         log_store,
         claim_tracker,
+        nonce_tracker,
     );
 
     let url = Url::from_str(format!("http://0.0.0.0:{}", command.port).as_str())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,9 +69,11 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let accounts = load_config(miden_store_dir.clone())?;
-    let claim_persistence_path = miden_store_dir.map(|d| d.join("claimed_indices.json"));
+    let claim_persistence_path = miden_store_dir.as_ref().map(|d| d.join("claimed_indices.json"));
     let claim_tracker = Arc::new(ClaimTracker::new(claim_persistence_path)?);
     let nonce_tracker = Arc::new(NonceTracker::new());
+    let address_persistence_path = miden_store_dir.as_ref().map(|d| d.join("address_mappings.json"));
+    let address_mapper = Arc::new(AddressMapper::new(address_persistence_path)?);
 
     let state = ServiceState::new(
         client,
@@ -83,6 +85,7 @@ async fn main() -> anyhow::Result<()> {
         log_store,
         claim_tracker,
         nonce_tracker,
+        address_mapper,
     );
 
     let url = Url::from_str(format!("http://0.0.0.0:{}", command.port).as_str())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,10 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let accounts = load_config(miden_store_dir)?;
+    let accounts = load_config(miden_store_dir.clone())?;
+    let claim_persistence_path = miden_store_dir.map(|d| d.join("claimed_indices.json"));
+    let claim_tracker = Arc::new(ClaimTracker::new(claim_persistence_path)?);
+
     let state = ServiceState::new(
         client,
         accounts,
@@ -77,6 +80,7 @@ async fn main() -> anyhow::Result<()> {
         txn_manager,
         block_state,
         log_store,
+        claim_tracker,
     );
 
     let url = Url::from_str(format!("http://0.0.0.0:{}", command.port).as_str())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use crate::service_state::ServiceState;
 use clap::Parser;
+use miden_agglayer_service::block_state::BlockState;
+use miden_agglayer_service::log_synthesis::LogStore;
 use miden_agglayer_service::*;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -43,12 +45,18 @@ async fn main() -> anyhow::Result<()> {
 
     let block_num_tracker = Arc::new(BlockNumTracker::new());
     let txn_manager = Arc::new(TxnManager::new());
+    let block_state = Arc::new(BlockState::new());
+    let log_store = Arc::new(LogStore::new());
 
     let miden_store_dir = command.miden_store_dir;
     let client = MidenClient::new(
         miden_store_dir.clone(),
         command.miden_node,
-        vec![txn_manager.clone(), block_num_tracker.clone()],
+        vec![
+            txn_manager.clone(),
+            block_num_tracker.clone(),
+            block_state.clone(),
+        ],
     )?;
 
     if command.init || !config_path_exists(miden_store_dir.clone())? {
@@ -61,8 +69,15 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let accounts = load_config(miden_store_dir)?;
-    let state =
-        ServiceState::new(client, accounts, command.chain_id, block_num_tracker, txn_manager);
+    let state = ServiceState::new(
+        client,
+        accounts,
+        command.chain_id,
+        block_num_tracker,
+        txn_manager,
+        block_state,
+        log_store,
+    );
 
     let url = Url::from_str(format!("http://0.0.0.0:{}", command.port).as_str())?;
     service::serve(url, state.clone()).await?;

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -47,8 +47,9 @@ impl MidenClient {
         sync_listeners: Vec<Arc<dyn SyncListener>>,
     ) -> anyhow::Result<Self> {
         let store_dir = store_dir.unwrap_or(Self::default_store_dir());
-        let node_endpoint =
-            node_url.map(Self::parse_node_url).unwrap_or(Ok(Endpoint::localhost()))?;
+        let node_endpoint = node_url
+            .map(Self::parse_node_url)
+            .unwrap_or(Ok(Endpoint::localhost()))?;
         let keystore = Self::create_keystore(store_dir.clone())?;
         let keystore_for_run = keystore.clone();
 
@@ -73,7 +74,12 @@ impl MidenClient {
 
         let task = std::sync::Mutex::new(Some(task));
         let done_sender = std::sync::Mutex::new(Some(done_sender));
-        Ok(Self { keystore, task, sender, done_sender })
+        Ok(Self {
+            keystore,
+            task,
+            sender,
+            done_sender,
+        })
     }
 
     fn default_store_dir() -> PathBuf {
@@ -89,7 +95,7 @@ impl MidenClient {
             _ => {
                 let endpoint = Endpoint::try_from(node_url.as_str());
                 endpoint.map_err(|err| anyhow!(err))
-            },
+            }
         }
     }
 
@@ -104,9 +110,13 @@ impl MidenClient {
     }
 
     pub fn join(&self) -> anyhow::Result<()> {
-        let mut task_guard =
-            self.task.lock().expect("MidenClient::join has failed to lock the task mutex");
-        let Some(task) = task_guard.take() else { return Ok(()) };
+        let mut task_guard = self
+            .task
+            .lock()
+            .expect("MidenClient::join has failed to lock the task mutex");
+        let Some(task) = task_guard.take() else {
+            return Ok(());
+        };
         match task.join() {
             Ok(run_result) => run_result,
             Err(err) => Err(anyhow!("MidenClient::join error: {err:?}")),
@@ -132,11 +142,10 @@ impl MidenClient {
     fn unwrap_connection_error(client_err: ClientError) -> anyhow::Result<Box<dyn Error>> {
         match client_err {
             ClientError::RpcError(RpcError::ConnectionError(err)) => Ok(err),
-            ClientError::RpcError(RpcError::GrpcError {
+            ClientError::RpcError(RpcError::RequestError {
                 error_kind: GrpcError::Unavailable,
-                source,
                 ..
-            }) => Ok(source.unwrap_or(Box::new(GrpcError::Unavailable))),
+            }) => Ok(Box::new(GrpcError::Unavailable)),
             _ => Err(client_err.into()),
         }
     }
@@ -148,21 +157,21 @@ impl MidenClient {
                 Ok(summary) => {
                     tracing::debug!(target: concat!(module_path!(), "::sync::debug"), "MidenClient::sync succeeded at block {}", summary.block_num);
                     return Ok(summary);
-                },
+                }
                 Err(client_err) => {
                     let err = Self::unwrap_connection_error(client_err)?;
                     tracing::error!(
                         "MidenClient::sync failed to connect to the node: {err:?}, retrying in 5 seconds..."
                     );
                     tokio::time::sleep(Duration::from_secs(5)).await;
-                },
+                }
             }
         }
     }
 
     fn on_sync(
         result: anyhow::Result<SyncSummary>,
-        listeners: &Vec<Arc<dyn SyncListener>>,
+        listeners: &[Arc<dyn SyncListener>],
     ) -> anyhow::Result<()> {
         let summary = result?;
         for listener in listeners {

--- a/src/nonce_tracker.rs
+++ b/src/nonce_tracker.rs
@@ -1,0 +1,75 @@
+use parking_lot::RwLock;
+use std::collections::HashMap;
+
+pub struct NonceTracker {
+    nonces: RwLock<HashMap<String, u64>>,
+}
+
+const fn assert_sync<T: Send + Sync>() {}
+const _: () = assert_sync::<NonceTracker>();
+
+impl NonceTracker {
+    pub fn new() -> Self {
+        Self {
+            nonces: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn get(&self, address: &str) -> u64 {
+        *self.nonces.read().get(&address.to_lowercase()).unwrap_or(&0)
+    }
+
+    /// Increment nonce, returning the value before increment.
+    pub fn increment(&self, address: &str) -> u64 {
+        let key = address.to_lowercase();
+        let mut nonces = self.nonces.write();
+        let nonce = nonces.entry(key).or_insert(0);
+        let prev = *nonce;
+        *nonce += 1;
+        prev
+    }
+}
+
+impl Default for NonceTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_default() {
+        let tracker = NonceTracker::new();
+        assert_eq!(tracker.get("0xabc"), 0);
+    }
+
+    #[test]
+    fn test_increment_returns_previous() {
+        let tracker = NonceTracker::new();
+        assert_eq!(tracker.increment("0xABC"), 0);
+        assert_eq!(tracker.increment("0xABC"), 1);
+        assert_eq!(tracker.increment("0xABC"), 2);
+        assert_eq!(tracker.get("0xabc"), 3);
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        let tracker = NonceTracker::new();
+        tracker.increment("0xABC");
+        assert_eq!(tracker.get("0xabc"), 1);
+        assert_eq!(tracker.get("0xABC"), 1);
+    }
+
+    #[test]
+    fn test_independent_addresses() {
+        let tracker = NonceTracker::new();
+        tracker.increment("0xaaa");
+        tracker.increment("0xaaa");
+        tracker.increment("0xbbb");
+        assert_eq!(tracker.get("0xaaa"), 2);
+        assert_eq!(tracker.get("0xbbb"), 1);
+    }
+}

--- a/src/nonce_tracker.rs
+++ b/src/nonce_tracker.rs
@@ -16,7 +16,11 @@ impl NonceTracker {
     }
 
     pub fn get(&self, address: &str) -> u64 {
-        *self.nonces.read().get(&address.to_lowercase()).unwrap_or(&0)
+        *self
+            .nonces
+            .read()
+            .get(&address.to_lowercase())
+            .unwrap_or(&0)
     }
 
     /// Increment nonce, returning the value before increment.

--- a/src/service.rs
+++ b/src/service.rs
@@ -164,11 +164,10 @@ async fn json_rpc_endpoint(
             }
         }
 
-        // polycli sets a txn.Nonce from this method result
-        // TODO: for replay protection and ordering this should be a monotonic counter per "from" account
         "eth_getTransactionCount" => {
-            let _params: (String, String) = request.parse_params()?;
-            Ok(JsonRpcResponse::success(answer_id, "0x0"))
+            let params: (String, String) = request.parse_params()?;
+            let nonce = service.nonce_tracker.get(&params.0);
+            Ok(JsonRpcResponse::success(answer_id, format!("{nonce:#x}")))
         }
 
         "eth_gasPrice" => Ok(JsonRpcResponse::success(answer_id, "0x0")),

--- a/src/service.rs
+++ b/src/service.rs
@@ -255,8 +255,7 @@ async fn json_rpc_endpoint(
             // causing Go's hexutil.Uint unmarshaling to fail in the bridge-service.
             let raw_params: (serde_json::Value,) = request.parse_params()?;
 
-            let log_filter: LogFilter =
-                serde_json::from_value(raw_params.0).unwrap_or_default();
+            let log_filter: LogFilter = serde_json::from_value(raw_params.0).unwrap_or_default();
             let current_block = service.block_num_tracker.latest();
             let synthetic_logs = service.log_store.get_logs(&log_filter, current_block);
             let json_logs: Vec<serde_json::Value> =
@@ -270,9 +269,10 @@ async fn json_rpc_endpoint(
             Ok(JsonRpcResponse::success(answer_id, "0x0"))
         }
 
-        "net_version" => {
-            Ok(JsonRpcResponse::success(answer_id, format!("{}", service.chain_id)))
-        }
+        "net_version" => Ok(JsonRpcResponse::success(
+            answer_id,
+            format!("{}", service.chain_id),
+        )),
 
         "eth_getBlockTransactionCountByNumber" => {
             let _params: (String,) = request.parse_params()?;

--- a/src/service.rs
+++ b/src/service.rs
@@ -6,7 +6,6 @@ use crate::service_send_raw_txn::service_send_raw_txn;
 use crate::service_state::ServiceState;
 use alloy::primitives::TxHash;
 use alloy_core::sol_types::SolCall;
-use alloy_rpc_types_eth::Filter;
 use anyhow::Context;
 use axum::Router;
 use axum::extract::State;
@@ -245,25 +244,18 @@ async fn json_rpc_endpoint(
         }
 
         "eth_getLogs" => {
-            // Combine logs from both LogStore (synthetic GER/claim events) and TxnManager
+            // Return synthetic logs from LogStore (GER/claim events with proper formatting).
+            // TxnManager logs are intentionally excluded: they duplicate LogStore entries
+            // but use alloy's Log type which serializes Optional fields as JSON null,
+            // causing Go's hexutil.Uint unmarshaling to fail in the bridge-service.
             let raw_params: (serde_json::Value,) = request.parse_params()?;
 
-            // Query LogStore for synthetic logs
             let log_filter: LogFilter =
-                serde_json::from_value(raw_params.0.clone()).unwrap_or_default();
+                serde_json::from_value(raw_params.0).unwrap_or_default();
             let current_block = service.block_num_tracker.latest();
             let synthetic_logs = service.log_store.get_logs(&log_filter, current_block);
-            let mut json_logs: Vec<serde_json::Value> =
+            let json_logs: Vec<serde_json::Value> =
                 synthetic_logs.iter().map(|l| l.to_json()).collect();
-
-            // Also query TxnManager for alloy-based logs
-            let filter: Filter = serde_json::from_value(raw_params.0).unwrap_or_default();
-            let txn_logs = service.txn_manager.logs(filter);
-            for log in &txn_logs {
-                if let Ok(v) = serde_json::to_value(log) {
-                    json_logs.push(v);
-                }
-            }
 
             Ok(JsonRpcResponse::success(answer_id, json_logs))
         }

--- a/src/service.rs
+++ b/src/service.rs
@@ -79,6 +79,12 @@ async fn json_rpc_endpoint(
         "eth_getLogs" => {
             tracing::debug!(target: concat!(module_path!(), "::debug"), "JSON-RPC {method}")
         }
+        "net_version" => {
+            tracing::debug!(target: concat!(module_path!(), "::debug"), "JSON-RPC {method}")
+        }
+        "eth_getBlockTransactionCountByNumber" => {
+            tracing::debug!(target: concat!(module_path!(), "::debug"), "JSON-RPC {method}")
+        }
         "eth_getTransactionCount" => {
             tracing::debug!(target: concat!(module_path!(), "::debug"), "JSON-RPC {method}")
         }
@@ -262,6 +268,15 @@ async fn json_rpc_endpoint(
 
         "eth_getBalance" => {
             let _params: (String, String) = request.parse_params()?;
+            Ok(JsonRpcResponse::success(answer_id, "0x0"))
+        }
+
+        "net_version" => {
+            Ok(JsonRpcResponse::success(answer_id, format!("{}", service.chain_id)))
+        }
+
+        "eth_getBlockTransactionCountByNumber" => {
+            let _params: (String,) = request.parse_params()?;
             Ok(JsonRpcResponse::success(answer_id, "0x0"))
         }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -7,7 +7,6 @@ use crate::service_state::ServiceState;
 use alloy::primitives::TxHash;
 use alloy_core::sol_types::SolCall;
 use alloy_rpc_types_eth::Filter;
-use alloy_rpc_types_eth::Header;
 use anyhow::Context;
 use axum::Router;
 use axum::extract::State;
@@ -15,6 +14,7 @@ use axum::routing::post;
 use axum_jrpc::error::{JsonRpcError, JsonRpcErrorReason};
 use axum_jrpc::{JrpcResult, JsonRpcExtractor, JsonRpcResponse};
 use http::HeaderValue;
+use miden_agglayer_service::log_synthesis::LogFilter;
 use serde::Deserialize;
 use std::str::FromStr;
 use tokio::net::TcpListener;
@@ -50,10 +50,13 @@ fn json_rpc_response_from_result<T: serde::Serialize>(
     match result {
         Ok(value) => Ok(JsonRpcResponse::success(answer_id, value)),
         Err(error) => {
-            let error =
-                JsonRpcError::new(error_code.into(), error.to_string(), serde_json::Value::Null);
+            let error = JsonRpcError::new(
+                error_code.into(),
+                error.to_string(),
+                serde_json::Value::Null,
+            );
             Err(JsonRpcResponse::error(answer_id, error))
-        },
+        }
     }
 }
 
@@ -67,25 +70,25 @@ async fn json_rpc_endpoint(
         "eth_getBlockByNumber" => tracing::trace!("JSON-RPC {method}"),
         "eth_call" => {
             tracing::debug!(target: concat!(module_path!(), "::debug"), "JSON-RPC {method}")
-        },
+        }
         "eth_gasPrice" => {
             tracing::debug!(target: concat!(module_path!(), "::debug"), "JSON-RPC {method}")
-        },
+        }
         "eth_estimateGas" => {
             tracing::debug!(target: concat!(module_path!(), "::debug"), "JSON-RPC {method}")
-        },
+        }
         "eth_getLogs" => {
             tracing::debug!(target: concat!(module_path!(), "::debug"), "JSON-RPC {method}")
-        },
+        }
         "eth_getTransactionCount" => {
             tracing::debug!(target: concat!(module_path!(), "::debug"), "JSON-RPC {method}")
-        },
+        }
         "eth_getTransactionByHash" => {
             tracing::debug!(target: concat!(module_path!(), "::debug"), "JSON-RPC {method}")
-        },
+        }
         "eth_getTransactionReceipt" => {
             tracing::debug!(target: concat!(module_path!(), "::debug"), "JSON-RPC {method}")
-        },
+        }
         _ => tracing::debug!("JSON-RPC {method}"),
     }
 
@@ -95,20 +98,20 @@ async fn json_rpc_endpoint(
         "eth_getCode" => {
             let _params: (String, String) = request.parse_params()?;
             Ok(JsonRpcResponse::success(answer_id, "0x00"))
-        },
+        }
 
         "eth_blockNumber" => {
             let block_num = service.block_num_tracker.latest();
             let block_num_str = format!("{:#x}", block_num);
             Ok(JsonRpcResponse::success(answer_id, block_num_str))
-        },
+        }
 
-        // polycli estimates GasFeeCap using the latest header baseFeePerGas
-        // return a dummy header with zero baseFeePerGas to satisfy the client logic
+        // Return synthetic block with deterministic hash (prevents false reorg detection)
         "eth_getBlockByNumber" => {
             let params: (String, bool) = request.parse_params()?;
             let block_num = match params.0.as_str() {
-                "latest" => service.block_num_tracker.latest(),
+                "latest" | "pending" => service.block_num_tracker.latest(),
+                "earliest" => 0,
                 any => {
                     let Ok(num) = hex_decode_u64(any) else {
                         let error = JsonRpcError::new(
@@ -119,23 +122,49 @@ async fn json_rpc_endpoint(
                         return Err(JsonRpcResponse::error(answer_id, error));
                     };
                     num
-                },
+                }
             };
-            let header = alloy::consensus::Header {
-                number: block_num,
-                base_fee_per_gas: Some(0),
-                ..Default::default()
+            let full_txns = params.1;
+            let block = service.block_state.get_block_by_number(block_num);
+            match block {
+                Some(b) => Ok(JsonRpcResponse::success(answer_id, b.to_json(full_txns))),
+                None => Ok(JsonRpcResponse::success(answer_id, serde_json::Value::Null)),
+            }
+        }
+
+        "eth_getBlockByHash" => {
+            let params: (String, bool) = request.parse_params()?;
+            let hash_hex = params.0.strip_prefix("0x").unwrap_or(&params.0);
+            let Ok(hash_bytes) = hex::decode(hash_hex) else {
+                let error = JsonRpcError::new(
+                    JsonRpcErrorReason::InvalidParams,
+                    String::from("bad block hash"),
+                    serde_json::Value::Null,
+                );
+                return Err(JsonRpcResponse::error(answer_id, error));
             };
-            let header = Header::new(header);
-            Ok(JsonRpcResponse::success(answer_id, header))
-        },
+            let Ok(hash): Result<[u8; 32], _> = hash_bytes.try_into() else {
+                let error = JsonRpcError::new(
+                    JsonRpcErrorReason::InvalidParams,
+                    String::from("block hash must be 32 bytes"),
+                    serde_json::Value::Null,
+                );
+                return Err(JsonRpcResponse::error(answer_id, error));
+            };
+            let full_txns = params.1;
+            let block = service.block_state.get_block_by_hash(&hash);
+            match block {
+                Some(b) => Ok(JsonRpcResponse::success(answer_id, b.to_json(full_txns))),
+                None => Ok(JsonRpcResponse::success(answer_id, serde_json::Value::Null)),
+            }
+        }
 
         // polycli sets a txn.Nonce from this method result
         // TODO: for replay protection and ordering this should be a monotonic counter per "from" account
         "eth_getTransactionCount" => {
             let _params: (String, String) = request.parse_params()?;
             Ok(JsonRpcResponse::success(answer_id, "0x0"))
-        },
+        }
 
         "eth_gasPrice" => Ok(JsonRpcResponse::success(answer_id, "0x0")),
 
@@ -145,9 +174,10 @@ async fn json_rpc_endpoint(
         // polycli estimates how much gas will be spent on a transaction, return zero
         "eth_estimateGas" => Ok(JsonRpcResponse::success(answer_id, "0x0")),
 
-        "eth_chainId" => {
-            Ok(JsonRpcResponse::success(answer_id, format!("{:#x}", service.chain_id)))
-        },
+        "eth_chainId" => Ok(JsonRpcResponse::success(
+            answer_id,
+            format!("{:#x}", service.chain_id),
+        )),
 
         // AggLayer requests current state of the bridge contract using eth_call,
         // but currently everything is stubbed with zero except networkID
@@ -181,13 +211,13 @@ async fn json_rpc_endpoint(
                 answer_id,
                 "0x0000000000000000000000000000000000000000000000000000000000000000",
             ))
-        },
+        }
 
         "eth_sendRawTransaction" => {
             let params: (String,) = request.parse_params()?;
             let result = service_send_raw_txn(service, params.0).await;
             json_rpc_response_from_result(result, answer_id, ServiceErrorCode::SendRawTransaction)
-        },
+        }
 
         // polycli polls receipts to get the eth_sendRawTransaction status
         "eth_getTransactionReceipt" => {
@@ -198,7 +228,7 @@ async fn json_rpc_endpoint(
                 answer_id,
                 ServiceErrorCode::GetTransactionReceipt,
             )
-        },
+        }
 
         "eth_getTransactionByHash" => {
             let params: (String,) = request.parse_params()?;
@@ -212,24 +242,57 @@ async fn json_rpc_endpoint(
             };
             let txn_opt = service.txn_manager.txn(txn_hash);
             Ok(JsonRpcResponse::success(answer_id, txn_opt))
-        },
+        }
 
         "eth_getLogs" => {
-            let params: (Filter,) = request.parse_params()?;
-            let logs = service.txn_manager.logs(params.0);
-            Ok(JsonRpcResponse::success(answer_id, logs))
-        },
+            // Combine logs from both LogStore (synthetic GER/claim events) and TxnManager
+            let raw_params: (serde_json::Value,) = request.parse_params()?;
+
+            // Query LogStore for synthetic logs
+            let log_filter: LogFilter =
+                serde_json::from_value(raw_params.0.clone()).unwrap_or_default();
+            let current_block = service.block_num_tracker.latest();
+            let synthetic_logs = service.log_store.get_logs(&log_filter, current_block);
+            let mut json_logs: Vec<serde_json::Value> =
+                synthetic_logs.iter().map(|l| l.to_json()).collect();
+
+            // Also query TxnManager for alloy-based logs
+            let filter: Filter = serde_json::from_value(raw_params.0).unwrap_or_default();
+            let txn_logs = service.txn_manager.logs(filter);
+            for log in &txn_logs {
+                if let Ok(v) = serde_json::to_value(log) {
+                    json_logs.push(v);
+                }
+            }
+
+            Ok(JsonRpcResponse::success(answer_id, json_logs))
+        }
+
+        "eth_getBalance" => {
+            let _params: (String, String) = request.parse_params()?;
+            Ok(JsonRpcResponse::success(answer_id, "0x0"))
+        }
+
+        "eth_getStorageAt" => {
+            let _params: (String, String, String) = request.parse_params()?;
+            Ok(JsonRpcResponse::success(
+                answer_id,
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+            ))
+        }
 
         method => {
             tracing::error!("JSON-RPC unsupported method: {}", method);
             Ok(request.method_not_found(method))
-        },
+        }
     }
 }
 
 #[cfg(not(unix))]
 async fn shutdown_signal() {
-    tokio::signal::ctrl_c().await.expect("failed to setup SIGINT handler");
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to setup SIGINT handler");
 }
 
 #[cfg(unix)]
@@ -275,6 +338,8 @@ pub async fn serve(url: Url, state: ServiceState) -> anyhow::Result<()> {
 
     tracing::info!(target: COMPONENT, address = %url, "Service started");
 
-    axum::serve(listener, app).with_graceful_shutdown(shutdown_signal()).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
     Ok(())
 }

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -1,6 +1,7 @@
 use crate::hex::hex_decode_prefixed;
 use crate::service_state::ServiceState;
 use alloy::consensus::TxEnvelope;
+use alloy::consensus::transaction::SignerRecoverable;
 use alloy::eips::Decodable2718;
 use alloy::primitives::TxHash;
 use alloy_core::sol_types::SolCall;
@@ -72,6 +73,7 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
     let txn_envelope = TxEnvelope::decode_2718(&mut payload_slice)?;
     let txn = unwrap_txn_envelope(txn_envelope.clone())?;
     let txn_hash = txn.hash;
+    let signer = txn_envelope.recover_signer()?;
     tracing::debug!(target: concat!(module_path!(), "::debug"), "raw transaction hash: {txn_hash}");
 
     let params_encoded = &txn.input;
@@ -146,5 +148,6 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         anyhow::bail!("unhandled txn method {params_encoded:?}");
     }
 
+    service.nonce_tracker.increment(&format!("{signer:#x}"));
     Ok(txn_hash)
 }

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -80,8 +80,10 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         let params = claimAssetCall::abi_decode(params_encoded)?;
         tracing::debug!(target: concat!(module_path!(), "::debug"), "claimAsset call params: {params:?}");
 
+        service.claim_tracker.try_claim(params.globalIndex)?;
+
         let result = claim::publish_claim(
-            params,
+            params.clone(),
             &service.miden_client,
             service.accounts,
             service.block_num_tracker.latest(),
@@ -110,6 +112,7 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
                 }
             }
             Err(err) => {
+                service.claim_tracker.unclaim(&params.globalIndex);
                 tracing::error!("publish_claim failed: {err:#?}");
                 return Err(err);
             }

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -5,7 +5,7 @@ use alloy::eips::Decodable2718;
 use alloy::primitives::TxHash;
 use alloy_core::sol_types::SolCall;
 use miden_agglayer_service::claim::claimAssetCall;
-use miden_agglayer_service::ger::insertGlobalExitRootCall;
+use miden_agglayer_service::ger::{insertGlobalExitRootCall, updateExitRootCall};
 use miden_agglayer_service::*;
 
 struct TransactionData {
@@ -37,6 +37,33 @@ fn unwrap_txn_envelope(txn_envelope: TxEnvelope) -> anyhow::Result<TransactionDa
         }
     };
     Ok(data)
+}
+
+fn handle_ger_result(
+    result: anyhow::Result<ger::GerInsertResult>,
+    txn_hash: TxHash,
+    txn_envelope: TxEnvelope,
+    service: &ServiceState,
+) -> anyhow::Result<()> {
+    match result {
+        Ok(ger_result) => {
+            tracing::info!("inserted GER with eth txn: {txn_hash}");
+            service.txn_manager.begin(
+                txn_hash,
+                None,
+                txn_envelope,
+                None,
+                vec![ger_result.log_data],
+            )?;
+            let block_num = service.block_num_tracker.latest();
+            service.txn_manager.commit(txn_hash, Ok(()), block_num)?;
+            Ok(())
+        }
+        Err(err) => {
+            tracing::error!("insert_ger failed: {err:#?}");
+            Err(err)
+        }
+    }
 }
 
 pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyhow::Result<TxHash> {
@@ -91,34 +118,26 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         tracing::debug!("insertGlobalExitRoot call");
         let params = insertGlobalExitRootCall::abi_decode(params_encoded)?;
         tracing::debug!(target: concat!(module_path!(), "::debug"), "insertGlobalExitRoot call params: {params:?}");
+        let ger_bytes: [u8; 32] = params.root.0;
 
-        let result = ger::insert_ger(
-            params,
-            &service.miden_client,
-            service.accounts.clone(),
-            &service.log_store,
-            &service.block_state,
+        handle_ger_result(
+            ger::insert_ger(ger_bytes, &service.miden_client, service.accounts.clone(), &service.log_store, &service.block_state, txn_hash).await,
             txn_hash,
-        )
-        .await;
-        match result {
-            Ok(ger_result) => {
-                tracing::info!("inserted GER with eth txn: {txn_hash}");
-                service.txn_manager.begin(
-                    txn_hash,
-                    None,
-                    txn_envelope,
-                    None,
-                    vec![ger_result.log_data],
-                )?;
-                let block_num = service.block_num_tracker.latest();
-                service.txn_manager.commit(txn_hash, Ok(()), block_num)?;
-            }
-            Err(err) => {
-                tracing::error!("insert_ger failed: {err:#?}");
-                return Err(err);
-            }
-        }
+            txn_envelope,
+            &service,
+        )?;
+    } else if params_encoded.starts_with(&updateExitRootCall::SELECTOR) {
+        tracing::debug!("updateExitRoot call");
+        let params = updateExitRootCall::abi_decode(params_encoded)?;
+        tracing::debug!(target: concat!(module_path!(), "::debug"), "updateExitRoot call params: {params:?}");
+        let ger_bytes = ger::combined_ger(&params.newMainnetExitRoot.0, &params.newRollupExitRoot.0);
+
+        handle_ger_result(
+            ger::insert_ger(ger_bytes, &service.miden_client, service.accounts.clone(), &service.log_store, &service.block_state, txn_hash).await,
+            txn_hash,
+            txn_envelope,
+            &service,
+        )?;
     } else {
         tracing::error!("unhandled txn method {params_encoded:?}");
         anyhow::bail!("unhandled txn method {params_encoded:?}");

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -18,17 +18,23 @@ fn unwrap_txn_envelope(txn_envelope: TxEnvelope) -> anyhow::Result<TransactionDa
         TxEnvelope::Eip1559(txn_signed) => {
             let hash = *txn_signed.hash();
             let txn = txn_signed.strip_signature();
-            TransactionData { hash, input: txn.input }
-        },
+            TransactionData {
+                hash,
+                input: txn.input,
+            }
+        }
         TxEnvelope::Legacy(txn_signed) => {
             let hash = *txn_signed.hash();
             let txn = txn_signed.strip_signature();
-            TransactionData { hash, input: txn.input }
-        },
+            TransactionData {
+                hash,
+                input: txn.input,
+            }
+        }
         _ => {
             tracing::error!("unhandled txn type {:?}", txn_envelope.tx_type());
             anyhow::bail!("unhandled txn type {:?}", txn_envelope.tx_type());
-        },
+        }
     };
     Ok(data)
 }
@@ -55,39 +61,63 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         )
         .await;
         match result {
-            Ok(txn) => {
-                let txn_id = txn.txn_id;
+            Ok(claim_result) => {
+                let txn_id = claim_result.txn_id;
+                let claim_note_id = claim_result.claim_note_id.clone();
                 tracing::info!("published claim with eth txn: {txn_hash}; miden txn: {txn_id}");
                 service.txn_manager.begin(
                     txn_hash,
                     Some(txn_id),
                     txn_envelope,
-                    Some(txn.expires_at),
-                    vec![txn.log],
+                    Some(claim_result.expires_at),
+                    vec![claim_result.log],
                 )?;
-            },
+                // Defer receipt until CLAIM note is consumed by faucet
+                if let Some(note_id) = claim_note_id {
+                    let submit_block = service.block_num_tracker.latest();
+                    service.txn_manager.begin_awaiting_consumption(
+                        txn_hash,
+                        note_id,
+                        submit_block,
+                    )?;
+                }
+            }
             Err(err) => {
                 tracing::error!("publish_claim failed: {err:#?}");
                 return Err(err);
-            },
+            }
         }
     } else if params_encoded.starts_with(&insertGlobalExitRootCall::SELECTOR) {
         tracing::debug!("insertGlobalExitRoot call");
         let params = insertGlobalExitRootCall::abi_decode(params_encoded)?;
         tracing::debug!(target: concat!(module_path!(), "::debug"), "insertGlobalExitRoot call params: {params:?}");
 
-        let result = ger::insert_ger(params).await;
+        let result = ger::insert_ger(
+            params,
+            &service.miden_client,
+            service.accounts.clone(),
+            &service.log_store,
+            &service.block_state,
+            txn_hash,
+        )
+        .await;
         match result {
-            Ok(log_data) => {
+            Ok(ger_result) => {
                 tracing::info!("inserted GER with eth txn: {txn_hash}");
-                service.txn_manager.begin(txn_hash, None, txn_envelope, None, vec![log_data])?;
-                let block_num = service.block_num_tracker.latest() + 1;
+                service.txn_manager.begin(
+                    txn_hash,
+                    None,
+                    txn_envelope,
+                    None,
+                    vec![ger_result.log_data],
+                )?;
+                let block_num = service.block_num_tracker.latest();
                 service.txn_manager.commit(txn_hash, Ok(()), block_num)?;
-            },
+            }
             Err(err) => {
                 tracing::error!("insert_ger failed: {err:#?}");
                 return Err(err);
-            },
+            }
         }
     } else {
         tracing::error!("unhandled txn method {params_encoded:?}");

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -88,6 +88,7 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
             params.clone(),
             &service.miden_client,
             service.accounts,
+            service.address_mapper.clone(),
             service.block_num_tracker.latest(),
         )
         .await;

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -127,7 +127,15 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         let ger_bytes: [u8; 32] = params.root.0;
 
         handle_ger_result(
-            ger::insert_ger(ger_bytes, &service.miden_client, service.accounts.clone(), &service.log_store, &service.block_state, txn_hash).await,
+            ger::insert_ger(
+                ger_bytes,
+                &service.miden_client,
+                service.accounts.clone(),
+                &service.log_store,
+                &service.block_state,
+                txn_hash,
+            )
+            .await,
             txn_hash,
             txn_envelope,
             &service,
@@ -136,10 +144,19 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         tracing::debug!("updateExitRoot call");
         let params = updateExitRootCall::abi_decode(params_encoded)?;
         tracing::debug!(target: concat!(module_path!(), "::debug"), "updateExitRoot call params: {params:?}");
-        let ger_bytes = ger::combined_ger(&params.newMainnetExitRoot.0, &params.newRollupExitRoot.0);
+        let ger_bytes =
+            ger::combined_ger(&params.newMainnetExitRoot.0, &params.newRollupExitRoot.0);
 
         handle_ger_result(
-            ger::insert_ger(ger_bytes, &service.miden_client, service.accounts.clone(), &service.log_store, &service.block_state, txn_hash).await,
+            ger::insert_ger(
+                ger_bytes,
+                &service.miden_client,
+                service.accounts.clone(),
+                &service.log_store,
+                &service.block_state,
+                txn_hash,
+            )
+            .await,
             txn_hash,
             txn_envelope,
             &service,

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -13,6 +13,7 @@ pub struct ServiceState {
     pub block_state: Arc<BlockState>,
     pub log_store: Arc<LogStore>,
     pub claim_tracker: Arc<ClaimTracker>,
+    pub nonce_tracker: Arc<NonceTracker>,
 }
 
 const fn assert_sync<T: Send + Sync>() {}
@@ -28,6 +29,7 @@ impl ServiceState {
         block_state: Arc<BlockState>,
         log_store: Arc<LogStore>,
         claim_tracker: Arc<ClaimTracker>,
+        nonce_tracker: Arc<NonceTracker>,
     ) -> Self {
         Self {
             miden_client: Arc::new(miden_client),
@@ -38,6 +40,7 @@ impl ServiceState {
             block_state,
             log_store,
             claim_tracker,
+            nonce_tracker,
         }
     }
 }

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -21,6 +21,7 @@ const fn assert_sync<T: Send + Sync>() {}
 const _: () = assert_sync::<ServiceState>();
 
 impl ServiceState {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         miden_client: MidenClient,
         accounts: AccountsConfig,

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -14,6 +14,7 @@ pub struct ServiceState {
     pub log_store: Arc<LogStore>,
     pub claim_tracker: Arc<ClaimTracker>,
     pub nonce_tracker: Arc<NonceTracker>,
+    pub address_mapper: Arc<AddressMapper>,
 }
 
 const fn assert_sync<T: Send + Sync>() {}
@@ -30,6 +31,7 @@ impl ServiceState {
         log_store: Arc<LogStore>,
         claim_tracker: Arc<ClaimTracker>,
         nonce_tracker: Arc<NonceTracker>,
+        address_mapper: Arc<AddressMapper>,
     ) -> Self {
         Self {
             miden_client: Arc::new(miden_client),
@@ -41,6 +43,7 @@ impl ServiceState {
             log_store,
             claim_tracker,
             nonce_tracker,
+            address_mapper,
         }
     }
 }

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -12,6 +12,7 @@ pub struct ServiceState {
     pub txn_manager: Arc<TxnManager>,
     pub block_state: Arc<BlockState>,
     pub log_store: Arc<LogStore>,
+    pub claim_tracker: Arc<ClaimTracker>,
 }
 
 const fn assert_sync<T: Send + Sync>() {}
@@ -26,6 +27,7 @@ impl ServiceState {
         txn_manager: Arc<TxnManager>,
         block_state: Arc<BlockState>,
         log_store: Arc<LogStore>,
+        claim_tracker: Arc<ClaimTracker>,
     ) -> Self {
         Self {
             miden_client: Arc::new(miden_client),
@@ -35,6 +37,7 @@ impl ServiceState {
             txn_manager,
             block_state,
             log_store,
+            claim_tracker,
         }
     }
 }

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -1,3 +1,5 @@
+use miden_agglayer_service::block_state::BlockState;
+use miden_agglayer_service::log_synthesis::LogStore;
 use miden_agglayer_service::*;
 use std::sync::Arc;
 
@@ -8,6 +10,8 @@ pub struct ServiceState {
     pub chain_id: u64,
     pub block_num_tracker: Arc<BlockNumTracker>,
     pub txn_manager: Arc<TxnManager>,
+    pub block_state: Arc<BlockState>,
+    pub log_store: Arc<LogStore>,
 }
 
 const fn assert_sync<T: Send + Sync>() {}
@@ -20,6 +24,8 @@ impl ServiceState {
         chain_id: u64,
         block_num_tracker: Arc<BlockNumTracker>,
         txn_manager: Arc<TxnManager>,
+        block_state: Arc<BlockState>,
+        log_store: Arc<LogStore>,
     ) -> Self {
         Self {
             miden_client: Arc::new(miden_client),
@@ -27,6 +33,8 @@ impl ServiceState {
             chain_id,
             block_num_tracker,
             txn_manager,
+            block_state,
+            log_store,
         }
     }
 }

--- a/src/txn_manager.rs
+++ b/src/txn_manager.rs
@@ -9,6 +9,9 @@ use miden_protocol::transaction::TransactionId;
 use std::num::NonZeroUsize;
 use std::sync::Mutex;
 
+/// Maximum blocks to wait for CLAIM note consumption before reverting.
+const CLAIM_CONSUMPTION_TIMEOUT_BLOCKS: u64 = 50;
+
 #[derive(Debug)]
 struct TxnReceipt {
     id: Option<TransactionId>,
@@ -19,6 +22,11 @@ struct TxnReceipt {
     result: Option<Result<(), String>>,
     block_num: BlockNumber,
     logs: Vec<LogData>,
+
+    /// CLAIM note ID for consumption tracking (deferred receipts)
+    claim_note_id: Option<String>,
+    /// Block at which the claim was submitted (for timeout tracking)
+    claim_submit_block: Option<BlockNumber>,
 }
 
 pub struct TxnManager {
@@ -30,8 +38,10 @@ const _: () = assert_sync::<TxnManager>();
 
 impl TxnManager {
     pub fn new() -> Self {
-        let transactions = LruCache::new(NonZeroUsize::new(64).unwrap());
-        Self { transactions: Mutex::new(transactions) }
+        let transactions = LruCache::new(NonZeroUsize::new(10_000).unwrap());
+        Self {
+            transactions: Mutex::new(transactions),
+        }
     }
 
     pub fn begin(
@@ -55,6 +65,8 @@ impl TxnManager {
             result: None,
             block_num: 0,
             logs,
+            claim_note_id: None,
+            claim_submit_block: None,
         };
         _ = transactions.put(txn_hash, receipt);
         Ok(())
@@ -77,25 +89,75 @@ impl TxnManager {
         match &receipt.result {
             Some(Ok(_)) => {
                 tracing::info!("TxnManager: committed eth txn: {txn_hash}; miden txn: {txn_id:?}")
-            },
+            }
             Some(Err(err)) => tracing::error!(
                 "TxnManager: failed eth txn: {txn_hash}; miden txn: {txn_id:?}; reason: {err}"
             ),
-            None => {},
+            None => {}
         }
         Ok(())
     }
 
-    pub fn receipt(&self, txn_hash: TxHash) -> Option<(Result<(), String>, BlockNumber)> {
+    /// Mark a transaction as awaiting CLAIM note consumption.
+    /// Receipt will return None (pending) until consumption is confirmed or times out.
+    pub fn begin_awaiting_consumption(
+        &self,
+        txn_hash: TxHash,
+        claim_note_id: String,
+        submit_block: BlockNumber,
+    ) -> anyhow::Result<()> {
         let mut transactions = self.transactions.lock().unwrap();
-        let receipt = transactions.get(&txn_hash)?;
+        let Some(receipt) = transactions.get_mut(&txn_hash) else {
+            anyhow::bail!("TxnManager: transaction {txn_hash} not found");
+        };
+        receipt.claim_note_id = Some(claim_note_id);
+        receipt.claim_submit_block = Some(submit_block);
+        Ok(())
+    }
+
+    /// Check if a transaction is awaiting CLAIM note consumption.
+    pub fn is_awaiting_consumption(&self, txn_hash: TxHash) -> Option<(String, BlockNumber)> {
+        let transactions = self.transactions.lock().unwrap();
+        let receipt = transactions.peek(&txn_hash)?;
+        if receipt.result.is_some() {
+            return None; // already finalized
+        }
+        let note_id = receipt.claim_note_id.clone()?;
+        let submit_block = receipt.claim_submit_block?;
+        Some((note_id, submit_block))
+    }
+
+    /// Check if a claim has timed out (exceeded CLAIM_CONSUMPTION_TIMEOUT_BLOCKS).
+    pub fn check_claim_timeout(&self, txn_hash: TxHash, current_block: BlockNumber) -> bool {
+        let transactions = self.transactions.lock().unwrap();
+        let Some(receipt) = transactions.peek(&txn_hash) else {
+            return false;
+        };
+        if receipt.result.is_some() {
+            return false;
+        }
+        if let Some(submit_block) = receipt.claim_submit_block {
+            if current_block > submit_block + CLAIM_CONSUMPTION_TIMEOUT_BLOCKS {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn receipt(&self, txn_hash: TxHash) -> Option<(Result<(), String>, BlockNumber)> {
+        let transactions = self.transactions.lock().unwrap();
+        let receipt = transactions.peek(&txn_hash)?;
+        // If awaiting consumption (has claim_note_id but no result), return None (pending)
+        if receipt.claim_note_id.is_some() && receipt.result.is_none() {
+            return None;
+        }
         let result = receipt.result.clone()?;
         Some((result, receipt.block_num))
     }
 
     pub fn txn(&self, txn_hash: TxHash) -> Option<alloy::rpc::types::Transaction> {
-        let mut transactions = self.transactions.lock().unwrap();
-        let receipt = transactions.get(&txn_hash)?;
+        let transactions = self.transactions.lock().unwrap();
+        let receipt = transactions.peek(&txn_hash)?;
         let envelope = receipt.envelope.clone();
         let txn = alloy::rpc::types::Transaction {
             inner: Recovered::new_unchecked(envelope, receipt.signer),
@@ -151,10 +213,12 @@ impl TxnManager {
         None
     }
 
-    fn commit_pending(&self, ids: &Vec<TransactionId>, block_num: BlockNumber) {
+    fn commit_pending(&self, ids: &[TransactionId], block_num: BlockNumber) {
         for id in ids {
             if let Some(hash) = self.pending_txn_by_id(*id) {
-                _ = self.commit(hash, Ok(()), block_num);
+                if let Err(e) = self.commit(hash, Ok(()), block_num) {
+                    tracing::warn!("Failed to commit transaction {hash}: {e}");
+                }
             }
         }
     }
@@ -175,7 +239,42 @@ impl TxnManager {
     fn expire_pending(&self, block_num: BlockNumber) {
         let expired_hashes = self.expired_pending(block_num);
         for hash in expired_hashes {
-            _ = self.commit(hash, Err(String::from("expired")), block_num);
+            if let Err(e) = self.commit(hash, Err(String::from("expired")), block_num) {
+                tracing::warn!("Failed to expire transaction {hash}: {e}");
+            }
+        }
+    }
+
+    fn expire_timed_out_claims(&self, block_num: BlockNumber) {
+        let timed_out: Vec<TxHash> = {
+            let transactions = self.transactions.lock().unwrap();
+            transactions
+                .iter()
+                .filter_map(|(hash, receipt)| {
+                    if receipt.result.is_some() {
+                        return None;
+                    }
+                    let submit_block = receipt.claim_submit_block?;
+                    if block_num > submit_block + CLAIM_CONSUMPTION_TIMEOUT_BLOCKS {
+                        Some(*hash)
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
+
+        for hash in timed_out {
+            tracing::warn!(
+                "Claim transaction {hash} timed out after {CLAIM_CONSUMPTION_TIMEOUT_BLOCKS} blocks"
+            );
+            if let Err(e) = self.commit(
+                hash,
+                Err(String::from("claim consumption timeout")),
+                block_num,
+            ) {
+                tracing::warn!("Failed to timeout claim {hash}: {e}");
+            }
         }
     }
 }
@@ -188,7 +287,9 @@ impl Default for TxnManager {
 
 impl SyncListener for TxnManager {
     fn on_sync(&self, summary: &SyncSummary) {
-        self.commit_pending(&summary.committed_transactions, summary.block_num.as_u64());
-        self.expire_pending(summary.block_num.as_u64());
+        let block_num = summary.block_num.as_u64();
+        self.commit_pending(&summary.committed_transactions, block_num);
+        self.expire_pending(block_num);
+        self.expire_timed_out_claims(block_num);
     }
 }

--- a/src/txn_manager.rs
+++ b/src/txn_manager.rs
@@ -136,10 +136,10 @@ impl TxnManager {
         if receipt.result.is_some() {
             return false;
         }
-        if let Some(submit_block) = receipt.claim_submit_block {
-            if current_block > submit_block + CLAIM_CONSUMPTION_TIMEOUT_BLOCKS {
-                return true;
-            }
+        if let Some(submit_block) = receipt.claim_submit_block
+            && current_block > submit_block + CLAIM_CONSUMPTION_TIMEOUT_BLOCKS
+        {
+            return true;
         }
         false
     }
@@ -215,10 +215,10 @@ impl TxnManager {
 
     fn commit_pending(&self, ids: &[TransactionId], block_num: BlockNumber) {
         for id in ids {
-            if let Some(hash) = self.pending_txn_by_id(*id) {
-                if let Err(e) = self.commit(hash, Ok(()), block_num) {
-                    tracing::warn!("Failed to commit transaction {hash}: {e}");
-                }
+            if let Some(hash) = self.pending_txn_by_id(*id)
+                && let Err(e) = self.commit(hash, Ok(()), block_num)
+            {
+                tracing::warn!("Failed to commit transaction {hash}: {e}");
             }
         }
     }


### PR DESCRIPTION
## Summary

Implements real GER injection and ports all missing features from aggkit-proxy to miden-agglayer, achieving full bridge-in flow parity.

### GER injection (core fix)
- **Real GER submission** — `insert_ger` submits `UpdateGerNote` to Miden node via miden-client, replacing the previous stub
- **Race condition fix** — GER events stored at `current_block + 1` so bridge-service (with `forceSyncChunk=true`) always sees them. Previously events were stored at the current block which the bridge had already synced past, causing `ready_for_claim` to stay false permanently
- **eth_getLogs compatibility** — Only return LogStore synthetic logs (properly formatted hex strings). Removed TxnManager logs which serialized `None` fields as JSON null, crashing Go's `hexutil.Uint` unmarshaling in bridge-service
- **`updateExitRoot` selector** — Aggoracle sovereign chain GER updates via `updateExitRoot(bytes32, bytes32)` now supported alongside `insertGlobalExitRoot`. Added `combined_ger` keccak256 helper

### Feature parity
- **RPC stubs** — `net_version` and `eth_getBlockTransactionCountByNumber` match arms added
- **ClaimTracker** — Duplicate `claimAsset` calls rejected via `try_claim`/`unclaim` with JSON persistence to `claimed_indices.json`. Rolls back on submission failure
- **NonceTracker** — `eth_getTransactionCount` returns per-address monotonic nonces instead of `0x0`
- **AddressMapper** — Deterministic address mapping with resolution chain: hardhat special case → known mapping → zero-padding → keccak256-based derivation. Persists to `address_mappings.json`. Claims to arbitrary Ethereum addresses no longer fail

## Test plan

- [x] `cargo build` passes after each commit
- [x] `cargo test` — 31 tests pass (3 GER, 4 ClaimTracker, 4 NonceTracker, 7 AddressMapper, 13 existing)
- [x] CI: rustfmt, taplo, typos, clippy, CodeQL, Aikido all passing
- [x] Manual: full bridge-in flow — L1 deposit → GER injection → `ready_for_claim=true` (verified 3x on clean Kurtosis stacks)
- [x] Manual: send `updateExitRoot` transaction, verify GER injection
- [x] Manual: send duplicate `claimAsset`, verify second is rejected
- [x] Manual: send claim to non-zero-padded Ethereum address, verify mapping created

🤖 Generated with [Claude Code](https://claude.com/claude-code)