### PR TITLE
feat: migrate to miden-agglayer 0.14.x + miden-client v0.14.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ fixtures/combined.json
 fixtures/l1-transactions.json
 fixtures/l1-raw-txs.txt
 fixtures/.env
+.miden-agglayer-data/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -56,9 +56,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dc44b606f29348ce7c127e7f872a6d2df3cfeff85b7d6bba62faca75112fdd"
+checksum = "50ab0cd8afe573d1f7dc2353698a51b1f93aec362c8211e28cfd3948c6adba39"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.31"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9d22005bf31b018f31ef9ecadb5d2c39cf4f6acc8db0456f72c815f3d7f757"
+checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ff99651d46cef43767b5e8262ea228cd05287409ccb0c947cc25e70a952f9"
+checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0701b0eda8051a2398591113e7862f807ccdd3315d0b441f06c2a0865a379b"
+checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c83c7a3c4e1151e8cac383d0a67ddf358f37e5ea51c95a1283d897c9de0a5a"
+checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -149,6 +149,7 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -177,7 +178,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -233,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def1626eea28d48c6cc0a6f16f34d4af0001906e4f889df6c660b39c86fd044d"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -251,15 +252,14 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2",
- "thiserror 2.0.18",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d9d1aba3f914f0e8db9e4616ae37f3d811426d95bdccf44e47d0605ab202f6"
+checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57586581f2008933241d16c3e3f633168b3a5d2738c5c42ea5246ec5e0ef17a"
+checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b36c2a0ed74e48851f78415ca5b465211bd678891ba11e88fee09eac534bab1"
+checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636c8051da58802e757b76c3b65af610b95799f72423dc955737dec73de234fd"
+checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -349,13 +349,13 @@ dependencies = [
  "derive_more",
  "foldhash 0.2.0",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3dd56e2eafe8b1803e325867ac2c8a4c73c9fb5f341ffd8347f9344458c5922"
+checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -392,7 +392,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -426,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91577235d341a1bdbee30a463655d08504408a4d51e9f72edbfc5a622829f402"
+checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -436,7 +436,7 @@ dependencies = [
  "alloy-transport-http",
  "futures",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tokio",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cff039bf01a17d76c0aace3a3a773d5f895eb4c68baaae729ec9da9e86c99c"
+checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73234a141ecce14e2989748c04fcac23deee67a445e2c4c167cfb42d4dacd1b6"
+checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010e101dbebe0c678248907a2545b574a87d078d82c2f6f5d0e8e7c9a6149a10"
+checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -493,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6d631f8b975229361d8af7b2c749af31c73b3cf1352f90e144ddb06227105e"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -504,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f40010b5e8f79b70bf163b38cd15f529b18ca88c4427c0e43441ee54e4ed82"
+checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4ec1cc27473819399a3f0da83bc1cef0ceaac8c1c93997696e46dc74377a58"
+checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -557,7 +557,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -591,7 +591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03bb3f02b9a7ab23dacd1822fa7f69aa5c8eefcdcf57fad085e0b8d76fb4334"
+checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -631,14 +631,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
+checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest",
+ "reqwest 0.13.2",
  "serde_json",
  "tower",
  "tracing",
@@ -663,11 +663,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
+checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -684,27 +684,12 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -717,15 +702,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -1029,6 +1005,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,16 +1204,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1216,6 +1223,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1232,19 +1248,20 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -1306,15 +1323,21 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1336,7 +1359,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1346,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1372,7 +1406,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -1393,7 +1427,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -1418,10 +1452,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "const-hex"
@@ -1430,7 +1489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -1440,6 +1499,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const_format"
@@ -1497,6 +1562,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1561,13 +1635,31 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1577,7 +1669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -1599,37 +1691,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "serde",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1641,18 +1708,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "serde",
  "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
- "quote",
  "syn 2.0.117",
 ]
 
@@ -1662,7 +1719,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -1731,7 +1788,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1794,10 +1851,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1863,7 +1932,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1941,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -1951,11 +2020,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "env_filter",
  "jiff",
@@ -1967,6 +2036,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -1998,9 +2078,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fastrlp"
@@ -2073,7 +2153,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2111,6 +2191,12 @@ checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2229,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -2275,6 +2361,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -2291,6 +2378,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "group"
@@ -2315,7 +2414,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2352,10 +2451,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "rayon",
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -2399,7 +2503,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2409,6 +2513,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2457,10 +2570,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "1.8.1"
+name = "hybrid-array"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2473,7 +2595,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2481,15 +2602,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2558,12 +2678,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2571,9 +2692,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2584,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2598,15 +2719,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2618,15 +2739,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2709,12 +2830,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2736,9 +2857,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2785,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -2814,6 +2935,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,10 +2990,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2844,7 +3011,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -2854,14 +3021,14 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b646a74e746cd25045aa0fd42f4f7f78aa6d119380182c7e63a5593c4ab8df6f"
+checksum = "fa468878266ad91431012b3e5ef1bf9b170eab22883503a318d46857afa4579a"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -2911,9 +3078,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -2923,9 +3090,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -2943,21 +3110,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -3064,12 +3225,12 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3095,7 +3256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "metrics",
  "metrics-util",
  "quanta",
@@ -3113,17 +3274,18 @@ dependencies = [
  "hashbrown 0.15.5",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
 
 [[package]]
 name = "miden-agglayer"
-version = "0.14.0-alpha.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e492a6044cf8875a64d7eec130d260f2eda1c783795261f00d5d52837ed027bd"
+checksum = "4302fc29d77db3d2c6323d1b211e503aafb91db2d572ef30c68829347fe79352"
 dependencies = [
+ "alloy-sol-types",
  "fs-err",
  "miden-assembly",
  "miden-core",
@@ -3163,7 +3325,7 @@ dependencies = [
  "miden-standards",
  "miden-tx",
  "parking_lot",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha3",
@@ -3181,36 +3343,38 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.20.6"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cca9632323bd4e32ae5b21b101ed417a646f5d72196b1bf3f1ca889a148322a"
+checksum = "d15646ebc95906b2a7cb66711d1e184f53fd6edc2605730bbcf0c2a129f792cf"
 dependencies = [
  "miden-core",
+ "miden-crypto",
  "miden-utils-indexing",
  "thiserror 2.0.18",
- "winter-air",
- "winter-prover",
+ "tracing",
 ]
 
 [[package]]
 name = "miden-assembly"
-version = "0.20.6"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2395b2917aea613a285d3425d1ca07e6c45442e2b34febdea2081db555df62fc"
+checksum = "ae6013b3a390e0dcb29242f4480a7727965887bbf0903466c88f362b4cb20c0e"
 dependencies = [
  "log",
  "miden-assembly-syntax",
  "miden-core",
  "miden-mast-package",
+ "miden-package-registry",
+ "miden-project",
  "smallvec",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.20.6"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f9bed037d137f209b9e7b28811ec78c0536b3f9259d6f4ceb5823c87513b346"
+checksum = "996156b8f7c5fe6be17dea71089c6d7985c2dec1e3a4fec068b1dfc690e25df5"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -3223,23 +3387,24 @@ dependencies = [
  "proptest",
  "regex",
  "rustc_version 0.4.1",
- "semver 1.0.27",
+ "semver 1.0.28",
+ "serde",
  "smallvec",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "miden-client"
-version = "0.14.0-alpha.1"
-source = "git+https://github.com/0xMiden/miden-client.git?branch=agglayer-integration-tests#ac3d953d6092a93e01b2a4bb9c464f395525390d"
+version = "0.14.0"
+source = "git+https://github.com/0xMiden/miden-client.git?rev=f7cdf263781999e8f81ba608f9c5a91218747d98#f7cdf263781999e8f81ba608f9c5a91218747d98"
 dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
  "futures",
  "getrandom 0.3.4",
+ "gloo-timers",
  "hex",
- "miden-mast-package",
  "miden-node-proto-build",
  "miden-note-transport-proto-build",
  "miden-protocol",
@@ -3249,10 +3414,11 @@ dependencies = [
  "miette",
  "prost",
  "prost-types",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tonic",
  "tonic-health",
  "tonic-prost",
@@ -3264,8 +3430,8 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.14.0-alpha.1"
-source = "git+https://github.com/0xMiden/miden-client.git?branch=agglayer-integration-tests#ac3d953d6092a93e01b2a4bb9c464f395525390d"
+version = "0.14.0"
+source = "git+https://github.com/0xMiden/miden-client.git?rev=f7cdf263781999e8f81ba608f9c5a91218747d98#f7cdf263781999e8f81ba608f9c5a91218747d98"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3282,9 +3448,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.20.6"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8714aa5f86c59e647b7417126b32adc4ef618f835964464f5425549df76b6d03"
+checksum = "fdec54a321cdf3d23e9ef615e91cb858038c6b4d4202507bdec048fc6d7763e4"
 dependencies = [
  "derive_more",
  "itertools 0.14.0",
@@ -3293,35 +3459,37 @@ dependencies = [
  "miden-formatting",
  "miden-utils-core-derive",
  "miden-utils-indexing",
+ "miden-utils-sync",
  "num-derive",
  "num-traits",
+ "proptest",
+ "proptest-derive",
+ "serde",
  "thiserror 2.0.18",
- "winter-math",
- "winter-utils",
 ]
 
 [[package]]
 name = "miden-core-lib"
-version = "0.20.6"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb16a4d39202c59a7964d3585cd5af21a46a759ff6452cb5f20723ed5af4362"
+checksum = "621e8fa911a790bcf3cd3aedce80bc10922a19d6181f08ff3ca078f955cff70b"
 dependencies = [
  "env_logger",
  "fs-err",
  "miden-assembly",
  "miden-core",
  "miden-crypto",
+ "miden-package-registry",
  "miden-processor",
  "miden-utils-sync",
- "sha2",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "miden-crypto"
-version = "0.19.8"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be59336a868de7c379eace9450563c2d7f4a0b7ab936835ec5a340dcd8d9a5ed"
+checksum = "0ed0a034a460e27723dcfdf25effffab84331c3b46b13e7a1bd674197cc71bfe"
 dependencies = [
  "blake3",
  "cc",
@@ -3330,32 +3498,41 @@ dependencies = [
  "ed25519-dalek",
  "flume",
  "glob",
- "hashbrown 0.16.1",
  "hkdf",
  "k256",
  "miden-crypto-derive",
+ "miden-field",
+ "miden-serde-utils",
  "num",
  "num-complex",
- "rand 0.9.2",
+ "p3-blake3",
+ "p3-challenger",
+ "p3-dft",
+ "p3-goldilocks",
+ "p3-keccak",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-miden-lifted-stark",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "rand_hc",
  "rayon",
- "sha2",
+ "serde",
+ "sha2 0.10.9",
  "sha3",
  "subtle",
  "thiserror 2.0.18",
- "winter-crypto",
- "winter-math",
- "winter-utils",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.19.8"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06f2e7a7ac7d01e03a7340224722e75494826fe6b61a3796b77fbb044d018287"
+checksum = "e8bf6ebde028e79bcc61a3632d2f375a5cc64caa17d014459f75015238cb1e08"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3363,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.20.6"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1494f102ad5b9fa43e391d2601186dc601f41ab7dcd8a23ecca9bf3ef930f4"
+checksum = "d6e50274d11c80b901cf6c90362de8c98c8c8ad6030c80624d683b63d899a0fb"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -3380,6 +3557,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-field"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38011348f4fb4c9e5ce1f471203d024721c00e3b60a91aa91aaefe6738d8b5ea"
+dependencies = [
+ "miden-serde-utils",
+ "num-bigint",
+ "p3-challenger",
+ "p3-field",
+ "p3-goldilocks",
+ "paste",
+ "rand 0.10.1",
+ "serde",
+ "subtle",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "miden-formatting"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3390,13 +3585,15 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.20.6"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692185bfbe0ecdb28bf623f1f8c88282cd6727ba081a28e23b301bdde1b45be4"
+checksum = "bc8b2e3447fcde1f0e6b76e5219f129517639772cb02ca543177f0584e315288"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
  "miden-core",
+ "miden-debug-types",
+ "serde",
  "thiserror 2.0.18",
 ]
 
@@ -3406,8 +3603,6 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eef536978f24a179d94fa2a41e4f92b28e7d8aab14b8d23df28ad2a3d7098b20"
 dependencies = [
- "backtrace",
- "backtrace-ext",
  "cfg-if",
  "futures",
  "indenter",
@@ -3418,13 +3613,9 @@ dependencies = [
  "rustc_version 0.2.3",
  "rustversion",
  "serde_json",
- "spin",
+ "spin 0.9.8",
  "strip-ansi-escapes",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
  "syn 2.0.117",
- "terminal_size 0.3.0",
  "textwrap",
  "thiserror 2.0.18",
  "trybuild",
@@ -3444,9 +3635,9 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.14.0-alpha.4"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ac57ddec6bf630b5301630c953ed23661575b70e2fcc3ff221c660f3006a30"
+checksum = "289194699f5acd63feb735c692fab0ff2e77aa67bf67dfd2608e0c573591a14b"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -3457,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto-build"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec23738a2eee393524a849a8dce982ad824050cc54abde145d4fb62b92c84198"
+checksum = "5e183c4e36c155edea086b79cd4395d70e3a905eb86778827e12a8e0d0110d2b"
 dependencies = [
  "fs-err",
  "miette",
@@ -3468,10 +3659,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-processor"
-version = "0.20.6"
+name = "miden-package-registry"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e09f7916b1e7505f74a50985a185fdea4c0ceb8f854a34c90db28e3f7da7ab6"
+checksum = "969ba3942052e52b3968e34dbd1c52c707e75777ee42ebdae2c8f57af56cf6cf"
+dependencies = [
+ "miden-assembly-syntax",
+ "miden-core",
+ "miden-mast-package",
+ "pubgrub",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "miden-processor"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ec6cecbf22bd92b73a931ee80b424e46b8b7cdf4f2f3c364c25c5c15d2840da"
 dependencies = [
  "itertools 0.14.0",
  "miden-air",
@@ -3484,14 +3690,29 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "winter-prover",
+]
+
+[[package]]
+name = "miden-project"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3840520c01881534fbbceb6b3687ec1c407fbaf310a35ce415fd3510abc52fdb"
+dependencies = [
+ "miden-assembly-syntax",
+ "miden-core",
+ "miden-mast-package",
+ "miden-package-registry",
+ "serde",
+ "serde-untagged",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
 name = "miden-protocol"
-version = "0.14.0-alpha.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a88effeac994eb55b8dc4f93fbfd71a5d916dfaba1099896e27a0ee42c488c1"
+checksum = "e860cc978d3467297de076e9bd22f0573b82ef73a3d223d6bb957731a45b8164"
 dependencies = [
  "bech32",
  "fs-err",
@@ -3506,23 +3727,22 @@ dependencies = [
  "miden-protocol-macros",
  "miden-utils-sync",
  "miden-verifier",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xoshiro",
  "regex",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "walkdir",
- "winter-rand-utils",
 ]
 
 [[package]]
 name = "miden-protocol-macros"
-version = "0.14.0-alpha.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb28b730005e5f8b08d615ea9216f8cab77b3a7439fa54d5e39d2ec43ef53a3"
+checksum = "4daec4a5a6f050a670a8639e78e017ab11ef0bf2e253b012505f25e6247c13e7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3531,23 +3751,27 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.20.6"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45e30526be72b8af0fd1d8b24c9cba8ac1187ca335dcee38b8e5e20234e7698"
+checksum = "6bb2c94e36f57684d7fa0cd382adeedc1728d502dbbe69ad1c12f4a931f45511"
 dependencies = [
+ "bincode",
  "miden-air",
+ "miden-core",
+ "miden-crypto",
  "miden-debug-types",
  "miden-processor",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
  "tracing",
- "winter-maybe-async",
- "winter-prover",
 ]
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.14.0-alpha.4"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fae30a877ba6481e62ed2a553277633c91a592686afa73ba91c2f15ed7e17f"
+checksum = "47e756825b1b271549df850ae87b6544be9e5d68353f9d2afc7a55a567e1a01e"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -3566,10 +3790,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-standards"
-version = "0.14.0-alpha.1"
+name = "miden-serde-utils"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cef036bbfec29acba92751a13d05844bbcf080140201097b419c9ad1927e367"
+checksum = "ff78082e9b4ca89863e68da01b35f8a4029ee6fd912e39fa41fde4273a7debab"
+dependencies = [
+ "p3-field",
+ "p3-goldilocks",
+]
+
+[[package]]
+name = "miden-standards"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f455a087f41c30636b45ead961d1e66114d2d20661887b307cede05307eeb942"
 dependencies = [
  "fs-err",
  "miden-assembly",
@@ -3584,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.14.0-alpha.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c67e0df9adcf29c9111df65acf408ae05952b8bc6569f571963676f97668d83f"
+checksum = "6d788795041ce5e6f947a3256314373171e4877c11b86fafeabcec4d8b8628d9"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -3598,9 +3832,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.20.6"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b1d490e6d7b509622d3c2cc69ffd66ad48bf953dc614579b568fe956ce0a6c"
+checksum = "3846c8674ccec0c37005f99c1a599a24790ba2a5e5f4e1c7aec5f456821df835"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3609,9 +3843,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.20.6"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52658f6dc091c1c78e8b35ee3e7ff3dad53051971a3c514e461f581333758fe7"
+checksum = "397f5d1e8679cf17cf7713ffd9654840791a6ed5818b025bbc2fbfdce846579a"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -3622,44 +3856,52 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.20.6"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff7bcb7875b222424bdfb657a7cf21a55e036aa7558ebe1f5d2e413b440d0d"
+checksum = "c8834e76299686bcce3de1685158aa4cff49b7fa5e0e00a6cc811e8f2cf5775f"
 dependencies = [
+ "miden-crypto",
+ "serde",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.20.6"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d53d1ab5b275d8052ad9c4121071cb184bc276ee74354b0d8a2075e5c1d1f0"
+checksum = "6a9e9747e9664c1a0997bb040ae291306ea0a1c74a572141ec66cec855c1b0e8"
 dependencies = [
  "lock_api",
  "loom",
+ "once_cell",
  "parking_lot",
 ]
 
 [[package]]
 name = "miden-verifier"
-version = "0.20.6"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13816663794beb15c8a4721c15252eb21f3b3233525684f60c7888837a98ff4"
+checksum = "c4580df640d889c9f3c349cd2268968e44a99a8cf0df6c36ae5b1fb273712b00"
 dependencies = [
+ "bincode",
  "miden-air",
  "miden-core",
+ "miden-crypto",
+ "serde",
  "thiserror 2.0.18",
  "tracing",
- "winter-verifier",
 ]
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.4.3"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4cfab04baffdda3fb9eafa5f873604059b89a1699aa95e4f1057397a69f0b5"
+checksum = "2eb29d7c049fb69373c7e775e3d4411e63e4ee608bc43826282ba62c6ec9f891"
 dependencies = [
  "miden-formatting",
+ "miden-serde-utils",
+ "serde",
+ "serde_repr",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -3678,7 +3920,7 @@ dependencies = [
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "terminal_size 0.4.3",
+ "terminal_size",
  "textwrap",
  "unicode-width 0.1.14",
 ]
@@ -3711,9 +3953,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -3785,9 +4027,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -3944,6 +4186,321 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "p3-air"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2ec9cbfc642fc5173817287c3f8b789d07743b5f7e812d058b7a03e344f9ab"
+dependencies = [
+ "p3-field",
+ "p3-matrix",
+ "tracing",
+]
+
+[[package]]
+name = "p3-blake3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b667f43b19499dd939c9e2553aa95688936a88360d50117dae3c8848d07dbc70"
+dependencies = [
+ "blake3",
+ "p3-symmetric",
+ "p3-util",
+]
+
+[[package]]
+name = "p3-challenger"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0b490c745a7d2adeeafff06411814c8078c432740162332b3cd71be0158a76"
+dependencies = [
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-monty-31",
+ "p3-symmetric",
+ "p3-util",
+ "tracing",
+]
+
+[[package]]
+name = "p3-commit"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916ae7989d5c3b49f887f5c55b2f9826bdbb81aaebf834503c4145d8b267c829"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
+ "serde",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55301e91544440254977108b85c32c09d7ea05f2f0dd61092a2825339906a4a7"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
+ "spin 0.10.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85affca7fc983889f260655c4cf74163eebb94605f702e4b6809ead707cba54f"
+dependencies = [
+ "itertools 0.14.0",
+ "num-bigint",
+ "p3-maybe-rayon",
+ "p3-util",
+ "paste",
+ "rand 0.10.1",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-goldilocks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca1081f5c47b940f2d75a11c04f62ea1cc58a5d480dd465fef3861c045c63cd"
+dependencies = [
+ "num-bigint",
+ "p3-challenger",
+ "p3-dft",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon1",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "p3-util",
+ "paste",
+ "rand 0.10.1",
+ "serde",
+]
+
+[[package]]
+name = "p3-keccak"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcf27615ece1995e4fcf4c69740f1cf515d1481367a20b4b3ce7f4f1b8d70f7"
+dependencies = [
+ "p3-symmetric",
+ "p3-util",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53428126b009071563d1d07305a9de8be0d21de00b57d2475289ee32ffca6577"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-util",
+ "rand 0.10.1",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-maybe-rayon"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082bf467011c06c768c579ec6eb9accb5e1e62108891634cc770396e917f978a"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "p3-mds"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35209e6214102ea6ec6b8cb1b9c15a9b8e597a39f9173597c957f123bced81b3"
+dependencies = [
+ "p3-dft",
+ "p3-field",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.10.1",
+]
+
+[[package]]
+name = "p3-miden-lifted-air"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c31c65fdc88952d7b301546add9670676e5b878aa0066dd929f107c203b006"
+dependencies = [
+ "p3-air",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "p3-miden-lifted-fri"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9932f1b0a16609a45cd4ee10a4d35412728bc4b38837c7979d7c85d8dcc9fc"
+dependencies = [
+ "p3-challenger",
+ "p3-commit",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-miden-lmcs",
+ "p3-miden-transcript",
+ "p3-util",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-lifted-stark"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3956ab7270c3cdd53ca9796d39ae1821984eb977415b0672110f9666bff5d8"
+dependencies = [
+ "p3-challenger",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-miden-lifted-air",
+ "p3-miden-lifted-fri",
+ "p3-miden-lmcs",
+ "p3-miden-stateful-hasher",
+ "p3-miden-transcript",
+ "p3-util",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-lmcs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c46791c983e772136db3d48f102431457451447abb9087deb6c8ce3c1efc86"
+dependencies = [
+ "p3-commit",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-miden-stateful-hasher",
+ "p3-miden-transcript",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.10.1",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-stateful-hasher"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec47a9d9615eb3d9d2a59b00d19751d9ad85384b55886827913d680d912eac6a"
+dependencies = [
+ "p3-field",
+ "p3-symmetric",
+]
+
+[[package]]
+name = "p3-miden-transcript"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c565647487e4a949f67e6f115b0391d6cb82ac8e561165789939bab23d0ae7"
+dependencies = [
+ "p3-challenger",
+ "p3-field",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "p3-monty-31"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffa8c99ec50c035020bbf5457c6a729ba6a975719c1a8dd3f16421081e4f650c"
+dependencies = [
+ "itertools 0.14.0",
+ "num-bigint",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-mds",
+ "p3-poseidon1",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "p3-util",
+ "paste",
+ "rand 0.10.1",
+ "serde",
+ "spin 0.10.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-poseidon1"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a018b618e3fa0aec8be933b1d8e404edd23f46991f6bf3f5c2f3f95e9413fe9"
+dependencies = [
+ "p3-field",
+ "p3-symmetric",
+ "rand 0.10.1",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256a668a9ba916f8767552f13d0ba50d18968bc74a623bfdafa41e2970c944d0"
+dependencies = [
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.10.1",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c60a71a1507c13611b0f2b0b6e83669fd5b76f8e3115bcbced5ccfdf3ca7807"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field",
+ "p3-util",
+ "serde",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8b766b9e9254bf3fa98d76e42cf8a5b30628c182dfd5272d270076ee12f0fc0"
+dependencies = [
+ "rayon",
+ "serde",
+ "transpose",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4023,7 +4580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4034,7 +4591,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4109,9 +4666,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "poly1305"
@@ -4119,7 +4676,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4141,27 +4698,27 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
 dependencies = [
  "base64",
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
- "hmac",
+ "hmac 0.13.0",
  "md-5",
  "memchr",
- "rand 0.9.2",
- "sha2",
+ "rand 0.10.1",
+ "sha2 0.11.0",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
+checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
 dependencies = [
  "bytes",
  "fallible-iterator 0.2.0",
@@ -4170,9 +4727,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -4230,6 +4787,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "priority-queue"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
+dependencies = [
+ "equivalent",
+ "indexmap 2.14.0",
+ "serde",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4271,21 +4839,32 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4381,10 +4960,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulldown-cmark"
-version = "0.13.1"
+name = "pubgrub"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+checksum = "3f5df7e552bc7edd075f5783a87fbfc21d6a546e32c16985679c488c18192d83"
+dependencies = [
+ "indexmap 2.14.0",
+ "log",
+ "priority-queue",
+ "rustc-hash",
+ "thiserror 2.0.18",
+ "version-ranges",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
  "bitflags",
  "memchr",
@@ -4447,10 +5040,11 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4517,13 +5111,24 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -4564,6 +5169,12 @@ dependencies = [
  "getrandom 0.3.4",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_hc"
@@ -4727,12 +5338,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -4780,7 +5428,7 @@ dependencies = [
  "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -4826,9 +5474,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc-hex"
@@ -4860,20 +5508,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.27",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -4885,16 +5520,17 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4927,11 +5563,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.103.9"
+name = "rustls-platform-verifier"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5094,9 +5758,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -5125,6 +5789,18 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-untagged"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_core",
+ "typeid",
 ]
 
 [[package]]
@@ -5172,10 +5848,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.0.4"
+name = "serde_repr"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -5202,7 +5889,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -5217,7 +5904,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5240,8 +5927,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -5256,9 +5954,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31139435f327c93c6038ed350ae4588e2c70a13d50599509fee6349967ba35a"
+checksum = "59cbb88c189d6352cc8ae96a39d19c7ecad8f7330b29461187f2587fdc2988d5"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5352,6 +6050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5372,6 +6079,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
@@ -5534,7 +6247,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -5558,22 +6271,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 0.38.44",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
-dependencies = [
- "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5677,10 +6380,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.2"
+name = "tiny-keccak"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5703,9 +6415,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -5719,9 +6431,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5730,9 +6442,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcea47c8f71744367793f16c2db1f11cb859d28f436bdb4ca9193eb1f787ee42"
+checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5747,7 +6459,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.2",
+ "rand 0.10.1",
  "socket2",
  "tokio",
  "tokio-util",
@@ -5795,28 +6507,28 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -5830,39 +6542,39 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -5948,9 +6660,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-web-wasm-client"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e21e20b94f808d6f2244a5d960d02c28dd82066abddd2f27019bac0535f310"
+checksum = "3c0469c353de5f665c95f898074b5b004b500c6722214c3249f1dc79c0a2a3f6"
 dependencies = [
  "base64",
  "byteorder",
@@ -5979,7 +6691,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -6097,6 +6809,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6115,8 +6837,14 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.0.6+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -6201,9 +6929,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -6229,7 +6957,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -6275,6 +7003,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e9bd4e9c9ff6a2a9b5969462ba26216af3e010df0377dad8320ab515262ef8"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "version_check"
@@ -6363,9 +7100,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6376,23 +7113,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6400,9 +7133,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6413,9 +7146,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -6437,7 +7170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6463,8 +7196,8 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver 1.0.27",
+ "indexmap 2.14.0",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -6483,9 +7216,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6499,6 +7232,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6615,11 +7357,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -6627,15 +7369,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -6660,17 +7393,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6708,9 +7441,9 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -6726,9 +7459,9 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6744,9 +7477,9 @@ checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6774,9 +7507,9 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6792,9 +7525,9 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6810,9 +7543,9 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6828,9 +7561,9 @@ checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6854,105 +7587,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "winter-air"
-version = "0.13.1"
+name = "winnow"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef01227f23c7c331710f43b877a8333f5f8d539631eea763600f1a74bf018c7c"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
- "libm",
- "winter-crypto",
- "winter-fri",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-crypto"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdb247bc142438798edb04067ab72a22cf815f57abbd7b78a6fa986fc101db8"
-dependencies = [
- "blake3",
- "sha3",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-fri"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd592b943f9d65545683868aaf1b601eb66e52bfd67175347362efff09101d3a"
-dependencies = [
- "winter-crypto",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-math"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aecfb48ee6a8b4746392c8ff31e33e62df8528a3b5628c5af27b92b14aef1ea"
-dependencies = [
- "winter-utils",
-]
-
-[[package]]
-name = "winter-maybe-async"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d31a19dae58475d019850e25b0170e94b16d382fbf6afee9c0e80fdc935e73e"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "winter-prover"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cc631ed56cd39b78ef932c1ec4060cc6a44d114474291216c32f56655b3048"
-dependencies = [
- "tracing",
- "winter-air",
- "winter-crypto",
- "winter-fri",
- "winter-math",
- "winter-maybe-async",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-rand-utils"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ff3b651754a7bd216f959764d0a5ab6f4b551c9a3a08fb9ccecbed594b614a"
-dependencies = [
- "rand 0.9.2",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-utils"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9951263ef5317740cd0f49e618db00c72fabb70b75756ea26c4d5efe462c04dd"
-dependencies = [
- "rayon",
-]
-
-[[package]]
-name = "winter-verifier"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0425ea81f8f703a1021810216da12003175c7974a584660856224df04b2e2fdb"
-dependencies = [
- "winter-air",
- "winter-crypto",
- "winter-fri",
- "winter-math",
- "winter-utils",
+ "memchr",
 ]
 
 [[package]]
@@ -6983,7 +7623,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -7014,7 +7654,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -7033,9 +7673,9 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7045,9 +7685,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -7070,9 +7710,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7081,9 +7721,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7093,18 +7733,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,18 +7753,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7154,9 +7794,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -7165,9 +7805,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -7176,9 +7816,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = [".github/"]
 license = "MIT"
 name = "miden-agglayer-service"
 readme = "README.md"
-rust-version = "1.90"
+rust-version = "1.93"
 version = "0.1.0"
 
 [[bin]]
@@ -68,19 +68,23 @@ url = { features = ["serde"], version = "2.5" }
 tokio-postgres = { version = "0.7", optional = true }
 deadpool-postgres = { version = "0.14", optional = true }
 
-# miden-base
-miden-base-agglayer = { package = "miden-agglayer", version = "0.14.0-alpha" }
+# miden-base — loose caret pins. Pinning to `=0.14.4` exactly caused a runtime
+# STARK verification regression in the miden-node NTX builder; the 0.14.6
+# transitive node deps that cargo picks when left alone are what actually work
+# with miden-client @ f7cdf26 in practice (confirmed by our first e2e-l1-to-l2
+# pass). Keep the caret; rely on the git rev pin below for reproducibility.
+miden-base-agglayer = { package = "miden-agglayer", version = "0.14" }
 miden-protocol = { default-features = false, features = [
   "std",
-], version = "0.14.0-alpha" }
-miden-standards = { default-features = false, version = "0.14.0-alpha" }
-miden-tx = { default-features = false, version = "0.14.0-alpha" }
+], version = "0.14" }
+miden-standards = { default-features = false, version = "0.14" }
+miden-tx = { default-features = false, version = "0.14" }
 
-# miden-client
+# miden-client (pinned to ajl-agglayer-integration-tests-v0.14.0 branch head for reproducibility)
 miden-client = { default-features = false, features = [
   "tonic",
-], git = "https://github.com/0xMiden/miden-client.git", branch = "agglayer-integration-tests" }
-miden-client-sqlite-store = { git = "https://github.com/0xMiden/miden-client.git", branch = "agglayer-integration-tests" }
+], git = "https://github.com/0xMiden/miden-client.git", rev = "f7cdf263781999e8f81ba608f9c5a91218747d98" }
+miden-client-sqlite-store = { git = "https://github.com/0xMiden/miden-client.git", rev = "f7cdf263781999e8f81ba608f9c5a91218747d98" }
 
 [features]
 default = []

--- a/Dockerfile.miden-node
+++ b/Dockerfile.miden-node
@@ -1,7 +1,8 @@
-# Build testing-node-builder from agglayer-integration-tests branch
-# This branch has a WORKING E2E bridge-in + bridge-out test with the NTX builder
-# correctly consuming CLAIM notes via network transactions.
-FROM rust:1.91-slim-bookworm AS builder
+# Build testing-node-builder from ajl-agglayer-integration-tests-v0.14.0 branch.
+# This is the first stable-0.14.x-compatible integration test branch; the CLAIM note
+# now targets the bridge (not the faucet), and the bridge gains an on-chain
+# token_registry_map alongside the faucet_registry_map.
+FROM rust:1.93-slim-bookworm AS builder
 
 RUN apt-get update && apt-get install -y \
     pkg-config \
@@ -15,16 +16,18 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /build
 
-# agglayer-integration-tests branch has:
-# - miden-node deps at =0.14.0-alpha.3
-# - Working agglayer bridge-in + bridge-out E2E test
-# - NTX builder correctly processes network notes (CONFIG_AGG_BRIDGE, UPDATE_GER, CLAIM)
+# ajl-agglayer-integration-tests-v0.14.0 branch has:
+# - miden-node + miden-protocol + miden-agglayer deps at 0.14 (stable, non-alpha)
+# - CLAIM notes targeting the bridge (not the faucet); bridge produces MINT note
+#   that the faucet consumes to create the final P2ID for the destination wallet
+# - Dual on-chain registration (faucet_registry_map + token_registry_map)
+# - EthAddress / EthEmbeddedAccountId type split
 # Pinned to specific commit for reproducible builds.
 RUN git clone https://github.com/0xMiden/miden-client.git . && \
-    git checkout ac3d953d6092a93e01b2a4bb9c464f395525390d
+    git checkout f7cdf263781999e8f81ba608f9c5a91218747d98
 
 RUN git rev-parse HEAD > /tmp/miden-client-commit.txt && \
-    echo "Branch: agglayer-integration-tests" >> /tmp/miden-client-commit.txt
+    echo "Branch: ajl-agglayer-integration-tests-v0.14.0" >> /tmp/miden-client-commit.txt
 
 # Patch: bind RPC to 0.0.0.0 for Docker port forwarding
 RUN sed -i 's|format!("127.0.0.1:{}", self.rpc_port)|format!("0.0.0.0:{}", self.rpc_port)|' \
@@ -57,9 +60,9 @@ RUN mkdir -p /app/data
 RUN printf '%s\n' \
     '#!/bin/bash' \
     'set -e' \
-    'echo "=== Miden Testing Node (agglayer-integration-tests) ==="' \
+    'echo "=== Miden Testing Node (ajl-agglayer-integration-tests-v0.14.0) ==="' \
     'cat /app/miden-client-commit.txt' \
-    'export AGGLAYER_GENESIS="${AGGLAYER_GENESIS:-1}"' \
+    'export AGGLAYER_GENESIS="${AGGLAYER_GENESIS:-0}"' \
     'echo "AGGLAYER_GENESIS=$AGGLAYER_GENESIS"' \
     'exec testing-node-builder "$@"' \
     > /usr/local/bin/entrypoint.sh && \

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -101,6 +101,19 @@ services:
       NETWORK_ID: "${NETWORK_ID:-1}"
       DATABASE_URL: "host=agglayer-postgres user=agglayer password=agglayer dbname=agglayer_store"
       RUST_LOG: "info"
+      # Force all tmp I/O onto the bind-mounted dir so rocksdb / rusqlite
+      # atomic-rename operations stay on the same device. Without this,
+      # miden-client's on-disk store fails at startup with
+      # "Invalid cross-device link".
+      TMPDIR: /var/lib/miden-agglayer-service/tmp
+    volumes:
+      # Bind mount so `docker compose run --rm --no-deps miden-agglayer --restore`
+      # shares the miden-client sqlite store + keystore + bridge_accounts.toml with
+      # the main service container. A *named* volume trips sqlite's
+      # "Invalid cross-device link" at startup because the rusqlite temp file
+      # lives on a different device than the mount target; a bind mount keeps
+      # everything on the host filesystem and sidesteps the rename boundary.
+      - ./.miden-agglayer-data:/var/lib/miden-agglayer-service
     command:
       - "--port=8546"
       - "--miden-node=http://miden-node:57291"

--- a/scripts/e2e-dynamic-erc20.sh
+++ b/scripts/e2e-dynamic-erc20.sh
@@ -62,7 +62,12 @@ wait_for() {
     local desc="$1" cmd="$2" timeout="$3" interval="${4:-5}"
     local elapsed=0
     log "Waiting: $desc (timeout: ${timeout}s)..."
-    while ! eval "$cmd" 2>/dev/null; do
+    # Run the probe in a subshell with pipefail disabled. Otherwise patterns
+    # like `docker logs ... | grep -q X` spuriously fail: grep -q exits on the
+    # first match, sending SIGPIPE to docker logs, whose 141 exit code trips
+    # pipefail and makes the probe look like a miss even when the match is
+    # there. Dropping pipefail inside the probe lets grep's exit code decide.
+    while ! ( set +o pipefail; eval "$cmd" ) 2>/dev/null; do
         elapsed=$((elapsed + interval))
         [[ $elapsed -ge $timeout ]] && fail "Timed out: $desc"
         echo -n "."
@@ -254,21 +259,36 @@ wait_for "certificate settled" \
     300 10
 pass "Certificate settled on L1"
 
-# Wait for deposit in bridge-service
+# Wait for the SPECIFIC TestToken deposit to appear in bridge-service. When
+# running inside the full suite, `e2e-l2-to-l1.sh` already produced an ETH
+# deposit that's `ready_for_claim` — a loose filter would match that and the
+# subsequent claim would pick the wrong (already-claimed) deposit and fail.
+EXPECTED_ORIG_ADDR=$(python3 -c "print('$TOKEN_ADDR'.lower())")
 wait_for "L2 deposit in bridge-service" \
-    "curl -sf '$BRIDGE_SERVICE_URL/bridges/$L1_DEST' 2>/dev/null | python3 -c \"import json,sys; d=json.load(sys.stdin); exit(0 if any(dep.get('ready_for_claim') and dep.get('network_id')==1 for dep in d.get('deposits',[])) else 1)\"" \
+    "curl -sf '$BRIDGE_SERVICE_URL/bridges/$L1_DEST' 2>/dev/null | python3 -c \"import json,sys; d=json.load(sys.stdin); want='$EXPECTED_ORIG_ADDR'; exit(0 if any(dep.get('ready_for_claim') and dep.get('network_id')==1 and (dep.get('claim_tx_hash') or '')=='' and (dep.get('orig_addr') or '').lower()==want for dep in d.get('deposits',[])) else 1)\"" \
     120 5
 pass "TestToken L2→L1 deposit synced and ready_for_claim"
 
-# Claim on L1 (same pattern as e2e-l2-to-l1.sh)
+# Claim on L1. Filter by BOTH origin token address (to skip any unrelated ETH
+# deposits left over from e2e-l2-to-l1.sh when this test runs inside the full
+# suite) AND unclaimed status (claim_tx_hash is empty). Without these, the
+# picker would grab the already-claimed ETH deposit and fail at cast send.
 DEPOSITS_JSON=$(curl -sf "$BRIDGE_SERVICE_URL/bridges/$L1_DEST")
 DEPOSIT_INFO=$(echo "$DEPOSITS_JSON" | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
+want = '$EXPECTED_ORIG_ADDR'
 for dep in d.get('deposits', []):
-    if dep.get('ready_for_claim') and dep.get('network_id') == 1:
-        print(json.dumps(dep))
-        break
+    if not dep.get('ready_for_claim'):
+        continue
+    if dep.get('network_id') != 1:
+        continue
+    if (dep.get('claim_tx_hash') or '') != '':
+        continue
+    if (dep.get('orig_addr') or '').lower() != want:
+        continue
+    print(json.dumps(dep))
+    break
 ")
 [[ -z "$DEPOSIT_INFO" ]] && fail "Could not find ready L2→L1 deposit"
 

--- a/scripts/e2e-fuzz-bridge.sh
+++ b/scripts/e2e-fuzz-bridge.sh
@@ -37,7 +37,7 @@ AGGKIT_CONTAINER="${AGGKIT_CONTAINER:-${COMPOSE_PROJECT_NAME}-aggkit-1}"
 FUNDED_KEY="0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"
 FUNDED_ADDR=$(cast wallet address --private-key "$FUNDED_KEY")
 DEST_NETWORK=1
-BRIDGE_ADDRESS=$(grep 'BRIDGE_ADDRESS=' "$FIXTURES_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "0xC8cbEBf950B9Df44d987c8619f092beA980fF038")
+BRIDGE_ADDRESS=$(grep -E '^BRIDGE_ADDRESS=' "$FIXTURES_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '"' || echo "0xC8cbEBf950B9Df44d987c8619f092beA980fF038")
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'; NC='\033[0m'
 log()  { echo -e "${GREEN}[$(date +%H:%M:%S)]${NC} $*"; }
@@ -52,7 +52,9 @@ FAILURES=0
 wait_for() {
     local desc="$1" cmd="$2" timeout="$3" interval="${4:-5}"
     local elapsed=0
-    while ! eval "$cmd" 2>/dev/null; do
+    # Subshell with pipefail off — see e2e-dynamic-erc20.sh for the SIGPIPE
+    # rationale.
+    while ! ( set +o pipefail; eval "$cmd" ) 2>/dev/null; do
         elapsed=$((elapsed + interval))
         if [[ $elapsed -ge $timeout ]]; then
             return 1
@@ -72,16 +74,29 @@ curl -sf "$L2_RPC" -X POST -H "Content-Type: application/json" \
     -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' >/dev/null 2>&1 \
     || { echo "L2 proxy not reachable"; exit 1; }
 
-# Get wallet address from proxy
+# Get wallet + bridge + faucet account IDs from the toml (bech32) and resolve
+# the wallet's hex form via bridge-out-tool — the toml stores bech32 strings
+# (mlcl1...) not hex, so a naive grep won't produce a 0x-prefixed WALLET_HEX.
 ACCOUNTS=$(docker exec "$AGGLAYER_CONTAINER" \
     cat /var/lib/miden-agglayer-service/bridge_accounts.toml 2>/dev/null) || true
-WALLET_HEX=""
-DEST_ADDR=""
-if [[ -n "${ACCOUNTS:-}" ]]; then
-    WALLET_HEX=$(echo "$ACCOUNTS" | grep 'wallet_hardhat' | head -1 | sed 's/.*"0x/0x/' | sed 's/".*//')
-    DEST_ADDR="0x00000000${WALLET_HEX#0x}00"
-fi
-[[ -z "$DEST_ADDR" ]] && { echo "Could not read wallet address"; exit 1; }
+[[ -z "${ACCOUNTS:-}" ]] && { echo "Could not read bridge_accounts.toml"; exit 1; }
+WALLET_ID=$(echo "$ACCOUNTS" | grep wallet_hardhat | sed 's/.*= "//;s/"//')
+BRIDGE_ID=$(echo "$ACCOUNTS" | grep 'bridge = ' | sed 's/.*= "//;s/"//')
+FAUCET_ID=$(echo "$ACCOUNTS" | grep faucet_eth | sed 's/.*= "//;s/"//')
+[[ -z "$WALLET_ID" || -z "$BRIDGE_ID" || -z "$FAUCET_ID" ]] \
+    && { echo "Could not parse wallet/bridge/faucet from bridge_accounts.toml"; exit 1; }
+
+# bridge-out-tool prints "wallet: 0x<hex>" even if the balance check fails
+WALLET_HEX=$(docker exec "$AGGLAYER_CONTAINER" bridge-out-tool \
+    --store-dir /var/lib/miden-agglayer-service \
+    --node-url http://miden-node:57291 \
+    --wallet-id "$WALLET_ID" --bridge-id "$BRIDGE_ID" --faucet-id "$FAUCET_ID" \
+    --amount 1 --dest-address 0xdead --dest-network 0 2>&1 | grep "wallet:" | awk '{print $NF}' || true)
+[[ -z "$WALLET_HEX" ]] && { echo "Could not resolve wallet hex via bridge-out-tool"; exit 1; }
+INNER="${WALLET_HEX#0x}"
+PREFIX="${INNER:0:16}"
+SUFFIX="${INNER:16:14}00"
+DEST_ADDR="0x00000000${PREFIX}${SUFFIX}"
 
 # Helper: get L2 wallet balance for a faucet
 l2_balance() {
@@ -91,16 +106,18 @@ l2_balance() {
         | python3 -c "import json,sys; r=json.load(sys.stdin); print(r.get('result','0'))" 2>/dev/null || echo "0"
 }
 
-# Helper: deploy an ERC-20 token
+# Helper: deploy an ERC-20 token. Uses fixtures/TestToken.sol (the same
+# contract e2e-dynamic-erc20.sh compiles against). The old `src/test_helpers/`
+# path no longer exists.
 deploy_token() {
     local name="$1" symbol="$2" decimals="$3" supply="$4"
-    # Use CREATE2 to get deterministic addresses based on salt
-    local salt=$(python3 -c "import hashlib; print('0x'+hashlib.sha256('${name}${symbol}${decimals}'.encode()).hexdigest())")
-    forge create --rpc-url "$L1_RPC" \
+    local out
+    out=$(forge create --rpc-url "$L1_RPC" \
         --private-key "$FUNDED_KEY" \
-        "src/test_helpers/TestToken.sol:TestToken" \
-        --constructor-args "$name" "$symbol" "$decimals" "$supply" \
-        --json 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin)['deployedTo'])" 2>/dev/null || echo ""
+        --broadcast \
+        "$FIXTURES_DIR/TestToken.sol:TestToken" \
+        --constructor-args "$name" "$symbol" "$decimals" "$supply" 2>&1) || { echo ""; return; }
+    echo "$out" | grep "Deployed to:" | awk '{print $NF}'
 }
 
 # Helper: bridge an ERC-20 token L1→L2

--- a/scripts/e2e-l1-to-l2.sh
+++ b/scripts/e2e-l1-to-l2.sh
@@ -35,7 +35,11 @@ wait_for() {
     local desc="$1" cmd="$2" timeout="$3" interval="${4:-5}"
     local elapsed=0
     log "Waiting: $desc (timeout: ${timeout}s)..."
-    while ! eval "$cmd" 2>/dev/null; do
+    # Run the probe in a subshell with pipefail disabled — see full comment
+    # in e2e-dynamic-erc20.sh::wait_for. `docker logs ... | grep -q` tripped
+    # pipefail because grep -q closes the pipe early, docker logs takes
+    # SIGPIPE, and the 141 exit was propagating as "no match".
+    while ! ( set +o pipefail; eval "$cmd" ) 2>/dev/null; do
         elapsed=$((elapsed + interval))
         [[ $elapsed -ge $timeout ]] && fail "Timed out: $desc"
         echo -n "."

--- a/scripts/e2e-l2-to-l1.sh
+++ b/scripts/e2e-l2-to-l1.sh
@@ -34,7 +34,9 @@ wait_for() {
     local desc="$1" cmd="$2" timeout="$3" interval="${4:-5}"
     local elapsed=0
     log "Waiting: $desc (timeout: ${timeout}s)..."
-    while ! eval "$cmd" 2>/dev/null; do
+    # Subshell with pipefail off — see e2e-dynamic-erc20.sh for the SIGPIPE
+    # rationale.
+    while ! ( set +o pipefail; eval "$cmd" ) 2>/dev/null; do
         elapsed=$((elapsed + interval))
         [[ $elapsed -ge $timeout ]] && fail "Timed out: $desc"
         echo -n "."

--- a/scripts/e2e-restore.sh
+++ b/scripts/e2e-restore.sh
@@ -43,7 +43,9 @@ wait_for() {
     local desc="$1" cmd="$2" timeout="$3" interval="${4:-5}"
     local elapsed=0
     log "Waiting: $desc (timeout: ${timeout}s)..."
-    while ! eval "$cmd" 2>/dev/null; do
+    # Subshell with pipefail off — see e2e-dynamic-erc20.sh for the SIGPIPE
+    # rationale.
+    while ! ( set +o pipefail; eval "$cmd" ) 2>/dev/null; do
         elapsed=$((elapsed + interval))
         [[ $elapsed -ge $timeout ]] && fail "Timed out: $desc"
         echo -n "."
@@ -96,7 +98,10 @@ echo ""
 # PART 2: Wipe PostgreSQL tables (simulate disaster)
 # ══════════════════════════════════════════════════════════════════════════════
 step "Part 2: Wiping all PostgreSQL tables (simulating data loss)..."
-pgquery "TRUNCATE service_state, synthetic_logs, ger_entries, transactions, transaction_logs, nonces, claimed_indices, address_mappings, bridge_out_processed, block_transactions CASCADE"
+# NOTE: keep this list in lockstep with migrations/*.sql. `block_transactions` was
+# removed from the schema but stuck around in this script until 0.14.x migration;
+# `faucet_registry` was added later.
+pgquery "TRUNCATE service_state, synthetic_logs, ger_entries, transactions, transaction_logs, nonces, claimed_indices, address_mappings, bridge_out_processed, faucet_registry CASCADE"
 # Re-insert the singleton service_state row
 pgquery "INSERT INTO service_state (id) VALUES (1)"
 

--- a/src/address_mapper.rs
+++ b/src/address_mapper.rs
@@ -1,5 +1,6 @@
 use crate::accounts_config::AccountsConfig;
 use alloy::primitives::Address;
+use miden_base_agglayer::{EthAddress, EthEmbeddedAccountId};
 use miden_protocol::account::AccountId;
 
 const HARDHAT_ADDRESS: Address = Address::new([
@@ -8,7 +9,7 @@ const HARDHAT_ADDRESS: Address = Address::new([
 ]);
 
 pub fn is_miden_compatible_address(address: Address) -> bool {
-    // The canonical EthAddressFormat embeds AccountId as:
+    // The canonical EthEmbeddedAccountId encoding embeds AccountId as:
     //   [4 zero bytes] [prefix(8 bytes)] [suffix(8 bytes)]
     // Only the first 4 bytes must be zero; byte 4 is the MSB of the prefix.
     address[0..4].iter().all(|b| *b == 0)
@@ -18,15 +19,14 @@ pub fn account_id_from_address(address: Address) -> Option<AccountId> {
     if !is_miden_compatible_address(address) {
         return None;
     }
-    // Extract prefix (8 bytes) and suffix (8 bytes) from canonical layout:
-    //   address[0..4]  = zero padding
-    //   address[4..12] = prefix (u64 big-endian)
-    //   address[12..20] = suffix (u64 big-endian)
-    let prefix = u64::from_be_bytes(address[4..12].try_into().ok()?);
-    let suffix = u64::from_be_bytes(address[12..20].try_into().ok()?);
-    let prefix_felt = miden_protocol::Felt::try_from(prefix).ok()?;
-    let suffix_felt = miden_protocol::Felt::try_from(suffix).ok()?;
-    AccountId::try_from([prefix_felt, suffix_felt]).ok()
+    // 0.14.x: wrap the 20-byte EVM address and use the dedicated embedded-AccountId type.
+    // `EthEmbeddedAccountId::try_from(eth_addr)` validates the 4 leading zero bytes and
+    // reconstructs the inner AccountId; failure here means the address wasn't a valid
+    // zero-padded Miden id even though `is_miden_compatible_address` thought it was.
+    let eth_addr = EthAddress::new(address.0.0);
+    EthEmbeddedAccountId::try_from(eth_addr)
+        .ok()
+        .map(AccountId::from)
 }
 
 /// Resolve an Ethereum address to a Miden AccountId.
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn test_account_id_from_address() {
         let expected_account_id = AccountId::from_hex("0x3d7c9747558851900f8206226dfbea").unwrap();
-        // Canonical EthAddressFormat: [4 zero bytes][prefix(8)][suffix(8)]
+        // Canonical EthEmbeddedAccountId: [4 zero bytes][prefix(8)][suffix(8)]
         // AccountId 0x3d7c9747558851900f8206226dfbea has:
         //   prefix = 0x3d7c974755885190, suffix = 0x0f8206226dfbea00
         let address = address!("0x000000003d7c9747558851900f8206226dfbea00");

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -13,14 +13,14 @@ use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
 use clap::Parser;
-use miden_base_agglayer::{B2AggNote, EthAddressFormat};
+use miden_base_agglayer::{B2AggNote, EthAddress};
 use miden_client::DebugMode;
 use miden_client::asset::{Asset, FungibleAsset};
 use miden_client::builder::ClientBuilder;
 use miden_client::keystore::FilesystemKeyStore;
 use miden_client::note::NoteAssets;
 use miden_client::rpc::Endpoint;
-use miden_client::transaction::{OutputNote, TransactionRequestBuilder};
+use miden_client::transaction::TransactionRequestBuilder;
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::account::AccountId;
 
@@ -209,7 +209,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Parse destination address
-    let l1_dest = EthAddressFormat::from_hex(&args.dest_address)
+    let l1_dest = EthAddress::from_hex(&args.dest_address)
         .map_err(|e| anyhow!("invalid dest address: {e}"))?;
 
     // Create B2AGG note
@@ -246,7 +246,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Submit transaction
     let tx_request = TransactionRequestBuilder::new()
-        .own_output_notes(vec![OutputNote::Full(b2agg)])
+        .own_output_notes(vec![b2agg])
         .build()
         .map_err(|e| anyhow!("tx request build failed: {e}"))?;
 

--- a/src/bridge_out.rs
+++ b/src/bridge_out.rs
@@ -247,9 +247,16 @@ impl SyncListener for BridgeOutScanner {
             if was_processed {
                 continue;
             }
-            // Use atomic block counter to avoid collisions with GER/claim events.
-            let block_number = self.store.advance_block_number().await?;
+            // Race-safe ordering: write the log at (current_latest + 1) BEFORE
+            // advancing `latest_block_number`. If we advance first, there's a
+            // window where `eth_blockNumber` returns N but no log exists at N —
+            // aggsender polls during that window, sees no bridges in [X, N],
+            // advances its cursor past N, and permanently misses our BridgeEvent.
+            // By writing the log first and then bumping `latest_block_number`,
+            // every reader who sees `latest >= N` also sees the log at N.
+            let block_number = self.store.get_latest_block_number().await? + 1;
             self.process_consumed_note(note, block_number).await;
+            self.store.set_latest_block_number(block_number).await?;
             tracing::info!(
                 block_number,
                 "advanced latest_block_number to include BridgeEvent"

--- a/src/bridge_out.rs
+++ b/src/bridge_out.rs
@@ -31,7 +31,7 @@ pub fn is_b2agg_note(details: &NoteDetails) -> bool {
 ///
 /// The destination_address is a standard 20-byte EVM address (e.g. `0xAbC...123`),
 /// NOT a Miden account ID. It comes from the bridge contract's `bridgeAsset()` call
-/// and is stored in the note via `EthAddressFormat::to_elements()`.
+/// and is stored in the note via `EthAddress::to_elements()`.
 ///
 /// Storage layout (6 felts):
 /// - items()[0]: destination_network (u32, byte-swapped via u32::from_le_bytes(dest.to_be_bytes()))
@@ -42,17 +42,17 @@ pub fn parse_b2agg_storage(storage: &NoteStorage) -> anyhow::Result<(u32, [u8; 2
     // Reverse the byte-swap applied during note creation:
     // build_note_storage does: u32::from_le_bytes(destination_network.to_be_bytes())
     // So to recover: u32::from_le_bytes(felt_value.to_be_bytes())
-    let raw_network = u32::try_from(items[0].as_int())
+    let raw_network = u32::try_from(items[0].as_canonical_u64())
         .context("destination_network overflow: felt value exceeds u32::MAX")?;
     let destination_network = u32::from_le_bytes(raw_network.to_be_bytes());
 
     // Reconstruct 20-byte address from 5 packed u32 felts (big-endian limb order).
     // Each felt holds a u32 value that represents 4 bytes in little-endian byte order.
-    // to_elements() in EthAddressFormat uses bytes_to_packed_u32_felts which reads
+    // to_elements() in EthAddress uses bytes_to_packed_u32_elements which reads
     // each 4-byte chunk as a little-endian u32.
     let mut address = [0u8; 20];
     for i in 0..5 {
-        let limb = u32::try_from(items[1 + i].as_int())
+        let limb = u32::try_from(items[1 + i].as_canonical_u64())
             .context("address limb overflow: felt value exceeds u32::MAX")?;
         address[i * 4..(i + 1) * 4].copy_from_slice(&limb.to_le_bytes());
     }

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -6,7 +6,7 @@ use crate::store::{FaucetEntry, Store};
 use alloy::primitives::{BlockNumber, Bytes, FixedBytes, LogData};
 use alloy::sol_types::SolEvent;
 use miden_base_agglayer::{
-    ClaimNoteStorage, EthAddressFormat, EthAmount, ExitRoot, GlobalIndex, LeafData, MetadataHash,
+    ClaimNoteStorage, EthAddress, EthAmount, ExitRoot, GlobalIndex, LeafData, MetadataHash,
     ProofData, SmtNode,
 };
 use miden_client::transaction::TransactionRequestBuilder;
@@ -14,7 +14,7 @@ use miden_protocol::Felt;
 use miden_protocol::account::AccountId;
 use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::note::Note;
-use miden_protocol::transaction::{OutputNote, TransactionId};
+use miden_protocol::transaction::TransactionId;
 use std::sync::{Arc, OnceLock};
 
 alloy_core::sol! {
@@ -107,7 +107,13 @@ async fn find_or_create_faucet(
         "auto-creating faucet for new ERC-20 token"
     );
 
-    // 3. Create faucet on Miden, deploy, register in bridge
+    // 3. Create faucet on Miden, deploy, register in bridge. The faucet's stored
+    //    metadata_hash must match the CLAIM note's leaf_data.metadata_hash, which is
+    //    keccak256(metadata) (both empty for native ETH and abi.encode(name,symbol,decimals)
+    //    for ERC-20s). Using MetadataHash::from_abi_encoded on the raw metadata bytes matches
+    //    the L1 bridge contract exactly.
+    let metadata_hash = MetadataHash::from_abi_encoded(metadata.as_ref());
+
     let faucet_account = faucet_ops::create_and_register_faucet(
         client,
         &symbol,
@@ -117,6 +123,7 @@ async fn find_or_create_faucet(
         scale,
         accounts.service.0,
         accounts.bridge.0,
+        metadata_hash,
     )
     .await?;
 
@@ -167,33 +174,25 @@ async fn create_claim(
 
     let leaf_data = LeafData {
         origin_network: params.originNetwork,
-        origin_token_address: EthAddressFormat::new(params.originTokenAddress.0.0),
+        origin_token_address: EthAddress::new(params.originTokenAddress.0.0),
         destination_network: params.destinationNetwork,
-        destination_address: EthAddressFormat::new(params.destinationAddress.0.0),
+        destination_address: EthAddress::new(params.destinationAddress.0.0),
         amount: EthAmount::new(params.amount.to_be_bytes::<32>()),
-        metadata_hash: MetadataHash::new(metadata_to_hash(&params.metadata)),
+        metadata_hash: MetadataHash::from_abi_encoded(params.metadata.as_ref()),
     };
 
+    let _ = faucet; // retained for amount-scaling metadata; not used to target the note now.
     let storage = ClaimNoteStorage {
         proof_data,
         leaf_data,
         miden_claim_amount: Felt::from(amount),
     };
 
-    let note = miden_base_agglayer::create_claim_note(storage, faucet.id, sender, rng)?;
+    // CLAIM notes now target the bridge account (0.14.x). The bridge validates the proof and
+    // produces a MINT note targeted at the faucet. The faucet then creates the final P2ID note
+    // for the destination wallet (derived from leaf_data.destination_address).
+    let note = miden_base_agglayer::create_claim_note(storage, accounts.bridge.0, sender, rng)?;
     Ok(note)
-}
-
-/// Compute metadata hash: keccak256 of metadata bytes.
-///
-/// The Solidity bridge contract always uses `keccak256(metadata)` in the leaf
-/// computation, even for empty metadata. For ETH deposits metadata is empty,
-/// so this returns `keccak256("")` = `0xc5d246...`, NOT all zeros.
-fn metadata_to_hash(metadata: &Bytes) -> [u8; 32] {
-    use sha3::{Digest, Keccak256};
-    let mut hasher = Keccak256::new();
-    hasher.update(metadata.as_ref());
-    hasher.finalize().into()
 }
 
 #[derive(Debug, Clone)]
@@ -254,23 +253,20 @@ async fn publish_claim_internal(
     tracing::info!("GER propagation wait complete, submitting CLAIM note");
 
     let txn_request = TransactionRequestBuilder::new()
-        .own_output_notes([OutputNote::Full(claim_note); 1])
+        .own_output_notes(vec![claim_note])
         .build()?;
 
-    // Execute and check the output notes before submission
+    // Execute and check the output notes before submission. `ExecutedTransaction` still
+    // produces `RawOutputNote::{Full, Partial}`, but the proven transaction now produces
+    // `OutputNote::{Public, Private}` — 0.14.x renamed the final-form variants.
     let tx_result = client
         .execute_transaction(accounts.service.0, txn_request)
         .await?;
     let exec_tx = tx_result.executed_transaction();
     for (i, note) in exec_tx.output_notes().iter().enumerate() {
         let variant = match note {
-            miden_protocol::transaction::OutputNote::Full(n) => {
-                let att = n.metadata().attachment();
-                let att_default = att == &miden_protocol::note::NoteAttachment::default();
-                format!("Full(attachment_empty={})", att_default)
-            }
-            miden_protocol::transaction::OutputNote::Partial(_) => "Partial".to_string(),
-            miden_protocol::transaction::OutputNote::Header(_) => "Header".to_string(),
+            miden_protocol::transaction::RawOutputNote::Full(_) => "Full",
+            miden_protocol::transaction::RawOutputNote::Partial(_) => "Partial",
         };
         tracing::info!(note_idx = i, variant = %variant, "executed tx output note");
     }
@@ -278,13 +274,8 @@ async fn publish_claim_internal(
     let proven_tx = client.prove_transaction(&tx_result).await?;
     for (i, note) in proven_tx.output_notes().iter().enumerate() {
         let variant = match note {
-            miden_protocol::transaction::OutputNote::Full(n) => {
-                let att = n.metadata().attachment();
-                let att_default = att == &miden_protocol::note::NoteAttachment::default();
-                format!("Full(attachment_empty={})", att_default)
-            }
-            miden_protocol::transaction::OutputNote::Partial(_) => "Partial".to_string(),
-            miden_protocol::transaction::OutputNote::Header(_) => "Header".to_string(),
+            miden_protocol::transaction::OutputNote::Public(_) => "Public",
+            miden_protocol::transaction::OutputNote::Private(_) => "Private",
         };
         tracing::info!(note_idx = i, variant = %variant, "proven tx output note");
     }
@@ -327,7 +318,10 @@ async fn publish_claim_internal(
 /// Creates a new client per call to avoid stale account state from the
 /// long-lived MidenClient's background sync loop. After faucet creation
 /// or prior CLAIMs, the service account's state drifts in the long-lived
-/// client, causing `IncorrectAccountInitialCommitment` errors.
+/// client, causing `IncorrectAccountInitialCommitment` errors. Recording
+/// of the ClaimEvent happens before the result is sent back so the event
+/// is in the store even if the HTTP caller disconnects.
+#[allow(clippy::too_many_arguments)]
 pub async fn publish_claim(
     params: claimAssetCall,
     client: &MidenClient,
@@ -467,14 +461,14 @@ mod tests {
     use alloy::primitives::address;
 
     #[test]
-    fn test_metadata_to_hash_empty() {
-        let metadata = Bytes::from(vec![]);
-        let hash = metadata_to_hash(&metadata);
-        // keccak256("")
+    fn test_metadata_hash_empty() {
+        // Empty metadata → keccak256("") → 0xc5d246...a470. This is what the L1 bridge
+        // contract puts in `leaf_data.metadata_hash` for native ETH deposits.
+        let hash = MetadataHash::from_abi_encoded(&[]);
         let expected =
             hex::decode("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
                 .unwrap();
-        assert_eq!(hash, expected.as_slice());
+        assert_eq!(hash.as_bytes(), expected.as_slice());
     }
 
     #[tokio::test]
@@ -501,14 +495,14 @@ mod tests {
     }
 
     #[test]
-    fn test_metadata_to_hash_non_empty() {
-        let metadata = Bytes::from(vec![0x01, 0x02, 0x03]);
-        let hash = metadata_to_hash(&metadata);
-        // keccak256([0x01, 0x02, 0x03])
+    fn test_metadata_hash_non_empty() {
+        // Non-empty raw bytes → keccak256(bytes). Sanity check that
+        // `MetadataHash::from_abi_encoded` is just keccak256, not ABI-aware.
+        let hash = MetadataHash::from_abi_encoded(&[0x01, 0x02, 0x03]);
         let expected =
             hex::decode("f1885eda54b7a053318cd41e2093220dab15d65381b1157a3633a83bfd5c9239")
                 .unwrap();
-        assert_eq!(hash, expected.as_slice());
+        assert_eq!(hash.as_bytes(), expected.as_slice());
     }
 
     #[test]

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -339,7 +339,13 @@ pub async fn publish_claim(
     let result_inner = result.clone();
 
     if node_url.is_empty() {
-        // Test path: use the existing MidenClient
+        // Test path: use the existing MidenClient.
+        //
+        // Race-safe ordering: write the txn+log at (current_latest + 1) BEFORE
+        // bumping `latest_block_number`. See the matching comment in
+        // `bridge_out.rs::on_post_sync`: advancing the counter first leaves a
+        // window where `eth_blockNumber` returns N but no log exists at block N
+        // yet, so aggsender / bridge-service skip the event entirely.
         let result_test = result.clone();
         client
             .with(move |client| {
@@ -352,7 +358,7 @@ pub async fn publish_claim(
                         latest_block_num,
                     )
                     .await?;
-                    let block_num = store.advance_block_number().await?;
+                    let block_num = store.get_latest_block_number().await? + 1;
                     let block_hash = block_state.get_block_hash(block_num);
                     store
                         .txn_begin(
@@ -369,6 +375,12 @@ pub async fn publish_claim(
                     store
                         .txn_commit(txn_hash, Ok(()), block_num, block_hash)
                         .await?;
+                    store.set_latest_block_number(block_num).await?;
+                    tracing::info!(
+                        eth_tx = %txn_hash,
+                        block_num,
+                        "ClaimEvent recorded (cancellation-safe)"
+                    );
                     let _ = result_test.set(value);
                     Ok(())
                 })
@@ -415,7 +427,10 @@ pub async fn publish_claim(
             .await?;
 
             // Record the ClaimEvent — cancellation-safe.
-            let block_num = store_clone.advance_block_number().await?;
+            // Race-safe ordering: write the txn+log at (current_latest + 1)
+            // BEFORE bumping `latest_block_number`. See `bridge_out.rs::on_post_sync`
+            // for the SIGPIPE/cursor-advance rationale.
+            let block_num = store_clone.get_latest_block_number().await? + 1;
             let block_hash = block_state.get_block_hash(block_num);
             store_clone
                 .txn_begin(
@@ -432,6 +447,7 @@ pub async fn publish_claim(
             store_clone
                 .txn_commit(txn_hash, Ok(()), block_num, block_hash)
                 .await?;
+            store_clone.set_latest_block_number(block_num).await?;
             tracing::info!(
                 eth_tx = %txn_hash,
                 block_num,

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -401,9 +401,9 @@ pub async fn publish_claim(
     let join_result = tokio::task::spawn_blocking(move || {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
+            use ::miden_client::DebugMode;
             use ::miden_client::builder::ClientBuilder;
             use ::miden_client::rpc::Endpoint;
-            use ::miden_client::DebugMode;
             use ::miden_client_sqlite_store::ClientBuilderSqliteExt;
 
             let ep = Endpoint::try_from(node_url.as_str())

--- a/src/faucet_ops.rs
+++ b/src/faucet_ops.rs
@@ -6,13 +6,12 @@
 use crate::accounts_config::AccountIdBech32;
 use crate::miden_client::MidenClientLib;
 use alloy::primitives::{Address, Bytes};
-use miden_base_agglayer::{ConfigAggBridgeNote, EthAddressFormat, create_agglayer_faucet};
+use miden_base_agglayer::{ConfigAggBridgeNote, EthAddress, MetadataHash, create_agglayer_faucet};
 use miden_client::Felt;
 use miden_client::asset::FungibleAsset;
 use miden_client::crypto::FeltRng;
 use miden_client::transaction::TransactionRequestBuilder;
 use miden_protocol::account::{Account, AccountId};
-use miden_protocol::transaction::OutputNote;
 
 /// Create a faucet on Miden, deploy it, and register it in the bridge.
 ///
@@ -30,9 +29,10 @@ pub async fn create_and_register_faucet(
     scale: u8,
     service_id: AccountId,
     bridge_id: AccountId,
+    metadata_hash: MetadataHash,
 ) -> anyhow::Result<Account> {
     let max_supply = Felt::new(FungibleAsset::MAX_AMOUNT);
-    let origin_addr = EthAddressFormat::new(*origin_token_address);
+    let origin_addr = EthAddress::new(*origin_token_address);
 
     let account = create_agglayer_faucet(
         client.rng().draw_word(),
@@ -43,6 +43,7 @@ pub async fn create_and_register_faucet(
         &origin_addr,
         origin_network,
         scale,
+        metadata_hash,
     );
     client.add_account(&account, false).await?;
 
@@ -70,20 +71,30 @@ pub async fn create_and_register_faucet(
     }
 
     // Register in bridge
-    register_faucet_in_bridge(client, service_id, bridge_id, account.id(), symbol).await?;
+    register_faucet_in_bridge(
+        client,
+        service_id,
+        bridge_id,
+        account.id(),
+        &origin_addr,
+        symbol,
+    )
+    .await?;
 
     Ok(account)
 }
 
-/// Register a faucet in the bridge's faucet registry via ConfigAggBridgeNote.
+/// Register a faucet in the bridge's faucet and token registries via ConfigAggBridgeNote.
 ///
 /// Required for CLAIM note FPI validation: the bridge account must know which
-/// faucets are valid sources for claim operations. Idempotent.
+/// faucets are valid sources for claim operations, and the on-chain `token_registry_map`
+/// must map `hash(origin_token_address)` to the faucet's `AccountId`. Idempotent.
 pub async fn register_faucet_in_bridge(
     client: &mut MidenClientLib,
     service_id: AccountId,
     bridge_id: AccountId,
     faucet_id: AccountId,
+    origin_token_address: &EthAddress,
     faucet_name: &str,
 ) -> anyhow::Result<()> {
     tracing::info!(
@@ -93,11 +104,17 @@ pub async fn register_faucet_in_bridge(
         AccountIdBech32(bridge_id),
     );
 
-    let note = ConfigAggBridgeNote::create(faucet_id, service_id, bridge_id, client.rng())
-        .map_err(|e| anyhow::anyhow!("failed to create ConfigAggBridgeNote: {e}"))?;
+    let note = ConfigAggBridgeNote::create(
+        faucet_id,
+        origin_token_address,
+        service_id,
+        bridge_id,
+        client.rng(),
+    )
+    .map_err(|e| anyhow::anyhow!("failed to create ConfigAggBridgeNote: {e}"))?;
 
     let txn = TransactionRequestBuilder::new()
-        .own_output_notes([OutputNote::Full(note); 1])
+        .own_output_notes(vec![note])
         .build()?;
 
     let txn_id = client.submit_new_transaction(service_id, txn).await?;

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -5,7 +5,7 @@ use alloy::primitives::{FixedBytes, LogData, TxHash};
 use alloy::sol_types::SolEvent;
 use alloy_rpc_types_eth::TransactionRequest;
 use miden_base_agglayer::{ExitRoot, UpdateGerNote};
-use miden_client::transaction::{OutputNote, TransactionRequestBuilder};
+use miden_client::transaction::TransactionRequestBuilder;
 use sha3::{Digest, Keccak256};
 use std::sync::Arc;
 
@@ -154,7 +154,7 @@ async fn submit_ger_to_miden(
                 }
 
                 let tx_request = TransactionRequestBuilder::new()
-                    .own_output_notes(vec![OutputNote::Full(note)])
+                    .own_output_notes(vec![note])
                     .build()?;
 
                 let tx_id = match client
@@ -269,7 +269,7 @@ pub async fn insert_ger(
                             client.rng(),
                         )?;
                         let tx_request = TransactionRequestBuilder::new()
-                            .own_output_notes(vec![OutputNote::Full(note)])
+                            .own_output_notes(vec![note])
                             .build()?;
                         client
                             .submit_new_transaction(ger_manager_id, tx_request)

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -1,11 +1,11 @@
 use crate::accounts_config::AccountsConfig;
 use crate::miden_client::MidenClient;
-use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use alloy::primitives::{FixedBytes, LogData, TxHash};
 use alloy::sol_types::SolEvent;
 use alloy_rpc_types_eth::TransactionRequest;
 use miden_base_agglayer::{ExitRoot, UpdateGerNote};
 use miden_client::transaction::TransactionRequestBuilder;
+use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use sha3::{Digest, Keccak256};
 use std::sync::Arc;
 
@@ -127,12 +127,12 @@ async fn submit_ger_to_miden(
     // This is Igor's approach: fresh client per operation. The miden-client
     // types (Endpoint, Client) are !Send, so we can't hold them across .await
     // points in the axum handler's future.
-    let result = tokio::task::spawn_blocking(move || {
+    tokio::task::spawn_blocking(move || {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
+            use ::miden_client::DebugMode;
             use ::miden_client::builder::ClientBuilder;
             use ::miden_client::rpc::Endpoint;
-            use ::miden_client::DebugMode;
 
             for attempt in 0..3u32 {
                 let ep = Endpoint::try_from(node_url.as_str())
@@ -147,8 +147,7 @@ async fn submit_ger_to_miden(
                 client.sync_state().await?;
 
                 let ger = ExitRoot::new(ger_bytes);
-                let note =
-                    UpdateGerNote::create(ger, ger_manager_id, bridge_id, client.rng())?;
+                let note = UpdateGerNote::create(ger, ger_manager_id, bridge_id, client.rng())?;
                 if attempt == 0 {
                     tracing::info!(note_id = %note.id(), "UpdateGerNote created");
                 }
@@ -193,9 +192,7 @@ async fn submit_ger_to_miden(
                         t.id == tx_id
                             && matches!(
                                 t.status,
-                                miden_client::transaction::TransactionStatus::Committed {
-                                    ..
-                                }
+                                miden_client::transaction::TransactionStatus::Committed { .. }
                             )
                     }) {
                         committed = true;
@@ -219,9 +216,7 @@ async fn submit_ger_to_miden(
         })
     })
     .await
-    .map_err(|e| anyhow::anyhow!("GER spawn_blocking: {e}"))?;
-
-    result
+    .map_err(|e| anyhow::anyhow!("GER spawn_blocking: {e}"))?
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -262,12 +257,8 @@ pub async fn insert_ger(
                             .unwrap_or(inner_accounts.service.0);
                         let bridge_id = inner_accounts.bridge.0;
                         let ger = ExitRoot::new(ger_bytes);
-                        let note = UpdateGerNote::create(
-                            ger,
-                            ger_manager_id,
-                            bridge_id,
-                            client.rng(),
-                        )?;
+                        let note =
+                            UpdateGerNote::create(ger, ger_manager_id, bridge_id, client.rng())?;
                         let tx_request = TransactionRequestBuilder::new()
                             .own_output_notes(vec![note])
                             .build()?;

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -290,9 +290,13 @@ pub async fn insert_ger(
             .await?;
         }
 
-        // Use the store's sequential block counter so GER events and claim
-        // events never collide on the same block number.
-        block_number = store.advance_block_number().await?;
+        // Race-safe ordering: write the log at (current_latest + 1) BEFORE
+        // bumping `latest_block_number`. See the matching comment in
+        // `bridge_out.rs::on_post_sync`: if we advance the counter first,
+        // aggsender / bridge-service can poll `eth_blockNumber` in the window
+        // where `latest == N` but the log at block `N` hasn't been written yet,
+        // permanently skipping the GER event.
+        block_number = store.get_latest_block_number().await? + 1;
         let block_hash = block_state.get_block_hash(block_number);
         let timestamp = block_state.get_block_timestamp(block_number);
 
@@ -309,6 +313,7 @@ pub async fn insert_ger(
                 timestamp,
             )
             .await?;
+        store.set_latest_block_number(block_number).await?;
     } else {
         tracing::debug!(
             ger = %hex::encode(ger_bytes),

--- a/src/init.rs
+++ b/src/init.rs
@@ -3,14 +3,13 @@ use crate::accounts_config::{AccountIdBech32, AccountsConfig};
 use crate::faucet_ops;
 use crate::miden_client::MidenClient;
 use crate::miden_client::MidenClientLib;
-use miden_base_agglayer::create_bridge_account;
+use miden_base_agglayer::{MetadataHash, create_bridge_account};
 use miden_client::crypto::FeltRng;
 use miden_client::keystore::{FilesystemKeyStore, Keystore};
 use miden_client::transaction::TransactionRequestBuilder;
 use miden_protocol::account::auth::{AuthScheme, AuthSecretKey};
 use miden_protocol::account::{Account, AccountId};
 use miden_protocol::note::NoteType;
-use miden_protocol::transaction::OutputNote;
 use miden_standards::account::auth::AuthSingleSig;
 use miden_standards::account::wallets::BasicWallet;
 use miden_standards::note::P2idNote;
@@ -22,7 +21,6 @@ struct Accounts {
     service: Account,
     bridge: Account,
     faucet_eth: Account,
-    faucet_agg: Account,
     wallet_hardhat: Account,
     ger_manager: Account,
 }
@@ -33,18 +31,24 @@ impl From<Accounts> for AccountsConfig {
             service: AccountIdBech32(accounts.service.id()),
             bridge: AccountIdBech32(accounts.bridge.id()),
             faucet_eth: Some(AccountIdBech32(accounts.faucet_eth.id())),
-            faucet_agg: Some(AccountIdBech32(accounts.faucet_agg.id())),
+            // AGG genesis faucet removed during 0.14.x migration: it registered under origin
+            // [0u8; 20] which collides with ETH in the new on-chain token_registry_map. Any
+            // additional token (POL, USDC, …) is auto-created by find_or_create_faucet in
+            // claim.rs on first bridge.
+            faucet_agg: None,
             wallet_hardhat: AccountIdBech32(accounts.wallet_hardhat.id()),
             ger_manager: Some(AccountIdBech32(accounts.ger_manager.id())),
         }
     }
 }
 
-fn create_auth_component() -> anyhow::Result<(AuthSingleSig, AuthSecretKey)> {
-    let key_pair = AuthSecretKey::new_falcon512_rpo();
+fn create_auth_component(
+    client: &mut MidenClientLib,
+) -> anyhow::Result<(AuthSingleSig, AuthSecretKey)> {
+    let key_pair = AuthSecretKey::new_falcon512_poseidon2_with_rng(client.rng());
     let auth_component = AuthSingleSig::new(
         key_pair.public_key().to_commitment(),
-        AuthScheme::Falcon512Rpo,
+        AuthScheme::Falcon512Poseidon2,
     );
     Ok((auth_component, key_pair))
 }
@@ -101,6 +105,7 @@ async fn add_faucet(
     scale: u8,
     service_id: AccountId,
     bridge_account_id: AccountId,
+    metadata_hash: MetadataHash,
 ) -> anyhow::Result<Account> {
     faucet_ops::create_and_register_faucet(
         client,
@@ -111,6 +116,7 @@ async fn add_faucet(
         scale,
         service_id,
         bridge_account_id,
+        metadata_hash,
     )
     .await
 }
@@ -119,27 +125,8 @@ async fn add_wallet(
     client: &mut MidenClientLib,
     keystore: Arc<FilesystemKeyStore>,
 ) -> anyhow::Result<Account> {
-    let (auth_component, key_pair) = create_auth_component()?;
+    let (auth_component, key_pair) = create_auth_component(client)?;
     let account = Account::builder(client.rng().draw_word().into())
-        .with_component(BasicWallet)
-        .with_auth_component(auth_component)
-        .build()?;
-    keystore.add_key(&key_pair, account.id()).await?;
-    client.add_account(&account, false).await?;
-    Ok(account)
-}
-
-/// Create a Network (public) wallet account for GER injection.
-/// Must be public so import_account_by_id can refresh its state after
-/// the NoteScreener bypass skips apply_transaction.
-async fn add_public_wallet(
-    client: &mut MidenClientLib,
-    keystore: Arc<FilesystemKeyStore>,
-) -> anyhow::Result<Account> {
-    use miden_protocol::account::AccountStorageMode;
-    let (auth_component, key_pair) = create_auth_component()?;
-    let account = Account::builder(client.rng().draw_word().into())
-        .storage_mode(AccountStorageMode::Network)
         .with_component(BasicWallet)
         .with_auth_component(auth_component)
         .build()?;
@@ -156,7 +143,9 @@ async fn add_accounts(
     let ger_manager = add_wallet(client, keystore.clone()).await?;
     deploy_account(client, ger_manager.id(), "ger_manager").await?;
     let bridge = add_bridge(client, keystore.clone(), service.id(), ger_manager.id()).await?;
-    // ETH: 18 origin decimals, 8 miden decimals → scale=10
+    // ETH: 18 origin decimals → 8 miden decimals (scale=10). Native ETH has empty metadata on
+    // the L1 bridge, so the faucet's stored metadata_hash is keccak256("") — matches any
+    // CLAIM leaf_data.metadata_hash for ETH deposits.
     let faucet_eth = add_faucet(
         client,
         "ETH",
@@ -166,18 +155,7 @@ async fn add_accounts(
         10,
         service.id(),
         bridge.id(),
-    )
-    .await?;
-    // AGG: 8 origin decimals, 8 miden decimals → scale=0
-    let faucet_agg = add_faucet(
-        client,
-        "AGG",
-        8,
-        &[0u8; 20],
-        0,
-        0,
-        service.id(),
-        bridge.id(),
+        MetadataHash::from_abi_encoded(&[]),
     )
     .await?;
     let wallet_hardhat = add_wallet(client, keystore.clone()).await?;
@@ -185,7 +163,6 @@ async fn add_accounts(
         service,
         bridge,
         faucet_eth,
-        faucet_agg,
         wallet_hardhat,
         ger_manager,
     })
@@ -207,7 +184,7 @@ async fn register_p2id_script(
     )?;
 
     let txn = TransactionRequestBuilder::new()
-        .own_output_notes([OutputNote::Full(note); 1])
+        .own_output_notes(vec![note])
         .build()?;
 
     let txn_id = client.submit_new_transaction(sender, txn).await?;
@@ -238,7 +215,7 @@ async fn init_internal(
     {
         use miden_protocol::note::NoteTag;
         let wallet_id = accounts.wallet_hardhat.id();
-        let prefix_u64 = wallet_id.prefix().as_felt().as_int();
+        let prefix_u64 = wallet_id.prefix().as_felt().as_canonical_u64();
         let hi32 = (prefix_u64 >> 32) as u32;
         let p2id_tag_value = hi32 & 0xFFFC0000u32; // top 14 bits
         let raw_tag = NoteTag::from(p2id_tag_value);

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,8 +219,8 @@ async fn main() -> anyhow::Result<()> {
     state.ger_l1_address = command.ger_l1_address;
     state.miden_store_dir = miden_store_dir.clone().unwrap_or_default();
     // miden_node was moved into MidenClient::new, re-read from env
-    state.miden_node_url = std::env::var("MIDEN_NODE_URL")
-        .unwrap_or_else(|_| "http://miden-node:57291".to_string());
+    state.miden_node_url =
+        std::env::var("MIDEN_NODE_URL").unwrap_or_else(|_| "http://miden-node:57291".to_string());
 
     // Initialize metrics
     let metrics_handle = metrics_exporter_prometheus::PrometheusBuilder::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,8 +155,9 @@ async fn main() -> anyhow::Result<()> {
     let accounts = load_config(miden_store_dir.clone())?;
 
     // Seed faucet registry if empty (first startup or InMemoryStore).
-    // Only ETH is seeded by default; other tokens (AGG, ERC-20s) are
-    // auto-created when first bridged via the dynamic faucet registry.
+    // Only ETH is seeded by default; ERC-20s are auto-created by claim.rs::find_or_create_faucet
+    // on first bridge. The AGG genesis placeholder was dropped in the 0.14.x migration — its
+    // placeholder origin collided with ETH in the new on-chain token_registry_map.
     if store.list_faucets().await?.is_empty() {
         use miden_agglayer_service::store::FaucetEntry;
         if let Some(faucet_eth) = &accounts.0.faucet_eth {
@@ -172,26 +173,6 @@ async fn main() -> anyhow::Result<()> {
                 })
                 .await?;
             tracing::info!("seeded faucet registry with default ETH faucet");
-        }
-        // AGG/POL faucet: registered when first bridged (origin address
-        // depends on the L1 POL token contract, which varies per deployment).
-        if let Some(faucet_agg) = &accounts.0.faucet_agg {
-            // Register by faucet_id only so bridge-out can resolve it.
-            // Use a placeholder origin; the real origin is set on first bridge.
-            let mut agg_origin = [0u8; 20];
-            agg_origin[0] = 0x01; // Distinct from ETH's zero address
-            store
-                .register_faucet(FaucetEntry {
-                    faucet_id: faucet_agg.0,
-                    origin_address: agg_origin,
-                    origin_network: 0,
-                    symbol: "AGG".into(),
-                    origin_decimals: 8,
-                    miden_decimals: 8,
-                    scale: 0,
-                })
-                .await?;
-            tracing::info!("seeded faucet registry with default AGG faucet");
         }
     }
 

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -287,7 +287,7 @@ async fn restore_gers(
 
                     let mut ger_bytes = [0u8; 32];
                     for (i, felt) in items.iter().take(8).enumerate() {
-                        let v: u32 = felt.as_int() as u32;
+                        let v: u32 = felt.as_canonical_u64() as u32;
                         ger_bytes[i * 4..(i + 1) * 4].copy_from_slice(&v.to_be_bytes());
                     }
 

--- a/src/service_admin.rs
+++ b/src/service_admin.rs
@@ -7,6 +7,7 @@
 use crate::faucet_ops;
 use crate::service_state::ServiceState;
 use crate::store::FaucetEntry;
+use miden_base_agglayer::MetadataHash;
 use miden_protocol::account::AccountId;
 use serde::Deserialize;
 use std::sync::{Arc, OnceLock};
@@ -18,6 +19,10 @@ pub struct RegisterFaucetParams {
     pub origin_network: u32,
     pub origin_decimals: u8,
     pub miden_decimals: u8,
+    /// Token display name used when computing the `MetadataHash`. Optional —
+    /// defaults to the symbol if not provided.
+    #[serde(default)]
+    pub name: Option<String>,
 }
 
 pub async fn admin_register_faucet(
@@ -55,10 +60,19 @@ pub async fn admin_register_faucet(
     let service_id = accounts.service.0;
     let bridge_id = accounts.bridge.0;
 
+    // Compute MetadataHash from (name, symbol, origin_decimals) — matches the L1 bridge
+    // contract's `keccak256(abi.encode(name, symbol, decimals))`. Callers that skip the
+    // `name` field get `name = symbol`.
+    let metadata_name = params.name.clone().unwrap_or_else(|| params.symbol.clone());
+    let metadata_hash =
+        MetadataHash::from_token_info(&metadata_name, &params.symbol, params.origin_decimals);
+
     // Create, deploy, register in bridge (using OnceLock pattern like publish_claim)
     let result = Arc::new(OnceLock::<AccountId>::new());
     let result_inner = result.clone();
     let symbol_clone = params.symbol.clone();
+    let miden_decimals = params.miden_decimals;
+    let origin_network = params.origin_network;
 
     state
         .miden_client
@@ -67,12 +81,13 @@ pub async fn admin_register_faucet(
                 let account = faucet_ops::create_and_register_faucet(
                     client,
                     &symbol_clone,
-                    params.miden_decimals,
+                    miden_decimals,
                     &origin_address,
-                    params.origin_network,
+                    origin_network,
                     scale,
                     service_id,
                     bridge_id,
+                    metadata_hash,
                 )
                 .await?;
                 let _ = result_inner.set(account.id());

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -393,7 +393,7 @@ impl Store for PgStore {
             )
             .await?;
         let log_index: i64 = row.get(0);
-        let topics = vec![
+        let topics = [
             UPDATE_HASH_CHAIN_VALUE_TOPIC.to_string(),
             format!("0x{}", hex::encode(global_exit_root)),
             format!("0x{}", hex::encode(new_chain)),
@@ -611,7 +611,7 @@ impl Store for PgStore {
 
         let logs: Vec<LogData> = log_rows
             .iter()
-            .filter_map(|r| {
+            .map(|r| {
                 let topics_bytes: Vec<Vec<u8>> = r.get(0);
                 let data_bytes: Vec<u8> = r.get(1);
                 let topics: Vec<alloy::primitives::B256> = topics_bytes
@@ -624,7 +624,7 @@ impl Store for PgStore {
                         }
                     })
                     .collect();
-                Some(LogData::new_unchecked(topics, data_bytes.into()))
+                LogData::new_unchecked(topics, data_bytes.into())
             })
             .collect();
 
@@ -674,10 +674,10 @@ impl Store for PgStore {
         block_hash: [u8; 32],
     ) -> anyhow::Result<()> {
         for id in ids {
-            if let Some(hash) = self.txn_pending_by_miden_id(*id).await? {
-                if let Err(e) = self.txn_commit(hash, Ok(()), block_num, block_hash).await {
-                    tracing::warn!("PgStore: failed to commit transaction {hash}: {e}");
-                }
+            if let Some(hash) = self.txn_pending_by_miden_id(*id).await?
+                && let Err(e) = self.txn_commit(hash, Ok(()), block_num, block_hash).await
+            {
+                tracing::warn!("PgStore: failed to commit transaction {hash}: {e}");
             }
         }
         Ok(())
@@ -696,13 +696,12 @@ impl Store for PgStore {
 
         for row in &rows {
             let hash_str: &str = row.get(0);
-            if let Ok(hash) = hash_str.parse::<TxHash>() {
-                if let Err(e) = self
+            if let Ok(hash) = hash_str.parse::<TxHash>()
+                && let Err(e) = self
                     .txn_commit(hash, Err("expired".to_string()), block_num, block_hash)
                     .await
-                {
-                    tracing::warn!("PgStore: failed to expire transaction {hash}: {e}");
-                }
+            {
+                tracing::warn!("PgStore: failed to expire transaction {hash}: {e}");
             }
         }
         Ok(())
@@ -894,7 +893,7 @@ impl Store for PgStore {
             )
             .await?;
 
-        Ok(rows.first().and_then(|r| pg_row_to_faucet_entry(r)))
+        Ok(rows.first().and_then(pg_row_to_faucet_entry))
     }
 
     async fn get_faucet_by_id(&self, faucet_id: AccountId) -> anyhow::Result<Option<FaucetEntry>> {
@@ -909,7 +908,7 @@ impl Store for PgStore {
             )
             .await?;
 
-        Ok(rows.first().and_then(|r| pg_row_to_faucet_entry(r)))
+        Ok(rows.first().and_then(pg_row_to_faucet_entry))
     }
 
     async fn list_faucets(&self) -> anyhow::Result<Vec<FaucetEntry>> {
@@ -923,10 +922,7 @@ impl Store for PgStore {
             )
             .await?;
 
-        Ok(rows
-            .iter()
-            .filter_map(|r| pg_row_to_faucet_entry(r))
-            .collect())
+        Ok(rows.iter().filter_map(pg_row_to_faucet_entry).collect())
     }
 }
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -25,19 +25,15 @@ pub fn test_accounts_config() -> AccountsConfig {
         service: dummy_account_id(),
         bridge: dummy_account_id(),
         faucet_eth: Some(dummy_account_id()),
-        faucet_agg: Some(dummy_account_id()),
+        faucet_agg: None,
         wallet_hardhat: dummy_account_id(),
         ger_manager: None,
     })
 }
 
-/// A second distinct test account ID for the AGG faucet.
-const TEST_ACCOUNT_HEX_2: &str = "0x3d7c9747558851900f8206226dfbeb";
-
-/// Seed the faucet registry with default ETH and AGG faucets for testing.
+/// Seed the faucet registry with the default ETH faucet for testing.
 pub async fn seed_test_faucets(store: &dyn Store) {
     let eth_id = AccountId::from_hex(TEST_ACCOUNT_HEX).unwrap();
-    let agg_id = AccountId::from_hex(TEST_ACCOUNT_HEX_2).unwrap();
     store
         .register_faucet(FaucetEntry {
             faucet_id: eth_id,
@@ -47,18 +43,6 @@ pub async fn seed_test_faucets(store: &dyn Store) {
             origin_decimals: 18,
             miden_decimals: 8,
             scale: 10,
-        })
-        .await
-        .unwrap();
-    store
-        .register_faucet(FaucetEntry {
-            faucet_id: agg_id,
-            origin_address: [0xAA; 20],
-            origin_network: 0,
-            symbol: "AGG".into(),
-            origin_decimals: 8,
-            miden_decimals: 8,
-            scale: 0,
         })
         .await
         .unwrap();


### PR DESCRIPTION
## Summary
- Bumps `miden-agglayer-service` off `0.14.0-alpha` onto the first stable `0.14.x` line: `miden-agglayer 0.14.4` + `miden-client` git rev `f7cdf263` (branch `ajl-agglayer-integration-tests-v0.14.0`). Every call site touching the renamed/retargeted 0.14.x API surface is updated.
- **CLAIM notes now target the bridge account**, not the faucet. Bridge validates, produces a MINT note; faucet consumes MINT and produces the final P2ID for the destination wallet. One extra NTX hop for bridge-in.
- Drops the `AGG` genesis faucet. It registered under origin `[0u8; 20]` which collides with ETH in the new on-chain `token_registry_map`; dynamic `find_or_create_faucet` in `claim.rs` handles any non-ETH token on first bridge.
- Closes three pre-existing races that were preventing the e2e test bed from passing in sequence, plus a handful of stale test harness bugs. Every e2e script now runs green on a fresh stack.

## 0.14.x API shifts picked up (migration commit)
- `EthAddressFormat` → `EthAddress` + `EthEmbeddedAccountId` split; zero-pad `AccountId` round-trip now via `EthEmbeddedAccountId::try_from(addr).ok().map(AccountId::from)` in `address_mapper.rs`.
- `create_agglayer_faucet` gains a trailing `MetadataHash` parameter. Init uses `MetadataHash::from_abi_encoded(&[])` (= `keccak256("")`) for the ETH faucet. `claim.rs::find_or_create_faucet` computes it from the raw bridge-contract metadata bytes, which matches whatever the L1 bridge put in `leaf_data.metadata_hash`. `service_admin.rs::admin_registerFaucet` uses `MetadataHash::from_token_info(name, symbol, decimals)`.
- `ConfigAggBridgeNote::create` gains an `origin_token_address` arg so the bridge can populate its new on-chain `token_registry_map`.
- `AuthScheme::Falcon512Rpo` → `Falcon512Poseidon2`; `AuthSecretKey::new_falcon512_rpo` → `new_falcon512_poseidon2_with_rng(client.rng())`. `create_auth_component` now takes `&mut MidenClientLib` to source the RNG.
- `own_output_notes(...)` takes `Note` directly — dropped all `OutputNote::Full` wraps on the builder side. `OutputNote` enum variants `Full/Header` → `Public/Private` on the proven-tx readback side; `RawOutputNote::{Full,Partial}` still in use on executed-tx readbacks.
- `Felt::as_int()` → `Felt::as_canonical_u64()`.
- `Dockerfile.miden-node` bumped to `rust:1.93-slim-bookworm` and pinned at the same miden-client commit so `testing-node-builder` stays in lockstep with the service.

### Why not exact-pin the miden-* crates
Pinning `miden-node-proto-build` + `miden-remote-prover-client` to `=0.14.4` caused a runtime STARK proof verification regression inside the miden-node NTX builder. Leaving them on caret `"0.14"` resolves to `0.14.6` and is the combination that actually runs. The git rev pin on `miden-client` is what gives us reproducibility. Comment in `Cargo.toml` spells this out so the next person doesn't re-introduce the pin.

## Race conditions closed (fix commit)
`bridge_out.rs::on_post_sync`, `ger.rs::submit_ger_to_miden`, and `claim.rs::publish_claim` used to call `store.advance_block_number()` first and then write the synthetic log. There was a window where `eth_blockNumber` returned `N` but no log existed at `N` yet — aggsender polled during that window, saw no bridges in `[X, N]`, advanced its cursor past `N`, and permanently missed the BridgeEvent/ClaimEvent/UpdateGerUpdate that landed there a few milliseconds later. Switched to `get_latest_block_number + 1` → write the log → `set_latest_block_number`. Every reader who sees `latest >= N` now also sees the log at N. This was surfacing as `Timed out: certificate settled` in `e2e-dynamic-erc20.sh` step 7 and `e2e-l2-to-l1.sh` when run in sequence.

## Docker / test harness bugs shaken out

- `docker-compose.e2e.yml`: added `./.miden-agglayer-data` bind mount on the service container plus `TMPDIR=/var/lib/miden-agglayer-service/tmp`. Without the bind mount `docker compose run --rm --no-deps miden-agglayer --restore` gets its own fresh sqlite store and `restore_gers` finds zero consumed notes; without the `TMPDIR` override, miden-client's on-disk store trips `Invalid cross-device link` at startup on macOS Docker (rusqlite temp file on container rootfs, target on a 9p bind mount, rename across devices fails). `.gitignore` covers the data dir.
- `wait_for()` in every e2e script runs its probe inside `( set +o pipefail; eval "$cmd" )`. `docker logs ... | grep -q X` was tripping pipefail: `grep -q` closes the pipe on the first match, `docker logs` takes SIGPIPE (exit 141), pipefail promotes that to the pipe's exit, the outer `while !` read it as still failing, and the loop polled until timeout. Symptom: `Timed out: auto-creating faucet` even though the service logged it on time.
- `e2e-dynamic-erc20.sh` filters its L2→L1 deposit lookup by origin token address AND unclaimed status — when run inside `e2e-test.sh all` the earlier ETH deposit from `e2e-l2-to-l1.sh` was still `ready_for_claim=true` and was getting picked up first.
- `e2e-restore.sh`'s `TRUNCATE` list was stale: `block_transactions` removed from the schema, `faucet_registry` added. Old list aborted the wipe half-way.
- `e2e-fuzz-bridge.sh`: reads bech32 account IDs from `bridge_accounts.toml` and resolves the wallet's 20-byte zero-padded EVM form via `bridge-out-tool` (same as `e2e-l1-to-l2.sh`); `BRIDGE_ADDRESS` grep is anchored so it stops also matching `L2_BRIDGE_ADDRESS`; `deploy_token` points at `fixtures/TestToken.sol:TestToken` with `--broadcast` and parses `Deployed to:` text (modern `forge create --json` doesn't emit JSON on the deploy path).

## AGG faucet removed (not just at runtime)
`init.rs`'s `Accounts` struct drops `faucet_agg`. The `From<Accounts> for AccountsConfig` impl writes `faucet_agg: None` for backwards compatibility with any on-disk TOML config files. `main.rs` drops the AGG store-seeding block. `test_helpers.rs` fixtures updated. Config-file schema unchanged — `accounts_config.rs::AccountsConfig::faucet_agg` stays as `Option<AccountIdBech32>` with `#[serde(default)]` so old TOML still deserializes.

## Test plan
All run on a fresh stack (`docker compose down -v && rm -rf .miden-agglayer-data && docker compose up -d`):

- [x] `cargo check --all-targets --features postgres`
- [x] `cargo test --features postgres` — **75/75 unit tests pass**
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --features postgres -- -D warnings`
- [x] `docker build -f Dockerfile.miden-node -t miden-infra/miden-node:agglayer-v0.1 .`
- [x] `docker compose -f docker-compose.e2e.yml build miden-agglayer`
- [x] Service init smoke: ETH faucet deployed + registered in bridge, no AGG logged, `bridge_accounts.toml` contains only `faucet_eth`
- [x] `bash scripts/e2e-test.sh all` — L1→L2 + L2→L1 + GER decomposition + Security (41/41) + Dynamic ERC-20 round-trip (full sequential pass on the same stack)
- [x] `bash scripts/e2e-restore.sh` — bridge-in → PostgreSQL wipe → `--restore` reconstructs state from consumed notes → L2→L1 on restored state
- [x] `bash scripts/e2e-fuzz-bridge.sh` — **26 passed, 0 failed** across 8 rounds (ETH amount edges, multi-decimal ERC-20s, error cases, rapid sequential GER stress, concurrent RPC, bridge-service consistency, faucet registry integrity, GER exit root resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)