### PR TITLE
fix: route GER injection through main MidenClient to unblock restore

### DIFF
--- a/src/ger.rs
+++ b/src/ger.rs
@@ -1,11 +1,9 @@
-use crate::accounts_config::AccountsConfig;
 use crate::miden_client::MidenClient;
 use alloy::primitives::{FixedBytes, LogData, TxHash};
 use alloy::sol_types::SolEvent;
 use alloy_rpc_types_eth::TransactionRequest;
 use miden_base_agglayer::{ExitRoot, UpdateGerNote};
 use miden_client::transaction::TransactionRequestBuilder;
-use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use sha3::{Digest, Keccak256};
 use std::sync::Arc;
 
@@ -96,129 +94,6 @@ pub struct GerInsertResult {
     pub is_new: bool,
 }
 
-/// Submit a GER to the Miden node using a fresh miden-client instance.
-///
-/// Creates a new client per call (like Igor's aggkit-proxy approach) to avoid
-/// stale state from the long-lived MidenClient's background sync loop.
-/// A fresh client syncs fresh state from the node, avoiding NoteScreener
-/// failures and account commitment drift after CLAIM processing.
-async fn submit_ger_to_miden(
-    ger_bytes: [u8; 32],
-    accounts: &AccountsConfig,
-    store_dir: std::path::PathBuf,
-    node_url: String,
-    keystore: Arc<miden_client::keystore::FilesystemKeyStore>,
-) -> anyhow::Result<()> {
-    // Use the dedicated ger_manager account for GER injection. This avoids
-    // stale state errors: the service account is continuously modified by
-    // the NTX builder (claim processing), making its state commitment
-    // unpredictable. The ger_manager account is only used for GER injection,
-    // so its state is stable between submissions.
-    let ger_manager_id = accounts
-        .ger_manager
-        .as_ref()
-        .map(|a| a.0)
-        .unwrap_or(accounts.service.0);
-    let bridge_id = accounts.bridge.0;
-
-    let store_path = store_dir.join("store.sqlite3");
-
-    // Run the entire GER injection in spawn_blocking with a dedicated runtime.
-    // This is Igor's approach: fresh client per operation. The miden-client
-    // types (Endpoint, Client) are !Send, so we can't hold them across .await
-    // points in the axum handler's future.
-    tokio::task::spawn_blocking(move || {
-        let rt = tokio::runtime::Runtime::new()?;
-        rt.block_on(async {
-            use ::miden_client::DebugMode;
-            use ::miden_client::builder::ClientBuilder;
-            use ::miden_client::rpc::Endpoint;
-
-            for attempt in 0..3u32 {
-                let ep = Endpoint::try_from(node_url.as_str())
-                    .map_err(|e| anyhow::anyhow!("invalid node URL: {e}"))?;
-                let mut client = ClientBuilder::new()
-                    .grpc_client(&ep, Some(10_000))
-                    .sqlite_store(store_path.clone())
-                    .authenticator(keystore.clone())
-                    .in_debug_mode(DebugMode::Enabled)
-                    .build()
-                    .await?;
-                client.sync_state().await?;
-
-                let ger = ExitRoot::new(ger_bytes);
-                let note = UpdateGerNote::create(ger, ger_manager_id, bridge_id, client.rng())?;
-                if attempt == 0 {
-                    tracing::info!(note_id = %note.id(), "UpdateGerNote created");
-                }
-
-                let tx_request = TransactionRequestBuilder::new()
-                    .own_output_notes(vec![note])
-                    .build()?;
-
-                let tx_id = match client
-                    .submit_new_transaction(ger_manager_id, tx_request)
-                    .await
-                {
-                    Ok(id) => id,
-                    Err(e) => {
-                        if attempt < 2 {
-                            tracing::warn!(attempt, "GER TX failed, retrying: {e:#?}");
-                            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-                            continue;
-                        }
-                        return Err(anyhow::anyhow!("{e:#}"));
-                    }
-                };
-
-                tracing::info!(
-                    tx_id = %tx_id,
-                    ger = %hex::encode(ger_bytes),
-                    "UpdateGerNote submitted to Miden node, waiting for commit..."
-                );
-
-                // Poll for commit
-                let timeout_secs: u64 = std::env::var("GER_COMMIT_TIMEOUT_SECS")
-                    .ok()
-                    .and_then(|v| v.parse().ok())
-                    .unwrap_or(30)
-                    .clamp(5, 120);
-                let mut committed = false;
-                for _ in 0..timeout_secs {
-                    let txns = client
-                        .get_transactions(miden_client::store::TransactionFilter::All)
-                        .await?;
-                    if txns.iter().any(|t| {
-                        t.id == tx_id
-                            && matches!(
-                                t.status,
-                                miden_client::transaction::TransactionStatus::Committed { .. }
-                            )
-                    }) {
-                        committed = true;
-                        break;
-                    }
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                    client.sync_state().await?;
-                }
-
-                if !committed {
-                    anyhow::bail!(
-                        "UpdateGerNote transaction {tx_id} not committed after {timeout_secs}s"
-                    );
-                }
-
-                tracing::info!(tx_id = %tx_id, "UpdateGerNote transaction committed");
-                return Ok(());
-            }
-
-            anyhow::bail!("GER injection failed after 3 attempts")
-        })
-    })
-    .await
-    .map_err(|e| anyhow::anyhow!("GER spawn_blocking: {e}"))?
-}
-
 #[allow(clippy::too_many_arguments)]
 pub async fn insert_ger(
     ger_bytes: [u8; 32],
@@ -229,8 +104,6 @@ pub async fn insert_ger(
     store: &Arc<dyn crate::store::Store>,
     block_state: &Arc<crate::block_state::BlockState>,
     txn_hash: TxHash,
-    store_dir: std::path::PathBuf,
-    node_url: String,
 ) -> anyhow::Result<GerInsertResult> {
     // Check dedup before doing any work
     let is_new = !store.has_seen_ger(&ger_bytes).await?;
@@ -243,43 +116,61 @@ pub async fn insert_ger(
             "GER injection: submitting to Miden..."
         );
 
-        if node_url.is_empty() {
-            // Test path: use the existing MidenClient
-            let inner_accounts = accounts.0.clone();
-            miden_client
-                .with(move |client| {
-                    Box::new(async move {
-                        client.sync_state().await?;
-                        let ger_manager_id = inner_accounts
-                            .ger_manager
-                            .as_ref()
-                            .map(|a| a.0)
-                            .unwrap_or(inner_accounts.service.0);
-                        let bridge_id = inner_accounts.bridge.0;
-                        let ger = ExitRoot::new(ger_bytes);
-                        let note =
-                            UpdateGerNote::create(ger, ger_manager_id, bridge_id, client.rng())?;
-                        let tx_request = TransactionRequestBuilder::new()
-                            .own_output_notes(vec![note])
-                            .build()?;
-                        client
-                            .submit_new_transaction(ger_manager_id, tx_request)
-                            .await?;
-                        Ok(())
-                    })
+        // Use the long-lived MidenClient. The dedicated ger_manager account
+        // (separate from the service account that the NTX builder constantly
+        // mutates via claim processing) keeps the account state stable across
+        // GER submissions, so we don't need a fresh client per call.
+        //
+        // Fresh-client-per-GER was removed because it shared the main sqlite
+        // and advanced the sync cursor past blocks where bridge NTX consumes
+        // the UpdateGerNote. The main client's subsequent sync_nullifiers only
+        // queries [current_cursor, tip], so those consumption events were never
+        // discovered and `NoteFilter::Consumed` returned nothing in restore.
+        let inner_accounts = accounts.0.clone();
+        miden_client
+            .with(move |client| {
+                Box::new(async move {
+                    client.sync_state().await?;
+                    let ger_manager_id = inner_accounts
+                        .ger_manager
+                        .as_ref()
+                        .map(|a| a.0)
+                        .unwrap_or(inner_accounts.service.0);
+                    let bridge_id = inner_accounts.bridge.0;
+                    let ger = ExitRoot::new(ger_bytes);
+                    let note = UpdateGerNote::create(ger, ger_manager_id, bridge_id, client.rng())?;
+                    tracing::info!(
+                        note_id = %note.id(),
+                        ger = %hex::encode(ger_bytes),
+                        "UpdateGerNote created"
+                    );
+                    let tx_request = TransactionRequestBuilder::new()
+                        .own_output_notes(vec![note])
+                        .build()?;
+                    let tx_id = client
+                        .submit_new_transaction(ger_manager_id, tx_request)
+                        .await?;
+                    tracing::info!(
+                        tx_id = %tx_id,
+                        ger = %hex::encode(ger_bytes),
+                        "UpdateGerNote submitted, waiting for commit..."
+                    );
+
+                    let committed = crate::miden_client::wait_for_transaction_commit(
+                        client,
+                        tx_id,
+                        30,
+                        std::time::Duration::from_secs(1),
+                    )
+                    .await?;
+                    if !committed {
+                        anyhow::bail!("UpdateGerNote tx {tx_id} not committed after 30s");
+                    }
+                    tracing::info!(tx_id = %tx_id, "UpdateGerNote transaction committed");
+                    Ok(())
                 })
-                .await?;
-        } else {
-            // Production path: fresh client per call (Igor's approach)
-            submit_ger_to_miden(
-                ger_bytes,
-                &accounts.0,
-                store_dir.clone(),
-                node_url.clone(),
-                miden_client.get_keystore(),
-            )
+            })
             .await?;
-        }
 
         // Race-safe ordering: write the log at (current_latest + 1) BEFORE
         // bumping `latest_block_number`. See the matching comment in

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -275,8 +275,6 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
                 &service.store,
                 &service.block_state,
                 txn_hash,
-                service.miden_store_dir.clone(),
-                service.miden_node_url.clone(),
             )
             .await,
             txn_hash,
@@ -305,8 +303,6 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
                 &service.store,
                 &service.block_state,
                 txn_hash,
-                service.miden_store_dir.clone(),
-                service.miden_node_url.clone(),
             )
             .await,
             txn_hash,


### PR DESCRIPTION
## Summary

- Drops the fresh-client-per-GER `spawn_blocking` path in `src/ger.rs` (~165 lines) and always submits `UpdateGerNote` through the long-lived `MidenClient::with()`.
- Removes the now-unused `store_dir` / `node_url` params from `insert_ger()` and both call sites in `service_send_raw_txn.rs`.
- Keeps fresh-client isolation in `claim.rs` unchanged — service-account drift under NTX pressure is the real problem there.

## Why

The fresh-client-per-GER pattern from PR #15 opened a separate miden-client on the shared sqlite for each injection. That client advanced the sync cursor past the blocks where bridge NTX consumes the `UpdateGerNote`. The main long-lived client's subsequent `sync_nullifiers` query is range-limited to `[current_cursor, tip]`, so nullifiers committed in skipped blocks are lost forever — `UpdateGerNote`s stay pinned at state `Expected(0)` and `NoteFilter::Consumed` returns nothing in `--restore`.

The dedicated `ger_manager` account (PR #13) was introduced specifically to keep GER submitter state stable across NTX activity, so fresh-client isolation is unnecessary for the GER path. Fresh-client stays in `claim.rs` where the service account genuinely drifts.

## Test plan

Verified on fresh stacks (rebuilt docker image, torn down and brought up between runs):

- [x] `cargo check --features postgres`
- [x] `cargo test --features postgres` — 75/75
- [x] `cargo clippy --all-targets --features postgres -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/e2e-test.sh` — 74 PASS / 0 FAIL (L1→L2, L2→L1, GER, Security 41/41, Dynamic ERC-20)
- [x] `bash scripts/e2e-restore.sh` — **PASS** (gers=1 restored, block=31, L2→L1 bridge-out on restored state works)
- [x] `bash scripts/e2e-fuzz-bridge.sh` — 27 PASS / 0 FAIL (sequential deposits, 5 rapid GER injections, concurrent RPC stress, faucet registry integrity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)