### PR TITLE
fix(accounts-config): write bridge_accounts.toml bech32 with the acti…

### DIFF
--- a/src/accounts_config.rs
+++ b/src/accounts_config.rs
@@ -263,6 +263,9 @@ mod tests {
         };
         save_config(cfg, &NetworkId::Testnet, Some(dir.path().to_path_buf())).unwrap();
         let loaded = load_config(Some(dir.path().to_path_buf())).unwrap();
-        assert_eq!(loaded.bridge.0, AccountId::from_hex(TEST_ACCOUNT_HEX).unwrap());
+        assert_eq!(
+            loaded.bridge.0,
+            AccountId::from_hex(TEST_ACCOUNT_HEX).unwrap()
+        );
     }
 }

--- a/src/accounts_config.rs
+++ b/src/accounts_config.rs
@@ -1,11 +1,11 @@
-use miden_client::rpc::Endpoint;
 use miden_protocol::account::AccountId;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use miden_protocol::address::NetworkId;
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt::{Display, Formatter};
 use std::path::{Component, PathBuf};
 use std::{env, fs};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct AccountsConfig {
     pub service: AccountIdBech32,
     pub bridge: AccountIdBech32,
@@ -27,21 +27,25 @@ pub struct AccountsConfig {
 #[derive(Debug, Clone)]
 pub struct AccountIdBech32(pub AccountId);
 
-impl Display for AccountIdBech32 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let net_id = Endpoint::localhost().to_network_id();
-        let str = self.0.to_bech32(net_id);
-        write!(f, "{str}")
+impl AccountIdBech32 {
+    /// Render the account id as a bech32 string for the given network.
+    ///
+    /// Bech32 encodes the network in its HRP. Using the wrong HRP makes the
+    /// address unfindable on the network's block explorer even though the
+    /// underlying account is valid on-chain — see PR introducing this method.
+    /// Any code that emits the bech32 form across a system boundary (on-disk
+    /// config, logs, API responses, support tickets) MUST pass the
+    /// `NetworkId` of the active node.
+    pub fn to_bech32(&self, net_id: NetworkId) -> String {
+        self.0.to_bech32(net_id)
     }
 }
 
-impl Serialize for AccountIdBech32 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let str = self.to_string();
-        serializer.serialize_str(&str)
+impl Display for AccountIdBech32 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // Network-agnostic hex form. For the bech32 form (which encodes the
+        // network HRP) call `to_bech32(net_id)` with an explicit NetworkId.
+        write!(f, "{}", self.0.to_hex())
     }
 }
 
@@ -50,9 +54,50 @@ impl<'de> Deserialize<'de> for AccountIdBech32 {
     where
         D: Deserializer<'de>,
     {
-        let str = String::deserialize(deserializer)?;
-        let (_, id) = AccountId::from_bech32(&str).map_err(serde::de::Error::custom)?;
+        let s = String::deserialize(deserializer)?;
+        let id = if s.starts_with("0x") || s.starts_with("0X") {
+            AccountId::from_hex(&s).map_err(serde::de::Error::custom)?
+        } else {
+            // `from_bech32` validates the bech32 checksum but doesn't constrain the HRP;
+            // older configs written before the network-id fix used the `mlcl` (local) HRP
+            // even on testnet. Both forms decode to the same on-chain account.
+            AccountId::from_bech32(&s)
+                .map(|(_, id)| id)
+                .map_err(serde::de::Error::custom)?
+        };
         Ok(Self(id))
+    }
+}
+
+/// On-disk representation. Holds the bech32 strings ready-encoded with the
+/// network id supplied at save time, so the bech32 HRP matches the active
+/// node. Constructing this from `AccountsConfig` is the only sanctioned way
+/// to serialize the config — there is intentionally no derived `Serialize`
+/// impl on `AccountsConfig` itself.
+#[derive(Serialize)]
+struct AccountsConfigOnDisk {
+    service: String,
+    bridge: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    faucet_eth: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    faucet_agg: Option<String>,
+    wallet_hardhat: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ger_manager: Option<String>,
+}
+
+impl AccountsConfigOnDisk {
+    fn from_config(config: &AccountsConfig, net_id: &NetworkId) -> Self {
+        let enc = |id: &AccountIdBech32| id.to_bech32(net_id.clone());
+        Self {
+            service: enc(&config.service),
+            bridge: enc(&config.bridge),
+            faucet_eth: config.faucet_eth.as_ref().map(&enc),
+            faucet_agg: config.faucet_agg.as_ref().map(&enc),
+            wallet_hardhat: enc(&config.wallet_hardhat),
+            ger_manager: config.ger_manager.as_ref().map(&enc),
+        }
     }
 }
 
@@ -100,9 +145,11 @@ pub fn config_path_exists(miden_store_dir: Option<PathBuf>) -> anyhow::Result<bo
 
 pub fn save_config(
     config: AccountsConfig,
+    net_id: &NetworkId,
     miden_store_dir: Option<PathBuf>,
 ) -> anyhow::Result<PathBuf> {
-    let config_toml = toml::to_string(&config)?;
+    let on_disk = AccountsConfigOnDisk::from_config(&config, net_id);
+    let config_toml = toml::to_string(&on_disk)?;
     let config_path = config_path(miden_store_dir)?;
     fs::write(config_path.clone(), config_toml)?;
     Ok(config_path)
@@ -118,6 +165,13 @@ pub fn load_config(miden_store_dir: Option<PathBuf>) -> anyhow::Result<AccountsC
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
+
+    const TEST_ACCOUNT_HEX: &str = "0x27525024cc2047507cb35ee9ed00d4";
+
+    fn dummy() -> AccountIdBech32 {
+        AccountIdBech32(AccountId::from_hex(TEST_ACCOUNT_HEX).unwrap())
+    }
 
     #[test]
     fn rejects_parent_dir_traversal() {
@@ -153,5 +207,62 @@ mod tests {
         assert!(result.is_ok());
         let path = result.unwrap();
         assert!(path.ends_with("bridge_accounts.toml"));
+    }
+
+    #[test]
+    fn save_writes_bech32_with_configured_network_hrp() {
+        let dir = tempdir().unwrap();
+        let cfg = AccountsConfig {
+            service: dummy(),
+            bridge: dummy(),
+            faucet_eth: Some(dummy()),
+            faucet_agg: None,
+            wallet_hardhat: dummy(),
+            ger_manager: Some(dummy()),
+        };
+        save_config(cfg, &NetworkId::Testnet, Some(dir.path().to_path_buf())).unwrap();
+        let body = fs::read_to_string(dir.path().join("bridge_accounts.toml")).unwrap();
+        // Every emitted id must use the `mtst` testnet HRP — never `mlcl`.
+        assert!(
+            body.contains("\"mtst1"),
+            "expected testnet (`mtst`) HRP in saved bech32; got:\n{body}"
+        );
+        assert!(
+            !body.contains("\"mlcl1"),
+            "saved bech32 must not use the local-network (`mlcl`) HRP; got:\n{body}"
+        );
+    }
+
+    #[test]
+    fn load_accepts_legacy_local_hrp_bech32() {
+        // Files written by previous versions used the local-network HRP
+        // unconditionally. They must still load — `from_bech32` ignores the HRP.
+        let dir = tempdir().unwrap();
+        let id = AccountId::from_hex(TEST_ACCOUNT_HEX).unwrap();
+        let local_hrp = NetworkId::new("mlcl").unwrap();
+        let legacy_bech32 = id.to_bech32(local_hrp);
+        let toml_body = format!(
+            "service = \"{b}\"\nbridge = \"{b}\"\nwallet_hardhat = \"{b}\"\n",
+            b = legacy_bech32
+        );
+        fs::write(dir.path().join("bridge_accounts.toml"), toml_body).unwrap();
+        let loaded = load_config(Some(dir.path().to_path_buf())).unwrap();
+        assert_eq!(loaded.bridge.0, id);
+    }
+
+    #[test]
+    fn save_then_load_roundtrips() {
+        let dir = tempdir().unwrap();
+        let cfg = AccountsConfig {
+            service: dummy(),
+            bridge: dummy(),
+            faucet_eth: None,
+            faucet_agg: None,
+            wallet_hardhat: dummy(),
+            ger_manager: None,
+        };
+        save_config(cfg, &NetworkId::Testnet, Some(dir.path().to_path_buf())).unwrap();
+        let loaded = load_config(Some(dir.path().to_path_buf())).unwrap();
+        assert_eq!(loaded.bridge.0, AccountId::from_hex(TEST_ACCOUNT_HEX).unwrap());
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -9,6 +9,7 @@ use miden_client::keystore::{FilesystemKeyStore, Keystore};
 use miden_client::transaction::TransactionRequestBuilder;
 use miden_protocol::account::auth::{AuthScheme, AuthSecretKey};
 use miden_protocol::account::{Account, AccountId};
+use miden_protocol::address::NetworkId;
 use miden_protocol::note::NoteType;
 use miden_standards::account::auth::AuthSingleSig;
 use miden_standards::account::wallets::BasicWallet;
@@ -195,6 +196,7 @@ async fn register_p2id_script(
 async fn init_internal(
     client: &mut MidenClientLib,
     keystore: Arc<FilesystemKeyStore>,
+    net_id: NetworkId,
     miden_store_dir: Option<PathBuf>,
 ) -> anyhow::Result<PathBuf> {
     client.sync_state().await?;
@@ -232,12 +234,13 @@ async fn init_internal(
     register_p2id_script(client, accounts.service.id()).await?;
 
     let config = AccountsConfig::from(accounts);
-    let config_path = accounts_config::save_config(config, miden_store_dir)?;
+    let config_path = accounts_config::save_config(config, &net_id, miden_store_dir)?;
     Ok(config_path)
 }
 
 pub async fn init(
     client: &MidenClient,
+    net_id: NetworkId,
     miden_store_dir: Option<PathBuf>,
 ) -> anyhow::Result<PathBuf> {
     let result = Arc::new(OnceLock::<PathBuf>::new());
@@ -246,7 +249,7 @@ pub async fn init(
 
     let future = client.with(|client| {
         Box::new(async move {
-            let result = init_internal(client, keystore, miden_store_dir).await?;
+            let result = init_internal(client, keystore, net_id, miden_store_dir).await?;
             result_internal.set(result).unwrap();
             Ok(())
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,8 +302,7 @@ async fn main() -> anyhow::Result<()> {
             command.miden_node.as_deref(),
         )?;
 
-        let config_path =
-            init::init(&init_client, init_net_id, miden_store_dir.clone()).await?;
+        let config_path = init::init(&init_client, init_net_id, miden_store_dir.clone()).await?;
         tracing::info!("new config created at {config_path:?}");
 
         init_client.shutdown()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,7 +293,17 @@ async fn main() -> anyhow::Result<()> {
             command.miden_debug,
         )?;
 
-        let config_path = init::init(&init_client, miden_store_dir.clone()).await?;
+        // Resolve the NetworkId from the same `--miden-node` flag MidenClient uses,
+        // so the bech32 strings written to bridge_accounts.toml use the active
+        // node's HRP (e.g. `mtst` on testnet). Without this, every saved id
+        // would be encoded with the local-network HRP (`mlcl`) regardless of
+        // which network the agglayer is actually deployed against.
+        let init_net_id = miden_agglayer_service::miden_client::resolve_network_id(
+            command.miden_node.as_deref(),
+        )?;
+
+        let config_path =
+            init::init(&init_client, init_net_id, miden_store_dir.clone()).await?;
         tracing::info!("new config created at {config_path:?}");
 
         init_client.shutdown()?;

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -63,6 +63,21 @@ pub fn parse_node_url(node_url: &str) -> anyhow::Result<Endpoint> {
     }
 }
 
+/// Resolves the `NetworkId` for the configured `--miden-node` value, applying
+/// the same `None` → localhost default as `MidenClient::new`. Use this so
+/// bech32 strings written by the service (notably `bridge_accounts.toml`) use
+/// the active node's HRP — e.g. `mtst` on testnet rather than the local
+/// network's `mlcl`.
+pub fn resolve_network_id(
+    node_url: Option<&str>,
+) -> anyhow::Result<miden_protocol::address::NetworkId> {
+    let endpoint = match node_url {
+        Some(url) => parse_node_url(url)?,
+        None => Endpoint::localhost(),
+    };
+    Ok(endpoint.to_network_id())
+}
+
 /// Builds an RPC client for the Miden node, optionally authenticating via a bearer token.
 ///
 /// When `api_key` is `Some`, the returned client sends `authorization: Bearer <api_key>` on


### PR DESCRIPTION
…ve node's HRP

`AccountIdBech32`'s `Display`/`Serialize` impls hard-coded `Endpoint::localhost().to_network_id()` ("mlcl"), so every id persisted in `bridge_accounts.toml` (service, bridge, faucet_eth, faucet_agg, wallet_hardhat, ger_manager) was encoded with the local-network HRP even when the agglayer was deployed against Bali testnet. The underlying account is fine on-chain — `from_bech32` ignores the HRP on read — but the string we hand to operators (Slack, support tickets, midenscan URLs) is unfindable on the network's block explorer.

Threads `NetworkId` through `init` → `save_config`, resolved from the same `--miden-node` flag `MidenClient::new` uses (new `resolve_network_id` helper in `miden_client.rs`). Serialization goes through a dedicated on-disk struct that bech32-encodes with the supplied network id; the misleading `Display`/`Serialize` impls on `AccountIdBech32` are removed (`Display` now renders the network-agnostic hex form). `Deserialize` accepts both bech32 (any HRP, including the legacy "mlcl") and hex, so existing on-disk files keep loading.