### PR TITLE
Fix EthAddressFormat encoding and improve bridge claim flow

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,3 @@
 # Config file for typos. For more information, see: https://github.com/crate-ci/typos
 [files]
-extend-exclude = ["*.lock", "dist"]
+extend-exclude = ["*.lock", "dist", "target"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3014,6 +3014,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml 0.9.12+spec-1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,6 +2997,7 @@ dependencies = [
  "alloy-core",
  "alloy-rpc-types-eth",
  "anyhow",
+ "async-trait",
  "axum",
  "axum-jrpc",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ alloy-core = { features = ["sol-types"], version = "1.5.2" }
 alloy-rpc-types-eth = { version = "1.5.2" }
 
 anyhow = { default-features = false, version = "1.0" }
+async-trait = "0.1"
 axum = { features = ["tokio"], version = "0.8" }
 axum-jrpc = { path = "axum-jrpc" }
 clap = { features = ["derive"], version = "4.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ readme = "README.md"
 rust-version = "1.90"
 version = "0.1.0"
 
+[dev-dependencies]
+tempfile = "3.10"
+
 [profile.dev.package."*"]
 opt-level = 1
 

--- a/src/address_mapper.rs
+++ b/src/address_mapper.rs
@@ -12,16 +12,25 @@ const HARDHAT_ADDRESS: Address = Address::new([
 ]);
 
 pub fn is_miden_compatible_address(address: Address) -> bool {
-    address[0..5].iter().all(|b| *b == 0)
+    // The canonical EthAddressFormat embeds AccountId as:
+    //   [4 zero bytes] [prefix(8 bytes)] [suffix(8 bytes)]
+    // Only the first 4 bytes must be zero; byte 4 is the MSB of the prefix.
+    address[0..4].iter().all(|b| *b == 0)
 }
 
 pub fn account_id_from_address(address: Address) -> Option<AccountId> {
     if !is_miden_compatible_address(address) {
         return None;
     }
-    let mut id_bytes = [0u8; 15];
-    id_bytes.copy_from_slice(&address[5..]);
-    AccountId::try_from(id_bytes).ok()
+    // Extract prefix (8 bytes) and suffix (8 bytes) from canonical layout:
+    //   address[0..4]  = zero padding
+    //   address[4..12] = prefix (u64 big-endian)
+    //   address[12..20] = suffix (u64 big-endian)
+    let prefix = u64::from_be_bytes(address[4..12].try_into().ok()?);
+    let suffix = u64::from_be_bytes(address[12..20].try_into().ok()?);
+    let prefix_felt = miden_protocol::Felt::try_from(prefix).ok()?;
+    let suffix_felt = miden_protocol::Felt::try_from(suffix).ok()?;
+    AccountId::try_from([prefix_felt, suffix_felt]).ok()
 }
 
 /// Deterministically derive a Miden AccountId from an Ethereum address.
@@ -164,21 +173,22 @@ mod tests {
         assert!(!is_miden_compatible_address(address!(
             "0x742d35Cc6634C0532925a3b844Bc9e7595f41111"
         )));
+        // Canonical format: 4 zero bytes + 16 bytes of AccountId data
         assert!(is_miden_compatible_address(address!(
-            "0x000000000034C0532925a3b844Bc9e7595f41111"
+            "0x000000003d7c9747558851900f8206226dfbea00"
         )));
     }
 
     #[test]
     fn test_account_id_from_address() {
         let expected_account_id = AccountId::from_hex("0x3d7c9747558851900f8206226dfbea").unwrap();
-        let address = address!("0x00000000003d7c9747558851900f8206226dfbea");
+        // Canonical EthAddressFormat: [4 zero bytes][prefix(8)][suffix(8)]
+        // AccountId 0x3d7c9747558851900f8206226dfbea has:
+        //   prefix = 0x3d7c974755885190, suffix = 0x0f8206226dfbea00
+        let address = address!("0x000000003d7c9747558851900f8206226dfbea00");
         assert_eq!(account_id_from_address(address), Some(expected_account_id));
 
         assert_eq!(account_id_from_address(Address::from([42u8; 20])), None);
-
-        let invalid_address = address!("0x000000000034C0532925a3b844Bc9e7595f41111");
-        assert_eq!(account_id_from_address(invalid_address), None);
     }
 
     #[test]
@@ -209,10 +219,9 @@ mod tests {
     #[test]
     fn test_resolve_zero_padded_address() {
         let mapper = AddressMapper::new(None).unwrap();
-        let addr = address!("0x00000000003d7c9747558851900f8206226dfbea");
+        // Canonical format: 4 zero bytes + prefix(8) + suffix(8)
+        let addr = address!("0x000000003d7c9747558851900f8206226dfbea00");
         let expected = AccountId::from_hex("0x3d7c9747558851900f8206226dfbea").unwrap();
-        // Use a dummy config (won't be used for zero-padded addresses)
-        // We can't easily create a full config here, so test derive_account_id directly
         let result = account_id_from_address(addr);
         assert_eq!(result, Some(expected));
         // Verify the mapper doesn't store zero-padded addresses

--- a/src/block_num_tracker.rs
+++ b/src/block_num_tracker.rs
@@ -18,6 +18,7 @@ impl BlockNumTracker {
     }
 }
 
+#[async_trait::async_trait]
 impl SyncListener for BlockNumTracker {
     fn on_sync(&self, summary: &SyncSummary) {
         let mut latest_ref = self.latest.write().unwrap();

--- a/src/block_state.rs
+++ b/src/block_state.rs
@@ -225,6 +225,7 @@ impl Default for BlockState {
     }
 }
 
+#[async_trait::async_trait]
 impl SyncListener for BlockState {
     fn on_sync(&self, summary: &SyncSummary) {
         self.set_current_block(summary.block_num.as_u64());

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -129,12 +129,13 @@ fn create_claim(
     Ok(note)
 }
 
-/// Compute metadata hash: keccak256 of metadata bytes, or zero for empty metadata.
+/// Compute metadata hash: keccak256 of metadata bytes.
+///
+/// The Solidity bridge contract always uses `keccak256(metadata)` in the leaf
+/// computation, even for empty metadata. For ETH deposits metadata is empty,
+/// so this returns `keccak256("")` = `0xc5d246...`, NOT all zeros.
 fn metadata_to_hash(metadata: &Bytes) -> [u8; 32] {
     use sha3::{Digest, Keccak256};
-    if metadata.is_empty() {
-        return [0u8; 32];
-    }
     let mut hasher = Keccak256::new();
     hasher.update(metadata.as_ref());
     hasher.finalize().into()
@@ -157,6 +158,16 @@ async fn publish_claim_internal(
     latest_block_num: BlockNumber,
 ) -> anyhow::Result<PublishClaimTxn> {
     let faucet = find_target_faucet(params.originTokenAddress, accounts);
+
+    tracing::info!(
+        global_index = %params.globalIndex,
+        origin_network = %params.originNetwork,
+        dest_address = %params.destinationAddress,
+        amount = %params.amount,
+        faucet_id = %crate::accounts_config::AccountIdBech32(faucet.id),
+        "creating CLAIM note"
+    );
+
     let claim_note = create_claim(
         params.clone(),
         faucet,
@@ -177,7 +188,7 @@ async fn publish_claim_internal(
     let txn_id = client
         .submit_new_transaction(accounts.service.0, txn_request)
         .await?;
-    tracing::debug!("submitted claim note txn: {txn_id}, claim_note_id: {claim_note_id}");
+    tracing::info!("submitted claim note txn: {txn_id}, claim_note_id: {claim_note_id}");
 
     let event = ClaimEvent::from(params);
     let log = event.encode_log_data();

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -244,26 +244,30 @@ mod tests {
         let metadata = Bytes::from(vec![]);
         let hash = metadata_to_hash(&metadata);
         // keccak256("")
-        let expected = hex::decode("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470").unwrap();
+        let expected =
+            hex::decode("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+                .unwrap();
         assert_eq!(hash, expected.as_slice());
     }
 
     #[test]
     fn test_find_target_faucet_eth() {
-        let accounts = crate::load_config(None).unwrap_or_else(|_| {
-             unsafe { std::mem::zeroed() }
-        });
-        let faucet = find_target_faucet(address!("0000000000000000000000000000000000000000"), &accounts.0);
+        let accounts = crate::load_config(None).unwrap_or_else(|_| unsafe { std::mem::zeroed() });
+        let faucet = find_target_faucet(
+            address!("0000000000000000000000000000000000000000"),
+            &accounts.0,
+        );
         assert_eq!(faucet.origin_token_decimals, 18);
         assert_eq!(faucet.decimals, 8);
     }
 
     #[test]
     fn test_find_target_faucet_agg() {
-        let accounts = crate::load_config(None).unwrap_or_else(|_| {
-             unsafe { std::mem::zeroed() }
-        });
-        let faucet = find_target_faucet(address!("742d35Cc6634C0532925a3b844Bc9e7595f41111"), &accounts.0);
+        let accounts = crate::load_config(None).unwrap_or_else(|_| unsafe { std::mem::zeroed() });
+        let faucet = find_target_faucet(
+            address!("742d35Cc6634C0532925a3b844Bc9e7595f41111"),
+            &accounts.0,
+        );
         assert_eq!(faucet.origin_token_decimals, 8);
         assert_eq!(faucet.decimals, 8);
     }

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -233,3 +233,38 @@ pub async fn publish_claim(
         .cloned()
         .ok_or_else(|| anyhow::anyhow!("publish_claim: closure completed but result was not set"))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::address;
+
+    #[test]
+    fn test_metadata_to_hash_empty() {
+        let metadata = Bytes::from(vec![]);
+        let hash = metadata_to_hash(&metadata);
+        // keccak256("")
+        let expected = hex::decode("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470").unwrap();
+        assert_eq!(hash, expected.as_slice());
+    }
+
+    #[test]
+    fn test_find_target_faucet_eth() {
+        let accounts = crate::load_config(None).unwrap_or_else(|_| {
+             unsafe { std::mem::zeroed() }
+        });
+        let faucet = find_target_faucet(address!("0000000000000000000000000000000000000000"), &accounts.0);
+        assert_eq!(faucet.origin_token_decimals, 18);
+        assert_eq!(faucet.decimals, 8);
+    }
+
+    #[test]
+    fn test_find_target_faucet_agg() {
+        let accounts = crate::load_config(None).unwrap_or_else(|_| {
+             unsafe { std::mem::zeroed() }
+        });
+        let faucet = find_target_faucet(address!("742d35Cc6634C0532925a3b844Bc9e7595f41111"), &accounts.0);
+        assert_eq!(faucet.origin_token_decimals, 8);
+        assert_eq!(faucet.decimals, 8);
+    }
+}

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -76,9 +76,27 @@ async fn submit_ger_to_miden(
     tracing::info!(
         tx_id = %tx_id,
         ger = %hex::encode(ger_bytes),
-        "UpdateGerNote submitted to Miden node"
+        "UpdateGerNote submitted to Miden node, waiting for commit..."
     );
 
+    // Poll for transaction commitment (max 30s)
+    let mut committed = false;
+    for _ in 0..30 {
+        // We can check if txn is in the store and has a block number
+        let txns = client.get_transactions(miden_client::store::TransactionFilter::All).await?;
+        if txns.iter().any(|t| t.id == tx_id && matches!(t.status, miden_client::transaction::TransactionStatus::Committed { .. })) {
+            committed = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        client.sync_state().await?; // Sync to get latest updates
+    }
+
+    if !committed {
+        anyhow::bail!("UpdateGerNote transaction {tx_id} not committed after 30s");
+    }
+
+    tracing::info!(tx_id = %tx_id, "UpdateGerNote transaction committed");
     Ok(())
 }
 

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -83,8 +83,16 @@ async fn submit_ger_to_miden(
     let mut committed = false;
     for _ in 0..30 {
         // We can check if txn is in the store and has a block number
-        let txns = client.get_transactions(miden_client::store::TransactionFilter::All).await?;
-        if txns.iter().any(|t| t.id == tx_id && matches!(t.status, miden_client::transaction::TransactionStatus::Committed { .. })) {
+        let txns = client
+            .get_transactions(miden_client::store::TransactionFilter::All)
+            .await?;
+        if txns.iter().any(|t| {
+            t.id == tx_id
+                && matches!(
+                    t.status,
+                    miden_client::transaction::TransactionStatus::Committed { .. }
+                )
+        }) {
             committed = true;
             break;
         }

--- a/src/init.rs
+++ b/src/init.rs
@@ -2,7 +2,9 @@ use crate::accounts_config;
 use crate::accounts_config::{AccountIdBech32, AccountsConfig};
 use crate::miden_client::MidenClient;
 use crate::miden_client::MidenClientLib;
-use miden_base_agglayer::{EthAddressFormat, create_agglayer_faucet, create_bridge_account};
+use miden_base_agglayer::{
+    ConfigAggBridgeNote, EthAddressFormat, create_agglayer_faucet, create_bridge_account,
+};
 use miden_client::Felt;
 use miden_client::asset::FungibleAsset;
 use miden_client::crypto::FeltRng;
@@ -146,6 +148,35 @@ async fn add_accounts(
     })
 }
 
+async fn register_faucet_in_bridge(
+    client: &mut MidenClientLib,
+    service_id: AccountId,
+    bridge_id: AccountId,
+    faucet_id: AccountId,
+    faucet_name: &str,
+) -> anyhow::Result<()> {
+    tracing::info!(
+        "registering {} faucet {} in bridge {}...",
+        faucet_name,
+        AccountIdBech32(faucet_id),
+        AccountIdBech32(bridge_id),
+    );
+
+    let note = ConfigAggBridgeNote::create(faucet_id, service_id, bridge_id, client.rng())
+        .map_err(|e| anyhow::anyhow!("failed to create ConfigAggBridgeNote: {e}"))?;
+
+    let txn = TransactionRequestBuilder::new()
+        .own_output_notes([OutputNote::Full(note); 1])
+        .build()?;
+
+    let txn_id = client.submit_new_transaction(service_id, txn).await?;
+    tracing::info!(
+        "registered {} faucet in bridge with txn_id {txn_id}",
+        faucet_name,
+    );
+    Ok(())
+}
+
 async fn register_p2id_script(
     client: &mut MidenClientLib,
     sender: AccountId,
@@ -177,6 +208,25 @@ async fn init_internal(
 ) -> anyhow::Result<PathBuf> {
     client.sync_state().await?;
     let accounts = add_accounts(client, keystore).await?;
+
+    // Register faucets in bridge's faucet registry (required for CLAIM note FPI validation)
+    register_faucet_in_bridge(
+        client,
+        accounts.service.id(),
+        accounts.bridge.id(),
+        accounts.faucet_eth.id(),
+        "ETH",
+    )
+    .await?;
+    register_faucet_in_bridge(
+        client,
+        accounts.service.id(),
+        accounts.bridge.id(),
+        accounts.faucet_agg.id(),
+        "AGG",
+    )
+    .await?;
+
     register_p2id_script(client, accounts.service.id()).await?;
     let config = AccountsConfig::from(accounts);
     let config_path = accounts_config::save_config(config, miden_store_dir)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,10 @@ pub mod log_synthesis;
 pub mod logging;
 pub mod miden_client;
 pub mod nonce_tracker;
+pub mod service;
+pub mod service_get_txn_receipt;
+pub mod service_send_raw_txn;
+pub mod service_state;
 mod txn_manager;
 
 pub const COMPONENT: &str = "miden-agglayer";
@@ -23,6 +27,7 @@ pub use claim_tracker::ClaimTracker;
 pub use miden_client::MidenClient;
 pub use nonce_tracker::NonceTracker;
 pub use txn_manager::TxnManager;
+pub use service_state::ServiceState;
 
 #[derive(Clone)]
 pub struct AccountsConfig(accounts_config::AccountsConfig);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,8 @@ pub use block_num_tracker::BlockNumTracker;
 pub use claim_tracker::ClaimTracker;
 pub use miden_client::MidenClient;
 pub use nonce_tracker::NonceTracker;
-pub use txn_manager::TxnManager;
 pub use service_state::ServiceState;
+pub use txn_manager::TxnManager;
 
 #[derive(Clone)]
 pub struct AccountsConfig(accounts_config::AccountsConfig);

--- a/src/log_synthesis.rs
+++ b/src/log_synthesis.rs
@@ -122,12 +122,16 @@ impl LogFilter {
                     addrs.iter().any(|a| a.to_lowercase() == log_addr)
                 }
             };
-            
+
             // SPECIAL CASE: The bridge-service filters logs by the Bridge contract address.
             // However, it ALSO needs UpdateHashChainValue logs which are emitted by the
             // GlobalExitRoot contract. If the log is an UpdateHashChainValue, we allow it
             // through even if the address doesn't match the filter.
-            let is_ger_update = log.topics.get(0).map(|t| t.to_lowercase() == UPDATE_HASH_CHAIN_VALUE_TOPIC.to_lowercase()).unwrap_or(false);
+            let is_ger_update = log
+                .topics
+                .first()
+                .map(|t| t.to_lowercase() == UPDATE_HASH_CHAIN_VALUE_TOPIC.to_lowercase())
+                .unwrap_or(false);
 
             if !matches_addr && !is_ger_update {
                 return false;

--- a/src/log_synthesis.rs
+++ b/src/log_synthesis.rs
@@ -122,7 +122,14 @@ impl LogFilter {
                     addrs.iter().any(|a| a.to_lowercase() == log_addr)
                 }
             };
-            if !matches_addr {
+            
+            // SPECIAL CASE: The bridge-service filters logs by the Bridge contract address.
+            // However, it ALSO needs UpdateHashChainValue logs which are emitted by the
+            // GlobalExitRoot contract. If the log is an UpdateHashChainValue, we allow it
+            // through even if the address doesn't match the filter.
+            let is_ger_update = log.topics.get(0).map(|t| t.to_lowercase() == UPDATE_HASH_CHAIN_VALUE_TOPIC.to_lowercase()).unwrap_or(false);
+
+            if !matches_addr && !is_ger_update {
                 return false;
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,13 @@
-use crate::service_state::ServiceState;
-use clap::Parser;
+use miden_agglayer_service::service_state::ServiceState;
+use miden_agglayer_service::*;
+use miden_agglayer_service::service;
 use miden_agglayer_service::block_state::BlockState;
 use miden_agglayer_service::log_synthesis::LogStore;
-use miden_agglayer_service::*;
+use clap::Parser;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use url::Url;
-
-mod service;
-mod service_get_txn_receipt;
-mod service_send_raw_txn;
-pub mod service_state;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -71,12 +67,12 @@ async fn main() -> anyhow::Result<()> {
     let accounts = load_config(miden_store_dir.clone())?;
     let claim_persistence_path = miden_store_dir
         .as_ref()
-        .map(|d| d.join("claimed_indices.json"));
+        .map(|d: &PathBuf| d.join("claimed_indices.json"));
     let claim_tracker = Arc::new(ClaimTracker::new(claim_persistence_path)?);
     let nonce_tracker = Arc::new(NonceTracker::new());
     let address_persistence_path = miden_store_dir
         .as_ref()
-        .map(|d| d.join("address_mappings.json"));
+        .map(|d: &PathBuf| d.join("address_mappings.json"));
     let address_mapper = Arc::new(AddressMapper::new(address_persistence_path)?);
 
     let state = ServiceState::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
-use miden_agglayer_service::service_state::ServiceState;
-use miden_agglayer_service::*;
-use miden_agglayer_service::service;
+use clap::Parser;
 use miden_agglayer_service::block_state::BlockState;
 use miden_agglayer_service::log_synthesis::LogStore;
-use clap::Parser;
+use miden_agglayer_service::service;
+use miden_agglayer_service::service_state::ServiceState;
+use miden_agglayer_service::*;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,9 +44,9 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("{command:?}");
 
     let block_num_tracker = Arc::new(BlockNumTracker::new());
-    let txn_manager = Arc::new(TxnManager::new());
     let block_state = Arc::new(BlockState::new());
     let log_store = Arc::new(LogStore::new());
+    let txn_manager = Arc::new(TxnManager::new(log_store.clone(), block_state.clone()));
 
     let miden_store_dir = command.miden_store_dir;
     let client = MidenClient::new(

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -88,14 +88,14 @@ impl MidenClient {
 
     #[cfg(test)]
     pub fn new_test() -> Self {
-        let store_dir = tempfile::tempdir().unwrap().into_path();
+        let store_dir = tempfile::tempdir().unwrap().keep();
         let keystore_path = store_dir.join("keystore");
         std::fs::create_dir_all(&keystore_path).unwrap();
         let keystore = FilesystemKeyStore::new(keystore_path).unwrap();
         let keystore = Arc::new(keystore);
         let (sender, mut receiver) = mpsc::channel::<Request>(1);
         let (done_sender, _done_receiver) = oneshot::channel::<()>();
-        
+
         // Start a mock task to handle 'with' calls
         thread::spawn(move || {
             while let Some(req) = receiver.blocking_recv() {
@@ -295,13 +295,15 @@ mod tests {
     #[tokio::test]
     async fn test_miden_client_test_with() {
         let client = MidenClient::new_test();
-        let res = client.with(|_client| {
-            Box::new(async move {
-                // This won't actually run in new_test's background thread
-                Ok(())
+        let res = client
+            .with(|_client| {
+                Box::new(async move {
+                    // This won't actually run in new_test's background thread
+                    Ok(())
+                })
             })
-        }).await;
-        
+            .await;
+
         // new_test background thread returns Ok(()) directly
         assert!(res.is_ok());
     }

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -26,8 +26,12 @@ struct Request {
     closure: BoxFutureFactory,
 }
 
+#[async_trait::async_trait]
 pub trait SyncListener: Send + Sync {
     fn on_sync(&self, summary: &SyncSummary);
+    async fn on_post_sync(&self, _client: &mut MidenClientLib) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 pub struct MidenClient {
@@ -169,13 +173,15 @@ impl MidenClient {
         }
     }
 
-    fn on_sync(
+    async fn on_sync(
         result: anyhow::Result<SyncSummary>,
+        client: &mut MidenClientLib,
         listeners: &[Arc<dyn SyncListener>],
     ) -> anyhow::Result<()> {
         let summary = result?;
         for listener in listeners {
             listener.on_sync(&summary);
+            listener.on_post_sync(client).await?;
         }
         Ok(())
     }
@@ -201,7 +207,7 @@ impl MidenClient {
 
         // initial sync
         tokio::select! {
-            result = Self::sync(&mut client) => Self::on_sync(result, &sync_listeners)?,
+            result = Self::sync(&mut client) => Self::on_sync(result, &mut client, &sync_listeners).await?,
             _ = &mut done_receiver => {
                 tracing::debug!("MidenClient::run loop done");
                 return Ok(());
@@ -218,7 +224,7 @@ impl MidenClient {
                 },
                 _ = sync_interval.tick() => {
                     tokio::select! {
-                        result = Self::sync(&mut client) => Self::on_sync(result, &sync_listeners)?,
+                        result = Self::sync(&mut client) => Self::on_sync(result, &mut client, &sync_listeners).await?,
                         _ = &mut done_receiver => break,
                     }
                 },

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -86,6 +86,33 @@ impl MidenClient {
         })
     }
 
+    #[cfg(test)]
+    pub fn new_test() -> Self {
+        let store_dir = tempfile::tempdir().unwrap().into_path();
+        let keystore_path = store_dir.join("keystore");
+        std::fs::create_dir_all(&keystore_path).unwrap();
+        let keystore = FilesystemKeyStore::new(keystore_path).unwrap();
+        let keystore = Arc::new(keystore);
+        let (sender, mut receiver) = mpsc::channel::<Request>(1);
+        let (done_sender, _done_receiver) = oneshot::channel::<()>();
+        
+        // Start a mock task to handle 'with' calls
+        thread::spawn(move || {
+            while let Some(req) = receiver.blocking_recv() {
+                // We can't actually run the closure because it needs MidenClientLib,
+                // which we don't have. But we can just signal success for tests.
+                let _ = req.response_sender.send(Ok(()));
+            }
+        });
+
+        Self {
+            keystore,
+            task: std::sync::Mutex::new(None),
+            sender,
+            done_sender: std::sync::Mutex::new(Some(done_sender)),
+        }
+    }
+
     fn default_store_dir() -> PathBuf {
         let current_dir = env::current_dir().unwrap_or(PathBuf::from("."));
         let base_dir = env::home_dir().unwrap_or(current_dir);
@@ -258,5 +285,24 @@ impl MidenClient {
             anyhow::bail!("MidenClient::with: failed to get a response - receiver is closed");
         };
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_miden_client_test_with() {
+        let client = MidenClient::new_test();
+        let res = client.with(|_client| {
+            Box::new(async move {
+                // This won't actually run in new_test's background thread
+                Ok(())
+            })
+        }).await;
+        
+        // new_test background thread returns Ok(()) directly
+        assert!(res.is_ok());
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -13,7 +13,7 @@ use axum::routing::post;
 use axum_jrpc::error::{JsonRpcError, JsonRpcErrorReason};
 use axum_jrpc::{JrpcResult, JsonRpcExtractor, JsonRpcResponse};
 use http::HeaderValue;
-use miden_agglayer_service::log_synthesis::LogFilter;
+use crate::log_synthesis::LogFilter;
 use serde::Deserialize;
 use std::str::FromStr;
 use tokio::net::TcpListener;
@@ -132,8 +132,8 @@ async fn json_rpc_endpoint(
             let full_txns = params.1;
             let block = service.block_state.get_block_by_number(block_num);
             match block {
-                Some(b) => Ok(JsonRpcResponse::success(answer_id, b.to_json(full_txns))),
-                None => Ok(JsonRpcResponse::success(answer_id, serde_json::Value::Null)),
+                Some(b) => Ok(JsonRpcResponse::success::<serde_json::Value, _>(answer_id, b.to_json(full_txns))),
+                None => Ok(JsonRpcResponse::success::<serde_json::Value, _>(answer_id, serde_json::Value::Null)),
             }
         }
 
@@ -159,8 +159,8 @@ async fn json_rpc_endpoint(
             let full_txns = params.1;
             let block = service.block_state.get_block_by_hash(&hash);
             match block {
-                Some(b) => Ok(JsonRpcResponse::success(answer_id, b.to_json(full_txns))),
-                None => Ok(JsonRpcResponse::success(answer_id, serde_json::Value::Null)),
+                Some(b) => Ok(JsonRpcResponse::success::<serde_json::Value, _>(answer_id, b.to_json(full_txns))),
+                None => Ok(JsonRpcResponse::success::<serde_json::Value, _>(answer_id, serde_json::Value::Null)),
             }
         }
 
@@ -259,9 +259,9 @@ async fn json_rpc_endpoint(
             let current_block = service.block_num_tracker.latest();
             let synthetic_logs = service.log_store.get_logs(&log_filter, current_block);
             let json_logs: Vec<serde_json::Value> =
-                synthetic_logs.iter().map(|l| l.to_json()).collect();
+                synthetic_logs.iter().map(|l: &crate::log_synthesis::SyntheticLog| l.to_json()).collect();
 
-            Ok(JsonRpcResponse::success(answer_id, json_logs))
+            Ok(JsonRpcResponse::success::<Vec<serde_json::Value>, _>(answer_id, json_logs))
         }
 
         "eth_getBalance" => {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,7 @@
 use crate::COMPONENT;
 use crate::hex::hex_decode_prefixed;
 use crate::hex::hex_decode_u64;
+use crate::log_synthesis::LogFilter;
 use crate::service_get_txn_receipt::service_get_txn_receipt;
 use crate::service_send_raw_txn::service_send_raw_txn;
 use crate::service_state::ServiceState;
@@ -13,7 +14,6 @@ use axum::routing::post;
 use axum_jrpc::error::{JsonRpcError, JsonRpcErrorReason};
 use axum_jrpc::{JrpcResult, JsonRpcExtractor, JsonRpcResponse};
 use http::HeaderValue;
-use crate::log_synthesis::LogFilter;
 use serde::Deserialize;
 use std::str::FromStr;
 use tokio::net::TcpListener;
@@ -132,8 +132,14 @@ async fn json_rpc_endpoint(
             let full_txns = params.1;
             let block = service.block_state.get_block_by_number(block_num);
             match block {
-                Some(b) => Ok(JsonRpcResponse::success::<serde_json::Value, _>(answer_id, b.to_json(full_txns))),
-                None => Ok(JsonRpcResponse::success::<serde_json::Value, _>(answer_id, serde_json::Value::Null)),
+                Some(b) => Ok(JsonRpcResponse::success::<serde_json::Value, _>(
+                    answer_id,
+                    b.to_json(full_txns),
+                )),
+                None => Ok(JsonRpcResponse::success::<serde_json::Value, _>(
+                    answer_id,
+                    serde_json::Value::Null,
+                )),
             }
         }
 
@@ -159,8 +165,14 @@ async fn json_rpc_endpoint(
             let full_txns = params.1;
             let block = service.block_state.get_block_by_hash(&hash);
             match block {
-                Some(b) => Ok(JsonRpcResponse::success::<serde_json::Value, _>(answer_id, b.to_json(full_txns))),
-                None => Ok(JsonRpcResponse::success::<serde_json::Value, _>(answer_id, serde_json::Value::Null)),
+                Some(b) => Ok(JsonRpcResponse::success::<serde_json::Value, _>(
+                    answer_id,
+                    b.to_json(full_txns),
+                )),
+                None => Ok(JsonRpcResponse::success::<serde_json::Value, _>(
+                    answer_id,
+                    serde_json::Value::Null,
+                )),
             }
         }
 
@@ -258,10 +270,14 @@ async fn json_rpc_endpoint(
             let log_filter: LogFilter = serde_json::from_value(raw_params.0).unwrap_or_default();
             let current_block = service.block_num_tracker.latest();
             let synthetic_logs = service.log_store.get_logs(&log_filter, current_block);
-            let json_logs: Vec<serde_json::Value> =
-                synthetic_logs.iter().map(|l: &crate::log_synthesis::SyntheticLog| l.to_json()).collect();
+            let json_logs: Vec<serde_json::Value> = synthetic_logs
+                .iter()
+                .map(|l: &crate::log_synthesis::SyntheticLog| l.to_json())
+                .collect();
 
-            Ok(JsonRpcResponse::success::<Vec<serde_json::Value>, _>(answer_id, json_logs))
+            Ok(JsonRpcResponse::success::<Vec<serde_json::Value>, _>(
+                answer_id, json_logs,
+            ))
         }
 
         "eth_getBalance" => {

--- a/src/service_get_txn_receipt.rs
+++ b/src/service_get_txn_receipt.rs
@@ -12,8 +12,9 @@ pub async fn service_get_txn_receipt(
     txn_hash: String,
 ) -> anyhow::Result<Option<TransactionReceipt<ReceiptEnvelope>>> {
     let txn_hash = TxHash::from_str(&txn_hash)?;
-    let Some((result, block_num)) = service.txn_manager.receipt(txn_hash) else {
-        return Ok(None);
+    let (result, block_num) = match service.txn_manager.receipt(txn_hash) {
+        Some((result, block_num)) => (result, block_num),
+        None => return Ok(None),
     };
     let status = result.is_ok();
 
@@ -36,4 +37,87 @@ pub async fn service_get_txn_receipt(
         contract_address: None,
     };
     Ok(Some(receipt))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_num_tracker::BlockNumTracker;
+    use crate::block_state::BlockState;
+    use crate::log_synthesis::LogStore;
+    use crate::nonce_tracker::NonceTracker;
+    use crate::txn_manager::TxnManager;
+    use crate::{AddressMapper, ClaimTracker, MidenClient};
+    use alloy::consensus::TxEnvelope;
+    use alloy::primitives::TxHash;
+    use std::sync::Arc;
+
+    fn create_test_service() -> ServiceState {
+        let log_store = Arc::new(LogStore::new());
+        let block_state = Arc::new(BlockState::new());
+        let txn_manager = Arc::new(TxnManager::new(log_store.clone(), block_state.clone()));
+        let miden_client = MidenClient::new_test();
+        let block_num_tracker = Arc::new(BlockNumTracker::new());
+        let nonce_tracker = Arc::new(NonceTracker::new());
+        let claim_tracker = Arc::new(ClaimTracker::new(None).unwrap());
+        let address_mapper = Arc::new(AddressMapper::new(None).unwrap());
+        
+        // Mock AccountsConfig - since it's a wrapper, we might need a way to create it.
+        // For now, let's assume it can be empty.
+        let accounts = crate::load_config(None).unwrap_or_else(|_| {
+             unsafe { std::mem::zeroed() }
+        });
+
+        ServiceState::new(
+            miden_client,
+            accounts,
+            1,
+            block_num_tracker,
+            txn_manager,
+            block_state,
+            log_store,
+            claim_tracker,
+            nonce_tracker,
+            address_mapper,
+        )
+    }
+
+    #[tokio::test]
+    async fn test_service_get_txn_receipt_not_found() {
+        let service = create_test_service();
+        let txn_hash = TxHash::from([1u8; 32]).to_string();
+        let result = service_get_txn_receipt(service, txn_hash).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_service_get_txn_receipt_found() {
+        let service = create_test_service();
+        let txn_hash = TxHash::from([2u8; 32]);
+        
+        // Mock a transaction in TxnManager
+        // We need a TxEnvelope. Legacy is easiest to create dummy.
+        let txn_envelope = TxEnvelope::Legacy(alloy::consensus::Signed::new_unchecked(
+            alloy::consensus::TxLegacy::default(),
+            alloy::primitives::Signature::test_signature(),
+            txn_hash,
+        ));
+
+        service.txn_manager.begin(
+            txn_hash,
+            None,
+            txn_envelope,
+            None,
+            vec![],
+        ).unwrap();
+        
+        service.txn_manager.commit(txn_hash, Ok(()), 123).unwrap();
+
+        let result = service_get_txn_receipt(service, txn_hash.to_string()).await.unwrap();
+        assert!(result.is_some());
+        let receipt = result.unwrap();
+        assert_eq!(receipt.transaction_hash, txn_hash);
+        assert_eq!(receipt.block_number, Some(123));
+        assert!(matches!(receipt.inner.as_receipt().unwrap().status, alloy::consensus::Eip658Value::Eip658(true)));
+    }
 }

--- a/src/service_get_txn_receipt.rs
+++ b/src/service_get_txn_receipt.rs
@@ -61,12 +61,10 @@ mod tests {
         let nonce_tracker = Arc::new(NonceTracker::new());
         let claim_tracker = Arc::new(ClaimTracker::new(None).unwrap());
         let address_mapper = Arc::new(AddressMapper::new(None).unwrap());
-        
+
         // Mock AccountsConfig - since it's a wrapper, we might need a way to create it.
         // For now, let's assume it can be empty.
-        let accounts = crate::load_config(None).unwrap_or_else(|_| {
-             unsafe { std::mem::zeroed() }
-        });
+        let accounts = crate::load_config(None).unwrap_or_else(|_| unsafe { std::mem::zeroed() });
 
         ServiceState::new(
             miden_client,
@@ -94,7 +92,7 @@ mod tests {
     async fn test_service_get_txn_receipt_found() {
         let service = create_test_service();
         let txn_hash = TxHash::from([2u8; 32]);
-        
+
         // Mock a transaction in TxnManager
         // We need a TxEnvelope. Legacy is easiest to create dummy.
         let txn_envelope = TxEnvelope::Legacy(alloy::consensus::Signed::new_unchecked(
@@ -103,21 +101,23 @@ mod tests {
             txn_hash,
         ));
 
-        service.txn_manager.begin(
-            txn_hash,
-            None,
-            txn_envelope,
-            None,
-            vec![],
-        ).unwrap();
-        
+        service
+            .txn_manager
+            .begin(txn_hash, None, txn_envelope, None, vec![])
+            .unwrap();
+
         service.txn_manager.commit(txn_hash, Ok(()), 123).unwrap();
 
-        let result = service_get_txn_receipt(service, txn_hash.to_string()).await.unwrap();
+        let result = service_get_txn_receipt(service, txn_hash.to_string())
+            .await
+            .unwrap();
         assert!(result.is_some());
         let receipt = result.unwrap();
         assert_eq!(receipt.transaction_hash, txn_hash);
         assert_eq!(receipt.block_number, Some(123));
-        assert!(matches!(receipt.inner.as_receipt().unwrap().status, alloy::consensus::Eip658Value::Eip658(true)));
+        assert!(matches!(
+            receipt.inner.as_receipt().unwrap().status,
+            alloy::consensus::Eip658Value::Eip658(true)
+        ));
     }
 }

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -5,9 +5,9 @@ use alloy::consensus::transaction::SignerRecoverable;
 use alloy::eips::Decodable2718;
 use alloy::primitives::TxHash;
 use alloy_core::sol_types::SolCall;
-use miden_agglayer_service::claim::claimAssetCall;
-use miden_agglayer_service::ger::{insertGlobalExitRootCall, updateExitRootCall};
-use miden_agglayer_service::*;
+use crate::claim::claimAssetCall;
+use crate::ger::{insertGlobalExitRootCall, updateExitRootCall};
+use crate::*;
 
 struct TransactionData {
     pub hash: TxHash,
@@ -144,12 +144,14 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         tracing::debug!("updateExitRoot call");
         let params = updateExitRootCall::abi_decode(params_encoded)?;
         tracing::debug!(target: concat!(module_path!(), "::debug"), "updateExitRoot call params: {params:?}");
-        let ger_bytes =
-            ger::combined_ger(&params.newMainnetExitRoot.0, &params.newRollupExitRoot.0);
+        
+        let mainnet_root = params.newMainnetExitRoot.0;
+        let rollup_root = params.newRollupExitRoot.0;
+        let combined_ger = ger::combined_ger(&mainnet_root, &rollup_root);
 
         handle_ger_result(
             ger::insert_ger(
-                ger_bytes,
+                combined_ger,
                 &service.miden_client,
                 service.accounts.clone(),
                 &service.log_store,
@@ -168,4 +170,82 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
 
     service.nonce_tracker.increment(&format!("{signer:#x}"));
     Ok(txn_hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_num_tracker::BlockNumTracker;
+    use crate::block_state::BlockState;
+    use crate::log_synthesis::LogStore;
+    use crate::nonce_tracker::NonceTracker;
+    use crate::txn_manager::TxnManager;
+    use crate::{AddressMapper, ClaimTracker, MidenClient, ServiceState};
+    use alloy::consensus::{TxEnvelope, Signed, TxLegacy};
+    use alloy::primitives::{TxHash, Signature};
+    use alloy::eips::Encodable2718;
+    use std::sync::Arc;
+
+    fn create_test_service() -> ServiceState {
+        let log_store = Arc::new(LogStore::new());
+        let block_state = Arc::new(BlockState::new());
+        let txn_manager = Arc::new(TxnManager::new(log_store.clone(), block_state.clone()));
+        let miden_client = MidenClient::new_test();
+        let block_num_tracker = Arc::new(BlockNumTracker::new());
+        let nonce_tracker = Arc::new(NonceTracker::new());
+        let claim_tracker = Arc::new(ClaimTracker::new(None).unwrap());
+        let address_mapper = Arc::new(AddressMapper::new(None).unwrap());
+        
+        let accounts = crate::load_config(None).unwrap_or_else(|_| {
+             unsafe { std::mem::zeroed() }
+        });
+
+        ServiceState::new(
+            miden_client,
+            accounts,
+            1,
+            block_num_tracker,
+            txn_manager,
+            block_state,
+            log_store,
+            claim_tracker,
+            nonce_tracker,
+            address_mapper,
+        )
+    }
+
+    #[tokio::test]
+    async fn test_service_send_raw_txn_invalid_hex() {
+        let service = create_test_service();
+        let result = service_send_raw_txn(service, "invalid".to_string()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_service_send_raw_txn_invalid_rlp() {
+        let service = create_test_service();
+        let result = service_send_raw_txn(service, "0x1234".to_string()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_service_send_raw_txn_unhandled_method() {
+        let service = create_test_service();
+        
+        // Create a dummy transaction with some random input
+        let txn = TxLegacy {
+            input: alloy::primitives::bytes!("12345678"),
+            ..Default::default()
+        };
+        let signature = Signature::test_signature();
+        let signed_txn = Signed::new_unchecked(txn, signature, TxHash::default());
+        let envelope = TxEnvelope::Legacy(signed_txn);
+        let mut encoded = Vec::new();
+        envelope.encode_2718(&mut encoded);
+        let input_hex = format!("0x{}", ::hex::encode(encoded));
+
+        let result = service_send_raw_txn(service, input_hex).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("unhandled txn method"));
+    }
 }

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -1,13 +1,13 @@
+use crate::claim::claimAssetCall;
+use crate::ger::{insertGlobalExitRootCall, updateExitRootCall};
 use crate::hex::hex_decode_prefixed;
 use crate::service_state::ServiceState;
+use crate::*;
 use alloy::consensus::TxEnvelope;
 use alloy::consensus::transaction::SignerRecoverable;
 use alloy::eips::Decodable2718;
 use alloy::primitives::TxHash;
 use alloy_core::sol_types::SolCall;
-use crate::claim::claimAssetCall;
-use crate::ger::{insertGlobalExitRootCall, updateExitRootCall};
-use crate::*;
 
 struct TransactionData {
     pub hash: TxHash,
@@ -144,7 +144,7 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         tracing::debug!("updateExitRoot call");
         let params = updateExitRootCall::abi_decode(params_encoded)?;
         tracing::debug!(target: concat!(module_path!(), "::debug"), "updateExitRoot call params: {params:?}");
-        
+
         let mainnet_root = params.newMainnetExitRoot.0;
         let rollup_root = params.newRollupExitRoot.0;
         let combined_ger = ger::combined_ger(&mainnet_root, &rollup_root);
@@ -181,9 +181,9 @@ mod tests {
     use crate::nonce_tracker::NonceTracker;
     use crate::txn_manager::TxnManager;
     use crate::{AddressMapper, ClaimTracker, MidenClient, ServiceState};
-    use alloy::consensus::{TxEnvelope, Signed, TxLegacy};
-    use alloy::primitives::{TxHash, Signature};
+    use alloy::consensus::{Signed, TxEnvelope, TxLegacy};
     use alloy::eips::Encodable2718;
+    use alloy::primitives::{Signature, TxHash};
     use std::sync::Arc;
 
     fn create_test_service() -> ServiceState {
@@ -195,10 +195,8 @@ mod tests {
         let nonce_tracker = Arc::new(NonceTracker::new());
         let claim_tracker = Arc::new(ClaimTracker::new(None).unwrap());
         let address_mapper = Arc::new(AddressMapper::new(None).unwrap());
-        
-        let accounts = crate::load_config(None).unwrap_or_else(|_| {
-             unsafe { std::mem::zeroed() }
-        });
+
+        let accounts = crate::load_config(None).unwrap_or_else(|_| unsafe { std::mem::zeroed() });
 
         ServiceState::new(
             miden_client,
@@ -231,7 +229,7 @@ mod tests {
     #[tokio::test]
     async fn test_service_send_raw_txn_unhandled_method() {
         let service = create_test_service();
-        
+
         // Create a dummy transaction with some random input
         let txn = TxLegacy {
             input: alloy::primitives::bytes!("12345678"),
@@ -246,6 +244,11 @@ mod tests {
 
         let result = service_send_raw_txn(service, input_hex).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("unhandled txn method"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("unhandled txn method")
+        );
     }
 }

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -1,6 +1,6 @@
-use miden_agglayer_service::block_state::BlockState;
-use miden_agglayer_service::log_synthesis::LogStore;
-use miden_agglayer_service::*;
+use crate::block_state::BlockState;
+use crate::log_synthesis::LogStore;
+use crate::*;
 use std::sync::Arc;
 
 #[derive(Clone)]

--- a/src/txn_manager.rs
+++ b/src/txn_manager.rs
@@ -1,13 +1,16 @@
-use crate::miden_client::SyncListener;
+use crate::block_state::BlockState;
+use crate::log_synthesis::{LogStore, SyntheticLog};
+use crate::miden_client::{MidenClientLib, SyncListener};
 use alloy::consensus::TxEnvelope;
 use alloy::consensus::transaction::{Recovered, SignerRecoverable};
 use alloy::primitives::{Address, BlockNumber, LogData, TxHash};
 use alloy_rpc_types_eth::{Filter, Log};
 use lru::LruCache;
 use miden_client::sync::SyncSummary;
+use miden_protocol::note::NoteId;
 use miden_protocol::transaction::TransactionId;
 use std::num::NonZeroUsize;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 /// Maximum blocks to wait for CLAIM note consumption before reverting.
 const CLAIM_CONSUMPTION_TIMEOUT_BLOCKS: u64 = 50;
@@ -31,16 +34,20 @@ struct TxnReceipt {
 
 pub struct TxnManager {
     transactions: Mutex<LruCache<TxHash, TxnReceipt>>,
+    log_store: Arc<LogStore>,
+    block_state: Arc<BlockState>,
 }
 
 const fn assert_sync<T: Send + Sync>() {}
 const _: () = assert_sync::<TxnManager>();
 
 impl TxnManager {
-    pub fn new() -> Self {
+    pub fn new(log_store: Arc<LogStore>, block_state: Arc<BlockState>) -> Self {
         let transactions = LruCache::new(NonZeroUsize::new(10_000).unwrap());
         Self {
             transactions: Mutex::new(transactions),
+            log_store,
+            block_state,
         }
     }
 
@@ -147,8 +154,8 @@ impl TxnManager {
     pub fn receipt(&self, txn_hash: TxHash) -> Option<(Result<(), String>, BlockNumber)> {
         let transactions = self.transactions.lock().unwrap();
         let receipt = transactions.peek(&txn_hash)?;
-        // If awaiting consumption (has claim_note_id but no result), return None (pending)
-        if receipt.claim_note_id.is_some() && receipt.result.is_none() {
+        // If awaiting consumption (has claim_note_id), return None (pending) until cleared
+        if receipt.claim_note_id.is_some() {
             return None;
         }
         let result = receipt.result.clone()?;
@@ -279,17 +286,75 @@ impl TxnManager {
     }
 }
 
-impl Default for TxnManager {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
+#[async_trait::async_trait]
 impl SyncListener for TxnManager {
     fn on_sync(&self, summary: &SyncSummary) {
         let block_num = summary.block_num.as_u64();
         self.commit_pending(&summary.committed_transactions, block_num);
         self.expire_pending(block_num);
         self.expire_timed_out_claims(block_num);
+    }
+
+    async fn on_post_sync(&self, client: &mut MidenClientLib) -> anyhow::Result<()> {
+        let awaiting: Vec<(TxHash, String)> = {
+            let transactions = self.transactions.lock().unwrap();
+            transactions
+                .iter()
+                .filter_map(|(hash, receipt)| {
+                    // Only check consumption if the creation txn is already committed
+                    if receipt.result.is_some() {
+                        receipt.claim_note_id.as_ref().map(|id| (*hash, id.clone()))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
+
+        for (txn_hash, note_id_str) in awaiting {
+            let note_id = NoteId::try_from_hex(&note_id_str)
+                .map_err(|e| anyhow::anyhow!("bad note id {note_id_str}: {e}"))?;
+
+            // Query client for note status. miden-client::Client::get_input_note is async.
+            let note_opt = client
+                .get_input_note(note_id)
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to get note {note_id_str}: {e}"))?;
+
+            if let Some(note) = note_opt
+                && note.is_consumed()
+            {
+                tracing::info!(
+                    "CLAIM note {note_id_str} consumed, finalizing eth txn {txn_hash}"
+                );
+
+                let mut transactions = self.transactions.lock().unwrap();
+                if let Some(receipt) = transactions.get_mut(&txn_hash) {
+                    receipt.claim_note_id = None;
+                    let logs = receipt.logs.clone();
+                    let block_num = receipt.block_num;
+                    let signer = receipt.signer;
+                    drop(transactions);
+
+                    // Add logs to LogStore once consumed
+                    for log_data in logs {
+                        let block_hash = self.block_state.get_block_hash(block_num);
+                        let log = SyntheticLog {
+                            address: format!("{:#x}", signer),
+                            topics: log_data.topics().iter().map(|t| t.to_string()).collect(),
+                            data: log_data.data.to_string(),
+                            block_number: block_num,
+                            block_hash,
+                            transaction_hash: format!("{txn_hash:#x}"),
+                            transaction_index: 0,
+                            log_index: 0,
+                            removed: false,
+                        };
+                        self.log_store.add_log(log);
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }

--- a/src/txn_manager.rs
+++ b/src/txn_manager.rs
@@ -3,7 +3,7 @@ use crate::log_synthesis::{LogStore, SyntheticLog};
 use crate::miden_client::{MidenClientLib, SyncListener};
 use alloy::consensus::TxEnvelope;
 use alloy::consensus::transaction::{Recovered, SignerRecoverable};
-use alloy::primitives::{Address, BlockNumber, LogData, TxHash};
+use alloy::primitives::{Address, B256, BlockNumber, LogData, TxHash};
 use alloy_rpc_types_eth::{Filter, Log};
 use lru::LruCache;
 use miden_client::sync::SyncSummary;
@@ -95,7 +95,27 @@ impl TxnManager {
         let txn_id = &receipt.id;
         match &receipt.result {
             Some(Ok(_)) => {
-                tracing::info!("TxnManager: committed eth txn: {txn_hash}; miden txn: {txn_id:?}")
+                tracing::info!("TxnManager: committed eth txn: {txn_hash}; miden txn: {txn_id:?}");
+
+                // Add logs to LogStore immediately on commit.
+                // This ensures bridge-service sees events as soon as txn is finalized.
+                let logs = receipt.logs.clone();
+                let signer = receipt.signer;
+                let block_hash = self.block_state.get_block_hash(block_num);
+                for log_data in logs {
+                    let log = SyntheticLog {
+                        address: format!("{:#x}", signer),
+                        topics: log_data.topics().iter().map(|t| t.to_string()).collect(),
+                        data: log_data.data.to_string(),
+                        block_number: block_num,
+                        block_hash,
+                        transaction_hash: format!("{txn_hash:#x}"),
+                        transaction_index: 0,
+                        log_index: 0,
+                        removed: false,
+                    };
+                    self.log_store.add_log(log);
+                }
             }
             Some(Err(err)) => tracing::error!(
                 "TxnManager: failed eth txn: {txn_hash}; miden txn: {txn_id:?}; reason: {err}"
@@ -283,6 +303,66 @@ impl TxnManager {
                 tracing::warn!("Failed to timeout claim {hash}: {e}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::consensus::Signed;
+    use alloy::primitives::Signature;
+
+    fn create_test_txn_manager() -> (Arc<TxnManager>, Arc<LogStore>, Arc<BlockState>) {
+        let log_store = Arc::new(LogStore::new());
+        let block_state = Arc::new(BlockState::new());
+        let txn_manager = Arc::new(TxnManager::new(log_store.clone(), block_state.clone()));
+        (txn_manager, log_store, block_state)
+    }
+
+    #[test]
+    fn test_txn_manager_lifecycle() {
+        let (txn_manager, log_store, _block_state) = create_test_txn_manager();
+        let txn_hash = TxHash::from([1u8; 32]);
+        let txn_envelope = TxEnvelope::Legacy(Signed::new_unchecked(
+            alloy::consensus::TxLegacy::default(),
+            Signature::test_signature(),
+            txn_hash,
+        ));
+
+        // Not found
+        assert!(txn_manager.receipt(txn_hash).is_none());
+
+        // Begin
+        txn_manager.begin(txn_hash, None, txn_envelope, None, vec![]).unwrap();
+        assert!(txn_manager.receipt(txn_hash).is_none());
+
+        // Commit
+        txn_manager.commit(txn_hash, Ok(()), 42).unwrap();
+        let (res, block_num) = txn_manager.receipt(txn_hash).unwrap();
+        assert!(res.is_ok());
+        assert_eq!(block_num, 42);
+        
+        // Logs should be added to LogStore if we had any
+    }
+
+    #[test]
+    fn test_txn_manager_with_logs() {
+        let (txn_manager, log_store, _block_state) = create_test_txn_manager();
+        let txn_hash = TxHash::from([2u8; 32]);
+        let txn_envelope = TxEnvelope::Legacy(Signed::new_unchecked(
+            alloy::consensus::TxLegacy::default(),
+            Signature::test_signature(),
+            txn_hash,
+        ));
+        
+        let log_data = LogData::new_unchecked(vec![B256::from([0xaa; 32])], alloy::primitives::bytes!("aabbcc"));
+        txn_manager.begin(txn_hash, None, txn_envelope, None, vec![log_data]).unwrap();
+        txn_manager.commit(txn_hash, Ok(()), 100).unwrap();
+
+        let filter = crate::log_synthesis::LogFilter::default();
+        let logs = log_store.get_logs(&filter, 100);
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].transaction_hash, format!("{txn_hash:#x}"));
     }
 }
 

--- a/src/txn_manager.rs
+++ b/src/txn_manager.rs
@@ -3,7 +3,7 @@ use crate::log_synthesis::{LogStore, SyntheticLog};
 use crate::miden_client::{MidenClientLib, SyncListener};
 use alloy::consensus::TxEnvelope;
 use alloy::consensus::transaction::{Recovered, SignerRecoverable};
-use alloy::primitives::{Address, B256, BlockNumber, LogData, TxHash};
+use alloy::primitives::{Address, BlockNumber, LogData, TxHash};
 use alloy_rpc_types_eth::{Filter, Log};
 use lru::LruCache;
 use miden_client::sync::SyncSummary;
@@ -306,66 +306,6 @@ impl TxnManager {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy::consensus::Signed;
-    use alloy::primitives::Signature;
-
-    fn create_test_txn_manager() -> (Arc<TxnManager>, Arc<LogStore>, Arc<BlockState>) {
-        let log_store = Arc::new(LogStore::new());
-        let block_state = Arc::new(BlockState::new());
-        let txn_manager = Arc::new(TxnManager::new(log_store.clone(), block_state.clone()));
-        (txn_manager, log_store, block_state)
-    }
-
-    #[test]
-    fn test_txn_manager_lifecycle() {
-        let (txn_manager, log_store, _block_state) = create_test_txn_manager();
-        let txn_hash = TxHash::from([1u8; 32]);
-        let txn_envelope = TxEnvelope::Legacy(Signed::new_unchecked(
-            alloy::consensus::TxLegacy::default(),
-            Signature::test_signature(),
-            txn_hash,
-        ));
-
-        // Not found
-        assert!(txn_manager.receipt(txn_hash).is_none());
-
-        // Begin
-        txn_manager.begin(txn_hash, None, txn_envelope, None, vec![]).unwrap();
-        assert!(txn_manager.receipt(txn_hash).is_none());
-
-        // Commit
-        txn_manager.commit(txn_hash, Ok(()), 42).unwrap();
-        let (res, block_num) = txn_manager.receipt(txn_hash).unwrap();
-        assert!(res.is_ok());
-        assert_eq!(block_num, 42);
-        
-        // Logs should be added to LogStore if we had any
-    }
-
-    #[test]
-    fn test_txn_manager_with_logs() {
-        let (txn_manager, log_store, _block_state) = create_test_txn_manager();
-        let txn_hash = TxHash::from([2u8; 32]);
-        let txn_envelope = TxEnvelope::Legacy(Signed::new_unchecked(
-            alloy::consensus::TxLegacy::default(),
-            Signature::test_signature(),
-            txn_hash,
-        ));
-        
-        let log_data = LogData::new_unchecked(vec![B256::from([0xaa; 32])], alloy::primitives::bytes!("aabbcc"));
-        txn_manager.begin(txn_hash, None, txn_envelope, None, vec![log_data]).unwrap();
-        txn_manager.commit(txn_hash, Ok(()), 100).unwrap();
-
-        let filter = crate::log_synthesis::LogFilter::default();
-        let logs = log_store.get_logs(&filter, 100);
-        assert_eq!(logs.len(), 1);
-        assert_eq!(logs[0].transaction_hash, format!("{txn_hash:#x}"));
-    }
-}
-
 #[async_trait::async_trait]
 impl SyncListener for TxnManager {
     fn on_sync(&self, summary: &SyncSummary) {
@@ -395,7 +335,6 @@ impl SyncListener for TxnManager {
             let note_id = NoteId::try_from_hex(&note_id_str)
                 .map_err(|e| anyhow::anyhow!("bad note id {note_id_str}: {e}"))?;
 
-            // Query client for note status. miden-client::Client::get_input_note is async.
             let note_opt = client
                 .get_input_note(note_id)
                 .await
@@ -404,9 +343,7 @@ impl SyncListener for TxnManager {
             if let Some(note) = note_opt
                 && note.is_consumed()
             {
-                tracing::info!(
-                    "CLAIM note {note_id_str} consumed, finalizing eth txn {txn_hash}"
-                );
+                tracing::info!("CLAIM note {note_id_str} consumed, finalizing eth txn {txn_hash}");
 
                 let mut transactions = self.transactions.lock().unwrap();
                 if let Some(receipt) = transactions.get_mut(&txn_hash) {
@@ -416,7 +353,6 @@ impl SyncListener for TxnManager {
                     let signer = receipt.signer;
                     drop(transactions);
 
-                    // Add logs to LogStore once consumed
                     for log_data in logs {
                         let block_hash = self.block_state.get_block_hash(block_num);
                         let log = SyntheticLog {
@@ -436,5 +372,73 @@ impl SyncListener for TxnManager {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::consensus::Signed;
+    use alloy::primitives::B256;
+    use alloy::primitives::Signature;
+
+    fn create_test_txn_manager() -> (Arc<TxnManager>, Arc<LogStore>, Arc<BlockState>) {
+        let log_store = Arc::new(LogStore::new());
+        let block_state = Arc::new(BlockState::new());
+        let txn_manager = Arc::new(TxnManager::new(log_store.clone(), block_state.clone()));
+        (txn_manager, log_store, block_state)
+    }
+
+    #[test]
+    fn test_txn_manager_lifecycle() {
+        let (txn_manager, _log_store, _block_state) = create_test_txn_manager();
+        let txn_hash = TxHash::from([1u8; 32]);
+        let txn_envelope = TxEnvelope::Legacy(Signed::new_unchecked(
+            alloy::consensus::TxLegacy::default(),
+            Signature::test_signature(),
+            txn_hash,
+        ));
+
+        // Not found
+        assert!(txn_manager.receipt(txn_hash).is_none());
+
+        // Begin
+        txn_manager
+            .begin(txn_hash, None, txn_envelope, None, vec![])
+            .unwrap();
+        assert!(txn_manager.receipt(txn_hash).is_none());
+
+        // Commit
+        txn_manager.commit(txn_hash, Ok(()), 42).unwrap();
+        let (res, block_num) = txn_manager.receipt(txn_hash).unwrap();
+        assert!(res.is_ok());
+        assert_eq!(block_num, 42);
+
+        // Logs should be added to LogStore if we had any
+    }
+
+    #[test]
+    fn test_txn_manager_with_logs() {
+        let (txn_manager, log_store, _block_state) = create_test_txn_manager();
+        let txn_hash = TxHash::from([2u8; 32]);
+        let txn_envelope = TxEnvelope::Legacy(Signed::new_unchecked(
+            alloy::consensus::TxLegacy::default(),
+            Signature::test_signature(),
+            txn_hash,
+        ));
+
+        let log_data = LogData::new_unchecked(
+            vec![B256::from([0xaa; 32])],
+            alloy::primitives::bytes!("aabbcc"),
+        );
+        txn_manager
+            .begin(txn_hash, None, txn_envelope, None, vec![log_data])
+            .unwrap();
+        txn_manager.commit(txn_hash, Ok(()), 100).unwrap();
+
+        let filter = crate::log_synthesis::LogFilter::default();
+        let logs = log_store.get_logs(&filter, 100);
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].transaction_hash, format!("{txn_hash:#x}"));
     }
 }


### PR DESCRIPTION
## Summary
- **Fix canonical address encoding**: `address_mapper.rs` now uses 4-byte zero prefix (not 5-byte) matching the `EthAddressFormat` spec `[4 zero bytes][prefix u64 BE][suffix u64 BE]`. The previous encoding caused a 1-byte shift that produced incorrect AccountIds, preventing wallets from discovering P2ID notes after NTX builder processing.
- **Add CLAIM note consumption tracking**: Deferred receipt handling for `claimAsset` transactions — the proxy now tracks CLAIM note IDs and waits for NTX builder to consume them before finalizing receipts.
- **Improve log synchronization**: Better alignment between L1 event logs and Miden transaction lifecycle for `eth_getLogs` and `eth_getTransactionReceipt`.

## Test plan
- [x] All 7 `address_mapper` unit tests pass (`cargo test`)
- [x] Full end-to-end bridge test: L1 deposit → bridge-service sync → GER injection → claim → NTX builder CLAIM→P2ID → wallet sync → consume P2ID → wallet has 100000000 fungible assets (1 ETH scaled 18→8 decimals)
- [x] Verified against Kurtosis-deployed infrastructure (geth L1, miden-node, bridge-service, aggkit oracle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)