### PR TITLE
fix(rd-862): close GER decomposition race via aggkit two-root mode

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -188,7 +188,10 @@ services:
 
   # ── AggKit (aggoracle + aggsender) ─────────────────────────────────────────
   aggkit:
-    image: ghcr.io/agglayer/aggkit:0.8.3-rc1
+    # Locally-built patched aggkit with UseUpdateExitRoot support (RD-862).
+    # See /Users/max/github/work/gateway/miden/aggkit branch rd-862/update-exit-root-mode.
+    # TODO: once the patch is upstreamed to agglayer/aggkit, switch back to a tagged image.
+    image: miden-agglayer/aggkit:rd-862
     restart: on-failure
     command: ["run", "--cfg=/etc/aggkit/config.toml", "--components=aggoracle,aggsender"]
     ports:

--- a/fixtures/aggkit-config.toml
+++ b/fixtures/aggkit-config.toml
@@ -37,6 +37,11 @@ EnableAggOracleCommittee = false
 [AggOracle.EVMSender]
 GlobalExitRootL2 = "0xa40d5f56745a118d0906a34e69aec8c0db1cb8fa"
 WaitPeriodMonitorTx = "5s"
+# RD-862: forward the uncombined (mainnet, rollup) exit root pair via
+# updateExitRoot(bytes32,bytes32) instead of insertGlobalExitRoot(bytes32).
+# Our miden-agglayer proxy otherwise has to decompose the one-way keccak hash
+# against live L1 state, which orphans 80%+ of GERs under rapid deposit load.
+UseUpdateExitRoot = true
 
 [AggOracle.EVMSender.EthTxManager]
 FrequencyToMonitorTxs = "1s"

--- a/scripts/e2e-rd862-repro.sh
+++ b/scripts/e2e-rd862-repro.sh
@@ -41,9 +41,9 @@ FIXTURES_DIR="$PROJECT_DIR/fixtures"
 # shellcheck source=/dev/null
 source "$FIXTURES_DIR/.env"
 
-L1_RPC="${L1_RPC:-http://localhost:8545}"
-L2_RPC="${L2_RPC:-http://localhost:8546}"
-BRIDGE_SERVICE_URL="${BRIDGE_SERVICE_URL:-http://localhost:18080}"
+L1_RPC="http://localhost:8545"
+L2_RPC="http://localhost:8546"
+BRIDGE_SERVICE_URL="http://localhost:18080"
 
 COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-miden-agglayer}"
 AGGLAYER_CONTAINER="${AGGLAYER_CONTAINER:-${COMPOSE_PROJECT_NAME}-miden-agglayer-1}"
@@ -92,7 +92,7 @@ FAUCET_ID=$(echo "$ACCOUNTS" | grep faucet_eth | sed 's/.*= "//;s/"//')
 
 WALLET_HEX=$(docker exec "$AGGLAYER_CONTAINER" bridge-out-tool \
     --store-dir /var/lib/miden-agglayer-service \
-    --node-url "${MIDEN_NODE_URL:-http://miden-node:57291}" \
+    --node-url http://miden-node:57291 \
     --wallet-id "$WALLET_ID" --bridge-id "$BRIDGE_ID" --faucet-id "$FAUCET_ID" \
     --amount 1 --dest-address 0xdead --dest-network 0 2>&1 \
     | grep "wallet:" | awk '{print $NF}' || true)

--- a/scripts/e2e-rd862-repro.sh
+++ b/scripts/e2e-rd862-repro.sh
@@ -41,9 +41,9 @@ FIXTURES_DIR="$PROJECT_DIR/fixtures"
 # shellcheck source=/dev/null
 source "$FIXTURES_DIR/.env"
 
-L1_RPC="http://localhost:8545"
-L2_RPC="http://localhost:8546"
-BRIDGE_SERVICE_URL="http://localhost:18080"
+L1_RPC="${L1_RPC:-http://localhost:8545}"
+L2_RPC="${L2_RPC:-http://localhost:8546}"
+BRIDGE_SERVICE_URL="${BRIDGE_SERVICE_URL:-http://localhost:18080}"
 
 COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-miden-agglayer}"
 AGGLAYER_CONTAINER="${AGGLAYER_CONTAINER:-${COMPOSE_PROJECT_NAME}-miden-agglayer-1}"
@@ -92,7 +92,7 @@ FAUCET_ID=$(echo "$ACCOUNTS" | grep faucet_eth | sed 's/.*= "//;s/"//')
 
 WALLET_HEX=$(docker exec "$AGGLAYER_CONTAINER" bridge-out-tool \
     --store-dir /var/lib/miden-agglayer-service \
-    --node-url http://miden-node:57291 \
+    --node-url "${MIDEN_NODE_URL:-http://miden-node:57291}" \
     --wallet-id "$WALLET_ID" --bridge-id "$BRIDGE_ID" --faucet-id "$FAUCET_ID" \
     --amount 1 --dest-address 0xdead --dest-network 0 2>&1 \
     | grep "wallet:" | awk '{print $NF}' || true)


### PR DESCRIPTION
## Status: ⏸️ HELD on upstream [agglayer/aggkit#1597](https://github.com/agglayer/aggkit/pull/1597)

The mergeable subset of this PR has been split out into **#40** (`Dockerfile.miden-node` alignment, miden-node local build, RD-862 stress harness, doc fix). Once #40 lands, this PR's diff shrinks to **just the aggkit-bound bits**:

- `docker-compose.e2e.yml`: switch aggkit from `ghcr.io/agglayer/aggkit:0.8.3-rc1` → locally-built `miden-agglayer/aggkit:rd-862`
- `fixtures/aggkit-config.toml`: `UseUpdateExitRoot = true`

Both changes are no-ops without aggkit#1597 — `UseUpdateExitRoot` is a new config flag the public aggkit doesn't recognise, and the patched image only exists locally.

## Summary (original)

- Confirmed RD-862: at N=30 back-to-back deposits, **85% of GERs orphan** at inject time because `fetch_l1_exit_roots()` reads live L1 latest state AFTER aggoracle minted the combined GER. By then L1 has typically advanced and the keccak verification fails — roots stored as `None` forever.
- The race is closed by an aggkit-side patch (separate PR upstream) that forwards the uncombined `(mainnet, rollup)` pair via `updateExitRoot(bytes32,bytes32)`. Our proxy already accepts that selector — the only thing missing was an aggoracle mode that doesn't drop the data on the floor.

## Validation

| Run | GERs orphan | deposit→ready_for_claim |
|---|---|---|
| Baseline (legacy `insertGlobalExitRoot`) | **18 / 21 (85%)** | 25 / 30, 240+s, tail stranded |
| With patch (`updateExitRoot(rollup,mainnet)`) | **0 / 8 (0%)** | **30 / 30, ~15s** |

(The reproducer harness `scripts/e2e-rd862-repro.sh` is in #40 and runs against the public aggkit image; it'll show the orphan rate stays high until aggkit#1597 ships, which is the point.)

## Cross-repo

The proper fix lives in `agglayer/aggkit`:
- New `UseUpdateExitRoot` config flag on `AggOracle.EVMSender` (opt-in; backward-compat).
- `L1InfoTreeSyncer` interface gains `GetLatestL1InfoLeaf()`; impl already has it.
- `ChainSender` gains additive `UsesTwoRootMode()` + `ProcessGERWithRoots()`.
- `EVMChainGERSender.InjectExitRoots()` packs `updateExitRoot(bytes32,bytes32)` calldata MANUALLY (selector `0x736ca7f4`) — `cdk-contracts-tooling@v0.0.12`'s binding only exposes the 1-arg overload.
- `go test ./aggoracle/...` green.

Tracking branch: [agglayer/aggkit#1597](https://github.com/agglayer/aggkit/pull/1597) — open, awaiting maintainer review.

## Unblock condition

When aggkit#1597 merges and a tagged release ships, this PR becomes a one-liner: swap `image: miden-agglayer/aggkit:rd-862` → `image: ghcr.io/agglayer/aggkit:<new-tag>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)