### PR TITLE
chore(e2e): bump cert-settle timeout 300s → 900s

### DIFF
--- a/scripts/e2e-dynamic-erc20.sh
+++ b/scripts/e2e-dynamic-erc20.sh
@@ -264,7 +264,7 @@ log "L1 TestToken balance before claim: $L1_TOKEN_BAL_BEFORE"
 
 wait_for "certificate settled" \
     "docker logs $AGGKIT_CONTAINER 2>&1 | grep -q 'changed status.*Settled.*NewLocalExitRoot: 0x[^2]'" \
-    300 10
+    900 10
 pass "Certificate settled on L1"
 
 # Wait for the SPECIFIC TestToken deposit to appear in bridge-service. When

--- a/scripts/e2e-l2-to-l1.sh
+++ b/scripts/e2e-l2-to-l1.sh
@@ -105,9 +105,13 @@ L1_BAL_BEFORE=$(cast balance --rpc-url "$L1_RPC" "$L1_DEST")
 log "L1 balance before settlement: $L1_BAL_BEFORE"
 
 log "Step 3/5: Waiting for certificate settlement on AggLayer..."
+# 900s, not 300s: cold-start agglayer prover can blow past 5 min on the first
+# proof of a fresh `make test-e2e` run (circuit compile + load). Warm reruns
+# settle in ~20s, well inside the original window. Keep the timeout wide so
+# cold first-runs don't trip a regression false alarm.
 wait_for "certificate settled" \
     "docker logs --since $TEST_START_TIME $AGGKIT_CONTAINER 2>&1 | grep -q 'changed status.*Settled.*NewLocalExitRoot: 0x[^2]'" \
-    300 10
+    900 10
 pass "Certificate settled on L1!"
 
 # ── Step 4: Wait for deposit to appear in bridge-service ──────────────────────


### PR DESCRIPTION
## Summary

Bumps the hardcoded `wait_for "certificate settled"` timeout from **300s → 900s** in `scripts/e2e-l2-to-l1.sh` and `scripts/e2e-dynamic-erc20.sh`.

## Why

Cold-start agglayer prover compiles + loads circuits on the first proof of a fresh `make test-e2e` run, which can blow past the 300s budget. Warm reruns of the same test settle in **~20s**, well inside the original window — this is purely a cold/warm differential, not a real bottleneck.

Caught this on the first post-#38-merge regression run on 2026-05-06: first run timed out at 300s; immediate re-run with bumped timeout settled in 20s. Same code, same machine.

## Why 900s and not, say, 600s

Headroom. The cold-start delta we observed was at the boundary; 900s gives generous margin for slower CI runners or contended dev laptops without affecting warm-path runtime (the wait exits as soon as the regex matches).

## Test plan

- [x] Re-ran `e2e-l2-to-l1.sh` and `e2e-dynamic-erc20.sh` against a hot stack — both pass (settle in ~1s and ~1s respectively, no impact)
- [x] No effect on warm-path runtime — the loop exits on first regex hit