### PR TITLE
chore(ci): batch-bump docker/* actions (consolidates #24–#27)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: gatewayfm/miden-agglayer
           tags: |
@@ -33,7 +33,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true


### PR DESCRIPTION
Consolidates the four open dependabot PRs into one workflow change. Each pin is a verified commit SHA.

## What changed

| action | old | new |
|---|---|---|
| `docker/setup-buildx-action` | `f7ce87c1` (v3.9.0) | `4d04d5d9` (v4.0.0) |
| `docker/login-action` | `c94ce9fb` (v3.7.0) | `4907a6dd` (v4.1.0) |
| `docker/metadata-action` | `318604b9` (v5.9.0) | `030e8812` (v6.0.0) |
| `docker/build-push-action` | `ca052bb5` (v5.4.0) | `bcafcacb` (v7.1.0) |

All four actions are now at latest major. This should also clear the `Node 20 deprecation` annotation the v0.1.2 release workflow emitted (the bumped versions run on Node 24).

## SHA verification

Each pin was sanity-checked against the action's own `git/refs/tags/{version}` on GitHub — the tag in each trailing comment resolves to exactly the SHA on the same line. Script:

```bash
for pair in \
  "docker/setup-buildx-action 4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd v4.0.0" \
  "docker/login-action         4907a6ddec9925e35a0a9e82d7399ccc52663121 v4.1.0" \
  "docker/metadata-action      030e881283bb7a6894de51c315a6bfe6a94e05cf v6.0.0" \
  "docker/build-push-action    bcafcacb16a39f128d818304e6c9c0c18556b85f v7.1.0"; do
  repo=$(echo "$pair" | awk '{print $1}')
  sha=$(echo "$pair" | awk '{print $2}')
  tag=$(echo "$pair" | awk '{print $3}')
  gh api "repos/$repo/git/refs/tags/$tag" --jq '.object.sha'
done
```
(Annotated-tag deref also performed; see commit body.)

## Supply-chain note

Continuing the SHA-pinning convention established in [`ec37235`](https://github.com/gateway-fm/miden-agglayer/commit/ec37235) — "ci: pin docker/* actions to commit SHAs in release workflow". A pinned SHA means even if the `v4.1.0` tag were re-pointed upstream, our workflow still runs the code we reviewed.

## Test plan

- [x] `release.yml` is the only file changed; no runtime code touched.
- [x] Each SHA verified against upstream tag resolution.
- [ ] Post-merge: cut any patch tag (e.g. the upcoming `v0.1.3` from PR #33) and confirm:
  1. The workflow still completes end-to-end.
  2. The Node 20 deprecation annotation is gone.

## Closes

- #24 — `docker/setup-buildx-action 3.9.0 -> 4.0.0`
- #25 — `docker/metadata-action      5.9.0 -> 6.0.0`
- #26 — `docker/login-action         3.7.0 -> 4.1.0`
- #27 — `docker/build-push-action    5.4.0 -> 7.1.0`