### PR TITLE
fix(claim): publish_claim now dials --miden-node URL (not an unset env var)

### DIFF
--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -19,7 +19,6 @@ use miden_client::asset::{Asset, FungibleAsset};
 use miden_client::builder::ClientBuilder;
 use miden_client::keystore::FilesystemKeyStore;
 use miden_client::note::NoteAssets;
-use miden_client::rpc::Endpoint;
 use miden_client::transaction::TransactionRequestBuilder;
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::account::AccountId;
@@ -109,9 +108,12 @@ async fn main() -> anyhow::Result<()> {
         std::fs::set_permissions(&keystore_path, perms)?;
     }
 
-    // Parse node endpoint
-    let node_endpoint =
-        Endpoint::try_from(args.node_url.as_str()).map_err(|e| anyhow!("invalid node URL: {e}"))?;
+    // Parse node endpoint via the shared resolver so the `devnet` / `testnet` shortcuts
+    // work the same way they do for the main service. Using `Endpoint::try_from` directly
+    // would silently reject those shortcuts (the same asymmetry that caused RD-856 on the
+    // fresh-client path in `src/claim.rs::publish_claim`).
+    let node_endpoint = miden_agglayer_service::miden_client::parse_node_url(&args.node_url)
+        .map_err(|e| anyhow!("invalid node URL {}: {e}", args.node_url))?;
 
     let mode = if args.miden_debug {
         DebugMode::Enabled

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -403,18 +403,31 @@ pub async fn publish_claim(
         rt.block_on(async {
             use ::miden_client::DebugMode;
             use ::miden_client::builder::ClientBuilder;
-            use ::miden_client::rpc::Endpoint;
             use ::miden_client_sqlite_store::ClientBuilderSqliteExt;
 
-            let ep = Endpoint::try_from(node_url.as_str())
-                .map_err(|e| anyhow::anyhow!("invalid node URL: {e}"))?;
+            // Resolve via the same helper `MidenClient::new` uses, so shortcut
+            // strings ("devnet" / "testnet") map to the same Endpoint across both
+            // code paths. See RD-856 — an asymmetric URL parse was how the fresh
+            // client ended up dialing the wrong hostname in the first place.
+            let ep = crate::miden_client::parse_node_url(&node_url)
+                .map_err(|e| anyhow::anyhow!("invalid node URL {node_url}: {e}"))?;
+            tracing::info!(
+                node_url = %node_url,
+                resolved = %ep,
+                "publish_claim: building fresh Miden client to dial node"
+            );
             let mut client = ClientBuilder::new()
                 .grpc_client(&ep, Some(10_000))
                 .sqlite_store(store_path)
                 .authenticator(keystore)
                 .in_debug_mode(DebugMode::Enabled)
                 .build()
-                .await?;
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "publish_claim: failed to build Miden client for {node_url}: {e}"
+                    )
+                })?;
             client.sync_state().await?;
 
             let value = publish_claim_internal(

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,7 +233,7 @@ async fn main() -> anyhow::Result<()> {
 
     let client = MidenClient::new(
         miden_store_dir.clone(),
-        command.miden_node,
+        command.miden_node.clone(),
         sync_listeners,
         command.miden_debug,
     )?;
@@ -267,9 +267,21 @@ async fn main() -> anyhow::Result<()> {
     state.l1_rpc_url = command.l1_rpc_url;
     state.ger_l1_address = command.ger_l1_address;
     state.miden_store_dir = miden_store_dir.clone().unwrap_or_default();
-    // miden_node was moved into MidenClient::new, re-read from env
-    state.miden_node_url =
-        std::env::var("MIDEN_NODE_URL").unwrap_or_else(|_| "http://miden-node:57291".to_string());
+    // The fresh `MidenClient` built per `publish_claim` in `src/claim.rs` must connect to
+    // the SAME node URL as `MidenClient::new` — that's what `command.miden_node` feeds.
+    // This used to read an independent `MIDEN_NODE_URL` env var with a `http://miden-node:57291`
+    // fallback; when the env var wasn't set by the deployment, fresh-client builds
+    // unconditionally failed with `dns error: Name or service not known` on the fallback
+    // hostname, while the persistent sync loop (which reads `command.miden_node`) kept
+    // working fine. Claims silently never landed. See RD-856.
+    state.miden_node_url = command
+        .miden_node
+        .clone()
+        .unwrap_or_else(|| "http://localhost:57291".to_string());
+    tracing::info!(
+        miden_node_url = %state.miden_node_url,
+        "fresh-client `publish_claim` path will dial this Miden node URL"
+    );
 
     // Initialize metrics
     let metrics_handle = metrics_exporter_prometheus::PrometheusBuilder::new()

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -46,6 +46,23 @@ pub trait SyncListener: Send + Sync {
     }
 }
 
+/// Shared node-URL resolver used by both the persistent `MidenClient` (background sync,
+/// GER injection) and the fresh-client path in `src/claim.rs::publish_claim`. Both code
+/// paths must dial the same node — funneling through this single function guarantees the
+/// shortcut strings (`"devnet"`, `"testnet"`) resolve identically, not just raw URLs.
+///
+/// Without this shared helper the two paths drifted: `MidenClient::new` used to resolve
+/// `"testnet"` to `https://rpc.testnet.miden.io` while `publish_claim` passed the literal
+/// string straight to `Endpoint::try_from`, which either fails or produces a wrong URL.
+/// See RD-856 for the diagnosis.
+pub fn parse_node_url(node_url: &str) -> anyhow::Result<Endpoint> {
+    match node_url {
+        "devnet" => Ok(Endpoint::devnet()),
+        "testnet" => Ok(Endpoint::testnet()),
+        _ => Endpoint::try_from(node_url).map_err(|err| anyhow!(err)),
+    }
+}
+
 pub struct MidenClient {
     keystore: Arc<FilesystemKeyStore>,
     task: std::sync::Mutex<Option<thread::JoinHandle<anyhow::Result<()>>>>,
@@ -196,14 +213,7 @@ impl MidenClient {
     }
 
     fn parse_node_url(node_url: String) -> anyhow::Result<Endpoint> {
-        match node_url.as_str() {
-            "devnet" => Ok(Endpoint::devnet()),
-            "testnet" => Ok(Endpoint::testnet()),
-            _ => {
-                let endpoint = Endpoint::try_from(node_url.as_str());
-                endpoint.map_err(|err| anyhow!(err))
-            }
-        }
+        parse_node_url(&node_url)
     }
 
     fn create_keystore(store_dir: PathBuf) -> anyhow::Result<Arc<FilesystemKeyStore>> {


### PR DESCRIPTION
## TL;DR

L1→L2 claims were failing with `dns error: Name or service not known` while GER injections kept working. Root cause: the fresh Miden client inside `publish_claim` was dialling a hard-coded fallback hostname `miden-node` — a k8s service that doesn't exist in our namespace. The persistent sync client always used the right URL, which is why GERs worked and claims never did.

This bug was invisible for ~18h because the deployed pod hadn't received a real `claimAsset` call until a Sepolia deposit landed [today](https://sepolia.etherscan.io/tx/0xe098283848d02929c39699600960ef41a98951ef4ee8ad952a6d7f2ccbc0067c). aggkit relayed it to miden-agglayer three times, each retry hit the DNS wall, aggkit gave up.

## Why the two paths had different URLs

`ServiceState` has two consumers of the Miden node URL:

| Caller | Source of URL | Worked? |
|---|---|---|
| Background sync + GER injection (persistent `MidenClient`) | `command.miden_node` from `--miden-node` CLI flag → `rpc.testnet.miden.io:443` | ✅ |
| `publish_claim` fresh client per call | `state.miden_node_url` → `std::env::var("MIDEN_NODE_URL").unwrap_or("http://miden-node:57291")` | ❌ (env var not set in helm) |

## Fix

**`src/main.rs`** — drop the env-var read; source `state.miden_node_url` from the same CLI flag the persistent client uses.

```diff
-    state.miden_node_url =
-        std::env::var("MIDEN_NODE_URL").unwrap_or_else(|_| "http://miden-node:57291".to_string());
+    state.miden_node_url = command
+        .miden_node
+        .clone()
+        .unwrap_or_else(|| "http://localhost:57291".to_string());
+    tracing::info!(miden_node_url = %state.miden_node_url,
+        "fresh-client `publish_claim` path will dial this Miden node URL");
```

**`src/claim.rs::publish_claim`** — log the dial target before building, and wrap the build error with the URL so future DNS-class failures include the hostname directly (so nobody has to dig through the git history to figure out where it's pointing).

## Why NOT revert the fresh-client-per-claim pattern

Commit [`9ebcabb`](https://github.com/gateway-fm/miden-agglayer/commit/9ebcabb) (2 Apr 2026) introduced the fresh-client pattern to dodge a state-drift bug where account nonce / Merkle-tree state went stale after a CLAIM, breaking subsequent GERs and dynamic faucet creation. A scan of upstream `miden-client` between our pin (`f7cdf263`) and `v0.14.4` (19 commits) shows no fix for post-submit account state reconciliation, so reverting to the persistent client is still unsafe. `ger.rs` already runs on the persistent client using a separate `ger_manager` account so it's not affected.

## Test plan

- [x] `cargo build` (workspace)
- [x] `make test-unit` — 70/70 pass
- [x] `make lint` — rustfmt + taplo + typos + clippy `-D warnings` all green
- [ ] Reviewer: after merge, cut `v0.1.3` tag so the release workflow republishes the Docker Hub image
- [ ] Ivan: re-deploy and re-send `bali-l1-deposit.sh` (the original Sepolia tx will still be sitting in aggkit's queue — it should claim on the first retry after the new image goes live)

## Observability already in place for verifying the fix post-deploy

- Startup log: `fresh-client publish_claim path will dial this Miden node URL` (should say `rpc.testnet.miden.io:443`).
- Per-claim log: `publish_claim: building fresh Miden client to dial node` fires just before the `build()`. If DNS still breaks, the error message now includes the hostname.
- Follow Grafana query: `{namespace="outpost-testnet-miden-testnet", service_name="miden-agglayer"} |~ "publish_claim|ClaimEvent|claim published"` — watch for `ClaimEvent recorded` once the rollout lands.

Related: RD-856.