### PR TITLE
ci: pin docker/* actions to commit SHAs in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -26,7 +26,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -35,7 +35,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary

The release workflow from #22 failed on the first `v0.1.0` run with:

> The actions docker/setup-buildx-action@v3, docker/login-action@v3, docker/metadata-action@v5, and docker/build-push-action@v5 are not allowed in gateway-fm/miden-agglayer because all actions must be pinned to a full-length commit SHA.

This PR pins each docker/* action to the latest commit SHA for its major version, with a `# vX.Y.Z` comment so dependabot can propose upgrades.

| Action | SHA | Version |
|---|---|---|
| docker/setup-buildx-action | `f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca` | v3.9.0 |
| docker/login-action | `c94ce9fb468520275223c153574b00df6fe4bcc9` | v3.7.0 |
| docker/metadata-action | `318604b99e75e41977312d83839a89be02ca4893` | v5.9.0 |
| docker/build-push-action | `ca052bb54ab0790a636c9b5f226502c73d547a25` | v5.4.0 |

## Test plan

- [ ] After merge: delete + re-push `v0.1.0` tag, confirm the workflow actually builds and pushes to ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)