### PR TITLE
security: pin GitHub Actions to commit SHA (RD-791)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,8 +14,8 @@ jobs:
     env:
       CARGO_PROFILE: release
     steps:
-      - uses: actions/checkout@main
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: make install-tools
       - run: make lint
       - run: make build


### PR DESCRIPTION
Pin all third-party action references to immutable commit SHAs to prevent tag-redirection attacks. Also enables Dependabot for github-actions ecosystem.

Ref: RD-791