### PR TITLE
ci: publish release image to Docker Hub (gatewayfm/miden-agglayer)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   docker:
@@ -17,18 +16,17 @@ jobs:
 
       - uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
-      - name: Log in to ghcr.io
+      - name: Log in to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: gatewayfm/miden-agglayer
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
## Summary
- Switch the release workflow from `ghcr.io/gateway-fm/miden-agglayer` to Docker Hub `gatewayfm/miden-agglayer`.
- Replace ghcr.io login (GITHUB_TOKEN) with Docker Hub login using `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets.
- Drop the now-unused `packages: write` permission.

Third-party `ghcr.io/...` image references in `docker-compose.e2e.yml` (foundry, zkevm-bridge-service, aggkit) are unchanged — only our own image moves.

## Prerequisites
Add the following repo secrets before the next tag push:
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN` (Docker Hub access token with push rights to `gatewayfm/miden-agglayer`)

## Test plan
- [ ] Configure `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets on the repo
- [ ] Push a test tag (e.g. `v0.1.1-rc1`) and confirm the image appears at https://hub.docker.com/r/gatewayfm/miden-agglayer with `latest`, `{version}`, and `{major}.{minor}` tags
- [ ] Verify `docker pull gatewayfm/miden-agglayer:latest` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)