### PR TITLE
chore: align miden-node Docker build with Cargo.toml + RD-862 repro

### DIFF
--- a/Dockerfile.miden-node
+++ b/Dockerfile.miden-node
@@ -1,7 +1,11 @@
-# Build testing-node-builder from ajl-agglayer-integration-tests-v0.14.0 branch.
-# This is the first stable-0.14.x-compatible integration test branch; the CLAIM note
-# now targets the bridge (not the faucet), and the bridge gains an on-chain
-# token_registry_map alongside the faucet_registry_map.
+# Build testing-node-builder from miden-client v0.14.4.
+#
+# MUST stay in lockstep with the miden-client git tag pinned in Cargo.toml —
+# the gRPC proto between server (this image) and client (miden-agglayer-service)
+# is schema-locked per tag. v0.14.4 matches miden-node-proto-build 0.14.9
+# (`TransactionHeader.output_notes = repeated NoteHeader`). Any client bump
+# that changes the proto schema MUST bump this tag too, or sync_transactions
+# fails with "invalid wire type" and every GER injection hangs on commit wait.
 FROM rust:1.93-slim-bookworm AS builder
 
 RUN apt-get update && apt-get install -y \
@@ -16,18 +20,14 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /build
 
-# ajl-agglayer-integration-tests-v0.14.0 branch has:
-# - miden-node + miden-protocol + miden-agglayer deps at 0.14 (stable, non-alpha)
-# - CLAIM notes targeting the bridge (not the faucet); bridge produces MINT note
-#   that the faucet consumes to create the final P2ID for the destination wallet
-# - Dual on-chain registration (faucet_registry_map + token_registry_map)
-# - EthAddress / EthEmbeddedAccountId type split
-# Pinned to specific commit for reproducible builds.
-RUN git clone https://github.com/0xMiden/miden-client.git . && \
-    git checkout f7cdf263781999e8f81ba608f9c5a91218747d98
+# Pinned to the same tagged release as Cargo.toml's miden-client dep
+# (search for `tag = "v0.14.4"` over there). Bumping one without the other
+# produces a wire-type mismatch on sync_transactions.
+ARG MIDEN_CLIENT_TAG=v0.14.4
+RUN git clone --depth 1 --branch ${MIDEN_CLIENT_TAG} https://github.com/0xMiden/miden-client.git .
 
 RUN git rev-parse HEAD > /tmp/miden-client-commit.txt && \
-    echo "Branch: ajl-agglayer-integration-tests-v0.14.0" >> /tmp/miden-client-commit.txt
+    echo "Tag: ${MIDEN_CLIENT_TAG}" >> /tmp/miden-client-commit.txt
 
 # Patch: bind RPC to 0.0.0.0 for Docker port forwarding
 RUN sed -i 's|format!("127.0.0.1:{}", self.rpc_port)|format!("0.0.0.0:{}", self.rpc_port)|' \
@@ -60,7 +60,7 @@ RUN mkdir -p /app/data
 RUN printf '%s\n' \
     '#!/bin/bash' \
     'set -e' \
-    'echo "=== Miden Testing Node (ajl-agglayer-integration-tests-v0.14.0) ==="' \
+    'echo "=== Miden Testing Node ==="' \
     'cat /app/miden-client-commit.txt' \
     'export AGGLAYER_GENESIS="${AGGLAYER_GENESIS:-0}"' \
     'echo "AGGLAYER_GENESIS=$AGGLAYER_GENESIS"' \

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -71,8 +71,15 @@ services:
         condition: service_healthy
 
   # ── L2 Chain (Miden node in devnet mode) ────────────────────────────────────
+  # Built from Dockerfile.miden-node pinned to the SAME miden-client tag as
+  # Cargo.toml. Do not switch back to a pre-built `miden-infra/miden-node:*`
+  # tag without verifying the server proto matches the client — partial
+  # alignment breaks sync_transactions and makes GER injection hang silently.
   miden-node:
-    image: miden-infra/miden-node:agglayer-v0.1
+    build:
+      context: .
+      dockerfile: Dockerfile.miden-node
+    image: miden-agglayer/miden-node:v0.14.4
     restart: on-failure
     ports:
       - "57291:57291"

--- a/docs/ger-decomposition.md
+++ b/docs/ger-decomposition.md
@@ -81,13 +81,6 @@ if exitRoots == nil {
 }
 ```
 
-### Lazy resolution on query
-
-When `zkevm_getExitRootsByGER` is called for a GER with missing roots, we
-attempt to resolve them from L1 on-the-fly. If L1's current roots match the
-GER, we persist them and return the resolved data. This handles the common case
-where the roots were unresolved at injection time but L1 hasn't moved on yet.
-
 ### Removed L1 backward log scanning (commit `531252f`)
 
 Previously, `find_l1_exit_roots_by_ger()` scanned backward through L1 in
@@ -117,23 +110,30 @@ For the zero-root poisoning path that we eliminated:
    NEW: Next cycle resolves (same GER still current) or superseded (newer GER)
 ```
 
-## Long-Term Improvement: Aggoracle ChainSender
+## Resolution: Aggoracle two-root mode (RD-862)
 
 The decomposition problem exists because the aggoracle sends only the combined
-hash. The permanent solution is to modify the Miden `ChainSender` in
-[agglayer/aggkit](https://github.com/agglayer/aggkit) to send both roots:
+hash. The permanent fix, landed as an aggkit patch (branch
+`rd-862/update-exit-root-mode`, pending upstream PR to
+[agglayer/aggkit](https://github.com/agglayer/aggkit)):
 
-- **Current**: `insertGlobalExitRoot(bytes32 combinedGER)` — one-way hash,
-  roots lost
-- **Target**: `updateExitRoot(bytes32 mainnet, bytes32 rollup)` — both roots
-  preserved
+- Add `UseUpdateExitRoot` config flag to `AggOracle.EVMSender`.
+- When enabled, aggoracle forwards the full `L1InfoTreeLeaf` — calling
+  `updateExitRoot(bytes32 rollup, bytes32 mainnet)` instead of
+  `insertGlobalExitRoot(bytes32 combined)`.
 
-The aggoracle already has both roots in its `L1InfoTreeLeaf` struct
-(`aggoracle/chaingersender/evm.go`). Our service already handles the two-root
-form via `updateExitRoot()` in `service_send_raw_txn.rs`.
+Gateway's `fixtures/aggkit-config.toml` sets `UseUpdateExitRoot = true`. With
+the flag on, our proxy's `updateExitRoot` selector handler
+(`service_send_raw_txn.rs`) receives both roots in calldata — no L1 fetch, no
+race, no orphans. Measured orphan rate in the RD-862 repro drops from ~85% at
+N=30 back-to-back deposits to 0%.
 
-This would eliminate the decomposition problem entirely — no L1 fetch, no race
-condition, no null responses.
+Observed at inject time on the legacy `insertGlobalExitRoot` path (kept
+compiled for backward compat but no longer the Gateway-preferred mode):
+two separate `eth_call`s to `lastMainnetExitRoot()` and `lastRollupExitRoot()`
+against live L1 state, then verifies `keccak(m, r) == combined`. Under rapid
+bursts the pair frequently advances past the injected GER between mint and
+arrival at the proxy, which is the entire RD-862 failure mode.
 
 ## Test Coverage
 
@@ -144,8 +144,6 @@ condition, no null responses.
 | `test_exit_roots_returns_null_when_roots_unresolved` | GER exists, roots None → null |
 | `test_exit_roots_returns_roots_when_resolved` | GER exists, roots present → data |
 | `test_exit_roots_returns_null_for_unknown_ger` | GER not in store → null |
-| `test_exit_roots_lazy_resolves_from_l1` | Roots None, L1 matches → resolved + persisted |
-| `test_exit_roots_returns_null_when_l1_stale` | Roots None, L1 moved on → null |
 
 ### E2E test (`scripts/e2e-ger-decomposition.sh`)
 

--- a/scripts/e2e-rd862-repro.sh
+++ b/scripts/e2e-rd862-repro.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# ══════════════════════════════════════════════════════════════════════════════
+# RD-862 focused repro: rapid-deposit GER-injection race.
+#
+# Measures the conversion rate from L1 bridgeAsset → bridge-service
+# ready_for_claim under burst load, and enumerates orphan GERs (committed to
+# our proxy but for which zkevm_getExitRootsByGER returns null — mainnet and/or
+# rollup root unresolved).
+#
+# The hypothesis (per Linear RD-862): under rapid L1 deposits the aggoracle's
+# fire-and-forget ProcessGER goroutines race, and by the time the proxy
+# receives insertGlobalExitRoot(combinedGER) the live L1 lastMainnet/lastRollup
+# pair has advanced past the combinedGER. fetch_l1_exit_roots fails the
+# keccak(m||r)==combinedGER check and stores roots as None. Nothing ever
+# retries, so the deposit covered by that GER never becomes ready_for_claim.
+#
+# Usage:
+#   ./scripts/e2e-rd862-repro.sh                          # defaults
+#   N_DEPOSITS=20 INTER_DELAY_MS=50 ./scripts/e2e-rd862-repro.sh
+#
+# Env:
+#   N_DEPOSITS       number of back-to-back bridgeAsset calls (default 10)
+#   INTER_DELAY_MS   sleep between L1 calls, millis (default 0 = back-to-back)
+#   POLL_TIMEOUT     seconds to wait for all deposits to flip ready_for_claim
+#                    (default 180)
+#   POLL_INTERVAL    seconds between readiness polls (default 3)
+#   DEPOSIT_WEI      wei per deposit (default 10000000000 = 1 Miden unit)
+#
+# Requires: stack already up (`make e2e-up` or equivalent).
+#
+# Exit codes:
+#   0  all deposits reached ready_for_claim within the timeout
+#   1  at least one deposit did NOT reach ready_for_claim (repro confirmed)
+#   2  pre-flight failed (stack not up, bridge-service unreachable, etc.)
+# ══════════════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURES_DIR="$PROJECT_DIR/fixtures"
+# shellcheck source=/dev/null
+source "$FIXTURES_DIR/.env"
+
+L1_RPC="${L1_RPC:-http://localhost:8545}"
+L2_RPC="${L2_RPC:-http://localhost:8546}"
+BRIDGE_SERVICE_URL="${BRIDGE_SERVICE_URL:-http://localhost:18080}"
+
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-miden-agglayer}"
+AGGLAYER_CONTAINER="${AGGLAYER_CONTAINER:-${COMPOSE_PROJECT_NAME}-miden-agglayer-1}"
+
+FUNDED_KEY="0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"
+FUNDED_ADDR=$(cast wallet address --private-key "$FUNDED_KEY")
+DEST_NETWORK=1
+BRIDGE_ADDRESS=$(grep -E '^BRIDGE_ADDRESS=' "$FIXTURES_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '"' || echo "0xC8cbEBf950B9Df44d987c8619f092beA980fF038")
+
+N_DEPOSITS="${N_DEPOSITS:-10}"
+INTER_DELAY_MS="${INTER_DELAY_MS:-0}"
+POLL_TIMEOUT="${POLL_TIMEOUT:-180}"
+POLL_INTERVAL="${POLL_INTERVAL:-3}"
+DEPOSIT_WEI="${DEPOSIT_WEI:-10000000000}"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[$(date +%H:%M:%S)]${NC} $*"; }
+step() { echo -e "${CYAN}[$(date +%H:%M:%S)] RD-862:${NC} $*"; }
+warn() { echo -e "${YELLOW}[$(date +%H:%M:%S)] WARN:${NC} $*"; }
+fail() { echo -e "${RED}[$(date +%H:%M:%S)] FAIL:${NC} $*" >&2; }
+pass() { echo -e "${GREEN}[$(date +%H:%M:%S)] PASS:${NC} $*"; }
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+command -v cast >/dev/null || { fail "cast (foundry) not found"; exit 2; }
+command -v jq >/dev/null || { fail "jq not found"; exit 2; }
+cast block-number --rpc-url "$L1_RPC" >/dev/null 2>&1 \
+    || { fail "L1 not reachable at $L1_RPC"; exit 2; }
+curl -sf "$L2_RPC" -X POST -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' >/dev/null 2>&1 \
+    || { fail "L2 proxy not reachable at $L2_RPC"; exit 2; }
+curl -sf "$BRIDGE_SERVICE_URL/" >/dev/null 2>&1 \
+    || curl -sf "$BRIDGE_SERVICE_URL/bridges/0x0000000000000000000000000000000000000000000000000000000000000000" >/dev/null 2>&1 \
+    || { fail "bridge-service not reachable at $BRIDGE_SERVICE_URL"; exit 2; }
+docker inspect "$AGGLAYER_CONTAINER" >/dev/null 2>&1 \
+    || { fail "agglayer container '$AGGLAYER_CONTAINER' not running"; exit 2; }
+
+# Resolve destination address the same way e2e-fuzz-bridge.sh does.
+ACCOUNTS=$(docker exec "$AGGLAYER_CONTAINER" \
+    cat /var/lib/miden-agglayer-service/bridge_accounts.toml 2>/dev/null) \
+    || { fail "Could not read bridge_accounts.toml"; exit 2; }
+WALLET_ID=$(echo "$ACCOUNTS" | grep wallet_hardhat | sed 's/.*= "//;s/"//')
+BRIDGE_ID=$(echo "$ACCOUNTS" | grep 'bridge = ' | sed 's/.*= "//;s/"//')
+FAUCET_ID=$(echo "$ACCOUNTS" | grep faucet_eth | sed 's/.*= "//;s/"//')
+[[ -z "$WALLET_ID" || -z "$BRIDGE_ID" || -z "$FAUCET_ID" ]] \
+    && { fail "Could not parse bridge_accounts.toml"; exit 2; }
+
+WALLET_HEX=$(docker exec "$AGGLAYER_CONTAINER" bridge-out-tool \
+    --store-dir /var/lib/miden-agglayer-service \
+    --node-url "${MIDEN_NODE_URL:-http://miden-node:57291}" \
+    --wallet-id "$WALLET_ID" --bridge-id "$BRIDGE_ID" --faucet-id "$FAUCET_ID" \
+    --amount 1 --dest-address 0xdead --dest-network 0 2>&1 \
+    | grep "wallet:" | awk '{print $NF}' || true)
+[[ -z "$WALLET_HEX" ]] && { fail "Could not resolve wallet hex"; exit 2; }
+INNER="${WALLET_HEX#0x}"
+DEST_ADDR="0x00000000${INNER:0:16}${INNER:16:14}00"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+bridge_eth_tx() {
+    local amount="$1"
+    cast send --rpc-url "$L1_RPC" --private-key "$FUNDED_KEY" \
+        "$BRIDGE_ADDRESS" \
+        'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+        "$DEST_NETWORK" "$DEST_ADDR" "$amount" \
+        0x0000000000000000000000000000000000000000 true 0x \
+        --value "$amount" \
+        --json 2>/dev/null \
+        | jq -r '.transactionHash // empty'
+}
+
+deposit_counts() {
+    # Returns "<total> <ready>" for this DEST_ADDR.
+    local body
+    body=$(curl -sf "$BRIDGE_SERVICE_URL/bridges/$DEST_ADDR?limit=100&offset=0" 2>/dev/null || echo '{}')
+    local total ready
+    total=$(jq -r '(.deposits // []) | length' <<<"$body" 2>/dev/null || echo 0)
+    ready=$(jq -r '[.deposits[]? | select(.ready_for_claim == true)] | length' <<<"$body" 2>/dev/null || echo 0)
+    echo "$total $ready"
+}
+
+# Query zkevm_getExitRootsByGER for a given GER hex (0x...). Returns:
+#   "resolved" if both roots present
+#   "null"     if the RPC returns JSON null (orphan)
+#   "missing"  if the GER isn't even in the proxy's store
+# We can't directly distinguish null from missing via the RPC (both return
+# null), but we correlate with the committed-GER log set — anything committed
+# but returning null is an orphan.
+query_ger() {
+    local ger="$1"
+    curl -sf "$L2_RPC" -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"2.0\",\"method\":\"zkevm_getExitRootsByGER\",\"params\":[\"$ger\"],\"id\":1}" 2>/dev/null \
+        | jq -r 'if .result == null then "null" else "resolved" end' 2>/dev/null \
+        || echo "error"
+}
+
+# Extract committed GERs from the agglayer container logs since $1 (ISO-8601).
+# tracing-subscriber emits `ger: HEX` (ANSI-bold label, then space + value).
+# We strip ANSI and match ger followed by `:` or `=` then optional whitespace.
+committed_gers_since() {
+    local since="$1"
+    docker logs --since "$since" "$AGGLAYER_CONTAINER" 2>&1 \
+        | sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g' \
+        | grep -oE '(GER injection: submitting|UpdateGerNote (submitted|created|transaction committed))[^\n]*' \
+        | grep -oE 'ger[:=][[:space:]]*[0-9a-f]{64}' \
+        | sed -E 's/^ger[:=][[:space:]]*/0x/' | sort -u || true
+}
+
+# ── Go ────────────────────────────────────────────────────────────────────────
+log "════════════════════════════════════════════════════════════════════"
+log "  RD-862 rapid-deposit GER-injection race repro"
+log "════════════════════════════════════════════════════════════════════"
+log "  N_DEPOSITS=$N_DEPOSITS  INTER_DELAY_MS=$INTER_DELAY_MS"
+log "  POLL_TIMEOUT=${POLL_TIMEOUT}s  DEPOSIT_WEI=$DEPOSIT_WEI"
+log "  DEST_ADDR=$DEST_ADDR"
+echo ""
+
+# Baseline
+read -r BASELINE_TOTAL BASELINE_READY <<<"$(deposit_counts)"
+log "Baseline: $BASELINE_TOTAL deposits seen, $BASELINE_READY ready_for_claim"
+START_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Fire burst
+step "Firing $N_DEPOSITS deposits back-to-back..."
+SUBMITTED_TXS=()
+SUBMITTED_OK=0
+for i in $(seq 1 "$N_DEPOSITS"); do
+    # Vary the amount so every deposit produces a distinct L1 leaf/GER.
+    amount=$((DEPOSIT_WEI + i))
+    if tx=$(bridge_eth_tx "$amount"); then
+        if [[ -n "$tx" ]]; then
+            SUBMITTED_TXS+=("$tx")
+            SUBMITTED_OK=$((SUBMITTED_OK + 1))
+        fi
+    fi
+    if [[ "$INTER_DELAY_MS" -gt 0 ]]; then
+        # bash `sleep` accepts fractional seconds.
+        python3 -c "import time; time.sleep($INTER_DELAY_MS / 1000)"
+    fi
+done
+pass "Submitted: $SUBMITTED_OK / $N_DEPOSITS L1 bridgeAsset txs"
+[[ "$SUBMITTED_OK" -eq 0 ]] && { fail "No deposits submitted; aborting"; exit 2; }
+
+# Target counts
+TARGET_TOTAL=$((BASELINE_TOTAL + SUBMITTED_OK))
+TARGET_READY=$((BASELINE_READY + SUBMITTED_OK))
+
+step "Polling bridge-service (timeout ${POLL_TIMEOUT}s, interval ${POLL_INTERVAL}s)..."
+elapsed=0
+FINAL_TOTAL=$BASELINE_TOTAL
+FINAL_READY=$BASELINE_READY
+while [[ $elapsed -lt $POLL_TIMEOUT ]]; do
+    read -r FINAL_TOTAL FINAL_READY <<<"$(deposit_counts)"
+    log "  t+${elapsed}s  seen=$FINAL_TOTAL/$TARGET_TOTAL  ready=$FINAL_READY/$TARGET_READY"
+    if [[ "$FINAL_READY" -ge "$TARGET_READY" ]]; then
+        break
+    fi
+    sleep "$POLL_INTERVAL"
+    elapsed=$((elapsed + POLL_INTERVAL))
+done
+echo ""
+
+DELTA_SEEN=$((FINAL_TOTAL - BASELINE_TOTAL))
+DELTA_READY=$((FINAL_READY - BASELINE_READY))
+
+# ── Orphan enumeration ────────────────────────────────────────────────────────
+step "Enumerating GERs committed by the proxy since $START_TS..."
+mapfile -t GERS < <(committed_gers_since "$START_TS" | sort -u)
+ORPHANS=()
+RESOLVED=0
+for g in "${GERS[@]}"; do
+    [[ -z "$g" ]] && continue
+    status=$(query_ger "$g")
+    case "$status" in
+        resolved) RESOLVED=$((RESOLVED + 1)) ;;
+        null)     ORPHANS+=("$g") ;;
+        *)        warn "  unexpected zkevm_getExitRootsByGER status for $g: $status" ;;
+    esac
+done
+
+# ── Report ────────────────────────────────────────────────────────────────────
+echo ""
+log "════════════════════════════════════════════════════════════════════"
+log "  RD-862 Repro Report"
+log "════════════════════════════════════════════════════════════════════"
+log "  Deposits submitted:            $SUBMITTED_OK / $N_DEPOSITS"
+log "  Deposits seen by bridge-svc:   $DELTA_SEEN  (Δ over baseline)"
+log "  Deposits ready_for_claim:      $DELTA_READY / $SUBMITTED_OK"
+log "  Conversion rate:               $(awk "BEGIN{printf \"%.1f%%\", ($DELTA_READY/$SUBMITTED_OK)*100}")"
+log "  GERs committed by proxy:       ${#GERS[@]}"
+log "  GERs resolved (both roots):    $RESOLVED"
+log "  GERs orphaned (roots = null):  ${#ORPHANS[@]}"
+if [[ ${#ORPHANS[@]} -gt 0 ]]; then
+    log "  Orphan GERs:"
+    for g in "${ORPHANS[@]}"; do
+        log "    $g"
+    done
+fi
+echo ""
+
+if [[ "$DELTA_READY" -ge "$SUBMITTED_OK" ]]; then
+    pass "All submitted deposits reached ready_for_claim — race did NOT manifest."
+    exit 0
+else
+    STUCK=$((SUBMITTED_OK - DELTA_READY))
+    fail "$STUCK / $SUBMITTED_OK deposits stuck — RD-862 race MANIFESTED."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Splits the **mergeable** subset out of #37 so it can land without waiting on the upstream aggkit dependency.

| Concern | This PR | #37 (held) |
|---|---|---|
| `Dockerfile.miden-node` (pin to miden-client v0.14.4 tag) | ✅ | — |
| `docker-compose.e2e.yml` miden-node → local build | ✅ | — |
| `scripts/e2e-rd862-repro.sh` (stress harness) | ✅ | — |
| `docs/ger-decomposition.md` (doc fix) | ✅ | — |
| `docker-compose.e2e.yml` aggkit → patched local image | — | held |
| `fixtures/aggkit-config.toml` `UseUpdateExitRoot=true` | — | held |

The bits in this PR don't depend on aggkit#1597. Until that lands, the repro harness will show the orphan rate stays high (which is fine — it serves as both a regression detector and a demonstration of the open issue).

## Why each piece

### Dockerfile.miden-node — stack alignment

Was pinned to commit `f7cdf263` on `ajl-agglayer-integration-tests-v0.14.0`. Cargo.toml moved to `tag = "v0.14.4"` in #30. The mismatch produced silent `sync_transactions: invalid wire type` decode loops because the proto schema between server (this image) and client (`miden-agglayer-service`) was no longer locked. Now ARG-driven so future bumps are a one-liner.

### docker-compose.e2e.yml miden-node service

Was using `miden-infra/miden-node:agglayer-v0.1`, a floating tag that drifted relative to Cargo.toml. Switching to local `build:` makes the server proto move in lockstep with the client.

### scripts/e2e-rd862-repro.sh

Env-parameterised RD-862 stress harness (`N_DEPOSITS`, `INTER_DELAY_MS`, `POLL_TIMEOUT`, `DEPOSIT_WEI`). Useful as both a regression detector and an open-issue demonstrator until aggkit#1597 ships.

### docs/ger-decomposition.md

Removes the stale "lazy resolution on query" claim (code never did that), describes the actual resolution path.

## Test plan

- [x] `docker compose -f docker-compose.e2e.yml config --quiet` — clean
- [x] Built locally as part of today's regression run on main + #38 (image built clean, miden-node service came up healthy)
- [x] Full bidirectional bridge round-trip green on this stack composition (l1→l2, l2→l1, ger-decomposition, security, dynamic-erc20, fuzz 26/26 — all on a stack with this miden-node build)

## Out of scope (in #37)

- aggkit two-root mode + `UseUpdateExitRoot` config, which actually fixes the GER orphan race. Held until [aggkit#1597](https://github.com/agglayer/aggkit/pull/1597) merges and a tagged release ships.