### PR TITLE
feat(observability): heartbeat every 5 min + un-gag sync-success debug target

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -39,9 +39,18 @@ fn log_filter() -> anyhow::Result<EnvFilter> {
         "winter_prover=off",
         "miden_processor=off",
         "miden_client::transaction=off",
-        // more verbose debug logs
+        // Per-request debug spam we never want by default — enable explicitly via
+        // RUST_LOG (e.g. `RUST_LOG='info,miden_agglayer_service::service::debug=debug'`).
+        // These fire once per JSON-RPC method / per raw txn so they would drown out
+        // everything else if left on.
+        //
+        // NOTE: `miden_agglayer_service::miden_client::sync::debug` is intentionally NOT
+        // silenced here. That target carries "sync succeeded at block X" — the one signal
+        // an operator needs to distinguish a healthy-idle service from a hung one. Default
+        // level stays INFO so it is still suppressed by default, but flipping
+        // `RUST_LOG=debug` (or targeting that directive specifically) now surfaces it
+        // without needing a rebuild.
         "miden_agglayer_service::service::debug=off",
-        "miden_agglayer_service::miden_client::sync::debug=off",
         "miden_agglayer_service::service_send_raw_txn::debug=off",
     ];
     let mut filter = env_or_default_filter();

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,6 +326,41 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
+    // Observability heartbeat: emit one INFO line every HEARTBEAT_INTERVAL so operators
+    // tailing logs can distinguish a healthy-idle service from a hung one. Without this,
+    // a successfully-syncing service produces zero output — sync-success logs are at
+    // DEBUG level (target `miden_agglayer_service::miden_client::sync::debug`) and every
+    // other `info!` is event-driven. See `logging.rs` for how to opt into the per-sync
+    // debug line instead of / in addition to this heartbeat.
+    {
+        const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+        let hb_client = state.miden_client.clone();
+        let hb_store = state.store.clone();
+        let started = std::time::Instant::now();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(HEARTBEAT_INTERVAL);
+            // Consume the immediate first tick; first heartbeat fires after one interval
+            // so it does not overlap with the "Service started" startup line.
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                let uptime_secs = started.elapsed().as_secs();
+                let miden_client_alive = hb_client.is_alive();
+                let latest_block = match hb_store.get_latest_block_number().await {
+                    Ok(n) => n.to_string(),
+                    Err(err) => format!("<err: {err:#}>"),
+                };
+                tracing::info!(
+                    target: "miden_agglayer_service::heartbeat",
+                    uptime_secs,
+                    miden_client_alive,
+                    latest_block,
+                    "heartbeat"
+                );
+            }
+        });
+    }
+
     let url = Url::from_str(format!("http://0.0.0.0:{}", command.port).as_str())?;
     service::serve(url, state.clone(), metrics_handle).await?;
 


### PR DESCRIPTION
## Summary

Today an operator could not tell a healthy-idle miden-agglayer from a hung one just by tailing logs — the topic came up live on [RD-856](https://linear.app/gateway-fm/issue/RD-856/) while diagnosing Ivan's service. Two overlapping reasons:

1. The sync-success log is at `debug!` level with target `miden_agglayer_service::miden_client::sync::debug`, **and** that target was force-disabled in the directive list in `logging.rs`. Setting `RUST_LOG=debug` on the deployed binary did nothing — you had to rebuild.
2. Every other `info!` call in the service is event-driven (bridge_out / faucet_ops / GER / claim). With no external events, the service is totally silent by design.

## What changed

**`logging.rs`** — drop the `miden_agglayer_service::miden_client::sync::debug=off` directive. Default level stays INFO so this is still suppressed out of the box, but flipping it on is now one env var away:

```
RUST_LOG='info,miden_agglayer_service::miden_client::sync::debug=debug'
```

Per-request `service::debug` and `service_send_raw_txn::debug` stay default-off — those would drown logs at any real JSON-RPC traffic rate and aren't needed to tell alive-from-hung.

**`main.rs`** — spawn a heartbeat task that emits one `info!` every 5 minutes:

```
target: miden_agglayer_service::heartbeat
uptime_secs = 300
miden_client_alive = true
latest_block = 12345
"heartbeat"
```

First tick is consumed so the first heartbeat fires after one interval (not back-to-back with the "Service started" line). Cheap: `is_alive()` is one atomic load, `get_latest_block_number()` is a single-row read.

## Example log output (steady state, `RUST_LOG=info`)

```
INFO miden-agglayer: Service started, address: http://0.0.0.0:8546/
INFO miden_agglayer_service::heartbeat: heartbeat  uptime_secs=300 miden_client_alive=true latest_block=89294
INFO miden_agglayer_service::heartbeat: heartbeat  uptime_secs=600 miden_client_alive=true latest_block=89301
...
```

Operator instantly sees it's alive AND syncing (`latest_block` advancing).

## Non-goals

- Metrics already exist (Prometheus recorder), this is purely about log-tail observability.
- No SLO/alerting wiring — just the data source.

## Test plan

- [x] `cargo build` (workspace) — clean
- [x] `make test-unit` — 70/70 pass
- [x] `make lint` — rustfmt + taplo + typos + clippy `-D warnings` all green
- [x] `grep sync::debug=off src/logging.rs` — zero matches
- [ ] Reviewer: once merged, cut a tag and confirm the heartbeat line appears in Ivan's Loki stream within 5 min of rollout. Not gating the merge on it — trivial to revert if something misbehaves.

## Related

- RD-856 investigation thread
- Follow-up to #30 (proto-sync fix) and the draft auth-header work in #29