### PR TITLE
feat(claim): swallow unresolvable-destination claims (RD-860)

### DIFF
--- a/migrations/003_unclaimable_claims.sql
+++ b/migrations/003_unclaimable_claims.sql
@@ -1,0 +1,34 @@
+-- RD-860: log of L1→L2 claims we refused to process because the destination could
+-- not be resolved to a Miden AccountId.
+--
+-- Claims land here when `address_mapper::resolve_address` fails (not hardhat, no
+-- explicit store mapping, not a zero-padded MidenAccountId). We short-circuit them
+-- in `service_send_raw_txn::handle_claim_asset` by emitting a synthetic `ClaimEvent`
+-- so aggkit marks the globalIndex complete and stops retrying — WITHOUT actually
+-- minting any L2 funds. This row is the only record that the claim was effectively
+-- dropped; a future operator rescue endpoint (tier 2) can query this table.
+--
+-- `global_index` is the authoritative key from the L1 bridge. eth_tx_hash is the
+-- aggkit-submitted eth tx that carried the claim. Both are indexed for fast lookup
+-- when a user shows up asking "where did my deposit go?".
+
+-- Column conventions here mirror the existing `claimed_indices` table
+-- (migrations/001_initial.sql): U256 values stored as lowercase `0x`-prefixed hex
+-- TEXT, addresses / tx hashes as `0x`-prefixed TEXT. That lets us join and cross-
+-- reference the two tables without conversion.
+CREATE TABLE IF NOT EXISTS unclaimable_claims (
+    global_index        TEXT PRIMARY KEY,
+    destination_address TEXT NOT NULL,
+    origin_network      INT NOT NULL,
+    origin_address      TEXT NOT NULL,
+    amount              TEXT NOT NULL,
+    reason              TEXT NOT NULL,
+    eth_tx_hash         TEXT NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_unclaimable_claims_eth_tx_hash
+    ON unclaimable_claims (eth_tx_hash);
+
+CREATE INDEX IF NOT EXISTS idx_unclaimable_claims_destination
+    ON unclaimable_claims (destination_address);

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -155,6 +155,72 @@ async fn handle_claim_asset(
         return Ok(txn_hash);
     }
 
+    // RD-860 — swallow unresolvable-destination claims permanently. If the
+    // destination address can't be resolved to a Miden AccountId, record the
+    // unclaimable entry, emit the synthetic ClaimEvent so aggkit marks the
+    // globalIndex complete and stops retrying, and return success to the
+    // caller. Funds remain locked on L1; an operator rescue endpoint (tier 2,
+    // future work) would let ops re-process by registering a destination
+    // mapping and replaying.
+    //
+    // Ordering: this check runs BEFORE C6's GER pre-check because the
+    // unresolvable-destination state is permanent (no amount of GER
+    // propagation will change it), whereas a missing GER is transient. Doing
+    // RD-860 first means aggkit gets a single decisive swallow instead of
+    // grinding through GER-not-seen retries before eventually hitting the
+    // same swallow.
+    if let Err(err) = crate::address_mapper::resolve_address(
+        &*service.store,
+        params.destinationAddress,
+        &service.accounts.0,
+    )
+    .await
+    {
+        ::metrics::counter!(
+            "claim_unclaimable_total",
+            "reason" => crate::store::UnclaimableReason::UnresolvableDestination.as_str()
+        )
+        .increment(1);
+        let newly_recorded = service
+            .store
+            .record_unclaimable_claim(crate::store::UnclaimableClaim {
+                global_index: params.globalIndex,
+                destination_address: params.destinationAddress,
+                origin_network: params.originNetwork,
+                origin_address: params.originTokenAddress,
+                amount: params.amount,
+                reason: crate::store::UnclaimableReason::UnresolvableDestination,
+                eth_tx_hash: txn_hash,
+            })
+            .await?;
+        tracing::warn!(
+            global_index = %params.globalIndex,
+            destination = %params.destinationAddress,
+            origin_network = params.originNetwork,
+            origin_address = %params.originTokenAddress,
+            amount = %params.amount,
+            eth_tx = %txn_hash,
+            newly_recorded,
+            err = %err,
+            "claim: unresolvable destination — short-circuiting so aggkit stops retrying. \
+             Funds remain on L1 pending operator rescue (RD-860)."
+        );
+
+        // Emit the synthetic ClaimEvent even though no Miden funds moved. aggkit expects
+        // the event log on the eth tx receipt to mark the globalIndex claimed; without
+        // it, aggkit will retry forever. The unclaimable_claims table is the SOURCE OF
+        // TRUTH for reconciliation — anyone auditing flows MUST compare ClaimEvent
+        // counts against `unclaimable_claims` to see how many funds are truly on L1.
+        let event = crate::claim::ClaimEvent::from(params.clone());
+        let log = <crate::claim::ClaimEvent as alloy::sol_types::SolEvent>::encode_log_data(&event);
+        record_local_immediate_success(service, txn_hash, txn_envelope, signer, vec![log]).await?;
+        service
+            .store
+            .nonce_increment(&format!("{signer:#x}"))
+            .await?;
+        return Ok(txn_hash);
+    }
+
     // C6 — gate on `has_seen_ger` BEFORE acquiring the claim lock.
     //
     // The CLAIM note's leaf proof is internally consistent (built from L1
@@ -689,7 +755,12 @@ mod tests {
             originNetwork: 0,
             originTokenAddress: Address::ZERO,
             destinationNetwork: 1,
-            destinationAddress: Address::from([0x42; 20]),
+            // Zero-padded MidenAccountId — resolvable, so RD-860's
+            // unresolvable-destination short-circuit doesn't pre-empt the C6
+            // GER pre-check we're testing here.
+            destinationAddress: alloy::primitives::address!(
+                "0x000000003d7c9747558851900f8206226dfbea00"
+            ),
             amount: U256::from(1_000u64),
             metadata: Default::default(),
         }
@@ -716,6 +787,10 @@ mod tests {
         let miden_client = service.miden_client.clone();
 
         let global_index = U256::from(42u64);
+        // Zero-padded resolvable destination (see address_mapper::account_id_from_address
+        // test vectors). This ensures the claim gets PAST the RD-860 short-circuit and
+        // fails inside publish_claim against the test MidenClient stub — exercising the
+        // "ClaimEvent not emitted on publish_claim error" guarantee this test is for.
         let calldata = claimAssetCall {
             smtProofLocalExitRoot: [FixedBytes::ZERO; 32],
             smtProofRollupExitRoot: [FixedBytes::ZERO; 32],
@@ -725,7 +800,9 @@ mod tests {
             originNetwork: 0,
             originTokenAddress: Address::ZERO,
             destinationNetwork: 1,
-            destinationAddress: Address::from([0x42; 20]),
+            destinationAddress: alloy::primitives::address!(
+                "0x000000003d7c9747558851900f8206226dfbea00"
+            ),
             amount: U256::from(1_000_000u64),
             metadata: Default::default(),
         }
@@ -779,6 +856,94 @@ mod tests {
             !store.is_claimed(&global_index).await.unwrap(),
             "claim should be unclaimed after publish_claim failure"
         );
+    }
+
+    /// RD-860: a claim whose destination cannot be resolved is swallowed — we record
+    /// it in the `unclaimable_claims` store, emit a synthetic `ClaimEvent` so aggkit
+    /// stops retrying, and return success to the caller. Neither `try_claim` nor the
+    /// MidenClient publish path should be touched.
+    #[tokio::test]
+    async fn test_claim_asset_unresolvable_destination_swallowed() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        let miden_client = service.miden_client.clone();
+
+        let global_index = U256::from(123u64);
+        // Non-zero-padded address with no store mapping — cannot be resolved by
+        // `address_mapper::resolve_address`, so the short-circuit path fires.
+        let dest = Address::from([0x42; 20]);
+        let calldata = claimAssetCall {
+            smtProofLocalExitRoot: [FixedBytes::ZERO; 32],
+            smtProofRollupExitRoot: [FixedBytes::ZERO; 32],
+            globalIndex: global_index,
+            mainnetExitRoot: FixedBytes::ZERO,
+            rollupExitRoot: FixedBytes::ZERO,
+            originNetwork: 7,
+            originTokenAddress: Address::from([0x11; 20]),
+            destinationNetwork: 1,
+            destinationAddress: dest,
+            amount: U256::from(1_000_000u64),
+            metadata: Default::default(),
+        }
+        .abi_encode();
+        let (input_hex, signer) = encode_legacy_tx(calldata);
+
+        let result = service_send_raw_txn(service, input_hex).await;
+        assert!(result.is_ok(), "swallow path must return Ok: {result:?}");
+        let tx_hash = result.unwrap();
+
+        // (1) globalIndex is NOT locked — short-circuit happened before try_claim.
+        assert!(
+            !store.is_claimed(&global_index).await.unwrap(),
+            "short-circuit must not lock globalIndex"
+        );
+
+        // (2) MidenClient was never invoked — publish_claim did not run.
+        assert!(
+            !miden_client.test_was_called(),
+            "MidenClient must not be invoked for an unresolvable destination"
+        );
+
+        // (3) unclaimable_claims record exists with the right fields.
+        let rec = store
+            .get_unclaimable_claim(&global_index)
+            .await
+            .unwrap()
+            .expect("unclaimable record must be present");
+        assert_eq!(rec.global_index, global_index);
+        assert_eq!(rec.destination_address, dest);
+        assert_eq!(rec.origin_network, 7);
+        assert_eq!(rec.origin_address, Address::from([0x11; 20]));
+        assert_eq!(rec.amount, U256::from(1_000_000u64));
+        assert_eq!(
+            rec.reason,
+            crate::store::UnclaimableReason::UnresolvableDestination
+        );
+        assert_eq!(rec.eth_tx_hash, tx_hash);
+
+        // (4) Exactly one synthetic ClaimEvent emitted (so aggkit marks done).
+        let filter = crate::log_synthesis::LogFilter {
+            from_block: Some("0x0".to_string()),
+            to_block: Some("0xFFFF".to_string()),
+            ..Default::default()
+        };
+        let logs = store.get_logs(&filter, 0xFFFF).await.unwrap();
+        let claim_logs: Vec<_> = logs
+            .iter()
+            .filter(|l| {
+                l.topics.first().map(|t| t.as_str())
+                    == Some(crate::log_synthesis::CLAIM_EVENT_TOPIC)
+            })
+            .collect();
+        assert_eq!(
+            claim_logs.len(),
+            1,
+            "swallow path must emit exactly one ClaimEvent so aggkit stops retrying"
+        );
+
+        // (5) Nonce incremented and receipt recorded so the RPC client sees success.
+        assert_eq!(store.nonce_get(&format!("{signer:#x}")).await.unwrap(), 1);
+        assert!(store.txn_receipt(tx_hash).await.unwrap().is_some());
     }
 
     #[tokio::test]

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1,6 +1,6 @@
 //! In-memory Store implementation — wraps HashMap/RwLock data structures.
 
-use super::{FaucetEntry, Store, TxnData, TxnEntry};
+use super::{FaucetEntry, Store, TxnData, TxnEntry, UnclaimableClaim};
 use crate::log_synthesis::{
     GerEntry, L2_GLOBAL_EXIT_ROOT_ADDRESS, LogFilter, SyntheticLog, UPDATE_HASH_CHAIN_VALUE_TOPIC,
 };
@@ -48,6 +48,9 @@ pub struct InMemoryStore {
     // Claims
     claimed: RwLock<HashSet<U256>>,
 
+    // Unclaimable claims — first-write wins per global_index (RD-860).
+    unclaimable: RwLock<HashMap<U256, UnclaimableClaim>>,
+
     // Address mappings
     address_mappings: RwLock<HashMap<Address, AccountId>>,
 
@@ -77,6 +80,7 @@ impl InMemoryStore {
             transactions: Mutex::new(LruCache::new(NonZeroUsize::new(10_000).unwrap())),
             nonces: RwLock::new(HashMap::new()),
             claimed: RwLock::new(HashSet::new()),
+            unclaimable: RwLock::new(HashMap::new()),
             address_mappings: RwLock::new(HashMap::new()),
             processed_notes: RwLock::new(HashSet::new()),
             deposit_counter: RwLock::new(0),
@@ -487,6 +491,25 @@ impl Store for InMemoryStore {
         Ok(self.claimed.read().contains(global_index))
     }
 
+    async fn record_unclaimable_claim(&self, entry: UnclaimableClaim) -> anyhow::Result<bool> {
+        use std::collections::hash_map::Entry;
+        let mut map = self.unclaimable.write();
+        match map.entry(entry.global_index) {
+            Entry::Occupied(_) => Ok(false),
+            Entry::Vacant(slot) => {
+                slot.insert(entry);
+                Ok(true)
+            }
+        }
+    }
+
+    async fn get_unclaimable_claim(
+        &self,
+        global_index: &U256,
+    ) -> anyhow::Result<Option<UnclaimableClaim>> {
+        Ok(self.unclaimable.read().get(global_index).cloned())
+    }
+
     // ── Address mappings ─────────────────────────────────────────
 
     async fn get_address_mapping(&self, eth: &Address) -> anyhow::Result<Option<AccountId>> {
@@ -602,6 +625,46 @@ mod tests {
         store.unclaim(&idx).await.unwrap();
         assert!(!store.is_claimed(&idx).await.unwrap());
         store.try_claim(idx).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_unclaimable_claims_first_write_wins() {
+        use crate::store::{UnclaimableClaim, UnclaimableReason};
+        let store = InMemoryStore::new();
+        let idx = U256::from(999u64);
+        let first = UnclaimableClaim {
+            global_index: idx,
+            destination_address: Address::from([0x42; 20]),
+            origin_network: 0,
+            origin_address: Address::ZERO,
+            amount: U256::from(100u64),
+            reason: UnclaimableReason::UnresolvableDestination,
+            eth_tx_hash: TxHash::default(),
+        };
+        let second = UnclaimableClaim {
+            // Same global_index, different everything else — mimics aggkit retrying
+            // the same claim with a new outer tx envelope.
+            global_index: idx,
+            destination_address: Address::from([0x77; 20]),
+            origin_network: 9,
+            origin_address: Address::from([0xaa; 20]),
+            amount: U256::from(200u64),
+            reason: UnclaimableReason::UnresolvableDestination,
+            eth_tx_hash: TxHash::from([0xff; 32]),
+        };
+
+        assert!(store.get_unclaimable_claim(&idx).await.unwrap().is_none());
+        assert!(
+            store.record_unclaimable_claim(first.clone()).await.unwrap(),
+            "first insert returns true"
+        );
+        assert!(
+            !store.record_unclaimable_claim(second).await.unwrap(),
+            "duplicate global_index returns false (first-write wins)"
+        );
+        let got = store.get_unclaimable_claim(&idx).await.unwrap().unwrap();
+        assert_eq!(got.destination_address, first.destination_address);
+        assert_eq!(got.amount, first.amount);
     }
 
     #[tokio::test]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -50,6 +50,38 @@ pub struct TxnEntry {
     pub logs: Vec<LogData>,
 }
 
+/// Record of a claim we dropped because the destination could not be resolved to a
+/// Miden AccountId. See RD-860: storing these lets operators inspect the backlog and
+/// audit what happened to a user's funds when support asks about a specific deposit.
+#[derive(Debug, Clone)]
+pub struct UnclaimableClaim {
+    pub global_index: U256,
+    pub destination_address: Address,
+    pub origin_network: u32,
+    pub origin_address: Address,
+    pub amount: U256,
+    pub reason: UnclaimableReason,
+    pub eth_tx_hash: TxHash,
+}
+
+/// Why a claim was dropped. Currently only one variant; kept as an enum so we can
+/// extend it without touching the schema (the textual `reason` column carries the
+/// variant name).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnclaimableReason {
+    /// `address_mapper::resolve_address` returned an error — the destination is neither
+    /// hardhat, store-registered, nor a zero-padded MidenAccountId.
+    UnresolvableDestination,
+}
+
+impl UnclaimableReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::UnresolvableDestination => "unresolvable_destination",
+        }
+    }
+}
+
 /// Full transaction data returned from the store.
 #[derive(Debug, Clone)]
 pub struct TxnData {
@@ -206,6 +238,21 @@ pub trait Store: Send + Sync + 'static {
     async fn try_claim(&self, global_index: U256) -> anyhow::Result<()>;
     async fn unclaim(&self, global_index: &U256) -> anyhow::Result<()>;
     async fn is_claimed(&self, global_index: &U256) -> anyhow::Result<bool>;
+
+    /// Record a claim we refused to process because its destination could not be
+    /// resolved. Idempotent by `global_index` — duplicate retries from aggkit must not
+    /// error or duplicate rows; the first record wins. Returns `true` if this was a new
+    /// insert (not a duplicate).
+    ///
+    /// See [RD-860] and `src/service_send_raw_txn::handle_claim_asset` for the
+    /// short-circuit path that calls this.
+    async fn record_unclaimable_claim(&self, entry: UnclaimableClaim) -> anyhow::Result<bool>;
+
+    /// Look up an unclaimable record by `global_index`. `None` if not dropped.
+    async fn get_unclaimable_claim(
+        &self,
+        global_index: &U256,
+    ) -> anyhow::Result<Option<UnclaimableClaim>>;
 
     // === Address mappings ===
     async fn get_address_mapping(&self, eth: &Address) -> anyhow::Result<Option<AccountId>>;

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -3,7 +3,7 @@
 //! Requires the `postgres` feature flag and a running PostgreSQL instance
 //! with the schema from `migrations/001_initial.sql` applied.
 
-use super::{FaucetEntry, Store, TxnData, TxnEntry};
+use super::{FaucetEntry, Store, TxnData, TxnEntry, UnclaimableClaim, UnclaimableReason};
 use crate::bridge_address::get_bridge_address;
 use crate::log_synthesis::{
     GerEntry, L2_GLOBAL_EXIT_ROOT_ADDRESS, LogFilter, SyntheticLog, UPDATE_HASH_CHAIN_VALUE_TOPIC,
@@ -970,6 +970,80 @@ impl Store for PgStore {
             )
             .await?;
         Ok(!rows.is_empty())
+    }
+
+    async fn record_unclaimable_claim(&self, entry: UnclaimableClaim) -> anyhow::Result<bool> {
+        let client = self.pool.get().await?;
+        let global_index_hex = format!("{:#x}", entry.global_index);
+        let destination_hex = format!("{:#x}", entry.destination_address);
+        let origin_hex = format!("{:#x}", entry.origin_address);
+        let amount_hex = format!("{:#x}", entry.amount);
+        let eth_tx_hex = format!("{:#x}", entry.eth_tx_hash);
+        let reason = entry.reason.as_str();
+        let origin_network = entry.origin_network as i32;
+
+        // First-write wins: ON CONFLICT DO NOTHING so aggkit retries don't error.
+        // `INSERT … RETURNING` tells us whether a row was actually added.
+        let rows = client
+            .query(
+                "INSERT INTO unclaimable_claims \
+                 (global_index, destination_address, origin_network, origin_address, amount, reason, eth_tx_hash) \
+                 VALUES ($1, $2, $3, $4, $5, $6, $7) \
+                 ON CONFLICT (global_index) DO NOTHING \
+                 RETURNING global_index",
+                &[
+                    &global_index_hex,
+                    &destination_hex,
+                    &origin_network,
+                    &origin_hex,
+                    &amount_hex,
+                    &reason,
+                    &eth_tx_hex,
+                ],
+            )
+            .await?;
+        Ok(!rows.is_empty())
+    }
+
+    async fn get_unclaimable_claim(
+        &self,
+        global_index: &U256,
+    ) -> anyhow::Result<Option<UnclaimableClaim>> {
+        let client = self.pool.get().await?;
+        let key = format!("{global_index:#x}");
+        let rows = client
+            .query(
+                "SELECT global_index, destination_address, origin_network, origin_address, \
+                        amount, reason, eth_tx_hash \
+                 FROM unclaimable_claims WHERE global_index = $1",
+                &[&key],
+            )
+            .await?;
+        let Some(row) = rows.into_iter().next() else {
+            return Ok(None);
+        };
+        let global_index_hex: String = row.get(0);
+        let destination_hex: String = row.get(1);
+        let origin_network: i32 = row.get(2);
+        let origin_hex: String = row.get(3);
+        let amount_hex: String = row.get(4);
+        let reason_str: String = row.get(5);
+        let eth_tx_hex: String = row.get(6);
+
+        let reason = match reason_str.as_str() {
+            "unresolvable_destination" => UnclaimableReason::UnresolvableDestination,
+            other => anyhow::bail!("unknown unclaimable_claims.reason value: {other}"),
+        };
+
+        Ok(Some(UnclaimableClaim {
+            global_index: U256::from_str_radix(global_index_hex.trim_start_matches("0x"), 16)?,
+            destination_address: destination_hex.parse()?,
+            origin_network: u32::try_from(origin_network)?,
+            origin_address: origin_hex.parse()?,
+            amount: U256::from_str_radix(amount_hex.trim_start_matches("0x"), 16)?,
+            reason,
+            eth_tx_hash: eth_tx_hex.parse()?,
+        }))
     }
 
     // ── Address mappings ─────────────────────────────────────────


### PR DESCRIPTION
Fixes [RD-860](https://linear.app/gateway-fm/issue/RD-860/swallow-unresolvable-destination-claims-so-one-bad-claim-cant-wedge).

> ⚠️ **Stacked on #33** (`fix/dns-retry-claim-ger-build`). GitHub shows only the delta on top of #33. Merge #33 first, then this.

## Problem

If aggkit delivers a `claimAsset` whose `destinationAddress` can't be resolved to a Miden `AccountId` (not hardhat, not a store-registered mapping, not a zero-padded `MidenAccountId`), `publish_claim` bails with `no known Miden AccountId for Ethereum address …`. aggkit treats the `eth_sendRawTransaction` error as retryable and hammers the same failure forever. Impact:

1. Wedges aggkit's `claimtxmanager` in an infinite retry loop.
2. Potentially blocks later claims behind it (depends on aggkit's queue semantics).
3. Burns miden-agglayer CPU — every retry rebuilds a fresh `MidenClient` (per the `9ebcabb` state-drift workaround).

On a public bridge, this is a cheap griefing/DoS vector: attacker pays L1 gas + a dust deposit with a bogus destination and stalls the claim queue.

## Fix (tier 1)

In `service_send_raw_txn::handle_claim_asset`, pre-check `resolve_address` **before** `try_claim`:

- On success → existing flow, unchanged.
- On failure →
  - Record in new `unclaimable_claims` store table (for operator visibility + future rescue endpoint).
  - Emit the synthetic `ClaimEvent` so aggkit marks the globalIndex complete and stops retrying.
  - Return success to the caller.
  - Increment `claim_unclaimable_total{reason=unresolvable_destination}` metric.
  - `WARN` log with `global_index`, `destination`, `eth_tx`, `origin_*`, `amount`.

No L2 funds move; the original L1 deposit remains locked in the bridge contract. Recovery is operator-driven — see **tier 2** in the RD-860 ticket for a planned rescue endpoint.

## Security posture

| Attack goal | Before | After |
|---|---|---|
| Wedge aggkit's claim queue with one bad destination | Yes, trivially | No — single short-circuit returns success immediately |
| Steal L2 funds via unresolvable destination | No (no funds released) | No (no funds released) |
| Burn miden-agglayer CPU per retry | Yes, indefinitely | One-shot record + log |
| Hide attack from operators | No (errors logged, but buried in retry noise) | No — every swallow writes a durable row to `unclaimable_claims` with full context |

## Changes

- `migrations/003_unclaimable_claims.sql` — new table, column format mirrors the existing `claimed_indices` table so `unclaimable_claims ⋈ claimed_indices` joins cleanly on `global_index`.
- `src/store/mod.rs` — `UnclaimableClaim` struct, `UnclaimableReason` enum (currently only `UnresolvableDestination`, designed to extend), two new trait methods: `record_unclaimable_claim` (idempotent, returns `true` for newly inserted) and `get_unclaimable_claim`.
- `src/store/memory.rs` — `HashMap`-backed impls. Unit test: first-write-wins behaviour on duplicate `global_index`.
- `src/store/postgres.rs` — `INSERT … ON CONFLICT DO NOTHING RETURNING` for idempotent inserts; `SELECT` for reads.
- `src/service_send_raw_txn.rs` — short-circuit path ahead of `try_claim`. New test `test_claim_asset_unresolvable_destination_swallowed` covers: (1) no globalIndex lock, (2) `MidenClient` never invoked, (3) record lands in store with correct fields, (4) exactly one `ClaimEvent` emitted, (5) nonce incremented and receipt recorded.

**Note on `test_claim_asset_no_event_on_failure`:** it used `destinationAddress = [0x42; 20]`, which now hits the short-circuit. Updated to use a zero-padded resolvable destination (`0x000000003d7c9747558851900f8206226dfbea00`) so the test still exercises the `publish_claim`-error path it was designed for.

## Deliberately NOT in this PR

- **Tier 2 rescue endpoint.** Operator-facing `/admin/rescue-claim` that re-processes a stuck claim after registering a new destination mapping. Separate ticket.
- **Tier 3 auto-bridge-back-out.** Needs L1 bridge contract support for claim-failure refunds, which the Polygon agglayer bridge doesn't have as a first-class feature.

## Test plan

- [x] `cargo build` (default features)
- [x] `cargo build --features postgres`
- [x] `cargo test --lib` — 72 passed (was 70; +2 for swallow + first-write-wins)
- [x] `cargo clippy --features postgres --all-targets -- -D warnings`
- [x] `make lint` — rustfmt + taplo + typos + clippy all green
- [ ] Post-merge: a claim to any non-zero-padded address on testnet should now return an `eth_sendRawTransaction` OK + a row in `unclaimable_claims`, instead of the aggkit retry loop we saw during the RD-856 investigation.

## SQL for operators

```sql
-- current backlog
SELECT global_index, destination_address, amount, reason, created_at
FROM unclaimable_claims
ORDER BY created_at DESC LIMIT 20;

-- size of the backlog
SELECT reason, COUNT(*) FROM unclaimable_claims GROUP BY reason;
```