### PR TITLE
ci: release workflow to publish Docker image to ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` so that pushing a `v*` tag builds the existing `Dockerfile` and publishes the image to `ghcr.io/gateway-fm/miden-agglayer`.

Tags published per release:
- `{version}` (e.g. `0.1.0`)
- `{major}.{minor}` (e.g. `0.1`)
- `latest`

Uses the built-in `GITHUB_TOKEN` with `packages: write` — no extra secrets needed.

After this merges, I'll push tag `v0.1.0` to trigger the first publish, then mark the ghcr package private (repo is public, but the user wants the image private).

## Test plan

- [x] Workflow YAML is syntactically valid
- [ ] After merge: push `v0.1.0` tag, confirm workflow succeeds and image appears at `ghcr.io/gateway-fm/miden-agglayer:0.1.0`
- [ ] Confirm package visibility set to private

🤖 Generated with [Claude Code](https://claude.com/claude-code)