### PR TITLE
feat: proxy recovery + resilient sync loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3326,6 +3326,7 @@ dependencies = [
  "miden-tx",
  "parking_lot",
  "reqwest 0.12.28",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,10 @@ reqwest = { version = "0.12", default-features = false, features = [
 http = { version = "1.3" }
 lru = { default-features = false, version = "0.16" }
 parking_lot = { version = "0.12" }
+# Direct dep so we can surgically clear stale `locked` flags in miden-client's
+# sqlite when a full --reset-miden-store would be overkill. Version matches
+# what miden-client-sqlite-store pulls in transitively.
+rusqlite = { version = "0.37", features = ["bundled"] }
 serde = { features = ["derive"], version = "1.0" }
 serde_json = { version = "1.0" }
 sha3 = { version = "0.10" }

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ test-e2e: ## Spin up docker stack, run E2E tests, tear down (fully self-containe
 	@echo "╔══════════════════════════════════════════════════════════════╗"
 	@echo "║  Starting E2E stack (Anvil, Miden node, PG, bridge, aggkit) ║"
 	@echo "╚══════════════════════════════════════════════════════════════╝"
+	@$(MAKE) --no-print-directory e2e-clean-data
 	$(E2E_COMPOSE) up -d --build --wait
 	@echo ""
 	@echo "Stack is up — running E2E tests..."
@@ -171,8 +172,19 @@ E2E_COMPOSE := docker compose -f docker-compose.e2e.yml --env-file fixtures/.env
 e2e-setup: ## One-time: extract Anvil snapshot + configs from Kurtosis
 	./scripts/setup-fixtures.sh
 
+.PHONY: e2e-clean-data
+e2e-clean-data: ## Wipe .miden-agglayer-data/ so proxy re-inits against the fresh miden-node
+	# The miden-node's genesis commitment is non-deterministic across container
+	# restarts, but the proxy's sqlite at .miden-agglayer-data/store.sqlite3
+	# pins a specific genesis. If we mount stale state into a fresh node, the
+	# client's sync is rejected with "accept header validation failed". Always
+	# start from a clean slate — the proxy's --init flow will redeploy accounts
+	# in ~45s, which is acceptable for E2E.
+	rm -rf .miden-agglayer-data
+	mkdir -p .miden-agglayer-data/tmp
+
 .PHONY: e2e-up
-e2e-up: ## Start full E2E environment
+e2e-up: e2e-clean-data ## Start full E2E environment (cleans data dir first)
 	$(E2E_COMPOSE) up -d --build --wait
 
 .PHONY: e2e-test

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ make build
 | `--rollup-address` | `ROLLUP_ADDRESS` | `0x414e...0e4e` | Rollup contract (eth_call forwarding) |
 | `--restore` | | | Reconstruct store from miden-node + L1, then exit |
 | `--init` | | | Initialize accounts config, then exit |
+| `--reset-miden-store` | | | Wipe miden-client sqlite before startup (preserves keystore + config) — see [Recovery](#recovery) |
+| `--unlock-miden-accounts` | | | Clear stale `locked` flags in miden-client sqlite, then exit — see [Recovery](#recovery) |
 
 ### ClaimSettler env vars
 
@@ -207,3 +209,59 @@ If the PostgreSQL store is lost, reconstruct state from authoritative sources:
 ```
 
 This scans the Miden node and L1 to rebuild claims, bridge-outs, GER entries, and synthetic logs.
+
+## Recovery
+
+When miden-client's local sqlite diverges from the node, the first tx submission
+surfaces it as an opaque `transaction conflicts with current mempool state` /
+`initial account commitment ... does not match current commitment ...` error.
+On startup, the proxy checks every managed account's lock status via the
+miden-client `AccountReader` API and logs an ERROR with a recovery hint if any
+account is locked. The `miden_locked_accounts_detected_total` metric is
+incremented too, so an alert can be wired to it.
+
+Two recovery modes are available:
+
+#### Surgical unlock — `--unlock-miden-accounts`
+
+Clears the `locked` flag on every row in miden-client's sqlite
+(`latest_account_headers` + `historical_account_headers`) and exits. Use this
+when the only symptom is a stale lock and the underlying on-chain state is
+actually fine.
+
+```bash
+./target/release/miden-agglayer-service \
+    --miden-store-dir /var/lib/miden \
+    --unlock-miden-accounts
+# then restart the proxy normally
+```
+
+Fast (milliseconds) and keeps all local state. Reaches into miden-client's
+private schema, so the operation may warn if miden-client bumps its schema;
+that's logged and non-fatal.
+
+#### Full reset — `--reset-miden-store`
+
+Deletes `store.sqlite3` (plus the `-wal`/`-shm` sidecars) so startup rebuilds
+an empty sqlite and re-syncs from the node. Keystore (private keys) and
+`bridge_accounts.toml` (on-chain account IDs) are preserved — wiping either
+would permanently lose control of the on-chain accounts.
+
+```bash
+./target/release/miden-agglayer-service \
+    --miden-node http://... \
+    --miden-store-dir /var/lib/miden \
+    --database-url postgres://... \
+    --reset-miden-store \
+    --restore
+```
+
+Combine with `--restore` to also rebuild the proxy's Postgres/in-memory store
+from on-chain notes in the same startup — otherwise the proxy resumes from a
+stale PgStore checkpoint.
+
+Caveat: after a reset the miden-client has an empty set of tracked accounts.
+Public accounts re-attach automatically via sync. Private accounts (if any)
+cannot be re-imported from the node alone — they would need a fresh `--init`
+(which mints new on-chain accounts and invalidates existing balances), so
+prefer `--unlock-miden-accounts` first when the divergence is recoverable.

--- a/scripts/e2e-dynamic-erc20.sh
+++ b/scripts/e2e-dynamic-erc20.sh
@@ -150,7 +150,8 @@ TX=$(cast send --rpc-url "$L1_RPC" \
     "$DEST_NETWORK" "$DEST_ADDR" "$BRIDGE_AMOUNT" \
     "$TOKEN_ADDR" true 0x \
     2>&1)
-echo "$TX" | grep -q "status.*1" || fail "L1 bridge tx failed: $TX"
+STATUS=$(printf '%s\n' "$TX" | awk '$1=="status"{print $2; exit}')
+[[ "$STATUS" == "1" ]] || fail "L1 bridge tx failed (status=$STATUS): $TX"
 pass "TestToken bridged on L1"
 
 # ── Step 3: Wait for auto-claim (which triggers faucet auto-creation) ─────────
@@ -334,7 +335,8 @@ CLAIM_TX=$(cast send --rpc-url "$L1_RPC" \
     "$AMOUNT_CLAIM" "$METADATA_CLAIM" \
     2>&1)
 
-if echo "$CLAIM_TX" | grep -q "status.*1"; then
+STATUS=$(printf '%s\n' "$CLAIM_TX" | awk '$1=="status"{print $2; exit}')
+if [[ "$STATUS" == "1" ]]; then
     pass "L1 claim transaction succeeded!"
 else
     warn "L1 claim tx output: $CLAIM_TX"

--- a/scripts/e2e-l1-to-l2.sh
+++ b/scripts/e2e-l1-to-l2.sh
@@ -91,7 +91,11 @@ TX=$(cast send --rpc-url "$L1_RPC" \
     "$DEST_NETWORK" "$DEST_ADDR" "$DEPOSIT_AMOUNT" \
     0x0000000000000000000000000000000000000000 true 0x \
     --value "$DEPOSIT_AMOUNT" 2>&1)
-echo "$TX" | grep -q "status.*1" || fail "L1 deposit tx failed: $TX"
+# Parse the status field from cast's receipt dump (format: "status  1 (success)").
+# Using grep on "status.*1" is fragile — the receipt's logs blob contains other
+# text that the shell pipe sometimes fails to match reliably.
+STATUS=$(printf '%s\n' "$TX" | awk '$1=="status"{print $2; exit}')
+[[ "$STATUS" == "1" ]] || fail "L1 deposit tx failed (status=$STATUS): $TX"
 pass "L1 deposit succeeded"
 
 # ── Step 2: Wait for deposit to be ready_for_claim ────────────────────────────

--- a/scripts/e2e-l2-to-l1.sh
+++ b/scripts/e2e-l2-to-l1.sh
@@ -182,11 +182,12 @@ CLAIM_TX=$(cast send --rpc-url "$L1_RPC" \
     "$AMOUNT_CLAIM" "$METADATA_CLAIM" \
     2>&1)
 
-if echo "$CLAIM_TX" | grep -q "status.*1"; then
+STATUS=$(printf '%s\n' "$CLAIM_TX" | awk '$1=="status"{print $2; exit}')
+if [[ "$STATUS" == "1" ]]; then
     pass "L1 claim transaction succeeded!"
 else
     warn "L1 claim tx output: $CLAIM_TX"
-    fail "L1 claim transaction failed"
+    fail "L1 claim transaction failed (status=$STATUS)"
 fi
 
 # Verify L1 balance change

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod log_synthesis;
 pub mod logging;
 pub mod metrics;
 pub mod miden_client;
+pub mod recovery;
 pub mod restore;
 pub mod service;
 pub(crate) mod service_admin;

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,22 @@ struct Command {
     #[arg(long)]
     restore: bool,
 
+    /// Big hammer recovery: wipe the miden-client sqlite store
+    /// (`store.sqlite3` + WAL/SHM) before starting so the proxy re-syncs from
+    /// the node. Keystore and `bridge_accounts.toml` are preserved.
+    ///
+    /// Combine with `--restore` to also rebuild the proxy store (PgStore /
+    /// InMemoryStore) from on-chain notes in the same startup.
+    #[arg(long)]
+    reset_miden_store: bool,
+
+    /// Surgical recovery: clear the `locked` flag on every account row in the
+    /// miden-client sqlite, then exit. Use when `--reset-miden-store` would
+    /// be overkill (i.e. the only symptom is a stale lock). Operator must
+    /// restart the proxy afterwards.
+    #[arg(long)]
+    unlock_miden_accounts: bool,
+
     /// L1 bridge contract address used for synthetic log emission
     #[arg(
         long,
@@ -83,6 +99,8 @@ impl std::fmt::Debug for Command {
                 &self.database_url.as_ref().map(|_| "[REDACTED]"),
             )
             .field("restore", &self.restore)
+            .field("reset_miden_store", &self.reset_miden_store)
+            .field("unlock_miden_accounts", &self.unlock_miden_accounts)
             .field("bridge_address", &self.bridge_address)
             .field(
                 "l1_rpc_url",
@@ -102,6 +120,37 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("{command:?}");
 
     let miden_store_dir = command.miden_store_dir;
+
+    // Resolve the effective store directory for recovery flags (which need a
+    // concrete path even when the user didn't pass `--miden-store-dir`).
+    let effective_store_dir = miden_store_dir.clone().unwrap_or_else(|| {
+        let base = std::env::home_dir().unwrap_or_else(|| PathBuf::from("."));
+        base.join(".miden")
+    });
+
+    // Surgical recovery: clear stale `locked` flags in miden-client's sqlite
+    // and exit. Operator restarts the proxy afterwards.
+    if command.unlock_miden_accounts {
+        let cleared = miden_agglayer_service::recovery::unlock_miden_accounts(&effective_store_dir)
+            .context("failed to clear locked flags in miden-client sqlite")?;
+        tracing::info!(
+            "unlock_miden_accounts: cleared {cleared} locked row(s); restart the proxy to pick up the change"
+        );
+        return Ok(());
+    }
+
+    // Big hammer recovery: wipe miden-client sqlite so startup re-syncs from
+    // the node. Must happen before ClientBuilder opens the sqlite file.
+    if command.reset_miden_store {
+        let removed = miden_agglayer_service::recovery::reset_miden_store(&effective_store_dir)
+            .context("failed to reset miden-client sqlite store")?;
+        tracing::warn!(
+            "reset_miden_store: removed {removed} sqlite file(s) from {}; \
+             keystore and bridge_accounts.toml preserved",
+            effective_store_dir.display()
+        );
+    }
+
     let needs_init = command.init || !config_path_exists(miden_store_dir.clone())?;
 
     // Phase 1: Run init if needed (with a minimal client, no BridgeOutScanner)
@@ -205,6 +254,46 @@ async fn main() -> anyhow::Result<()> {
 
         client.shutdown()?;
         return Ok(());
+    }
+
+    // Startup diagnostic: once the initial sync completes, check whether any
+    // managed account is marked `locked` in miden-client's local state. A
+    // stale lock is a symptom of a previous crash or commitment divergence and
+    // will otherwise surface later as opaque "transaction conflicts with
+    // current mempool state" errors on the first tx submission.
+    {
+        let client_ref = &client;
+        let accounts_ref = &accounts.0;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while !client_ref.is_alive() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+        if client_ref.is_alive() {
+            match miden_agglayer_service::recovery::detect_locked_accounts(client_ref, accounts_ref)
+                .await
+            {
+                Ok(locked) if !locked.is_empty() => {
+                    tracing::error!(
+                        "startup: {} managed account(s) are LOCKED in miden-client: {:?}. \
+                         This usually means local state diverged from the node. \
+                         Recovery: restart with --unlock-miden-accounts (surgical) or \
+                         --reset-miden-store --restore (full resync).",
+                        locked.len(),
+                        locked
+                    );
+                    ::metrics::counter!("miden_locked_accounts_detected_total")
+                        .increment(locked.len() as u64);
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    tracing::warn!("startup: lock-status check failed: {err:#}");
+                }
+            }
+        } else {
+            tracing::warn!(
+                "startup: miden-client not alive within 30s — skipping lock-status check"
+            );
+        }
     }
 
     let mut state = ServiceState::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,46 +256,6 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // Startup diagnostic: once the initial sync completes, check whether any
-    // managed account is marked `locked` in miden-client's local state. A
-    // stale lock is a symptom of a previous crash or commitment divergence and
-    // will otherwise surface later as opaque "transaction conflicts with
-    // current mempool state" errors on the first tx submission.
-    {
-        let client_ref = &client;
-        let accounts_ref = &accounts.0;
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-        while !client_ref.is_alive() && std::time::Instant::now() < deadline {
-            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-        }
-        if client_ref.is_alive() {
-            match miden_agglayer_service::recovery::detect_locked_accounts(client_ref, accounts_ref)
-                .await
-            {
-                Ok(locked) if !locked.is_empty() => {
-                    tracing::error!(
-                        "startup: {} managed account(s) are LOCKED in miden-client: {:?}. \
-                         This usually means local state diverged from the node. \
-                         Recovery: restart with --unlock-miden-accounts (surgical) or \
-                         --reset-miden-store --restore (full resync).",
-                        locked.len(),
-                        locked
-                    );
-                    ::metrics::counter!("miden_locked_accounts_detected_total")
-                        .increment(locked.len() as u64);
-                }
-                Ok(_) => {}
-                Err(err) => {
-                    tracing::warn!("startup: lock-status check failed: {err:#}");
-                }
-            }
-        } else {
-            tracing::warn!(
-                "startup: miden-client not alive within 30s — skipping lock-status check"
-            );
-        }
-    }
-
     let mut state = ServiceState::new(
         client,
         accounts,
@@ -316,6 +276,55 @@ async fn main() -> anyhow::Result<()> {
         .install_recorder()
         .context("failed to install metrics recorder")?;
     miden_agglayer_service::metrics::init_metrics();
+
+    // Startup diagnostic: once the initial sync completes, check whether any
+    // managed account is marked `locked` in miden-client's local state. A
+    // stale lock is a symptom of a previous crash or commitment divergence and
+    // will otherwise surface later as opaque "transaction conflicts with
+    // current mempool state" errors on the first tx submission.
+    //
+    // Runs in the background so it doesn't delay `service::serve`. Worst case,
+    // a locked account is flagged a few seconds into the proxy's lifetime
+    // instead of strictly before it serves traffic.
+    {
+        let diag_client = state.miden_client.clone();
+        let diag_accounts = state.accounts.0.clone();
+        tokio::spawn(async move {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(120);
+            while !diag_client.is_alive() && std::time::Instant::now() < deadline {
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            }
+            if !diag_client.is_alive() {
+                tracing::warn!(
+                    "startup diagnostic: miden-client not alive within 120s — skipping lock-status check"
+                );
+                return;
+            }
+            match miden_agglayer_service::recovery::detect_locked_accounts(
+                &diag_client,
+                &diag_accounts,
+            )
+            .await
+            {
+                Ok(locked) if !locked.is_empty() => {
+                    tracing::error!(
+                        "startup diagnostic: {} managed account(s) are LOCKED in miden-client: {:?}. \
+                         This usually means local state diverged from the node. \
+                         Recovery: restart with --unlock-miden-accounts (surgical) or \
+                         --reset-miden-store --restore (full resync).",
+                        locked.len(),
+                        locked
+                    );
+                    ::metrics::counter!("miden_locked_accounts_detected_total")
+                        .increment(locked.len() as u64);
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    tracing::warn!("startup diagnostic: lock-status check failed: {err:#}");
+                }
+            }
+        });
+    }
 
     let url = Url::from_str(format!("http://0.0.0.0:{}", command.port).as_str())?;
     service::serve(url, state.clone(), metrics_handle).await?;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -7,4 +7,13 @@ pub fn init_metrics() {
     describe_counter!("bridge_outs_total", "Total bridge-out operations");
     describe_counter!("store_errors_total", "Total store operation errors");
     describe_histogram!("rpc_request_duration_seconds", "JSON-RPC request duration");
+    describe_counter!(
+        "miden_client_build_errors_total",
+        "Failed attempts to build Miden client connection"
+    );
+    describe_counter!(
+        "miden_client_restarts_total",
+        "Background thread restarts after crash"
+    );
+    describe_counter!("miden_sync_errors_total", "Sync errors by kind");
 }

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -10,12 +10,22 @@ use std::error::Error;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::AtomicUsize;
 use std::thread;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+
+/// Minimum backoff delay for retries.
+const BACKOFF_MIN: Duration = Duration::from_secs(1);
+/// Maximum backoff delay for retries.
+const BACKOFF_MAX: Duration = Duration::from_secs(60);
+
+fn next_backoff(current: Duration) -> Duration {
+    (current * 2).min(BACKOFF_MAX)
+}
 
 pub type MidenClientLib = miden_client::Client<FilesystemKeyStore>;
 
@@ -41,6 +51,7 @@ pub struct MidenClient {
     task: std::sync::Mutex<Option<thread::JoinHandle<anyhow::Result<()>>>>,
     sender: mpsc::Sender<Request>,
     done_sender: std::sync::Mutex<Option<oneshot::Sender<()>>>,
+    alive: Arc<AtomicBool>,
     #[cfg(test)]
     call_count: Arc<AtomicUsize>,
 }
@@ -64,22 +75,44 @@ impl MidenClient {
 
         let (sender, receiver) = mpsc::channel::<Request>(1);
         let (done_sender, done_receiver) = oneshot::channel::<()>();
+        let alive = Arc::new(AtomicBool::new(false));
+        let alive_for_run = alive.clone();
 
         let runtime = tokio::runtime::Runtime::new()?;
         let task = thread::spawn(move || -> anyhow::Result<()> {
-            let result = runtime.block_on(tokio::task::LocalSet::new().run_until(Self::run(
-                store_dir,
-                node_endpoint,
-                keystore_for_run,
-                receiver,
-                done_receiver,
-                sync_listeners,
-                debug_mode,
-            )));
-            if let Err(err) = &result {
-                tracing::error!("MidenClient::run stopped: {err:#?}");
+            let local_set = tokio::task::LocalSet::new();
+            let mut receiver = receiver;
+            let mut done_receiver = done_receiver;
+
+            loop {
+                let result =
+                    runtime.block_on(local_set.run_until(Self::run(
+                        store_dir.clone(),
+                        node_endpoint.clone(),
+                        keystore_for_run.clone(),
+                        &mut receiver,
+                        &mut done_receiver,
+                        &sync_listeners,
+                        debug_mode,
+                        &alive_for_run,
+                    )));
+
+                match result {
+                    Ok(()) => {
+                        // Clean shutdown (done_receiver signalled)
+                        alive_for_run.store(false, Ordering::Release);
+                        return Ok(());
+                    }
+                    Err(err) => {
+                        alive_for_run.store(false, Ordering::Release);
+                        metrics::counter!("miden_client_restarts_total").increment(1);
+                        tracing::error!(
+                            "MidenClient::run crashed: {err:#}, restarting in 5s..."
+                        );
+                        std::thread::sleep(Duration::from_secs(5));
+                    }
+                }
             }
-            result
         });
 
         let task = std::sync::Mutex::new(Some(task));
@@ -89,9 +122,15 @@ impl MidenClient {
             task,
             sender,
             done_sender,
+            alive,
             #[cfg(test)]
             call_count: Arc::new(AtomicUsize::new(0)),
         })
+    }
+
+    /// Returns true if the background thread is connected and syncing.
+    pub fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::Acquire)
     }
 
     #[cfg(test)]
@@ -136,6 +175,7 @@ impl MidenClient {
             task: std::sync::Mutex::new(None),
             sender,
             done_sender: std::sync::Mutex::new(Some(done_sender)),
+            alive: Arc::new(AtomicBool::new(true)),
             call_count,
         }
     }
@@ -218,7 +258,7 @@ impl MidenClient {
         self.join()
     }
 
-    fn unwrap_connection_error(client_err: ClientError) -> anyhow::Result<Box<dyn Error>> {
+    pub(crate) fn unwrap_connection_error(client_err: ClientError) -> anyhow::Result<Box<dyn Error>> {
         match client_err {
             ClientError::RpcError(RpcError::ConnectionError(err)) => Ok(err),
             ClientError::RpcError(RpcError::RequestError {
@@ -230,6 +270,7 @@ impl MidenClient {
     }
 
     async fn sync(client: &mut MidenClientLib) -> anyhow::Result<SyncSummary> {
+        let mut backoff = BACKOFF_MIN;
         loop {
             let result = client.sync_state().await;
             match result {
@@ -240,17 +281,20 @@ impl MidenClient {
                 Err(client_err) => {
                     match Self::unwrap_connection_error(client_err) {
                         Ok(conn_err) => {
+                            metrics::counter!("miden_sync_errors_total", "kind" => "connection").increment(1);
                             tracing::error!(
-                                "MidenClient::sync connection error: {conn_err:?}, retrying in 5s..."
+                                "MidenClient::sync connection error: {conn_err:?}, retrying in {backoff:?}..."
                             );
                         }
                         Err(other_err) => {
+                            metrics::counter!("miden_sync_errors_total", "kind" => "other").increment(1);
                             tracing::error!(
-                                "MidenClient::sync non-connection error: {other_err:#}, retrying in 5s..."
+                                "MidenClient::sync non-connection error: {other_err:#}, retrying in {backoff:?}..."
                             );
                         }
                     }
-                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    tokio::time::sleep(backoff).await;
+                    backoff = next_backoff(backoff);
                 }
             }
         }
@@ -269,16 +313,18 @@ impl MidenClient {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn run(
         store_dir: PathBuf,
         node_endpoint: Endpoint,
         keystore: Arc<FilesystemKeyStore>,
-        mut receiver: mpsc::Receiver<Request>,
-        mut done_receiver: oneshot::Receiver<()>,
-        sync_listeners: Vec<Arc<dyn SyncListener>>,
+        receiver: &mut mpsc::Receiver<Request>,
+        done_receiver: &mut oneshot::Receiver<()>,
+        sync_listeners: &[Arc<dyn SyncListener>],
         debug_mode: bool,
+        alive: &AtomicBool,
     ) -> anyhow::Result<()> {
-        // node client
+        // node client — retry build with exponential backoff
         let node_timeout_ms: u64 = 10_000;
         let mode = if debug_mode {
             DebugMode::Enabled
@@ -286,26 +332,53 @@ impl MidenClient {
             DebugMode::Disabled
         };
 
-        let mut client = ClientBuilder::new()
-            .grpc_client(&node_endpoint, Some(node_timeout_ms))
-            .sqlite_store(store_dir.join("store.sqlite3"))
-            .authenticator(keystore)
-            .in_debug_mode(mode)
-            .build()
-            .await?;
+        let mut client;
+        let mut backoff = BACKOFF_MIN;
+        loop {
+            let build_result = ClientBuilder::new()
+                .grpc_client(&node_endpoint, Some(node_timeout_ms))
+                .sqlite_store(store_dir.join("store.sqlite3"))
+                .authenticator(keystore.clone())
+                .in_debug_mode(mode)
+                .build()
+                .await;
+
+            match build_result {
+                Ok(c) => {
+                    client = c;
+                    break;
+                }
+                Err(err) => {
+                    metrics::counter!("miden_client_build_errors_total").increment(1);
+                    tracing::error!(
+                        "MidenClient build failed: {err:#}, retrying in {backoff:?}..."
+                    );
+                    tokio::select! {
+                        _ = tokio::time::sleep(backoff) => {},
+                        _ = &mut *done_receiver => {
+                            tracing::debug!("MidenClient::run shutdown during build retry");
+                            return Ok(());
+                        }
+                    }
+                    backoff = next_backoff(backoff);
+                }
+            }
+        }
 
         // initial sync
         tokio::select! {
             result = Self::sync(&mut client) => {
-                if let Err(err) = Self::on_sync(result, &mut client, &sync_listeners).await {
+                if let Err(err) = Self::on_sync(result, &mut client, sync_listeners).await {
                     tracing::error!("MidenClient initial sync listener error: {err:#}");
                 }
             },
-            _ = &mut done_receiver => {
+            _ = &mut *done_receiver => {
                 tracing::debug!("MidenClient::run loop done");
                 return Ok(());
             }
         }
+
+        alive.store(true, Ordering::Release);
         let mut sync_interval = tokio::time::interval(Duration::from_secs(5));
 
         loop {
@@ -318,14 +391,14 @@ impl MidenClient {
                 _ = sync_interval.tick() => {
                     tokio::select! {
                         result = Self::sync(&mut client) => {
-                            if let Err(err) = Self::on_sync(result, &mut client, &sync_listeners).await {
+                            if let Err(err) = Self::on_sync(result, &mut client, sync_listeners).await {
                                 tracing::error!("MidenClient sync listener error: {err:#}");
                             }
                         },
-                        _ = &mut done_receiver => break,
+                        _ = &mut *done_receiver => break,
                     }
                 },
-                _ = &mut done_receiver => break,
+                _ = &mut *done_receiver => break,
             }
         }
 
@@ -361,6 +434,7 @@ impl MidenClient {
 /// Poll until a transaction is committed on the Miden node.
 ///
 /// Returns `true` if committed within the given number of attempts.
+/// Connection errors during sync are retried up to 3 times per attempt.
 pub async fn wait_for_transaction_commit(
     client: &mut MidenClientLib,
     txn_id: miden_protocol::transaction::TransactionId,
@@ -369,7 +443,32 @@ pub async fn wait_for_transaction_commit(
 ) -> anyhow::Result<bool> {
     for _ in 0..max_attempts {
         tokio::time::sleep(poll_interval).await;
-        client.sync_state().await?;
+
+        // Retry sync on connection errors (up to 3 retries per poll attempt)
+        let mut sync_ok = false;
+        for retry in 0..3u32 {
+            match client.sync_state().await {
+                Ok(_) => {
+                    sync_ok = true;
+                    break;
+                }
+                Err(client_err) => match MidenClient::unwrap_connection_error(client_err) {
+                    Ok(conn_err) => {
+                        tracing::warn!(
+                            "wait_for_transaction_commit: sync connection error (retry {}/3): {conn_err:?}",
+                            retry + 1
+                        );
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                    }
+                    Err(other_err) => return Err(other_err),
+                },
+            }
+        }
+        if !sync_ok {
+            tracing::error!("wait_for_transaction_commit: sync failed after 3 retries, skipping poll");
+            continue;
+        }
+
         let txns = client
             .get_transactions(miden_client::store::TransactionFilter::All)
             .await?;

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -10,9 +10,9 @@ use std::error::Error;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(test)]
 use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -85,17 +85,16 @@ impl MidenClient {
             let mut done_receiver = done_receiver;
 
             loop {
-                let result =
-                    runtime.block_on(local_set.run_until(Self::run(
-                        store_dir.clone(),
-                        node_endpoint.clone(),
-                        keystore_for_run.clone(),
-                        &mut receiver,
-                        &mut done_receiver,
-                        &sync_listeners,
-                        debug_mode,
-                        &alive_for_run,
-                    )));
+                let result = runtime.block_on(local_set.run_until(Self::run(
+                    store_dir.clone(),
+                    node_endpoint.clone(),
+                    keystore_for_run.clone(),
+                    &mut receiver,
+                    &mut done_receiver,
+                    &sync_listeners,
+                    debug_mode,
+                    &alive_for_run,
+                )));
 
                 match result {
                     Ok(()) => {
@@ -106,9 +105,7 @@ impl MidenClient {
                     Err(err) => {
                         alive_for_run.store(false, Ordering::Release);
                         metrics::counter!("miden_client_restarts_total").increment(1);
-                        tracing::error!(
-                            "MidenClient::run crashed: {err:#}, restarting in 5s..."
-                        );
+                        tracing::error!("MidenClient::run crashed: {err:#}, restarting in 5s...");
                         std::thread::sleep(Duration::from_secs(5));
                     }
                 }
@@ -258,7 +255,9 @@ impl MidenClient {
         self.join()
     }
 
-    pub(crate) fn unwrap_connection_error(client_err: ClientError) -> anyhow::Result<Box<dyn Error>> {
+    pub(crate) fn unwrap_connection_error(
+        client_err: ClientError,
+    ) -> anyhow::Result<Box<dyn Error>> {
         match client_err {
             ClientError::RpcError(RpcError::ConnectionError(err)) => Ok(err),
             ClientError::RpcError(RpcError::RequestError {
@@ -281,13 +280,15 @@ impl MidenClient {
                 Err(client_err) => {
                     match Self::unwrap_connection_error(client_err) {
                         Ok(conn_err) => {
-                            metrics::counter!("miden_sync_errors_total", "kind" => "connection").increment(1);
+                            metrics::counter!("miden_sync_errors_total", "kind" => "connection")
+                                .increment(1);
                             tracing::error!(
                                 "MidenClient::sync connection error: {conn_err:?}, retrying in {backoff:?}..."
                             );
                         }
                         Err(other_err) => {
-                            metrics::counter!("miden_sync_errors_total", "kind" => "other").increment(1);
+                            metrics::counter!("miden_sync_errors_total", "kind" => "other")
+                                .increment(1);
                             tracing::error!(
                                 "MidenClient::sync non-connection error: {other_err:#}, retrying in {backoff:?}..."
                             );
@@ -465,7 +466,9 @@ pub async fn wait_for_transaction_commit(
             }
         }
         if !sync_ok {
-            tracing::error!("wait_for_transaction_commit: sync failed after 3 retries, skipping poll");
+            tracing::error!(
+                "wait_for_transaction_commit: sync failed after 3 retries, skipping poll"
+            );
             continue;
         }
 

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -238,10 +238,18 @@ impl MidenClient {
                     return Ok(summary);
                 }
                 Err(client_err) => {
-                    let err = Self::unwrap_connection_error(client_err)?;
-                    tracing::error!(
-                        "MidenClient::sync failed to connect to the node: {err:?}, retrying in 5 seconds..."
-                    );
+                    match Self::unwrap_connection_error(client_err) {
+                        Ok(conn_err) => {
+                            tracing::error!(
+                                "MidenClient::sync connection error: {conn_err:?}, retrying in 5s..."
+                            );
+                        }
+                        Err(other_err) => {
+                            tracing::error!(
+                                "MidenClient::sync non-connection error: {other_err:#}, retrying in 5s..."
+                            );
+                        }
+                    }
                     tokio::time::sleep(Duration::from_secs(5)).await;
                 }
             }
@@ -288,7 +296,11 @@ impl MidenClient {
 
         // initial sync
         tokio::select! {
-            result = Self::sync(&mut client) => Self::on_sync(result, &mut client, &sync_listeners).await?,
+            result = Self::sync(&mut client) => {
+                if let Err(err) = Self::on_sync(result, &mut client, &sync_listeners).await {
+                    tracing::error!("MidenClient initial sync listener error: {err:#}");
+                }
+            },
             _ = &mut done_receiver => {
                 tracing::debug!("MidenClient::run loop done");
                 return Ok(());
@@ -305,7 +317,11 @@ impl MidenClient {
                 },
                 _ = sync_interval.tick() => {
                     tokio::select! {
-                        result = Self::sync(&mut client) => Self::on_sync(result, &mut client, &sync_listeners).await?,
+                        result = Self::sync(&mut client) => {
+                            if let Err(err) = Self::on_sync(result, &mut client, &sync_listeners).await {
+                                tracing::error!("MidenClient sync listener error: {err:#}");
+                            }
+                        },
                         _ = &mut done_receiver => break,
                     }
                 },

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -1,0 +1,231 @@
+//! Recovery helpers for when the miden-client local state diverges from the node.
+//!
+//! Two modes are exposed:
+//!
+//! 1. **Full reset** (`reset_miden_store`) — the "big hammer". Deletes
+//!    `store.sqlite3` (and its WAL/SHM sidecars) so that the next startup
+//!    rebuilds an empty sqlite DB and re-syncs everything from the node. The
+//!    keystore (private keys) and `bridge_accounts.toml` (on-chain account IDs)
+//!    are preserved — wiping either would permanently lose control of the
+//!    on-chain accounts.
+//!
+//! 2. **Surgical unlock** (`unlock_miden_accounts`) — clears the `locked`
+//!    column on every row in miden-client's `latest_account_headers` and
+//!    `historical_account_headers` tables. Use when the only symptom is a
+//!    stale lock flag (see `detect_locked_accounts`) and a full resync would
+//!    be overkill.
+//!
+//! Surgical unlock reaches directly into miden-client's sqlite schema because
+//! miden-client v0.14.x does not expose a public unlock API. The column names
+//! come from `crates/sqlite-store/src/store.sql` in miden-client.
+
+use anyhow::{Context, Result};
+use miden_client::ClientError;
+use miden_protocol::account::AccountId;
+use rusqlite::Connection;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+use crate::accounts_config::AccountsConfig;
+use crate::miden_client::MidenClient;
+
+const SQLITE_FILES: &[&str] = &["store.sqlite3", "store.sqlite3-wal", "store.sqlite3-shm"];
+
+/// Resolve the sqlite path miden-client uses inside `store_dir`.
+pub fn sqlite_path(store_dir: &Path) -> PathBuf {
+    store_dir.join("store.sqlite3")
+}
+
+/// Big hammer: delete `store.sqlite3` (and its WAL/SHM sidecars) from
+/// `store_dir`. Keystore and `bridge_accounts.toml` are preserved.
+///
+/// No-op for files that do not exist. Returns the number of files deleted.
+pub fn reset_miden_store(store_dir: &Path) -> Result<usize> {
+    let mut removed = 0;
+    for name in SQLITE_FILES {
+        let path = store_dir.join(name);
+        match fs::remove_file(&path) {
+            Ok(()) => {
+                tracing::info!("reset_miden_store: deleted {}", path.display());
+                removed += 1;
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(err).with_context(|| format!("deleting {}", path.display()));
+            }
+        }
+    }
+    Ok(removed)
+}
+
+/// Surgical unlock: open the miden-client sqlite store directly and clear the
+/// `locked` flag on every tracked account row. Returns the total number of
+/// rows updated across both header tables.
+///
+/// Intended for the case where the proxy's local state has a stale lock but
+/// the on-chain account is actually fine — cheaper than a full resync. If the
+/// sqlite file does not exist, returns 0.
+pub fn unlock_miden_accounts(store_dir: &Path) -> Result<usize> {
+    let db_path = sqlite_path(store_dir);
+    if !db_path.exists() {
+        return Ok(0);
+    }
+    let conn =
+        Connection::open(&db_path).with_context(|| format!("opening {}", db_path.display()))?;
+    let mut total = 0;
+    for table in ["latest_account_headers", "historical_account_headers"] {
+        let sql = format!("UPDATE {table} SET locked = 0 WHERE locked = 1");
+        match conn.execute(&sql, []) {
+            Ok(n) => {
+                if n > 0 {
+                    tracing::info!("unlock_miden_accounts: cleared {n} rows in {table}");
+                }
+                total += n;
+            }
+            Err(rusqlite::Error::SqliteFailure(_, Some(msg)))
+                if msg.contains("no such table") || msg.contains("no such column") =>
+            {
+                tracing::warn!(
+                    "unlock_miden_accounts: skipping {table} (schema mismatch: {msg}); \
+                     miden-client may have changed its schema"
+                );
+            }
+            Err(err) => {
+                return Err(err).with_context(|| format!("updating {table}"));
+            }
+        }
+    }
+    Ok(total)
+}
+
+/// After initial sync, query the miden-client for the lock status of every
+/// account listed in `accounts`. Returns the subset that are currently locked.
+///
+/// The proxy will refuse to process work against a locked account, so surfacing
+/// this at startup is more actionable than letting the first tx submission fail
+/// with `transaction conflicts with current mempool state`.
+pub async fn detect_locked_accounts(
+    client: &MidenClient,
+    accounts: &AccountsConfig,
+) -> Result<Vec<AccountId>> {
+    let mut ids: Vec<AccountId> = vec![
+        accounts.service.0,
+        accounts.bridge.0,
+        accounts.wallet_hardhat.0,
+    ];
+    if let Some(f) = &accounts.faucet_eth {
+        ids.push(f.0);
+    }
+    if let Some(f) = &accounts.faucet_agg {
+        ids.push(f.0);
+    }
+    if let Some(g) = &accounts.ger_manager {
+        ids.push(g.0);
+    }
+
+    let mut locked = Vec::new();
+    for id in ids {
+        let result = Arc::new(OnceLock::<bool>::new());
+        let result_set = result.clone();
+        client
+            .with(move |c| {
+                Box::new(async move {
+                    let reader = c.account_reader(id);
+                    let is_locked = match reader.status().await {
+                        Ok(status) => status.is_locked(),
+                        // An account the client doesn't track cannot be locked.
+                        Err(ClientError::AccountDataNotFound(_)) => false,
+                        Err(err) => return Err(err.into()),
+                    };
+                    let _ = result_set.set(is_locked);
+                    Ok(())
+                })
+            })
+            .await?;
+        if result.get().copied().unwrap_or(false) {
+            locked.push(id);
+        }
+    }
+    Ok(locked)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn reset_miden_store_removes_sqlite_files_and_keeps_others() {
+        let dir = tempdir().unwrap();
+        let p = dir.path();
+
+        fs::write(p.join("store.sqlite3"), b"x").unwrap();
+        fs::write(p.join("store.sqlite3-wal"), b"x").unwrap();
+        fs::write(p.join("store.sqlite3-shm"), b"x").unwrap();
+        fs::write(p.join("bridge_accounts.toml"), b"x").unwrap();
+        fs::create_dir_all(p.join("keystore")).unwrap();
+        fs::write(p.join("keystore").join("key.json"), b"x").unwrap();
+
+        let removed = reset_miden_store(p).unwrap();
+        assert_eq!(removed, 3);
+        assert!(!p.join("store.sqlite3").exists());
+        assert!(!p.join("store.sqlite3-wal").exists());
+        assert!(!p.join("store.sqlite3-shm").exists());
+        assert!(p.join("bridge_accounts.toml").exists());
+        assert!(p.join("keystore").join("key.json").exists());
+    }
+
+    #[test]
+    fn reset_miden_store_is_idempotent() {
+        let dir = tempdir().unwrap();
+        assert_eq!(reset_miden_store(dir.path()).unwrap(), 0);
+        assert_eq!(reset_miden_store(dir.path()).unwrap(), 0);
+    }
+
+    #[test]
+    fn unlock_miden_accounts_is_noop_when_no_sqlite() {
+        let dir = tempdir().unwrap();
+        assert_eq!(unlock_miden_accounts(dir.path()).unwrap(), 0);
+    }
+
+    #[test]
+    fn unlock_miden_accounts_clears_locked_rows() {
+        let dir = tempdir().unwrap();
+        let db_path = sqlite_path(dir.path());
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE latest_account_headers (id INTEGER PRIMARY KEY, locked BOOLEAN NOT NULL);
+             CREATE TABLE historical_account_headers (id INTEGER PRIMARY KEY, locked BOOLEAN NOT NULL);
+             INSERT INTO latest_account_headers (id, locked) VALUES (1, 1), (2, 0), (3, 1);
+             INSERT INTO historical_account_headers (id, locked) VALUES (1, 1), (2, 1);",
+        )
+        .unwrap();
+        drop(conn);
+
+        let n = unlock_miden_accounts(dir.path()).unwrap();
+        assert_eq!(n, 4);
+
+        let conn = Connection::open(&db_path).unwrap();
+        let still_locked: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM latest_account_headers WHERE locked = 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(still_locked, 0);
+    }
+
+    #[test]
+    fn unlock_miden_accounts_survives_unknown_schema() {
+        let dir = tempdir().unwrap();
+        let db_path = sqlite_path(dir.path());
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch("CREATE TABLE unrelated (x INTEGER);")
+            .unwrap();
+        drop(conn);
+
+        assert_eq!(unlock_miden_accounts(dir.path()).unwrap(), 0);
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -335,8 +335,21 @@ async fn shutdown_signal() {
     }
 }
 
-async fn health_check() -> impl IntoResponse {
-    axum::Json(serde_json::json!({ "status": "ok" }))
+async fn health_check(State(service): State<ServiceState>) -> impl IntoResponse {
+    if service.miden_client.is_alive() {
+        (
+            http::StatusCode::OK,
+            axum::Json(serde_json::json!({ "status": "ok" })),
+        )
+    } else {
+        (
+            http::StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(serde_json::json!({
+                "status": "degraded",
+                "reason": "node connection lost"
+            })),
+        )
+    }
 }
 
 pub async fn serve(


### PR DESCRIPTION
## Summary

Bundles two related fixes for proxy resilience, as requested by Igor:

1. **Resilient sync loop** (from #20): background `MidenClient::run` retries build + sync with exponential backoff on transient errors instead of killing the proxy.
2. **Recovery modes** (new): when miden-client's local sqlite diverges from the node (stale `locked` flag, `initial account commitment … does not match …` on submit), there are now two operator-facing recovery paths plus a startup diagnostic that surfaces the condition.

### New recovery flags

- `--reset-miden-store` — deletes `store.sqlite3` (+ WAL/SHM) before startup so the client re-syncs from the node. Keystore and `bridge_accounts.toml` preserved. Combine with `--restore` to rebuild the proxy's PgStore in the same run.
- `--unlock-miden-accounts` — clears the `locked` column in miden-client's sqlite and exits. Surgical alternative when a full resync would be overkill.

### Startup diagnostic

After initial sync, each managed account's lock status is checked via `AccountReader::status()`. If any are locked, an ERROR is logged (plus `miden_locked_accounts_detected_total` metric increments) so operators see divergence before the first tx submission fails with an opaque mempool conflict.

Full rationale, tradeoffs, and a caveat about private accounts are documented in the new `## Recovery` section of the README.

## Test plan

- [x] `cargo test --lib` — 70 tests pass (5 new recovery tests covering wipe-is-idempotent, keystore/toml preservation, surgical unlock clears rows, schema-mismatch is non-fatal)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] Manual: trigger a lock via a crashed-mid-tx scenario, verify startup diagnostic logs the ERROR, verify `--unlock-miden-accounts` clears it and proxy resumes
- [ ] Manual: wipe sqlite via `--reset-miden-store --restore` on a running cluster, verify re-sync completes and proxy serves traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)