### PR TITLE
security: fix path traversal vulnerability in accounts_config

### DIFF
--- a/src/accounts_config.rs
+++ b/src/accounts_config.rs
@@ -2,7 +2,7 @@ use miden_client::rpc::Endpoint;
 use miden_protocol::account::AccountId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{Display, Formatter};
-use std::path::PathBuf;
+use std::path::{Component, PathBuf};
 use std::{env, fs};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -46,18 +46,48 @@ impl<'de> Deserialize<'de> for AccountIdBech32 {
     }
 }
 
-fn config_path(miden_store_dir_opt: Option<PathBuf>) -> PathBuf {
+/// Reject paths containing parent-directory (`..`) traversal components.
+fn sanitize_store_dir(dir: &PathBuf) -> anyhow::Result<PathBuf> {
+    for component in dir.components() {
+        if matches!(component, Component::ParentDir) {
+            anyhow::bail!(
+                "path traversal detected: store directory must not contain '..' \
+                 components, got: {dir:?}"
+            );
+        }
+    }
+
+    // Canonicalize when the directory already exists on disk so that any
+    // symlink-based traversal is also resolved. When it does not yet exist
+    // (first run / --init), the lexical check above is sufficient.
+    if dir.exists() {
+        let canonical = dir.canonicalize()?;
+        // After resolving symlinks, re-verify there are no `..` segments.
+        for component in canonical.components() {
+            if matches!(component, Component::ParentDir) {
+                anyhow::bail!(
+                    "path traversal detected after canonicalization: {canonical:?}"
+                );
+            }
+        }
+        return Ok(canonical);
+    }
+    Ok(dir.clone())
+}
+
+fn config_path(miden_store_dir_opt: Option<PathBuf>) -> anyhow::Result<PathBuf> {
     let miden_store_dir = miden_store_dir_opt.unwrap_or_else(|| {
         let current_dir = env::current_dir().unwrap_or(PathBuf::from("."));
         let base_dir = env::home_dir().unwrap_or(current_dir);
         base_dir.join(".miden")
     });
-    miden_store_dir.join("bridge_accounts.toml")
+    let safe_dir = sanitize_store_dir(&miden_store_dir)?;
+    Ok(safe_dir.join("bridge_accounts.toml"))
 }
 
-pub fn config_path_exists(miden_store_dir: Option<PathBuf>) -> std::io::Result<bool> {
-    let config_path = config_path(miden_store_dir);
-    fs::exists(&config_path)
+pub fn config_path_exists(miden_store_dir: Option<PathBuf>) -> anyhow::Result<bool> {
+    let config_path = config_path(miden_store_dir)?;
+    Ok(fs::exists(&config_path)?)
 }
 
 pub fn save_config(
@@ -65,14 +95,55 @@ pub fn save_config(
     miden_store_dir: Option<PathBuf>,
 ) -> anyhow::Result<PathBuf> {
     let config_toml = toml::to_string(&config)?;
-    let config_path = config_path(miden_store_dir);
+    let config_path = config_path(miden_store_dir)?;
     fs::write(config_path.clone(), config_toml)?;
     Ok(config_path)
 }
 
 pub fn load_config(miden_store_dir: Option<PathBuf>) -> anyhow::Result<AccountsConfig> {
-    let config_path = config_path(miden_store_dir);
+    let config_path = config_path(miden_store_dir)?;
     let config_toml = fs::read_to_string(config_path)?;
     let config = toml::from_str(&config_toml)?;
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_parent_dir_traversal() {
+        let bad = Some(PathBuf::from("/tmp/../etc"));
+        let result = config_path(bad);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("path traversal"),
+            "expected path traversal error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_embedded_traversal() {
+        let bad = Some(PathBuf::from("/home/user/.miden/../../etc"));
+        let result = config_path(bad);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn allows_clean_absolute_path() {
+        let good = Some(PathBuf::from("/tmp/miden-test-store"));
+        let result = config_path(good);
+        assert!(result.is_ok());
+        let path = result.unwrap();
+        assert!(path.ends_with("bridge_accounts.toml"));
+    }
+
+    #[test]
+    fn allows_default_path() {
+        let result = config_path(None);
+        assert!(result.is_ok());
+        let path = result.unwrap();
+        assert!(path.ends_with("bridge_accounts.toml"));
+    }
 }

--- a/src/accounts_config.rs
+++ b/src/accounts_config.rs
@@ -65,9 +65,7 @@ fn sanitize_store_dir(dir: &PathBuf) -> anyhow::Result<PathBuf> {
         // After resolving symlinks, re-verify there are no `..` segments.
         for component in canonical.components() {
             if matches!(component, Component::ParentDir) {
-                anyhow::bail!(
-                    "path traversal detected after canonicalization: {canonical:?}"
-                );
+                anyhow::bail!("path traversal detected after canonicalization: {canonical:?}");
             }
         }
         return Ok(canonical);


### PR DESCRIPTION
## Summary
- **Fixes Aikido-flagged path traversal vulnerability** in `accounts_config.rs` where user-supplied `--miden-store-dir` CLI argument was used directly in file operations without validation
- Adds `sanitize_store_dir()` that rejects paths containing `..` (parent directory) components and canonicalizes existing paths to resolve symlink-based traversal
- Changes `config_path()` return type from `PathBuf` to `anyhow::Result<PathBuf>` so validation errors propagate to callers
- Adds 4 unit tests covering traversal rejection and legitimate path acceptance

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo test` — all 46 tests pass (including 4 new path validation tests)
- [ ] Manual: verify `--miden-store-dir /tmp/test` still works
- [ ] Manual: verify `--miden-store-dir /tmp/../etc` is rejected with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)