### PR TITLE
fix(deps): bump miden-client to v0.14.4 — fixes sync_transactions proto decode loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -637,7 +637,7 @@ checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "reqwest 0.13.2",
  "serde_json",
  "tower",
@@ -718,7 +718,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -729,7 +729,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2055,7 +2055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3396,8 +3396,8 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.14.0"
-source = "git+https://github.com/0xMiden/miden-client.git?rev=f7cdf263781999e8f81ba608f9c5a91218747d98#f7cdf263781999e8f81ba608f9c5a91218747d98"
+version = "0.14.4"
+source = "git+https://github.com/0xMiden/miden-client.git?tag=v0.14.4#18d921f15754e7deaf0659916820abea52fbea03"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3418,6 +3418,7 @@ dependencies = [
  "rand 0.9.3",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -3431,8 +3432,8 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.14.0"
-source = "git+https://github.com/0xMiden/miden-client.git?rev=f7cdf263781999e8f81ba608f9c5a91218747d98#f7cdf263781999e8f81ba608f9c5a91218747d98"
+version = "0.14.4"
+source = "git+https://github.com/0xMiden/miden-client.git?tag=v0.14.4#18d921f15754e7deaf0659916820abea52fbea03"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3636,9 +3637,9 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.14.6"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "289194699f5acd63feb735c692fab0ff2e77aa67bf67dfd2608e0c573591a14b"
+checksum = "6e457758c9a6aa5f70f687f1081833f102572ee1d02baf549625868917495815"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -3649,9 +3650,9 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto-build"
-version = "0.3.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e183c4e36c155edea086b79cd4395d70e3a905eb86778827e12a8e0d0110d2b"
+checksum = "ec23738a2eee393524a849a8dce982ad824050cc54abde145d4fb62b92c84198"
 dependencies = [
  "fs-err",
  "miette",
@@ -3990,7 +3991,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4885,7 +4886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -4906,7 +4907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5522,7 +5523,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5581,7 +5582,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6038,7 +6039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6249,7 +6250,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6258,7 +6259,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6277,7 +6278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7288,7 +7289,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,11 +84,25 @@ miden-protocol = { default-features = false, features = [
 miden-standards = { default-features = false, version = "0.14" }
 miden-tx = { default-features = false, version = "0.14" }
 
-# miden-client (pinned to ajl-agglayer-integration-tests-v0.14.0 branch head for reproducibility)
+# miden-client v0.14.4 (tagged release).
+#
+# Previously pinned to a commit on the `ajl-agglayer-integration-tests-v0.14.0` branch
+# (rev f7cdf263). That rev expected `TransactionHeader.output_notes = repeated NoteSyncRecord`
+# in proto-build 0.14.4–0.14.6 — a short-lived schema that miden-node v0.14.7+ reverted
+# back to `repeated NoteHeader` (miden-node commit cf0a333a). Running our client against
+# a v0.14.7+ server therefore produced `invalid wire type: SixtyFourBit (expected
+# LengthDelimited)` decode failures on every `SyncTransactions` response.
+#
+# v0.14.4 of miden-client (which includes miden-client PR #2008 "detect erased notes")
+# flipped its Rust decode path back to `Vec<NoteHeader>`, realigning client ↔ server.
+# Cargo's semver resolution now pulls miden-node-proto-build 0.14.9, matching the server
+# schema. The `ajl-agglayer-integration-tests-v0.14.0` branch only diverges in
+# integration-test code (test_utils/common.rs behind the `testing` feature), so losing
+# that branch does not affect miden-agglayer's library usage.
 miden-client = { default-features = false, features = [
   "tonic",
-], git = "https://github.com/0xMiden/miden-client.git", rev = "f7cdf263781999e8f81ba608f9c5a91218747d98" }
-miden-client-sqlite-store = { git = "https://github.com/0xMiden/miden-client.git", rev = "f7cdf263781999e8f81ba608f9c5a91218747d98" }
+], git = "https://github.com/0xMiden/miden-client.git", tag = "v0.14.4" }
+miden-client-sqlite-store = { git = "https://github.com/0xMiden/miden-client.git", tag = "v0.14.4" }
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

Unblocks the deployed service, which has been looping on `sync_transactions` with a protobuf decode error since the testnet node was upgraded past `v0.14.7`.

Root cause: miden-client was pinned to a commit baked against a short-lived `TransactionHeader.output_notes = repeated NoteSyncRecord` schema (proto-build `0.14.4–0.14.6`). miden-node reverted that to `repeated NoteHeader` at `v0.14.7`. Our client was still expecting the middle schema, so every `SyncTransactions` response failed to decode at exactly `AccountId.id` — wire type `SixtyFourBit` vs `LengthDelimited`.

## What changed

`Cargo.toml`: `miden-client` + `miden-client-sqlite-store` pin moves from

```
git = "https://github.com/0xMiden/miden-client.git"
rev = "f7cdf263781999e8f81ba608f9c5a91218747d98"
```

to

```
git = "https://github.com/0xMiden/miden-client.git"
tag = "v0.14.4"
```

`cargo update` then pulls `miden-node-proto-build v0.14.6 → v0.14.9`.

## Proto timeline (so the next person doesn't have to dig this up)

| miden-node tag | `TransactionHeader.output_notes` |
|---|---|
| v0.14.0 | `repeated NoteHeader` |
| v0.14.4 – v0.14.6 | `repeated NoteSyncRecord` |
| **v0.14.7 – v0.14.9** | `repeated NoteHeader` (reverted) |

| miden-node-proto-build (crate) | Schema baked in |
|---|---|
| 0.14.6 | `NoteSyncRecord` |
| **0.14.9** | `NoteHeader` |

The Status RPC doesn't touch output_notes, so both `rpc.testnet.miden.io` and `miden-testnet.eu-central-8.gateway.fm` report a healthy `version=0.14.8` + matching genesis — the mismatch only surfaces on `sync_transactions`. That's why the service retried forever with increasing backoff instead of erroring out cleanly.

## Why v0.14.4 instead of rebasing the `ajl-agglayer-integration-tests-v0.14.0` branch

The only non-test divergence on `ajl` is `crates/rust-client/src/test_utils/common.rs`, which is behind the `testing` feature and unused by miden-agglayer's production code. Dropping the branch pin costs nothing.

## Test plan

- [x] `cargo build` (workspace) — clean
- [x] `make test-unit` — 70/70
- [x] `make lint` — rustfmt + taplo + typos + clippy `-D warnings` all green
- [x] Confirmed v0.14.4 `transaction.rs` decode path uses `Vec<NoteHeader>`
- [ ] Reviewer: once merged, cut the next patch tag so the release workflow republishes the Docker Hub image; Ivan should then see `sync_transactions` succeed against the gateway

## Related

- Linear: [RD-856](https://linear.app/gateway-fm/issue/RD-856/) (separate auth-header work, tracked as draft [#29](https://github.com/gateway-fm/miden-agglayer/pull/29))
- Upstream proto revert: [miden-node@cf0a333a](https://github.com/0xMiden/miden-node/commit/cf0a333a)
- Upstream client decode change: [miden-client#2008](https://github.com/0xMiden/miden-client/pull/2008)