### PR TITLE
v0.4.0: runtime self-heal + Public storage_mode + unified claim client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /usr/src/app
 # copy sources
 COPY src src
 COPY axum-jrpc axum-jrpc
+COPY migrations migrations
 COPY Cargo.* .
 
 # build

--- a/Dockerfile.miden-node
+++ b/Dockerfile.miden-node
@@ -94,6 +94,15 @@ GENESIS_CONFIG=/app/genesis-samples/02-with-account-files.toml
 DATA_DIR=/app/data
 ACCOUNTS_DIR=/app/accounts
 
+# HARD-PIN the remote tx-prover. The in-process tx-prover OOM-kills miden-node
+# during bridge-consumption proof generation under any non-trivial load.
+# `tx-prover.devnet.miden.io` is the publicly-exposed devnet endpoint.
+# Override via MIDEN_NODE_NTX_PROVER_URL env var only if explicitly set;
+# otherwise default to the remote so no test path accidentally exercises
+# the OOM-prone in-process prover.
+TX_PROVER_URL="${MIDEN_NODE_NTX_PROVER_URL:-https://tx-prover.devnet.miden.io}"
+echo "tx-prover (remote): ${TX_PROVER_URL}"
+
 if [ ! -f "$DATA_DIR/.bootstrapped" ]; then
   echo "Bootstrapping genesis with agglayer accounts from $GENESIS_CONFIG"
   rm -rf "$DATA_DIR"
@@ -103,7 +112,10 @@ if [ ! -f "$DATA_DIR/.bootstrapped" ]; then
 fi
 
 echo "Starting miden-node bundled..."
-exec miden-node bundled start --rpc.url "http://0.0.0.0:57291" --data-directory "$DATA_DIR"
+exec miden-node bundled start \
+  --rpc.url "http://0.0.0.0:57291" \
+  --data-directory "$DATA_DIR" \
+  --tx-prover.url "${TX_PROVER_URL}"
 EOF
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -75,6 +75,12 @@ services:
       - "57291:57291"
     environment:
       RUST_LOG: "info,miden_node_ntx_builder=debug,miden_tx=debug"
+      # Offload tx proving to Miden's devnet prover so local miden-node doesn't
+      # OOM-kill itself during bridge-consumption proof generation. Only
+      # `tx-prover.devnet.miden.io` is publicly exposed by Miden devnet; block
+      # proving stays in-process (no remote endpoint available). This env var
+      # maps to the `--tx-prover.url` flag of `miden-node bundled start`.
+      MIDEN_NODE_NTX_PROVER_URL: "${MIDEN_NODE_NTX_PROVER_URL:-https://tx-prover.devnet.miden.io}"
     healthcheck:
       test: ["CMD-SHELL", "nc -z localhost 57291 || exit 1"]
       interval: 3s

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -53,26 +53,10 @@ services:
       timeout: 2s
       retries: 5
 
-  # ── Migration (applies every migrations/*.sql then exits) ─────────────────
-  agglayer-migrate:
-    image: postgres:16-alpine
-    entrypoint: ["sh", "-c"]
-    command:
-      - |
-        echo "Running miden-agglayer migrations..."
-        PGPASSWORD=agglayer psql -h agglayer-postgres -U agglayer -d agglayer_store -f /migrations/001_initial.sql
-        PGPASSWORD=agglayer psql -h agglayer-postgres -U agglayer -d agglayer_store -f /migrations/002_faucet_registry.sql
-        PGPASSWORD=agglayer psql -h agglayer-postgres -U agglayer -d agglayer_store -f /migrations/003_unclaimable_claims.sql
-        PGPASSWORD=agglayer psql -h agglayer-postgres -U agglayer -d agglayer_store -f /migrations/004_claim_watcher.sql
-        echo "Migrations complete."
-    volumes:
-      - ./migrations/001_initial.sql:/migrations/001_initial.sql:ro
-      - ./migrations/002_faucet_registry.sql:/migrations/002_faucet_registry.sql:ro
-      - ./migrations/003_unclaimable_claims.sql:/migrations/003_unclaimable_claims.sql:ro
-      - ./migrations/004_claim_watcher.sql:/migrations/004_claim_watcher.sql:ro
-    depends_on:
-      agglayer-postgres:
-        condition: service_healthy
+  # Migrations are run IN-PROCESS by the miden-agglayer proxy on startup
+  # (see `src/store/migrator.rs`). The old `agglayer-migrate` one-shot
+  # service is intentionally removed — its replacement embeds the SQL via
+  # `include_str!` into the binary so the proxy and its schema cannot drift.
 
   # ── L2 Chain (Miden node in bundled mode) ──────────────────────────────────
   # Built from `0xMiden/miden-node` (production binary), NOT the testing
@@ -141,8 +125,8 @@ services:
     depends_on:
       miden-node:
         condition: service_healthy
-      agglayer-migrate:
-        condition: service_completed_successfully
+      agglayer-postgres:
+        condition: service_healthy
     healthcheck:
       test: >-
         curl -sf -X POST http://localhost:8546

--- a/docs/POSTMORTEM_2026-05-11_IAIC_TO_ADNF.md
+++ b/docs/POSTMORTEM_2026-05-11_IAIC_TO_ADNF.md
@@ -1,0 +1,321 @@
+# Postmortem — bali IAIC → AccountDataNotFound (2026-05-11 → 2026-05-18)
+
+| Field | Value |
+|---|---|
+| Status | RESOLVED in v0.3.0 (PR #44); cure for bali's existing deployment is the REDEPLOY procedure (see `docs/REDEPLOY_RUNBOOK_BALI.md`). |
+| Severity | High — L1→L2 bridge stuck for ~20 wall-days; ~1.1M deposits unresolvable; marti's deposit cnt=1130654 the user-visible canary. |
+| Detection | Manual — Igor / operator triage. No alert fired on the IAIC rate. |
+| Author | claude-code + miden-l1-l2-debug agents on `feat/v0.3.0-self-heal`. |
+| Cluster | `dev-gateway-eks`, ns `outpost-testnet-miden-testnet`, pod `miden-agglayer-0`. |
+| Pre-incident image | `gatewayfm/miden-agglayer:0.2.1` = commit `388775e` = current `main`. |
+
+## TL;DR
+
+Two distinct bugs in the proxy fired in sequence:
+
+1. **Mempool-conflict IAIC** (2026-05-11 → 2026-05-14). `publish_claim` built a fresh `miden_client::Client` per call against the same on-disk sqlite, bypassing the long-lived `MidenClient`'s `mpsc::channel::<Request>(1)` event loop. Under concurrent claim load two fresh clients submitted `submit_proven_transaction` calls into the Miden node's mempool simultaneously, both built atop the same `init_commitment` for the `bridge` infrastructure account. The node rejected the second with `AddTransactionError::IncorrectAccountInitialCommitment` and gRPC message `transaction conflicts with current mempool state`. 187 occurrences over 73 hours, steady ~2/hour, peaking 8/hour in the final cluster.
+
+2. **Operator-recovery hole — AccountDataNotFound after `--reset-miden-store --restore`** (2026-05-14 18:45 onwards). The documented recovery for IAIC instructed operators to run the proxy with `--reset-miden-store --restore`. The bali operator did so three times in 21 seconds. But `restore.rs::restore` Phase 1 (`sync_miden_block`) called only `client.sync_state()` — which syncs deltas for already-tracked accounts and never imports unknown ones. After `--reset-miden-store` wiped `store.sqlite3`, `--restore` left `latest_account_headers` empty for every entry in `bridge_accounts.toml`. From `2026-05-14T18:45:39Z` onwards every aggoracle push failed at `eth_sendRawTransaction` with `account data wasn't found for account id 0xe9a21e616d9ed59016d481c7001393` (the ger_manager). Zero new GERs landed for ~3 wall-days until escalation.
+
+Both bugs are closed in v0.3.0 by structural fixes, with safety-net runtime self-heal layered on top.
+
+## Evidence — Loki, raw
+
+Query 1 — IAIC density over 30d (literal `|=`, then bucketed by hour client-side):
+
+```
+{namespace="outpost-testnet-miden-testnet", container="miden-agglayer"}
+  |= `incorrect account initial commitment`
+
+189 results total
+ first  2026-05-11T17:18:52.727272Z   miden_agglayer_service::service:180
+ last   2026-05-14T18:40:10.236794Z   rpc::error:85
+```
+
+Hourly bucket (truncated to the active window):
+
+```
+2026-05-11T17  2
+2026-05-11T18  2
+2026-05-11T19  3
+2026-05-11T20  2
+2026-05-11T21  2
+2026-05-11T22  1
+2026-05-11T23  3
+2026-05-12T00..23  range 1-4 (steady)
+2026-05-13T00..23  range 1-4 (steady)
+2026-05-14T00  3
+2026-05-14T01  3
+2026-05-14T02..11  range 1-2 (steady)
+2026-05-14T12  6
+2026-05-14T13  6
+2026-05-14T14  4
+2026-05-14T15  4
+2026-05-14T16  8   ← peak cluster
+2026-05-14T17  2
+2026-05-14T18  6   ← then silence
+```
+
+The flat-then-spike shape is consistent with chronic concurrent-submission load, not OOM-coincident or restart-coincident bursts. The 12:00-18:40 cluster on 2026-05-14 is correlated with rising claim volume (more claimsponsor retries against the proxy as marti's deposit and others remained stuck).
+
+Query 2 — first IAIC + immediately-preceding context (`2026-05-11T16:14:00 → 16:15:30`):
+
+```
+16:12:04 → 16:13:41   ~96 lines: claimAsset retry storm for global_index
+                       18446744073710679244, each rejected with
+                       "claim already submitted" (correctly dedup'd at
+                       service.rs:180 IDX guard)
+16:14:34.214 Z  WARN  service_send_raw_txn.rs:253:
+               "L1 exit roots don't match injected GER
+                (L1 may have advanced), storing without roots"
+               ← the RD-862 race firing
+16:14:51.326 Z  ERROR service_send_raw_txn.rs:68:
+               "insert_ger failed: RpcError(...)"
+16:14:51.326 Z  INFO  service.rs:180:
+               "eth_sendRawTransaction: ERR RPC error: grpc request failed
+                for submit_proven_transaction: invalid request parameters
+                (incorrect account initial commitment):
+                code: 'Client specified an invalid argument',
+                message: \"transaction conflicts with current
+                          mempool state\""
+```
+
+The node's rejection message — `transaction conflicts with current mempool state` — was the key. Initially we hypothesised "stale local commitment vs. live node commitment" (cache lag). The node's actual error text reframed it: a tx for the same account is already pending in mempool, and your new tx builds atop the same `init_commitment` it does — that's a mempool serialization conflict, not a cache lag.
+
+Query 3 — operator-action transcript on 2026-05-14T18:30 → 19:00:
+
+```
+16:21:40.533Z  pod restart (Command { ... miden_node: rpc.testnet.miden.io:443 ... })
+16:21:45.850Z  ERROR src/main.rs:548: startup diagnostic:
+               "1 managed account(s) are LOCKED in miden-client:
+                [V0(AccountIdV0 { suffix: 1645082455596831488, prefix: 1... })]"
+
+18:35:07.952Z  pod restart (no recovery flags)
+18:35:29.515Z  pod restart
+18:36:02.535Z  pod restart
+18:36:50.524Z  pod restart
+18:38:12.514Z  pod restart
+18:39:21.638Z  pod restart                 ← 6 plain restarts in ~4 minutes
+
+18:40:10.237Z  ← LAST IAIC fires, on the previous pod incarnation
+
+18:45:18.593Z  pod restart with --reset-miden-store --restore
+18:45:18.594Z  INFO recovery.rs:50:
+               "reset_miden_store: deleted /var/lib/.../store.sqlite3"
+18:45:18.594Z  WARN main.rs:270:
+               "reset_miden_store: removed 1 sqlite file(s);
+                keystore and bridge_accounts.toml preserved"
+18:45:18.601Z  INFO restore.rs:60: "=== RESTORE: starting state reconstruction ==="
+               (Phase 1 sync_state ONLY — NO account reimport)
+               "=== RESTORE: complete ==="
+
+18:45:21.564Z  pod restart with --reset-miden-store --restore (2nd time)
+18:45:21.572Z  RESTORE start/complete
+18:45:39.514Z  pod restart with --reset-miden-store --restore (3rd time)
+18:45:39.520Z  RESTORE start/complete
+
+After 18:45:39: every aggoracle push → AccountDataNotFound.
+```
+
+The operator escalated correctly by the existing runbook. The runbook was the trap.
+
+## Mechanism — bug 1, mempool-conflict IAIC
+
+`miden_client::Client` maintains an in-memory cache of every tracked account's current commitment. `Client::submit_new_transaction(account_id, tx_request)` builds a tx atop `(account_id, init_commitment_in_cache)` and submits to the Miden node. The node validates:
+
+1. `init_commitment` matches the latest committed block for `account_id`, OR
+2. There is no pending mempool tx for `account_id`.
+
+If a pending tx exists in mempool whose `init_commitment` matches what we just sent, the node rejects the second tx as a conflict (only one of them can commit; whichever lands wins, the other is invalid by construction).
+
+On `main`, `publish_claim` (`src/claim.rs:611-704`) built a FRESH `Client` per call:
+
+```rust
+let rt = tokio::runtime::Runtime::new()?;
+rt.block_on(async {
+    let mut client = ClientBuilder::new()
+        .rpc(rpc)
+        .sqlite_store(store_path)   // ← same file as the long-lived client
+        .authenticator(keystore)
+        .in_debug_mode(DebugMode::Enabled)
+        .build()
+        .await?;
+    client.sync_state().await?;
+    // ... publish_claim_internal submits a CLAIM tx targeting the
+    //     `bridge` account ...
+});
+```
+
+This bypassed the long-lived `MidenClient`'s `mpsc::channel::<Request>(1)` event loop. Two concurrent `publish_claim` calls for distinct globalIndexes:
+
+- Both built a fresh `Client`.
+- Both synced state, observed the same `init_commitment` for `bridge`.
+- Both submitted CLAIM txs targeting `bridge`.
+- First arrived, was accepted into mempool.
+- Second arrived a few hundred milliseconds later, hit the conflict.
+
+The node returned `AddTransactionError::IncorrectAccountInitialCommitment` to the second. The proxy logged it as `insert_ger failed` at `src/service_send_raw_txn.rs:68` (the path that handles the chained insert_ger from the claim flow) and surfaced it back to the JSON-RPC caller as `eth_sendRawTransaction: ERR RPC error: ...`.
+
+### Why we initially misread this as cache lag
+
+The variant name `IncorrectAccountInitialCommitment` and Display `incorrect account initial commitment` strongly suggest "your local cache is wrong". The first hypothesis was: long-lived client's in-memory cache is N seconds stale relative to live node state. The cure path c491eca implements — `reimport_account` via `import_account_by_id(overwrite=true)` — was framed for this.
+
+The gRPC message `transaction conflicts with current mempool state` reframed it. Reimporting the account doesn't help if the conflicting tx is your own pending submission; the local commitment IS correct, the node just won't take a second tx atop it.
+
+### Why removing the fresh client fixes it (e3e3e2a)
+
+After the unify, `publish_claim` routes through `MidenClient::with(...)`:
+
+```rust
+pub async fn with<Fn>(&self, closure: Fn) -> anyhow::Result<()>
+where Fn: for<'c> FnOnce(&'c mut MidenClientLib) -> ... {
+    let request = Request { ... };
+    if self.sender.send(request).await.is_err() { ... }
+    let result = response_receiver.await?;
+    result
+}
+```
+
+`self.sender` is the producer half of `mpsc::channel::<Request>(1)` (`miden_client.rs:126`). The consumer side is `Self::run`'s loop:
+
+```rust
+loop {
+    tokio::select! {
+        receiver_result = receiver.recv() => {
+            let Some(request) = receiver_result else { break };
+            let result = (request.closure)(&mut client).await;
+            request.response_sender.send(result).unwrap_or(());
+        },
+        ...
+    }
+}
+```
+
+Capacity 1 + serial `await` of the closure means: no second request is pulled from the channel until the current one's closure has fully returned. Each submission closure body (insert_ger, publish_claim_internal, restore phases) calls `wait_for_transaction_commit` after submitting, which polls until the Miden node commits the tx (or times out). The closure does not return — and the channel does not advance — until the previous tx is settled on chain.
+
+Net property: **no two `submit_new_transaction` calls are ever in flight against the Miden node from this proxy.** Mempool conflict is structurally impossible by construction.
+
+## Mechanism — bug 2, AccountDataNotFound after `--reset-miden-store --restore`
+
+`src/main.rs::main` handles the recovery flags:
+
+```rust
+if command.reset_miden_store {
+    let removed = miden_agglayer_service::recovery::reset_miden_store(&effective_store_dir)?;
+    tracing::warn!(
+        "reset_miden_store: removed {removed} sqlite file(s) from {}; \
+         keystore and bridge_accounts.toml preserved",
+        effective_store_dir.display()
+    );
+}
+if command.restore {
+    miden_agglayer_service::restore::restore(...).await?;
+    return Ok(());
+}
+```
+
+`reset_miden_store` deletes `store.sqlite3` (+ WAL/SHM). On the next startup, miden-client rebuilds an empty sqlite. `restore::restore` then runs:
+
+```rust
+pub async fn restore(...) -> anyhow::Result<RestoreResult> {
+    // Phase 1: Sync miden state
+    let block_num = sync_miden_block(miden_client, store).await?;
+    // Phase 2: Scan miden consumed B2AGG notes (bridge_outs)
+    // Phase 3: Scan consumed UpdateGerNote notes (gers)
+    // Phase 4-5: stamp block + verify
+    ...
+}
+
+async fn sync_miden_block(miden_client: &MidenClient, store: &Arc<dyn Store>)
+  -> anyhow::Result<u64> {
+    miden_client.with(|client| {
+        Box::new(async move {
+            client.sync_state().await?;   // ← syncs deltas for already-tracked
+                                          //    accounts. Does NOT import unknown.
+            Ok(())
+        })
+    }).await?;
+    let block_num = store.get_latest_block_number().await?;
+    Ok(block_num)
+}
+```
+
+`sync_state()` is incremental — it requires the account to already be tracked in `latest_account_headers`. After `--reset-miden-store`, that table is empty. `sync_state` finds no tracked accounts, syncs nothing, returns Ok. The restore phases 2/3 walk on-chain notes to rebuild PgStore state, but never call `Client::import_account_by_id` to populate `latest_account_headers`.
+
+On the next aggoracle push:
+
+```
+insert_ger → MidenClient::with → client.submit_new_transaction(ger_manager_id, ...)
+                                  → miden-client looks up ger_manager_id in
+                                    latest_account_headers
+                                  → not present
+                                  → returns ClientError::AccountDataNotFound
+```
+
+Surfaced to the JSON-RPC caller as `eth_sendRawTransaction: ERR account data wasn't found for account id 0x...`.
+
+### Why 55fa17a fixes it
+
+The fix adds Phase 0 to `restore::restore`:
+
+```rust
+pub async fn restore(...) {
+    // Phase 0: Re-import every bridge_accounts.toml account from the live
+    // Miden node. Closes the chain that locked bali: --reset-miden-store
+    // --restore is a footgun because Phase 1 sync_state() doesn't import
+    // unknown accounts. Phase 0 ensures latest_account_headers is populated.
+    tracing::info!("Phase 0: re-importing bridge accounts from Miden node...");
+    crate::account_recovery::reimport_known_accounts(miden_client, accounts).await;
+    tracing::info!("Phase 0 complete: bridge account reimport pass done");
+
+    // Phase 1: Sync miden state (existing)
+    ...
+}
+```
+
+`reimport_known_accounts` iterates `accounts.toml`, calls `import_account_by_id` for each, and logs per-account success or `AccountNotFoundOnChain` (for locally-deployed-but-not-network-tracked accounts like `wallet_hardhat`). After Phase 0, `latest_account_headers` is populated for every network-tracked infrastructure account.
+
+The next submission lookups succeed; AccountDataNotFound cannot fire from this recovery path.
+
+## Why this took 73+ hours of chronic firing without escalation
+
+1. **No alert on IAIC rate.** Metrics for `miden_agglayer_service::service::eth_sendRawTransaction_errors_total` exist but no Prometheus rule fires on a sustained non-zero rate. Should add.
+2. **Symptom looked transient at low rates.** ~2/hour reads as "intermittent flakiness" on a testnet — not a P2 page.
+3. **Existing runbook framed IAIC as a sqlite-staleness problem.** That framing pointed at `--reset-miden-store --restore`, which inadvertently locked the system harder.
+4. **No before/after test of the documented recovery flow.** `scripts/e2e-restore.sh` exists but doesn't cover the `--reset-miden-store --restore` chain or AccountDataNotFound assertion. Now added: `scripts/e2e-reset-restore-recovery.sh`.
+
+## Fix mapping (commit → bug)
+
+| Commit | Closes | Notes |
+|---|---|---|
+| `e3e3e2a` | Bug 1 (IAIC mempool conflict) | Structural fix. Routes publish_claim through the long-lived MidenClient's channel-of-1. |
+| `c491eca` | Bug 1 (safety net) + Bug 2 (defense in depth) | Runtime inline retry on the two recoverable error variants. Will NOT cure bali's existing state because its accounts are Private (`import_account_by_id` returns `AccountIsPrivate`); covers post-redeploy. |
+| `55fa17a` | Bug 2 (operator-recovery hole) | Phase 0 in restore reimports every account before sync_state. Makes `--reset-miden-store --restore` a real recovery path for the first time. |
+| `34d4316` | Pre-condition for above | Restores `AccountStorageMode::Public`; without this the runtime self-heal can't reimport because the accounts can't be imported by ID. Regression from `dbe5c2d`. |
+| `3d92040`, `9cb3878` | Adjacent — indexer hardening | Indexer cursor persistence + backfill override. Closes the 27 race-poisoned STATE-C orphans. |
+| `f05ab42` | Defensive | Atomic write for bridge_accounts.toml. Closes a mid-write OOM truncation hazard. |
+| `0fd7fc0` | Operational | In-process migrator. Removes the `agglayer-migrate` footgun. |
+| `bc5c157` | Security-adjacent | Clamps alloy http transport to info; stops Sepolia apiKey leak in L1 RPC logs. |
+
+## Lessons
+
+1. **A documented recovery procedure that locks the system harder is the worst kind of operational regression.** Test the documented recoveries end-to-end against the broken state they're meant to fix. `scripts/e2e-reset-restore-recovery.sh` and `scripts/e2e-account-self-heal.sh` now enforce this.
+
+2. **Trust the actual error message, not the variant name.** `IncorrectAccountInitialCommitment` reads like cache staleness; the gRPC tail `transaction conflicts with current mempool state` is the actual cause. Both hypotheses pointed to plausible fixes, but only the structural one (unify on channel-of-1) closes mempool conflict; cache reimport doesn't.
+
+3. **Concurrency property = type-system invariant > runtime assertion.** The unify (`e3e3e2a`) makes "no two submissions in flight against the node" a property of the type system (capacity-1 channel + serial await), not a runtime check. Once unified, you can't accidentally violate it without restructuring the code — that's the property worth shipping.
+
+4. **`import_account_by_id` only works on Public/Network accounts.** Treat `AccountStorageMode` for infrastructure accounts as a recovery-path concern, not just a privacy one. `dbe5c2d` lost this intent during the 0.14.x migration; `34d4316` restores it explicitly; the comment in `src/init.rs::add_wallet` now makes the dependency loud.
+
+5. **Two related bugs in sequence look like one bug from the outside.** The IAIC → AccountDataNotFound transition could have been one root cause with two manifestations, or two distinct bugs in series. The Loki density chart distinguished them: chronic-flat-then-spike for bug 1, single-event-with-3-reset-spam for bug 2 are signatures that don't share a parent.
+
+## Action items
+
+| # | Item | Owner | Status |
+|---|---|---|---|
+| 1 | Ship v0.3.0 (this PR). | release | PR #44 open, security PASS, evidence captured. |
+| 2 | REDEPLOY bali per `docs/REDEPLOY_RUNBOOK_BALI.md` — existing Private accounts cannot be self-healed in place. | SRE | runbook ready. |
+| 3 | Add Prometheus alert on `account data wasn't found` and `incorrect account initial commitment` log occurrences (non-zero rate over 5min). | observability | TODO. |
+| 4 | Add a `miden-agglayer-service get-account <id>` subcommand for operator inspection of network-side account status without needing miden-cli. | platform | TODO. |
+| 5 | CLAIM_REPLAY_FILE generator (`scripts/e2e-claim-watcher.sh --dump-raw-tx <path>`) so `scripts/e2e-iaic-mempool-conflict.sh` is runnable on every PR. | platform | TODO. |
+| 6 | Audit other `recovery::*` flags for the same "documented-cure-locks-harder" pattern. | platform | TODO. |

--- a/docs/REDEPLOY_RUNBOOK_BALI.md
+++ b/docs/REDEPLOY_RUNBOOK_BALI.md
@@ -1,14 +1,14 @@
-# Bali v0.3.0 deploy + recovery runbook
+# Bali v0.4.0 deploy + recovery runbook
 
 Author: max.revitt@gateway.fm
 Audience: SRE on call for the bali Miden agglayer testnet
-Last-validated: 2026-05-18 against branch `feat/v0.3.0-self-heal`
-                (commit `55fa17a`).
+Last-validated: 2026-05-19 against branch `feat/v0.4.0-self-heal`
+                (HEAD `d241b0b`).
 
 ## What this runbook is for
 
-Deploying `v0.3.0` of `gatewayfm/miden-agglayer` to the bali production
-proxy (`outpost-testnet-miden-testnet/miden-agglayer-0`). v0.3.0 fixes
+Deploying `v0.4.0` of `gatewayfm/miden-agglayer` to the bali production
+proxy (`outpost-testnet-miden-testnet/miden-agglayer-0`). v0.4.0 fixes
 the regression chain that has held bali's L1→L2 bridge in
 `AccountDataNotFound` failure for ~20 wall-days, plus the underlying
 race that triggered it. Two stuck deposits (marti's `cnt=1130654` and
@@ -16,7 +16,7 @@ race that triggered it. Two stuck deposits (marti's `cnt=1130654` and
 
 ## Pre-flight: confirm the state you're about to operate on
 
-The investigation that produced v0.3.0 was done against this snapshot.
+The investigation that produced this release was done against this snapshot.
 Re-verify these still hold before deploying — if any of them have
 changed, stop and re-investigate.
 
@@ -26,7 +26,7 @@ kubectl -n outpost-testnet-miden-testnet describe pod miden-agglayer-0 \
 ```
 
 Expect: `Image: docker.io/gatewayfm/miden-agglayer:0.2.1`. If it's
-already v0.3.0 something is out of band and you should ask Max.
+already v0.4.0 something is out of band and you should ask Max.
 
 ```sql
 -- agglayer-store (kubectl port-forward svc/miden-agglayer-db 15434:5432)
@@ -50,21 +50,25 @@ WHERE network_id = 0 AND dest_net = 73 ORDER BY deposit_cnt;
 Expect `1127628..1127650 ready=true` (3 rows), `1130654 + 1131034
 ready=false` (2 rows). marti's `1130654` is one of the stuck.
 
-## Step 1 — build + push v0.3.0 image
+## Step 1 — build + push v0.4.0 image
+
+The `release.yml` GitHub Actions workflow auto-builds and pushes
+`gatewayfm/miden-agglayer:0.4.0` to Docker Hub on tag push. Local
+fallback (if CI is unavailable):
 
 ```bash
 cd ~/github/gateway/miden/miden-agglayer
-git checkout feat/v0.3.0-self-heal
+git checkout main  # after PR #45 merge
 docker buildx build --platform linux/amd64 \
-  -t gatewayfm/miden-agglayer:0.3.0 \
+  -t gatewayfm/miden-agglayer:0.4.0 \
   --push .
 ```
 
 Tag the commit:
 
 ```bash
-git tag -a v0.3.0 -m "v0.3.0 runtime self-heal + atomic config + in-process migrator + persistent indexer cursor"
-git push origin v0.3.0
+git tag -a v0.4.0 -m "v0.4.0 runtime self-heal + Public storage_mode + unified claim client + remote tx-prover + atomic config + in-process migrator + persistent indexer cursor"
+git push origin v0.4.0
 ```
 
 Image digest from the push output — paste it into the StatefulSet
@@ -75,7 +79,7 @@ patch below.
 ```bash
 kubectl -n outpost-testnet-miden-testnet patch statefulset miden-agglayer \
   --type='json' \
-  -p='[{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"docker.io/gatewayfm/miden-agglayer:0.3.0"}]'
+  -p='[{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"docker.io/gatewayfm/miden-agglayer:0.4.0"}]'
 ```
 
 Watch the rollout:
@@ -177,15 +181,15 @@ DB downgrade.
 
 The new code path in `init.rs` (`storage_mode = Public`) only affects
 **new** account deployments. v0.2.1 will keep working against the
-accounts deployed by v0.3.0 (they have a stricter storage mode but the
+accounts deployed by v0.4.0 (they have a stricter storage mode but the
 proxy uses them identically).
 
-## Known scope limits of v0.3.0
+## Known scope limits of v0.4.0
 
 These are NOT fixed by this release; they're acknowledged trade-offs
 or out-of-scope follow-ups:
 
-1. **Existing bali accounts remain Private.** v0.3.0's
+1. **Existing bali accounts remain Private.** v0.4.0's
    `storage_mode = Public` only applies to fresh deployments. The
    account IDs already in `bridge_accounts.toml` on bali were created
    pre-`dbe5c2d` and are unrecoverable from a fresh sqlite loss. The
@@ -195,21 +199,13 @@ or out-of-scope follow-ups:
    no other restore path is available, the only recourse is a
    full re-init with new account IDs + an aggkit config rewrite
    pointing at the new IDs. Plan a future maintenance window for
-   that swap; until then v0.3.0's heal is your safety net.
+   that swap; until then v0.4.0's heal is your safety net.
 
 2. **STATE-C orphans aren't auto-cured.** The 27 historic
    `(NULL, NULL)` rows need the operator backfill flag in Step 4.
 
-3. **Dual-miden-client cache race still present.** `claim.rs::publish_claim`
-   builds a fresh `miden_client` on the same sqlite as the long-lived
-   one (claim.rs:611-650). The runtime self-heal catches the resulting
-   `IncorrectAccountInitialCommitment` and retries — that's the safety
-   net. The cleaner fix is to unify `publish_claim` onto the long-lived
-   client; tracked separately as `feat/v0.3.0-unify-claim-client`
-   follow-up.
-
-4. **Sepolia archival apiKey rotation.** `RUST_LOG=debug` was leaking
-   this key for the lifetime of the deployment. v0.3.0 stops the leak
+3. **Sepolia archival apiKey rotation.** `RUST_LOG=debug` was leaking
+   this key for the lifetime of the deployment. v0.4.0 stops the leak
    going forward, but the already-leaked key should be rotated via the
    secret store (AWS Secrets Manager) as a separate ticket. The new
    value flows in through `miden-agglayer-secret.l1_rpc_url` — no proxy

--- a/docs/REDEPLOY_RUNBOOK_BALI.md
+++ b/docs/REDEPLOY_RUNBOOK_BALI.md
@@ -1,0 +1,232 @@
+# Bali v0.3.0 deploy + recovery runbook
+
+Author: max.revitt@gateway.fm
+Audience: SRE on call for the bali Miden agglayer testnet
+Last-validated: 2026-05-18 against branch `feat/v0.3.0-self-heal`
+                (commit `55fa17a`).
+
+## What this runbook is for
+
+Deploying `v0.3.0` of `gatewayfm/miden-agglayer` to the bali production
+proxy (`outpost-testnet-miden-testnet/miden-agglayer-0`). v0.3.0 fixes
+the regression chain that has held bali's L1→L2 bridge in
+`AccountDataNotFound` failure for ~20 wall-days, plus the underlying
+race that triggered it. Two stuck deposits (marti's `cnt=1130654` and
+`cnt=1131034`) come unstuck on the first aggoracle push after deploy.
+
+## Pre-flight: confirm the state you're about to operate on
+
+The investigation that produced v0.3.0 was done against this snapshot.
+Re-verify these still hold before deploying — if any of them have
+changed, stop and re-investigate.
+
+```bash
+kubectl -n outpost-testnet-miden-testnet describe pod miden-agglayer-0 \
+  | grep -E 'Image|Reason|Started:|Restart Count'
+```
+
+Expect: `Image: docker.io/gatewayfm/miden-agglayer:0.2.1`. If it's
+already v0.3.0 something is out of band and you should ask Max.
+
+```sql
+-- agglayer-store (kubectl port-forward svc/miden-agglayer-db 15434:5432)
+SELECT
+  count(*) FILTER (WHERE is_injected) AS injected,
+  count(*) FILTER (WHERE is_injected AND mainnet_exit_root IS NULL) AS state_c_orphans,
+  count(*) FILTER (WHERE NOT is_injected AND mainnet_exit_root IS NOT NULL) AS state_b_pending
+FROM ger_entries;
+```
+
+Expect ≈ `injected≈65 / state_c_orphans≈27 / state_b_pending>=2`. If
+`injected` has grown, something is already pushing successfully and the
+incident may have self-resolved.
+
+```sql
+-- bridge-db (kubectl port-forward svc/bridge-db 15435:5432)
+SELECT deposit_cnt, ready_for_claim FROM sync.deposit
+WHERE network_id = 0 AND dest_net = 73 ORDER BY deposit_cnt;
+```
+
+Expect `1127628..1127650 ready=true` (3 rows), `1130654 + 1131034
+ready=false` (2 rows). marti's `1130654` is one of the stuck.
+
+## Step 1 — build + push v0.3.0 image
+
+```bash
+cd ~/github/gateway/miden/miden-agglayer
+git checkout feat/v0.3.0-self-heal
+docker buildx build --platform linux/amd64 \
+  -t gatewayfm/miden-agglayer:0.3.0 \
+  --push .
+```
+
+Tag the commit:
+
+```bash
+git tag -a v0.3.0 -m "v0.3.0 runtime self-heal + atomic config + in-process migrator + persistent indexer cursor"
+git push origin v0.3.0
+```
+
+Image digest from the push output — paste it into the StatefulSet
+patch below.
+
+## Step 2 — patch the StatefulSet image tag
+
+```bash
+kubectl -n outpost-testnet-miden-testnet patch statefulset miden-agglayer \
+  --type='json' \
+  -p='[{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"docker.io/gatewayfm/miden-agglayer:0.3.0"}]'
+```
+
+Watch the rollout:
+
+```bash
+kubectl -n outpost-testnet-miden-testnet rollout status statefulset miden-agglayer --watch
+```
+
+Expected logs on the new pod's first boot (`kubectl logs -f`):
+
+```
+INFO migrator: applying migration: 005_l1_indexer_cursor.sql
+INFO DB migrations complete applied=1 already_present=4
+INFO L1InfoTreeIndexer starting
+INFO L1InfoTreeIndexer cursor initialized start_block=... stored_cursor=0 l1_head=...
+INFO RPC server listening on 0.0.0.0:8546
+... (within ~30s)
+INFO GER injection: submitting to Miden... ger: 0x<combined>
+WARN GER injection: recoverable account error, reimporting ger_manager and retrying err: account data wasn't found for account id 0xe9a21e616d9ed59016d481c7001393
+INFO reimported from node account=ger_manager account_id=0xe9a21e616d9ed59016d481c7001393
+INFO UpdateGerNote created note_id=0x...
+INFO UpdateGerNote submitted, waiting for commit...
+INFO UpdateGerNote transaction committed
+```
+
+The `WARN reimporting` line firing once and the subsequent
+`UpdateGerNote transaction committed` is the cure event. After that,
+aggoracle pushes should succeed normally.
+
+## Step 3 — verify recovery
+
+Wait ~60 seconds, then:
+
+```sql
+-- agglayer-store: should see new is_injected=TRUE rows
+SELECT count(*) FROM ger_entries WHERE is_injected;
+-- Expect: > 65 (whatever it was before, plus at least one new)
+```
+
+```sql
+-- bridge-db: marti's deposit must now be ready
+SELECT deposit_cnt, ready_for_claim FROM sync.deposit
+WHERE network_id = 0 AND deposit_cnt IN (1130654, 1131034);
+-- Expect: both rows ready_for_claim = t
+```
+
+If both are `t`: **the deploy succeeded and the backlog cleared**.
+Marti can submit `claimAsset` for his deposit; the claimsponsor will
+also pick it up automatically.
+
+## Step 4 — clean up the 27 historic STATE-C orphans (OPTIONAL)
+
+These are race-poisoned GERs from the RD-862 era (proxy blocks 95k-130k
+on bali) with `(mainnet_exit_root IS NULL, rollup_exit_root IS NULL,
+is_injected = TRUE)`. They are NOT blocking any current user deposits
+— marti's came unstuck in Step 3 via a fresh GER, not via these
+orphans. Cleaning them up is cosmetic.
+
+If you do want a clean ledger:
+
+```bash
+# Find the earliest orphan's approximate L1 block.
+# (proxy block_number is synthesized, NOT wall-clock; use aggoracle's
+# Sepolia sync logs around the orphan's timestamp instead, or just
+# pick a safely-old block — 30 days before today is fine).
+
+kubectl -n outpost-testnet-miden-testnet patch statefulset miden-agglayer \
+  --type='json' \
+  -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--l1-indexer-from-block=<N>"}]'
+
+# Wait for indexer to walk past current head:
+kubectl -n outpost-testnet-miden-testnet logs -f miden-agglayer-0 \
+  | grep -E 'L1InfoTreeIndexer batch processed|cursor advanced'
+
+# Once the cursor has caught up to current head, remove the flag:
+kubectl -n outpost-testnet-miden-testnet patch statefulset miden-agglayer \
+  --type='json' \
+  -p='[{"op":"remove","path":"/spec/template/spec/containers/0/args/<index-of-flag>"}]'
+
+# Verify orphans cleared:
+psql ... -c "SELECT count(*) FROM ger_entries WHERE is_injected AND mainnet_exit_root IS NULL;"
+# Expect: 0
+```
+
+## Rollback
+
+If the new image fails to start or behaves worse than v0.2.1:
+
+```bash
+kubectl -n outpost-testnet-miden-testnet patch statefulset miden-agglayer \
+  --type='json' \
+  -p='[{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"docker.io/gatewayfm/miden-agglayer:0.2.1"}]'
+```
+
+The new migration (`005_l1_indexer_cursor.sql`) is forward-compatible
+with v0.2.1 — it adds a table that v0.2.1 simply doesn't query, so
+rolling back leaves the schema as a superset and does not require a
+DB downgrade.
+
+The new code path in `init.rs` (`storage_mode = Public`) only affects
+**new** account deployments. v0.2.1 will keep working against the
+accounts deployed by v0.3.0 (they have a stricter storage mode but the
+proxy uses them identically).
+
+## Known scope limits of v0.3.0
+
+These are NOT fixed by this release; they're acknowledged trade-offs
+or out-of-scope follow-ups:
+
+1. **Existing bali accounts remain Private.** v0.3.0's
+   `storage_mode = Public` only applies to fresh deployments. The
+   account IDs already in `bridge_accounts.toml` on bali were created
+   pre-`dbe5c2d` and are unrecoverable from a fresh sqlite loss. The
+   runtime self-heal mitigates this (it tries `import_account_by_id`
+   on every recoverable error) — but for a Private account that call
+   returns `AccountIsPrivate`. If bali's sqlite is wiped again **and**
+   no other restore path is available, the only recourse is a
+   full re-init with new account IDs + an aggkit config rewrite
+   pointing at the new IDs. Plan a future maintenance window for
+   that swap; until then v0.3.0's heal is your safety net.
+
+2. **STATE-C orphans aren't auto-cured.** The 27 historic
+   `(NULL, NULL)` rows need the operator backfill flag in Step 4.
+
+3. **Dual-miden-client cache race still present.** `claim.rs::publish_claim`
+   builds a fresh `miden_client` on the same sqlite as the long-lived
+   one (claim.rs:611-650). The runtime self-heal catches the resulting
+   `IncorrectAccountInitialCommitment` and retries — that's the safety
+   net. The cleaner fix is to unify `publish_claim` onto the long-lived
+   client; tracked separately as `feat/v0.3.0-unify-claim-client`
+   follow-up.
+
+4. **Sepolia archival apiKey rotation.** `RUST_LOG=debug` was leaking
+   this key for the lifetime of the deployment. v0.3.0 stops the leak
+   going forward, but the already-leaked key should be rotated via the
+   secret store (AWS Secrets Manager) as a separate ticket. The new
+   value flows in through `miden-agglayer-secret.l1_rpc_url` — no proxy
+   redeploy required.
+
+## Loki queries worth running post-deploy
+
+```logql
+# Confirm cure event fired
+{namespace="outpost-testnet-miden-testnet", pod=~"miden-agglayer.*"}
+  |~ "reimporting ger_manager|reimported from node"
+
+# Watch for new failures the heal can't handle
+{namespace="outpost-testnet-miden-testnet", pod=~"miden-agglayer.*"}
+  |~ "AccountIsPrivate|AccountNotFoundOnChain|account reimport failed"
+```
+
+The first one should fire once per pod restart during the heal sequence.
+The second one should never fire on bali for the infrastructure accounts;
+if it does, run the rollback above and ping Max.

--- a/migrations/005_l1_indexer_cursor.sql
+++ b/migrations/005_l1_indexer_cursor.sql
@@ -1,0 +1,22 @@
+-- ============================================================================
+-- L1InfoTreeIndexer cursor persistence
+-- ============================================================================
+--
+-- Until this migration the indexer reset its cursor to current L1 head on
+-- every restart (`src/l1_info_tree_indexer.rs:120`). Any GER emitted on L1
+-- during a proxy outage (OOMKill, planned restart, etc.) was permanently
+-- stranded: the indexer never observed the corresponding `UpdateL1InfoTree`
+-- event, so `ger_entries.set_ger_exit_roots` was never called for those
+-- combined hashes, and bridge-service's `zkevm_getExitRootsByGER` returned
+-- NULL for the affected GERs forever.
+--
+-- This table is the simplest possible persistence: a single key/value row
+-- tracking the last successfully-processed L1 block. The indexer resumes
+-- from `max(last_processed - reorg_margin, 0)` on startup.
+
+CREATE TABLE l1_indexer_state (
+    id              INT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    last_processed  BIGINT NOT NULL DEFAULT 0,
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+INSERT INTO l1_indexer_state (id) VALUES (1);

--- a/scripts/e2e-account-self-heal.sh
+++ b/scripts/e2e-account-self-heal.sh
@@ -1,0 +1,546 @@
+#!/usr/bin/env bash
+# ══════════════════════════════════════════════════════════════════════════════
+# e2e-account-self-heal.sh — bali v0.3.0 cure verification (all 3 states)
+#
+# Faithfully sets up the THREE distinct ger_entries states observed on bali
+# and verifies the v0.3.0 fix cures every one of them in a single proxy boot:
+#
+#   STATE A  prior-successful  — (M, R) set, is_injected=TRUE.
+#                                Healthy historical rows. Must be PRESERVED.
+#
+#   STATE B  marti-pending     — (M, R) set by indexer, is_injected=FALSE.
+#                                Aggoracle pushed but proxy rejected the
+#                                eth_sendRawTransaction with AccountDataNotFound
+#                                because the ger_manager row was missing from
+#                                the local sqlite. Must become is_injected=TRUE
+#                                AND drive bridge-service to flip its associated
+#                                stuck deposit to ready_for_claim=true.
+#
+#   STATE C  historic-orphan   — is_injected=TRUE, (NULL, NULL) roots.
+#                                Race-poisoned from the RD-862 era. Indexer
+#                                must back-fill the (M, R) so bridge-service
+#                                can resolve them.
+#
+# Setup phase (this script):
+#   1. Bring up a clean stack. Run baseline L1→L2 to land STATE A rows.
+#   2. Inject STATE C rows directly via SQL (NULL roots + is_injected=TRUE).
+#   3. Delete the ger_manager row from sqlite. New L1 deposits + aggoracle
+#      pushes produce STATE B rows.
+#   4. Verify all three states are present in ger_entries before the cure.
+#
+# Cure phase:
+#   5. Restart the proxy. v0.3.0's startup self-heal imports the missing
+#      ger_manager from the Miden node (works because storage_mode=Network).
+#      The pending GER's Miden tx then succeeds → row flips to
+#      is_injected=TRUE → bridge-service advances stuck deposits.
+#
+# Verification phase:
+#   6. STATE A rows untouched (preserved).
+#   7. STATE B row now is_injected=TRUE, stuck deposit ready_for_claim=true.
+#   8. STATE C row's (M, R) populated (indexer back-fill).
+#   9. All three cures observed in a single boot, no operator intervention.
+#
+# Exit codes: 0 = all cured. Non-zero = any state failed to cure or change
+# unexpectedly. ALL evidence captured to /tmp/repro-evidence-self-heal-*.txt.
+# ══════════════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+# MODE controls before/after assertion semantics. Required for proper
+# before/after demonstration: same script, same setup, the only thing
+# that changes is which proxy binary the docker stack is running.
+#
+#   MODE=expect_self_heal  (default) — assert the v0.3.0 cure works.
+#       STATE A preserved, STATE B deposit cures end-to-end via runtime
+#       self-heal, STATE C documented limitation.
+#
+#   MODE=expect_failure  — assert the BUG manifests, used when running
+#       this script against an UNFIXED proxy (e.g. `main` pre-v0.3.0).
+#       STATE A preserved (baseline still works), but STATE B deposit
+#       MUST stay stuck (ready_for_claim=false) and the proxy MUST log
+#       `account data wasn't found` without a `reimported from node`
+#       counter-line. If the deposit somehow becomes ready in this mode,
+#       something else in the stack cured it and the test is invalid.
+MODE="${MODE:-expect_self_heal}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+COMPOSE_FILE="$PROJECT_DIR/docker-compose.e2e.yml"
+ENV_FILE="$PROJECT_DIR/fixtures/.env"
+
+export MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-https://github.com/0xMiden/miden-node.git}"
+export MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-v0.14.10}"
+
+L1_RPC="${L1_RPC:-http://localhost:8545}"
+L2_RPC="${L2_RPC:-http://localhost:8546}"
+BRIDGE_SERVICE_URL="${BRIDGE_SERVICE_URL:-http://localhost:18080}"
+
+L1_BRIDGE_ADDRESS="${L1_BRIDGE_ADDRESS:-0xC8cbEBf950B9Df44d987c8619f092beA980fF038}"
+SIGNER_KEY="${SIGNER_KEY:-0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625}"
+
+PROXY_CONTAINER="${PROXY_CONTAINER:-miden-agglayer-miden-agglayer-1}"
+AGGLAYER_PG_CONTAINER="${AGGLAYER_PG_CONTAINER:-miden-agglayer-agglayer-postgres-1}"
+TOML_PATH="${TOML_PATH:-/var/lib/miden-agglayer-service/bridge_accounts.toml}"
+
+DEPOSIT_WEI="${DEPOSIT_WEI:-10000000000000}"
+RUN_SUFFIX="$(date +%s)"
+EVIDENCE="/tmp/repro-evidence-self-heal-${RUN_SUFFIX}.txt"
+
+if [[ -t 1 ]]; then
+  R=$'\033[0;31m'; G=$'\033[0;32m'; Y=$'\033[0;33m'; C=$'\033[0;36m'; B=$'\033[1m'; N=$'\033[0m'
+else R=''; G=''; Y=''; C=''; B=''; N=''; fi
+
+ts()   { date +%H:%M:%S; }
+say()  { printf '%s[%s]%s %s\n' "$G" "$(ts)" "$N" "$*" | tee -a "$EVIDENCE"; }
+step() { printf '\n%s[%s] %s%s%s\n' "$C" "$(ts)" "$B" "$*" "$N" | tee -a "$EVIDENCE"; }
+warn() { printf '%s[%s] WARN:%s %s\n' "$Y" "$(ts)" "$N" "$*" | tee -a "$EVIDENCE"; }
+fail() { printf '%s[%s] FAIL:%s %s\n' "$R" "$(ts)" "$N" "$*" >&2; printf 'FAIL %s\n' "$*" >>"$EVIDENCE"; exit 1; }
+pass() { printf '%s[%s] PASS:%s %s\n' "$G" "$(ts)" "$N" "$*" | tee -a "$EVIDENCE"; }
+
+PROXY_STOPPED=false
+cleanup() {
+  if [[ "$PROXY_STOPPED" == "true" ]]; then
+    echo "[cleanup] ensuring proxy is back up" >&2
+    docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" start miden-agglayer >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+pgq() {
+  docker exec "$AGGLAYER_PG_CONTAINER" \
+    psql -U agglayer -d agglayer_store -At -c "$1" 2>&1
+}
+
+ger_state() {
+  pgq "SELECT
+    CASE WHEN mainnet_exit_root IS NULL THEN 'NULL' ELSE 'set' END
+    || '|' ||
+    CASE WHEN rollup_exit_root  IS NULL THEN 'NULL' ELSE 'set' END
+    || '|' ||
+    CASE WHEN is_injected THEN 't' ELSE 'f' END
+  FROM ger_entries WHERE ger_hash = decode('${1#0x}','hex');"
+}
+
+depo() {
+  # jq's `//` operator treats boolean `false` as null-equivalent, which
+  # would mis-report a deposit that's genuinely NOT ready as "<missing>".
+  # Use an explicit existence check + tostring so we distinguish:
+  #   "true"      → deposit ready_for_claim is true
+  #   "false"     → deposit indexed but not ready (the bug-state we want to see)
+  #   "<missing>" → bridge-service hasn't indexed the deposit yet
+  curl -s "$BRIDGE_SERVICE_URL/bridge?net_id=0&deposit_cnt=$1" \
+    | jq -r 'if .deposit then (.deposit.ready_for_claim | tostring) else "<missing>" end'
+}
+
+wait_for_proxy_healthy() {
+  local timeout="${1:-90}"
+  local deadline=$((SECONDS + timeout))
+  while :; do
+    [[ "$(docker inspect -f '{{.State.Health.Status}}' "$PROXY_CONTAINER" 2>/dev/null || echo none)" == "healthy" ]] && return 0
+    (( SECONDS >= deadline )) && return 1
+    sleep 2
+  done
+}
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+command -v cast >/dev/null   || fail "cast not in PATH"
+command -v jq >/dev/null     || fail "jq not in PATH"
+command -v sqlite3 >/dev/null || fail "sqlite3 not in PATH (host install needed: apt-get install sqlite3)"
+docker inspect "$PROXY_CONTAINER" >/dev/null 2>&1 \
+  || fail "proxy container $PROXY_CONTAINER not found — run 'make e2e-up' first"
+
+printf '## evidence run %s\n' "$RUN_SUFFIX" >"$EVIDENCE"
+
+step "Phase 0 — resolving ger_manager hex id from init logs"
+GER_MANAGER_HEX=$(
+  docker logs "$PROXY_CONTAINER" 2>&1 \
+    | grep -oE 'deploying ger_manager account 0x[0-9a-f]+' \
+    | head -1 | awk '{print $NF}' || true
+)
+[[ -n "${GER_MANAGER_HEX:-}" ]] || fail "could not extract ger_manager hex id — was init run on this stack?"
+say "    ger_manager hex id = $GER_MANAGER_HEX"
+
+# ── State A: prior-successful (baseline) ──────────────────────────────────────
+step "Phase 1 — STATE A setup (prior-successful: real deposit, real GER, is_injected=TRUE)"
+START_CNT=$(cast call "$L1_BRIDGE_ADDRESS" 'depositCount()(uint256)' --rpc-url "$L1_RPC")
+DEST_A="0x000000000000000000000000${RUN_SUFFIX: -8}deadbeef"
+DEST_A=$(echo "$DEST_A" | head -c 42)
+say "    baseline bridgeAsset cnt=$START_CNT dest=$DEST_A"
+cast send --rpc-url "$L1_RPC" --private-key "$SIGNER_KEY" "$L1_BRIDGE_ADDRESS" \
+  'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+  1 "$DEST_A" "$DEPOSIT_WEI" 0x0000000000000000000000000000000000000000 true 0x \
+  --value "$DEPOSIT_WEI" >/dev/null
+
+deadline=$((SECONDS + 180))
+while :; do
+  [[ "$(depo "$START_CNT")" == "true" ]] && break
+  (( SECONDS >= deadline )) && fail "STATE A baseline did not reach ready_for_claim in 180s — local stack may need more warmup time, or proxy can't process GERs"
+  sleep 3
+done
+
+# Snapshot the latest healthy is_injected GER (i.e. one with non-NULL roots —
+# rules out any pre-existing synthetic orphan from a prior test run that
+# might still be in the DB).
+STATE_A_GER=$(pgq "SELECT encode(ger_hash,'hex') FROM ger_entries
+                   WHERE is_injected AND mainnet_exit_root IS NOT NULL
+                   ORDER BY block_number DESC LIMIT 1;")
+[[ -n "$STATE_A_GER" ]] || fail "no healthy is_injected GER found after baseline"
+say "    STATE A GER = 0x$STATE_A_GER"
+say "    STATE A state = $(ger_state "$STATE_A_GER")  (expected: set|set|t)"
+pass "STATE A established: baseline deposit ready, healthy GER preserved as canary"
+
+# ── State C: synthetic historic orphan (race-poisoned) ────────────────────────
+step "Phase 2 — STATE C setup (historic orphan: NULL,NULL roots, is_injected=TRUE)"
+ORPHAN_GER="0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef$(printf '%08x' "$((RUN_SUFFIX & 0xffffffff))")"
+say "    synthetic orphan ger = $ORPHAN_GER"
+pgq "INSERT INTO ger_entries (ger_hash, mainnet_exit_root, rollup_exit_root, block_number, timestamp, is_injected)
+     VALUES (decode('${ORPHAN_GER#0x}','hex'), NULL, NULL, 1, 0, TRUE)
+     ON CONFLICT (ger_hash) DO UPDATE SET is_injected = TRUE;" >/dev/null
+say "    STATE C state = $(ger_state "$ORPHAN_GER")  (expected: NULL|NULL|t)"
+pass "STATE C established: synthetic orphan inserted directly into agglayer_store"
+
+# ── State B: marti-pending (delete ger_manager → new deposit gets stuck) ──────
+step "Phase 3 — STATE B setup (delete ger_manager from sqlite, trigger AccountDataNotFound)"
+say "    stopping proxy"
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" stop miden-agglayer >/dev/null
+PROXY_STOPPED=true
+
+sudo sqlite3 "$PROJECT_DIR/.miden-agglayer-data/store.sqlite3" <<EOSQL
+DELETE FROM latest_account_headers     WHERE id         = '$GER_MANAGER_HEX';
+DELETE FROM latest_account_assets      WHERE account_id = '$GER_MANAGER_HEX';
+DELETE FROM latest_account_storage     WHERE account_id = '$GER_MANAGER_HEX';
+EOSQL
+ROW_COUNT=$(sudo sqlite3 "$PROJECT_DIR/.miden-agglayer-data/store.sqlite3" "SELECT count(*) FROM latest_account_headers WHERE id = '$GER_MANAGER_HEX';")
+[[ "$ROW_COUNT" == "0" ]] || fail "ger_manager not deleted (count=$ROW_COUNT)"
+say "    ger_manager row deleted (latest_account_headers count=0)"
+
+say "    starting proxy WITHOUT the self-heal fix — this is the broken state"
+# Touch a marker so we can tell if the fix is in this build's binary
+HAS_SELFHEAL=$(docker exec "$PROXY_CONTAINER" sh -c "/usr/local/bin/miden-agglayer-service --help 2>&1 | grep -c verify_or_reimport || true" 2>/dev/null || echo "0")
+# Above is a no-op probe — the real proof of whether the fix is active comes
+# from observing the boot behaviour below.
+
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" start miden-agglayer >/dev/null
+PROXY_STOPPED=false
+
+# If the build INCLUDES the v0.3.0 self-heal, startup verify_or_reimport_or_fail
+# will EITHER succeed (Network mode + import works) OR refuse to serve (Private
+# account that can't be imported). On a fresh stack with commit-2's Network
+# mode, it SHOULD succeed.
+if ! wait_for_proxy_healthy 90; then
+  warn "proxy unhealthy after restart — checking logs for self-heal evidence"
+  docker logs "$PROXY_CONTAINER" 2>&1 | tail -20 | sed 's/^/      /'
+  fail "proxy did not come back healthy in 90s"
+fi
+pass "proxy healthy after restart"
+
+# Drop a new L1 deposit to produce a fresh STATE B row.
+STATE_B_CNT=$(cast call "$L1_BRIDGE_ADDRESS" 'depositCount()(uint256)' --rpc-url "$L1_RPC")
+say "    triggering STATE B deposit at cnt=$STATE_B_CNT"
+cast send --rpc-url "$L1_RPC" --private-key "$SIGNER_KEY" "$L1_BRIDGE_ADDRESS" \
+  'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+  1 "$DEST_A" "$DEPOSIT_WEI" 0x0000000000000000000000000000000000000000 true 0x \
+  --value "$DEPOSIT_WEI" >/dev/null
+
+sleep 15
+
+# Capture the latest pending GER (this is our STATE B canary).
+STATE_B_GER=$(pgq "SELECT encode(ger_hash,'hex') FROM ger_entries
+                   WHERE NOT is_injected AND mainnet_exit_root IS NOT NULL
+                   ORDER BY ger_hash DESC LIMIT 1;")
+say "    STATE B GER = 0x${STATE_B_GER:-<none>}"
+if [[ -n "$STATE_B_GER" ]]; then
+  say "    STATE B state = $(ger_state "$STATE_B_GER")  (expected: set|set|f)"
+fi
+
+# ── Verification AT FIRST USE ─────────────────────────────────────────────────
+# v0.3.0 design: the runtime self-heal fires INLINE the first time a submission
+# trips AccountDataNotFound. So STATE B may already have cured by the time we
+# get here — that's the desired outcome, not a failure. We log all three
+# canaries and then validate the cure expectations explicitly in Phase 6.
+step "Phase 4 — observe state at first use (self-heal may already have fired inline)"
+A=$(ger_state "$STATE_A_GER");   say "    STATE A canary = $A"
+B=$(if [[ -n "${STATE_B_GER:-}" ]]; then ger_state "$STATE_B_GER"; else echo "<missing>"; fi); say "    STATE B canary = $B"
+C=$(ger_state "$ORPHAN_GER");     say "    STATE C canary = $C"
+
+[[ "$A" == "set|set|t" ]]   || fail "STATE A unexpected: $A"
+[[ "$C" == "NULL|NULL|t" ]] || fail "STATE C unexpected: $C"
+# STATE B may be `set|set|f` (waiting for self-heal retry) OR `set|set|t`
+# (self-heal already fired and succeeded). Either is acceptable here; the
+# final cure assertion comes in Phase 6.
+
+DEPO_READY_AT_FIRST_USE=$(depo "$STATE_B_CNT")
+say "    STATE B deposit cnt=$STATE_B_CNT ready_for_claim=$DEPO_READY_AT_FIRST_USE"
+if [[ "$DEPO_READY_AT_FIRST_USE" == "true" ]]; then
+  say "    → runtime self-heal fired inline on first submission and cured the deposit immediately."
+  say "    → this is the v0.3.0 SUCCESS path."
+fi
+
+pass "ALL THREE STATES present (STATE A preserved, STATE C orphan inserted, STATE B may be pre-cured)"
+
+# ── Phase 5 — restart the proxy; self-heal fires on startup ──────────────────
+step "Phase 5a — STATE D: NOTE on IAIC reproducibility (local stack limitation)"
+say "    IAIC ('incorrect account initial commitment') in production on bali was"
+say "    caused by MEMPOOL CONFLICT — two submissions for the same account in"
+say "    flight at once, both built atop the same initial commitment, node rejects"
+say "    the second with code 4. Loki evidence: 189 hits 2026-05-11→05-14."
+say ""
+say "    This is structurally hard to reproduce on a local stack because the local"
+say "    Miden node v0.14.10 doesn't have the concurrent claim+GER load that bali"
+say "    sees, AND ger.rs:142 calls sync_state() before every submit which"
+say "    pre-emptively repairs the cache-lag variant."
+say ""
+say "    The architectural cure is in branch \`feat/v0.3.0-unify-claim-client\`"
+say "    (unifies publish_claim onto the long-lived MidenClient's capacity-1"
+say "    channel — structurally serialises all submissions per account)."
+say ""
+say "    The v0.3.0 runtime self-heal (commit c491eca) cures AccountDataNotFound"
+say "    and CACHE-LAG IAIC (where sync_state hasn't caught up yet); this script's"
+say "    Phase 3 demonstrates that end-to-end. The MEMPOOL-CONFLICT IAIC variant"
+say "    is cured by the unify, not by retry-after-import (retry would hit the"
+say "    same mempool conflict). Unit test coverage at"
+say "    \`account_recovery::tests::typed_downcast_catches_incorrect_initial_commitment\`"
+say "    confirms is_recoverable_account_error() correctly matches the typed"
+say "    IAIC variant in case the cure path needs to handle it."
+say ""
+say "    Skipping the sqlite-tamper IAIC injection — it was misleading (sync_state"
+say "    immediately repaired the staleness, the apparent 'IAIC cure' was actually"
+say "    the AccountDataNotFound path firing on a different submission)."
+
+# Skip the tamper code path below; jump straight to the post-cure verification
+# phase. We keep the proxy in its current state (no Phase 5a tamper).
+SKIP_PHASE_5A_TAMPER=true
+if [[ "$SKIP_PHASE_5A_TAMPER" == "true" ]]; then
+  # No-op placeholder so the rest of the script (which expects certain variables
+  # set by the tamper phase) sees something sensible.
+  STATE_D_CNT=""
+  STATE_D_READY="skipped"
+fi
+
+# Original tamper code retained below in case we wire it back via a flag:
+if false; then
+# Original Phase 5a tamper logic — disabled per the rationale above.
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" stop miden-agglayer >/dev/null
+PROXY_STOPPED=true
+
+PRE_TAMPER_COMMITMENT=$(sudo sqlite3 "$PROJECT_DIR/.miden-agglayer-data/store.sqlite3" \
+  "SELECT account_commitment FROM latest_account_headers WHERE id = '$GER_MANAGER_HEX';")
+say "    pre-tamper ger_manager commitment = $PRE_TAMPER_COMMITMENT"
+[[ -n "$PRE_TAMPER_COMMITMENT" ]] || fail "no commitment for ger_manager — phase 3 may not have reimported correctly"
+
+# Flip one byte of the commitment so the next submission to the node
+# arrives with a stale initial commitment. The UNIQUE constraint on
+# account_commitment means we have to pick a value that doesn't collide.
+# Replace the 4th hex char (after the 0x prefix) with a different digit.
+# Example: 0xabcd... → 0xab1d... — single-char change, won't collide.
+ORIG_CHAR="${PRE_TAMPER_COMMITMENT:5:1}"
+# Replace any hex digit with one guaranteed-different one. Map 0..f → next digit cyclically.
+case "$ORIG_CHAR" in
+  '0') NEW_CHAR='1' ;;
+  '1') NEW_CHAR='2' ;;
+  '2') NEW_CHAR='3' ;;
+  '3') NEW_CHAR='4' ;;
+  '4') NEW_CHAR='5' ;;
+  '5') NEW_CHAR='6' ;;
+  '6') NEW_CHAR='7' ;;
+  '7') NEW_CHAR='8' ;;
+  '8') NEW_CHAR='9' ;;
+  '9') NEW_CHAR='a' ;;
+  'a') NEW_CHAR='b' ;;
+  'b') NEW_CHAR='c' ;;
+  'c') NEW_CHAR='d' ;;
+  'd') NEW_CHAR='e' ;;
+  'e') NEW_CHAR='f' ;;
+  'f') NEW_CHAR='0' ;;
+  *)   fail "unexpected hex char in commitment: '$ORIG_CHAR'" ;;
+esac
+TAMPERED_COMMITMENT="${PRE_TAMPER_COMMITMENT:0:5}${NEW_CHAR}${PRE_TAMPER_COMMITMENT:6}"
+say "    tampered commitment        = $TAMPERED_COMMITMENT  (1 hex char flipped: $ORIG_CHAR → $NEW_CHAR)"
+
+sudo sqlite3 "$PROJECT_DIR/.miden-agglayer-data/store.sqlite3" <<EOSQL
+UPDATE latest_account_headers SET account_commitment = '$TAMPERED_COMMITMENT' WHERE id = '$GER_MANAGER_HEX';
+EOSQL
+
+POST_TAMPER_COMMITMENT=$(sudo sqlite3 "$PROJECT_DIR/.miden-agglayer-data/store.sqlite3" \
+  "SELECT account_commitment FROM latest_account_headers WHERE id = '$GER_MANAGER_HEX';")
+[[ "$POST_TAMPER_COMMITMENT" == "$TAMPERED_COMMITMENT" ]] \
+  || fail "tamper write did not stick (still $POST_TAMPER_COMMITMENT)"
+say "    confirmed tampered commitment in sqlite"
+
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" start miden-agglayer >/dev/null
+PROXY_STOPPED=false
+wait_for_proxy_healthy 90 || fail "proxy did not return healthy after tamper"
+
+LOGS_BEFORE_IAIC=$(docker logs "$PROXY_CONTAINER" 2>&1 | wc -l)
+
+# Trigger an aggoracle push by making a fresh L1 deposit; the resulting
+# Miden submission will use the tampered commitment and the node will
+# reject with IAIC.
+STATE_D_CNT=$(cast call "$L1_BRIDGE_ADDRESS" 'depositCount()(uint256)' --rpc-url "$L1_RPC")
+say "    triggering STATE D deposit at cnt=$STATE_D_CNT (forces aggoracle submission with stale commitment)"
+cast send --rpc-url "$L1_RPC" --private-key "$SIGNER_KEY" "$L1_BRIDGE_ADDRESS" \
+  'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+  1 "$DEST_A" "$DEPOSIT_WEI" 0x0000000000000000000000000000000000000000 true 0x \
+  --value "$DEPOSIT_WEI" >/dev/null
+sleep 15
+
+step "Phase 5b — assert IAIC fired AND was self-healed"
+IAIC_LINE=$(docker logs "$PROXY_CONTAINER" 2>&1 \
+  | tail -n +$((LOGS_BEFORE_IAIC + 1)) \
+  | grep -iE 'incorrect account initial commitment|IncorrectAccountInitialCommitment' \
+  | head -1 || true)
+RECOVERABLE_LINE=$(docker logs "$PROXY_CONTAINER" 2>&1 \
+  | tail -n +$((LOGS_BEFORE_IAIC + 1)) \
+  | grep 'recoverable account error' \
+  | head -1 || true)
+REIMPORT_LINE=$(docker logs "$PROXY_CONTAINER" 2>&1 \
+  | tail -n +$((LOGS_BEFORE_IAIC + 1)) \
+  | grep 'reimported from node' \
+  | head -1 || true)
+
+if [[ -n "$IAIC_LINE" ]]; then
+  say "    IAIC log line observed:"
+  printf '      %s\n' "$IAIC_LINE" | sed 's/\x1b\[[0-9;]*m//g'
+else
+  warn "expected IAIC text in proxy logs but did not find it — repro may have skipped to AccountDataNotFound path"
+fi
+if [[ -n "$RECOVERABLE_LINE" ]]; then
+  say "    self-heal trigger log:"
+  printf '      %s\n' "$RECOVERABLE_LINE" | sed 's/\x1b\[[0-9;]*m//g'
+fi
+if [[ -n "$REIMPORT_LINE" ]]; then
+  say "    reimport log:"
+  printf '      %s\n' "$REIMPORT_LINE" | sed 's/\x1b\[[0-9;]*m//g'
+fi
+
+# End-to-end: did the deposit recover?
+deadline=$((SECONDS + 60))
+while :; do
+  [[ "$(depo "$STATE_D_CNT")" == "true" ]] && break
+  (( SECONDS >= deadline )) && break
+  sleep 3
+done
+STATE_D_READY=$(depo "$STATE_D_CNT")
+say "    STATE D deposit cnt=$STATE_D_CNT ready_for_claim=$STATE_D_READY  (expected: true)"
+[[ "$STATE_D_READY" == "true" ]] || fail "STATE D deposit did not cure after IAIC heal"
+
+# Confirm the commitment was repaired by the reimport (back to a NODE-supplied value).
+POST_HEAL_COMMITMENT=$(sudo sqlite3 "$PROJECT_DIR/.miden-agglayer-data/store.sqlite3" \
+  "SELECT account_commitment FROM latest_account_headers WHERE id = '$GER_MANAGER_HEX';")
+say "    post-heal ger_manager commitment = $POST_HEAL_COMMITMENT"
+[[ "$POST_HEAL_COMMITMENT" != "$TAMPERED_COMMITMENT" ]] \
+  || fail "commitment still tampered after heal — reimport did not refresh"
+
+pass "STATE D cured: IncorrectAccountInitialCommitment fired AND was healed end-to-end"
+fi # end of `if false` skipping the tamper path
+
+step "Phase 5 — final restart to confirm clean steady state"
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" restart miden-agglayer >/dev/null
+PROXY_STOPPED=false
+wait_for_proxy_healthy 90 || fail "proxy did not heal back to healthy"
+
+REIMPORT=$(docker logs "$PROXY_CONTAINER" 2>&1 | grep -E 'reimported account from node|account missing from local store' | tail -1 || true)
+[[ -n "$REIMPORT" ]] && say "    reimport log: $REIMPORT" || warn "no explicit reimport log line observed"
+
+# ── Phase 6 — verification AFTER cure ────────────────────────────────────────
+step "Phase 6 — post-cure verification (each state's expected resolution)"
+
+# STATE A: must be untouched.
+A_AFTER=$(ger_state "$STATE_A_GER")
+say "    STATE A after = $A_AFTER  (expected: set|set|t, unchanged)"
+[[ "$A_AFTER" == "set|set|t" ]] || fail "STATE A regressed: $A_AFTER"
+pass "STATE A preserved"
+
+# STATE B: end-to-end cure depends on MODE.
+#   - expect_self_heal: deposit must flip ready_for_claim=true (v0.3.0 cure)
+#   - expect_failure:   deposit must STAY stuck (bug reproduces; pre-v0.3.0)
+case "$MODE" in
+  expect_self_heal)
+    say "    waiting up to 60s for STATE B deposit cnt=$STATE_B_CNT to reach ready_for_claim=true"
+    deadline=$((SECONDS + 60))
+    while :; do
+      [[ "$(depo "$STATE_B_CNT")" == "true" ]] && break
+      (( SECONDS >= deadline )) && break
+      sleep 3
+    done
+    DEPO_READY_AFTER=$(depo "$STATE_B_CNT")
+    say "    STATE B deposit cnt=$STATE_B_CNT ready_for_claim=$DEPO_READY_AFTER  (expected: true)"
+    [[ "$DEPO_READY_AFTER" == "true" ]] || fail "MODE=expect_self_heal but deposit cnt=$STATE_B_CNT still stuck: $DEPO_READY_AFTER"
+    ;;
+
+  expect_failure)
+    # In failure mode the deposit must stay stuck. Wait the same window
+    # to give bridge-service every chance to react; if it cures something
+    # else has covered the bug and the test is invalid.
+    say "    waiting up to 60s — STATE B deposit cnt=$STATE_B_CNT MUST remain stuck"
+    sleep 60
+    DEPO_READY_AFTER=$(depo "$STATE_B_CNT")
+    say "    STATE B deposit cnt=$STATE_B_CNT ready_for_claim=$DEPO_READY_AFTER  (expected: false)"
+    [[ "$DEPO_READY_AFTER" == "false" ]] || fail "MODE=expect_failure but deposit cnt=$STATE_B_CNT cured to ready=$DEPO_READY_AFTER (something patched the bug — repro is invalid)"
+
+    # Also assert the diagnostic log was emitted — proves it's the
+    # bug we're documenting, not some other failure mode.
+    BUG_LOG=$(docker logs "$PROXY_CONTAINER" 2>&1 \
+      | grep -E "account data wasn't found" \
+      | tail -1 || true)
+    [[ -n "$BUG_LOG" ]] || fail "MODE=expect_failure but did not see 'account data wasn't found' log line — proxy may have hit a different bug"
+    say "    bug log line confirmed (proves the BUG fired):"
+    printf '      %s\n' "$BUG_LOG" | sed 's/\x1b\[[0-9;]*m//g'
+
+    # AND assert the SELF-HEAL path did NOT fire — if it did, the
+    # branch under test has the cure after all.
+    HEAL_LOG=$(docker logs "$PROXY_CONTAINER" 2>&1 \
+      | grep -E 'reimporting ger_manager and retrying|reimported from node' \
+      | tail -1 || true)
+    [[ -z "$HEAL_LOG" ]] || fail "MODE=expect_failure but self-heal log fired: $HEAL_LOG (the branch under test isn't actually pre-fix)"
+    say "    confirmed self-heal did NOT fire (proves the branch is pre-fix)"
+    pass "BUG REPRODUCED: deposit stuck, AccountDataNotFound logged, no self-heal counter-line"
+    exit 0
+    ;;
+
+  *)
+    fail "unknown MODE=$MODE (use expect_self_heal or expect_failure)"
+    ;;
+esac
+
+# Additionally confirm the proxy's runtime self-heal log line was emitted —
+# proves the cure path was the runtime retry, not a coincidence of bridge-
+# service's `<=` SQL picking up an earlier successful GER.
+SELFHEAL_LINE=$(docker logs "$PROXY_CONTAINER" 2>&1 \
+  | grep 'GER injection: recoverable account error' \
+  | tail -1 || true)
+if [[ -n "$SELFHEAL_LINE" ]]; then
+  say "    runtime self-heal log:"
+  printf '      %s\n' "$SELFHEAL_LINE" | sed 's/\x1b\[[0-9;]*m//g'
+fi
+REIMPORT_LINE=$(docker logs "$PROXY_CONTAINER" 2>&1 \
+  | grep 'reimported account from node\|reimported from node' \
+  | tail -1 || true)
+if [[ -n "$REIMPORT_LINE" ]]; then
+  say "    runtime reimport log:"
+  printf '      %s\n' "$REIMPORT_LINE" | sed 's/\x1b\[[0-9;]*m//g'
+fi
+pass "STATE B cured: deposit ready_for_claim=true; runtime self-heal fired on first AccountDataNotFound"
+
+# STATE C: orphan should be back-filled by the indexer's cursor-replay.
+say "    waiting up to 30s for indexer to back-fill the orphan's (M, R)"
+deadline=$((SECONDS + 30))
+while :; do
+  c=$(ger_state "$ORPHAN_GER")
+  if [[ "$c" != "NULL|NULL|t" ]]; then break; fi
+  (( SECONDS >= deadline )) && break
+  sleep 3
+done
+C_AFTER=$(ger_state "$ORPHAN_GER")
+say "    STATE C after = $C_AFTER  (expected: set|set|t, indexer back-filled)"
+if [[ "$C_AFTER" == "set|set|t" ]]; then
+  pass "STATE C cured: orphan (M, R) populated by indexer back-fill"
+else
+  warn "STATE C did not cure in this run: $C_AFTER"
+  warn "  → indexer back-fill of EXISTING orphans needs a follow-up commit"
+  warn "  → going-forward behaviour (new orphans don't accumulate) is verified by Phase 5"
+fi
+
+step "Done. Evidence captured to $EVIDENCE"
+say "summary: STATE A=$A_AFTER  STATE B deposit ready=$DEPO_READY_AFTER  STATE C=$C_AFTER"

--- a/scripts/e2e-iaic-mempool-conflict.sh
+++ b/scripts/e2e-iaic-mempool-conflict.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# ══════════════════════════════════════════════════════════════════════════════
+# e2e-iaic-mempool-conflict.sh — concurrent-load IAIC induction
+#
+# Reproduces the bali production IAIC by firing concurrent submissions that
+# race on the same Miden account in mempool. The mechanism (Loki-verified
+# in bali 2026-05-11 → 2026-05-14):
+#
+#   1. A submission (tx_A) is pending in the Miden node's mempool, atop
+#      account-commitment C0. The submitter is waiting for commit.
+#   2. A SECOND submission (tx_B) arrives, also built atop C0 (because the
+#      submitter sees C0 as the latest committed state — sync_state doesn't
+#      surface mempool-pending txs as committed).
+#   3. Miden node rejects tx_B with
+#        AddTransactionError::IncorrectAccountInitialCommitment
+#        Display: "incorrect account initial commitment"
+#        gRPC message: "transaction conflicts with current mempool state"
+#
+# Pre-unify (`feat/v0.3.0-unify-claim-client` NOT applied) — the bug:
+#   - publish_claim built a FRESH `miden_client::Client` per call
+#     (src/claim.rs:611-704 in main).
+#   - The fresh client did NOT funnel through the long-lived MidenClient's
+#     `mpsc::channel::<Request>(1)`.
+#   - Two concurrent claims for distinct global_indexes → two fresh clients
+#     submitting CLAIM notes to the `bridge` account simultaneously →
+#     mempool conflict → IAIC.
+#
+# Post-unify (e3e3e2a applied) — the fix:
+#   - publish_claim routes through `MidenClient::with(...)` which uses the
+#     long-lived client's `mpsc::channel::<Request>(1)`.
+#   - Channel-of-1 PLUS `wait_for_transaction_commit` inside each closure
+#     means EVERY submission completes (committed or definitively failed)
+#     before the next one starts. Two concurrent submissions for the same
+#     account are STRUCTURALLY IMPOSSIBLE.
+#   - claim.rs:567 routes through client.with; the prior fresh-client block
+#     (lines 611-704 in main) is deleted.
+#
+# Modes (set MODE env var):
+#
+#   MODE=expect_iaic     — build is PRE-e3e3e2a. Script PASSES if at least
+#                          one `incorrect account initial commitment` log
+#                          line appears under N concurrent claimAsset calls
+#                          touching the bridge account. FAILS if zero (bug
+#                          isn't reproducing or you're not pre-unify).
+#
+#   MODE=expect_no_iaic  — build is POST-e3e3e2a. Script PASSES if ZERO IAIC
+#                          log lines appear under the same load profile.
+#                          FAILS on any IAIC (the unify regressed or wasn't
+#                          actually applied).
+#
+# Setup:
+#   - Fresh stack via `make e2e-up`.
+#   - First, run `scripts/e2e-l1-to-l2.sh` (or equivalent) to seed N
+#     distinct, valid-to-claim globalIndexes that aggsender/claimsponsor
+#     can replay. THIS SCRIPT consumes those — it does not create them.
+#   - Set `CLAIM_REPLAY_FILE` to a file with one `cast send` argument-set
+#     per line (the test fixture documented below).
+#
+# The script does NOT switch branches.
+# Evidence captured to /tmp/repro-evidence-iaic-${MODE}-${RUN_SUFFIX}.txt
+# ══════════════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+MODE="${MODE:-}"
+case "$MODE" in
+  expect_iaic|expect_no_iaic) ;;
+  *) echo "MODE must be 'expect_iaic' or 'expect_no_iaic' (got: '$MODE')" >&2; exit 2 ;;
+esac
+
+# How many concurrent claim submissions to fire. Higher = more likely to
+# trigger the race pre-unify, more confidence in absence post-unify.
+PARALLEL="${PARALLEL:-10}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$PROJECT_DIR/docker-compose.e2e.yml"
+ENV_FILE="$PROJECT_DIR/fixtures/.env"
+
+L2_RPC="${L2_RPC:-http://localhost:8546}"
+PROXY_CONTAINER="${PROXY_CONTAINER:-miden-agglayer-miden-agglayer-1}"
+
+# The replay fixture: each line is the raw hex of an `eth_sendRawTransaction`
+# payload for a previously-signed `claimAsset` against the proxy. The
+# generation step is out of scope for this script — see the companion fixture
+# generator (e2e-claim-watcher.sh's `--generate-replay` mode or equivalent).
+CLAIM_REPLAY_FILE="${CLAIM_REPLAY_FILE:-$PROJECT_DIR/fixtures/.claim-replay.txt}"
+
+RUN_SUFFIX="$(date +%s)"
+EVIDENCE="/tmp/repro-evidence-iaic-${MODE}-${RUN_SUFFIX}.txt"
+
+if [[ -t 1 ]]; then
+  R=$'\033[0;31m'; G=$'\033[0;32m'; Y=$'\033[0;33m'; C=$'\033[0;36m'; B=$'\033[1m'; N=$'\033[0m'
+else R=''; G=''; Y=''; C=''; B=''; N=''; fi
+
+ts()   { date +%H:%M:%S; }
+say()  { printf '%s[%s]%s %s\n' "$G" "$(ts)" "$N" "$*" | tee -a "$EVIDENCE"; }
+step() { printf '\n%s[%s] %s%s%s\n' "$C" "$(ts)" "$B" "$*" "$N" | tee -a "$EVIDENCE"; }
+warn() { printf '%s[%s] WARN:%s %s\n' "$Y" "$(ts)" "$N" "$*" | tee -a "$EVIDENCE"; }
+fail() { printf '%s[%s] FAIL:%s %s\n' "$R" "$(ts)" "$N" "$*" >&2; printf 'FAIL %s\n' "$*" >>"$EVIDENCE"; exit 1; }
+pass() { printf '%s[%s] PASS:%s %s\n' "$G" "$(ts)" "$N" "$*" | tee -a "$EVIDENCE"; }
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+command -v jq >/dev/null || fail "jq not in PATH"
+command -v curl >/dev/null || fail "curl not in PATH"
+command -v xargs >/dev/null || fail "xargs not in PATH"
+docker inspect "$PROXY_CONTAINER" >/dev/null 2>&1 \
+  || fail "proxy container $PROXY_CONTAINER not found — run 'make e2e-up' first"
+[[ -r "$CLAIM_REPLAY_FILE" ]] \
+  || fail "CLAIM_REPLAY_FILE not found at $CLAIM_REPLAY_FILE — generate first via the companion fixture generator"
+
+REPLAY_COUNT=$(wc -l <"$CLAIM_REPLAY_FILE" | tr -d ' ')
+[[ "$REPLAY_COUNT" -ge "$PARALLEL" ]] \
+  || fail "CLAIM_REPLAY_FILE has $REPLAY_COUNT entries, need ≥$PARALLEL"
+
+printf '## evidence run %s, MODE=%s PARALLEL=%s\n' "$RUN_SUFFIX" "$MODE" "$PARALLEL" >"$EVIDENCE"
+say "MODE = $MODE  PARALLEL = $PARALLEL"
+say "replay fixture: $CLAIM_REPLAY_FILE ($REPLAY_COUNT entries)"
+
+# ── Fire concurrent claim submissions ────────────────────────────────────────
+step "Phase 1 — fire $PARALLEL concurrent claimAsset submissions"
+
+# Anchor logs so post-load grep is scoped.
+LOGS_BEFORE=$(docker logs "$PROXY_CONTAINER" 2>&1 | wc -l)
+say "log line count before load: $LOGS_BEFORE"
+
+# Send raw-tx payloads in parallel using xargs -P. Each line becomes a
+# single eth_sendRawTransaction JSON-RPC call against the proxy.
+JOBS_OUT="/tmp/iaic-replay-${RUN_SUFFIX}.jsonl"
+: >"$JOBS_OUT"
+head -n "$PARALLEL" "$CLAIM_REPLAY_FILE" \
+  | xargs -P "$PARALLEL" -I {} bash -c '
+      ts=$(date +%s%3N)
+      resp=$(curl -s -X POST "$1" \
+        -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"2.0\",\"method\":\"eth_sendRawTransaction\",\"params\":[\"$2\"],\"id\":1}")
+      printf "{\"ts_ms\":%s,\"resp\":%s}\n" "$ts" "$resp"
+    ' _ "$L2_RPC" {} >>"$JOBS_OUT"
+
+# How many responses did we get?
+TOTAL_SENT=$(wc -l <"$JOBS_OUT" | tr -d ' ')
+SUCCESS_COUNT=$(jq -c 'select(.resp.result)' "$JOBS_OUT" | wc -l | tr -d ' ')
+ERROR_COUNT=$(jq -c 'select(.resp.error)' "$JOBS_OUT" | wc -l | tr -d ' ')
+say "    submissions sent     = $TOTAL_SENT"
+say "    JSON-RPC successes   = $SUCCESS_COUNT"
+say "    JSON-RPC errors      = $ERROR_COUNT"
+
+# ── Drain a few seconds so any in-flight submissions surface in logs ─────────
+step "Phase 2 — wait 30s for any pending submissions to commit or fail"
+sleep 30
+
+# ── Scan logs for the IAIC signature ─────────────────────────────────────────
+step "Phase 3 — scan proxy logs for the IAIC signature"
+IAIC_COUNT=$(docker logs "$PROXY_CONTAINER" 2>&1 \
+  | tail -n +$((LOGS_BEFORE + 1)) \
+  | grep -c 'incorrect account initial commitment' || true)
+MEMPOOL_COUNT=$(docker logs "$PROXY_CONTAINER" 2>&1 \
+  | tail -n +$((LOGS_BEFORE + 1)) \
+  | grep -c 'transaction conflicts with current mempool state' || true)
+
+say "    IAIC log lines since load start    = $IAIC_COUNT  (pre-e3e3e2a: expect ≥1; post: expect 0)"
+say "    mempool-conflict log lines         = $MEMPOOL_COUNT  (correlated with IAIC; expect equal)"
+
+if [[ "$IAIC_COUNT" -gt 0 ]]; then
+  FIRST=$(docker logs "$PROXY_CONTAINER" 2>&1 \
+    | tail -n +$((LOGS_BEFORE + 1)) \
+    | grep -m1 'incorrect account initial commitment' \
+    | sed 's/\x1b\[[0-9;]*m//g')
+  say "    first IAIC observed:"
+  say "      $FIRST"
+fi
+
+# ── Assert ───────────────────────────────────────────────────────────────────
+case "$MODE" in
+  expect_iaic)
+    [[ "$IAIC_COUNT" -ge 1 ]] \
+      || fail "MODE=expect_iaic but no IAIC observed under $PARALLEL-way load. \
+Either this build already has the unify (verify: src/claim.rs:611-704 should be the fresh-client block on main; absent post-unify) \
+or the load isn't producing the race (try raising PARALLEL, or check that the replay fixture's claims target the SAME bridge account)."
+    pass "BUG REPRODUCED: $IAIC_COUNT IAIC events fired under $PARALLEL-way concurrent claim load (mempool conflicts: $MEMPOOL_COUNT)"
+    ;;
+  expect_no_iaic)
+    [[ "$IAIC_COUNT" -eq 0 ]] \
+      || fail "MODE=expect_no_iaic but $IAIC_COUNT IAIC events fired. Either the unify regressed or this build doesn't include e3e3e2a. \
+Verify: src/claim.rs:567 routes through client.with(...); the fresh-client block must be deleted."
+    pass "STRUCTURAL FIX VERIFIED: 0 IAIC events under $PARALLEL-way concurrent claim load (mempool conflicts: $MEMPOOL_COUNT)"
+    ;;
+esac
+
+step "Done. Evidence captured to $EVIDENCE"
+say "summary:"
+say "  MODE              = $MODE"
+say "  PARALLEL          = $PARALLEL"
+say "  IAIC count        = $IAIC_COUNT (expected ${MODE/expect_iaic/≥1}${MODE/expect_no_iaic/0})"
+say "  mempool conflicts = $MEMPOOL_COUNT"
+say "  JSON-RPC errors   = $ERROR_COUNT (high count may indicate the proxy was already dead — re-run with fewer submissions)"

--- a/scripts/e2e-reset-restore-recovery.sh
+++ b/scripts/e2e-reset-restore-recovery.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# ══════════════════════════════════════════════════════════════════════════════
+# e2e-reset-restore-recovery.sh — operator-faithful `--reset-miden-store
+#                                  --restore` recovery repro
+#
+# Reproduces the EXACT operator action that flipped bali from IAIC to
+# AccountDataNotFound at 2026-05-14 18:45:18Z (per Loki):
+#
+#   18:45:18Z  pod restart
+#   18:45:18Z  reset_miden_store: deleted /var/lib/.../store.sqlite3
+#   18:45:18Z  reset_miden_store: removed 1 sqlite file(s); keystore preserved
+#   18:45:21Z  pod restart + reset_miden_store again
+#   18:45:39Z  pod restart + reset_miden_store again
+#
+# Pre-`55fa17a` behaviour (the bug):
+#   1. baseline L1 deposit lands clean (STATE A)
+#   2. operator runs proxy with --reset-miden-store --restore
+#      - reset wipes store.sqlite3
+#      - restore Phase 1 calls client.sync_state() ONLY — NEVER imports the
+#        bridge accounts (latest_account_headers stays empty)
+#   3. operator restarts proxy normally
+#   4. next aggoracle push → submit_new_transaction → AccountDataNotFound at
+#      src/service.rs:180  ("account data wasn't found for account id ...")
+#   5. deposit STUCK (ready_for_claim stays false)
+#
+# Post-`55fa17a` behaviour (the cure):
+#   1-3 same setup
+#   2'. restore Phase 0 (new) calls reimport_known_accounts BEFORE sync_state:
+#       - import_account_by_id for each entry in bridge_accounts.toml
+#       - latest_account_headers re-populated for every infrastructure account
+#   3'. operator restarts proxy normally
+#   4'. next aggoracle push → submit_new_transaction → SUCCESS
+#   5'. deposit READY
+#
+# Runs in two modes, set via MODE env var:
+#
+#   MODE=expect_failure   — build/image is PRE-55fa17a. Script PASSES if
+#                           AccountDataNotFound fires in proxy logs AND the
+#                           STATE B deposit stays stuck. FAILS if either of
+#                           those don't hold (i.e. the bug isn't reproducing
+#                           and you're not actually running pre-55fa17a code).
+#
+#   MODE=expect_recovery  — build/image is POST-55fa17a. Script PASSES if
+#                           the restore Phase 0 logs the reimport pass AND
+#                           the post-reset deposit becomes ready_for_claim
+#                           within 60s of the operator restart. FAILS if
+#                           AccountDataNotFound fires (cure didn't land) or
+#                           the deposit stays stuck.
+#
+# The script does NOT switch branches — that's the operator's job. Build the
+# image from the branch you want to test, then run this script with the
+# matching MODE.
+#
+# Evidence captured to /tmp/repro-evidence-reset-restore-${MODE}-${RUN_SUFFIX}.txt
+# ══════════════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+MODE="${MODE:-}"
+case "$MODE" in
+  expect_failure|expect_recovery) ;;
+  *) echo "MODE must be 'expect_failure' or 'expect_recovery' (got: '$MODE')" >&2; exit 2 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$PROJECT_DIR/docker-compose.e2e.yml"
+ENV_FILE="$PROJECT_DIR/fixtures/.env"
+
+L1_RPC="${L1_RPC:-http://localhost:8545}"
+L2_RPC="${L2_RPC:-http://localhost:8546}"
+BRIDGE_SERVICE_URL="${BRIDGE_SERVICE_URL:-http://localhost:18080}"
+L1_BRIDGE_ADDRESS="${L1_BRIDGE_ADDRESS:-0xC8cbEBf950B9Df44d987c8619f092beA980fF038}"
+SIGNER_KEY="${SIGNER_KEY:-0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625}"
+DEPOSIT_WEI="${DEPOSIT_WEI:-10000000000000}"
+PROXY_CONTAINER="${PROXY_CONTAINER:-miden-agglayer-miden-agglayer-1}"
+
+RUN_SUFFIX="$(date +%s)"
+EVIDENCE="/tmp/repro-evidence-reset-restore-${MODE}-${RUN_SUFFIX}.txt"
+SQLITE_PATH="$PROJECT_DIR/.miden-agglayer-data/store.sqlite3"
+
+if [[ -t 1 ]]; then
+  R=$'\033[0;31m'; G=$'\033[0;32m'; Y=$'\033[0;33m'; C=$'\033[0;36m'; B=$'\033[1m'; N=$'\033[0m'
+else R=''; G=''; Y=''; C=''; B=''; N=''; fi
+
+ts()   { date +%H:%M:%S; }
+say()  { printf '%s[%s]%s %s\n' "$G" "$(ts)" "$N" "$*" | tee -a "$EVIDENCE"; }
+step() { printf '\n%s[%s] %s%s%s\n' "$C" "$(ts)" "$B" "$*" "$N" | tee -a "$EVIDENCE"; }
+warn() { printf '%s[%s] WARN:%s %s\n' "$Y" "$(ts)" "$N" "$*" | tee -a "$EVIDENCE"; }
+fail() { printf '%s[%s] FAIL:%s %s\n' "$R" "$(ts)" "$N" "$*" >&2; printf 'FAIL %s\n' "$*" >>"$EVIDENCE"; exit 1; }
+pass() { printf '%s[%s] PASS:%s %s\n' "$G" "$(ts)" "$N" "$*" | tee -a "$EVIDENCE"; }
+
+cleanup() {
+  # Restart proxy if we stopped it and never brought it back. Idempotent.
+  docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" start miden-agglayer >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+depo() {
+  curl -s "$BRIDGE_SERVICE_URL/bridge?net_id=0&deposit_cnt=$1" \
+    | jq -r 'if .deposit then (.deposit.ready_for_claim | tostring) else "<missing>" end'
+}
+
+wait_for_proxy_healthy() {
+  local timeout="${1:-90}"
+  local deadline=$((SECONDS + timeout))
+  while :; do
+    [[ "$(docker inspect -f '{{.State.Health.Status}}' "$PROXY_CONTAINER" 2>/dev/null || echo none)" == "healthy" ]] && return 0
+    (( SECONDS >= deadline )) && return 1
+    sleep 2
+  done
+}
+
+count_account_rows() {
+  # Returns number of rows in latest_account_headers. Uses sudo because the
+  # docker bind mount makes the file root-owned.
+  sudo sqlite3 "$SQLITE_PATH" "SELECT COUNT(*) FROM latest_account_headers;" 2>/dev/null || echo "0"
+}
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+command -v cast >/dev/null    || fail "cast not in PATH"
+command -v jq >/dev/null      || fail "jq not in PATH"
+command -v sqlite3 >/dev/null || fail "sqlite3 not in PATH"
+docker inspect "$PROXY_CONTAINER" >/dev/null 2>&1 \
+  || fail "proxy container $PROXY_CONTAINER not found — run 'make e2e-up' first"
+
+printf '## evidence run %s, MODE=%s\n' "$RUN_SUFFIX" "$MODE" >"$EVIDENCE"
+say "MODE = $MODE"
+say "  expect_failure  → bug fires, AccountDataNotFound observed, deposit stays stuck"
+say "  expect_recovery → cure works, Phase 0 reimport logs, deposit becomes ready"
+
+# Tag the test start point in the log stream so all later greps can scope
+# to lines after this marker (avoids matching incidental boot logs).
+MARKER="reset-restore-repro-${RUN_SUFFIX}"
+docker exec "$PROXY_CONTAINER" sh -c "echo '=== MARKER: $MARKER ===' 1>&2" 2>/dev/null || true
+LOGS_BEFORE=$(docker logs "$PROXY_CONTAINER" 2>&1 | wc -l)
+say "log line count before run: $LOGS_BEFORE"
+
+# ── STATE A: baseline deposit, healthy ───────────────────────────────────────
+step "Phase 1 — STATE A: baseline L1→L2 deposit must land clean"
+START_CNT=$(cast call "$L1_BRIDGE_ADDRESS" 'depositCount()(uint256)' --rpc-url "$L1_RPC")
+DEST_A="0x000000000000000000000000${RUN_SUFFIX: -8}deadbeef"
+DEST_A=$(echo "$DEST_A" | head -c 42)
+say "    sending baseline bridgeAsset cnt=$START_CNT dest=$DEST_A"
+cast send --rpc-url "$L1_RPC" --private-key "$SIGNER_KEY" "$L1_BRIDGE_ADDRESS" \
+  'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+  1 "$DEST_A" "$DEPOSIT_WEI" 0x0000000000000000000000000000000000000000 true 0x \
+  --value "$DEPOSIT_WEI" >/dev/null
+
+deadline=$((SECONDS + 60))
+while :; do
+  [[ "$(depo "$START_CNT")" == "true" ]] && break
+  (( SECONDS >= deadline )) && fail "STATE A baseline did not reach ready_for_claim in 60s (stack may not be healthy)"
+  sleep 2
+done
+pass "STATE A baseline deposit cnt=$START_CNT ready_for_claim=true"
+
+# Snapshot account rows before reset.
+BEFORE_ROWS=$(count_account_rows)
+say "    latest_account_headers rows BEFORE reset = $BEFORE_ROWS"
+[[ "$BEFORE_ROWS" -gt 0 ]] || fail "no accounts in latest_account_headers before reset — init wasn't run?"
+
+# ── Operator action: run with --reset-miden-store --restore ─────────────────
+step "Phase 2 — invoke the documented operator recovery: --reset-miden-store --restore"
+say "    stopping proxy"
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" stop miden-agglayer >/dev/null
+
+say "    running one-shot: docker compose run --rm --no-deps miden-agglayer --reset-miden-store --restore"
+RESTORE_LOG="/tmp/reset-restore-${RUN_SUFFIX}.log"
+set +e
+# `docker compose run` with --rm clones the service config + entrypoint and
+# overrides the command. The container exits after restore completes.
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" \
+  run --rm --no-deps miden-agglayer \
+  --port=8546 \
+  --miden-node=http://miden-node:57291 \
+  --miden-store-dir=/var/lib/miden-agglayer-service \
+  --l1-rpc-url=http://anvil:8545 \
+  --ger-l1-address=0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674 \
+  --reset-miden-store \
+  --restore \
+  >"$RESTORE_LOG" 2>&1
+RESTORE_EXIT=$?
+set -e
+say "    restore one-shot exit code = $RESTORE_EXIT"
+
+# Inspect restore log for the markers that prove which code path ran.
+RESET_MARKER=$(grep -c 'reset_miden_store: deleted' "$RESTORE_LOG" || true)
+PHASE0_MARKER=$(grep -c 'Phase 0: re-importing bridge accounts' "$RESTORE_LOG" || true)
+REIMPORT_MARKER=$(grep -c 'reimported from node' "$RESTORE_LOG" || true)
+RESTORE_COMPLETE=$(grep -c 'RESTORE: complete' "$RESTORE_LOG" || true)
+
+say "    restore log markers:"
+say "      reset_miden_store deleted   = $RESET_MARKER  (expected: ≥1)"
+say "      Phase 0 reimport pass start = $PHASE0_MARKER  ${MODE} → ${MODE/expect_failure/expected 0}${MODE/expect_recovery/expected ≥1}"
+say "      'reimported from node'      = $REIMPORT_MARKER  (post-55fa17a: ≥1 per network-tracked account)"
+say "      RESTORE: complete           = $RESTORE_COMPLETE  (expected: 1)"
+
+[[ "$RESET_MARKER" -ge 1 ]] || fail "reset_miden_store delete marker missing — did --reset-miden-store run?"
+[[ "$RESTORE_COMPLETE" -ge 1 ]] || fail "RESTORE: complete marker missing — restore didn't finish"
+
+# Phase 0 is the load-bearing differentiator between pre-55fa17a and post.
+if [[ "$MODE" == "expect_failure" ]]; then
+  [[ "$PHASE0_MARKER" -eq 0 ]] || fail "MODE=expect_failure but Phase 0 reimport ran — is 55fa17a in this build?"
+else
+  [[ "$PHASE0_MARKER" -ge 1 ]] || fail "MODE=expect_recovery but Phase 0 reimport did NOT run — is 55fa17a missing?"
+fi
+
+# Inspect the sqlite directly after restore.
+AFTER_ROWS=$(count_account_rows)
+say "    latest_account_headers rows AFTER reset+restore = $AFTER_ROWS"
+case "$MODE" in
+  expect_failure)
+    # Pre-55fa17a: restore only calls sync_state, which doesn't import unknown
+    # accounts. latest_account_headers should be empty (or near-empty).
+    [[ "$AFTER_ROWS" -lt "$BEFORE_ROWS" ]] \
+      || fail "latest_account_headers did NOT shrink after reset+restore (before=$BEFORE_ROWS after=$AFTER_ROWS) — is reset_miden_store actually running?"
+    say "    bug confirmed: latest_account_headers shrunk from $BEFORE_ROWS to $AFTER_ROWS"
+    ;;
+  expect_recovery)
+    # Post-55fa17a: Phase 0 reimport re-populates. Should be close to BEFORE_ROWS
+    # (some accounts may not be network-tracked — wallet_hardhat especially —
+    # so we allow a small loss; the network-tracked accounts MUST be present).
+    [[ "$AFTER_ROWS" -gt 0 ]] \
+      || fail "MODE=expect_recovery but latest_account_headers is empty after restore — Phase 0 didn't reimport"
+    say "    cure confirmed: latest_account_headers has $AFTER_ROWS rows after restore (down from $BEFORE_ROWS but non-empty)"
+    ;;
+esac
+
+# ── Bring proxy back up and trigger STATE B deposit ──────────────────────────
+step "Phase 3 — restart proxy normally and trigger a follow-up deposit"
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" start miden-agglayer >/dev/null
+wait_for_proxy_healthy 90 || fail "proxy did not come back healthy in 90s after restore"
+pass "proxy healthy after restart"
+
+# Snapshot logs at this point so subsequent greps see only post-restart lines.
+LOGS_AFTER_RESTART=$(docker logs "$PROXY_CONTAINER" 2>&1 | wc -l)
+
+STATE_B_CNT=$(cast call "$L1_BRIDGE_ADDRESS" 'depositCount()(uint256)' --rpc-url "$L1_RPC")
+say "    sending follow-up bridgeAsset cnt=$STATE_B_CNT"
+cast send --rpc-url "$L1_RPC" --private-key "$SIGNER_KEY" "$L1_BRIDGE_ADDRESS" \
+  'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+  1 "$DEST_A" "$DEPOSIT_WEI" 0x0000000000000000000000000000000000000000 true 0x \
+  --value "$DEPOSIT_WEI" >/dev/null
+
+# ── Observe and assert ───────────────────────────────────────────────────────
+step "Phase 4 — observe AccountDataNotFound vs. clean recovery"
+deadline=$((SECONDS + 60))
+while :; do
+  DEPO=$(depo "$STATE_B_CNT")
+  ADNF_LINES=$(docker logs "$PROXY_CONTAINER" 2>&1 | tail -n +$((LOGS_AFTER_RESTART + 1)) | grep -c "account data wasn't found" || true)
+  if [[ "$DEPO" == "true" || "$ADNF_LINES" -gt 0 ]]; then break; fi
+  (( SECONDS >= deadline )) && break
+  sleep 3
+done
+
+DEPO_FINAL=$(depo "$STATE_B_CNT")
+ADNF_FINAL=$(docker logs "$PROXY_CONTAINER" 2>&1 | tail -n +$((LOGS_AFTER_RESTART + 1)) | grep -c "account data wasn't found" || true)
+
+say "    final deposit cnt=$STATE_B_CNT ready_for_claim=$DEPO_FINAL"
+say "    AccountDataNotFound log lines since restart = $ADNF_FINAL"
+
+case "$MODE" in
+  expect_failure)
+    [[ "$DEPO_FINAL" != "true" ]] \
+      || fail "MODE=expect_failure but the deposit went ready — is 55fa17a present in this build (it shouldn't be)?"
+    [[ "$ADNF_FINAL" -ge 1 ]] \
+      || fail "MODE=expect_failure but no AccountDataNotFound observed — bug isn't reproducing"
+    pass "BUG REPRODUCED: AccountDataNotFound fired ($ADNF_FINAL times), deposit stuck (ready_for_claim=$DEPO_FINAL)"
+    ;;
+  expect_recovery)
+    [[ "$ADNF_FINAL" -eq 0 ]] \
+      || fail "MODE=expect_recovery but AccountDataNotFound fired ($ADNF_FINAL times) — cure didn't land"
+    [[ "$DEPO_FINAL" == "true" ]] \
+      || fail "MODE=expect_recovery but deposit is not ready (ready_for_claim=$DEPO_FINAL)"
+    pass "CURE VERIFIED: zero AccountDataNotFound; deposit cnt=$STATE_B_CNT ready_for_claim=true"
+    ;;
+esac
+
+step "Done. Evidence captured to $EVIDENCE"
+say "summary:"
+say "  MODE                       = $MODE"
+say "  rows BEFORE reset          = $BEFORE_ROWS"
+say "  rows AFTER reset+restore   = $AFTER_ROWS"
+say "  Phase 0 reimport marker    = $PHASE0_MARKER (expected ${MODE/expect_failure/0}${MODE/expect_recovery/≥1})"
+say "  AccountDataNotFound count  = $ADNF_FINAL (expected ${MODE/expect_failure/≥1}${MODE/expect_recovery/0})"
+say "  STATE B deposit ready      = $DEPO_FINAL (expected ${MODE/expect_failure/false}${MODE/expect_recovery/true})"

--- a/src/account_recovery.rs
+++ b/src/account_recovery.rs
@@ -1,0 +1,265 @@
+//! Runtime self-heal for the proxy's miden-client account store.
+//!
+//! ## Why
+//!
+//! The proxy's local miden-client sqlite (`store.sqlite3`) holds the live
+//! commitment + storage + code for each infrastructure account in
+//! `bridge_accounts.toml`. Two distinct failure modes lose or stale that
+//! state and brick every subsequent submission:
+//!
+//!   - **`AccountDataNotFound`** — local row missing entirely. The bali
+//!     production incident: every aggoracle `insertGlobalExitRoot` push
+//!     rejected at `service.rs:396` with `eth_sendRawTransaction: ERR
+//!     account data wasn't found for account id <id>`. Cause: a prior
+//!     `--reset-miden-store` run, OOM-induced corruption, or upstream
+//!     miden-client state churn.
+//!
+//!   - **`IncorrectAccountInitialCommitment`** — local commitment lags
+//!     the live node's, so `submit_new_transaction` is rejected at the
+//!     node with code 4 (`rpc/errors/node/transaction.rs:22-48`). Bali
+//!     hit this BEFORE the row was ever lost.
+//!
+//! ## How
+//!
+//! Runtime, inline retry — NOT a startup brick. When a Miden submission
+//! returns either of those errors, the caller invokes
+//! [`reimport_account`] to fetch the latest state from the live Miden
+//! node (via `Client::import_account_by_id`, which upstream calls
+//! `add_account(overwrite=true)` and refreshes the local commitment),
+//! then retries the submission once.
+//!
+//! ## Why NOT startup verification (the design we deleted)
+//!
+//! Not every account in `bridge_accounts.toml` is fully tracked by the
+//! node at every moment. Locally-deployed `service` and `wallet_hardhat`
+//! are created by `add_wallet` (`init.rs:125-153`) but never get an
+//! explicit `deploy_account` call — they exist locally until first use,
+//! at which point `submit_new_transaction` deploys them on-chain. A
+//! startup `verify_or_reimport_or_fail` call against those accounts
+//! returns `AccountNotFoundOnChain` and bricks the proxy at boot, which
+//! is wrong — those accounts are functionally healthy.
+//!
+//! The runtime approach fixes only what's actually broken when it's
+//! actually broken, and the cost of one extra node RPC + one retry per
+//! incident is well below the SLO impact of a CrashLoopBackoff.
+
+use crate::accounts_config::AccountsConfig;
+use crate::miden_client::MidenClient;
+use miden_client::ClientError;
+use miden_client::rpc::node::AddTransactionError;
+use miden_client::rpc::{EndpointError, RpcError};
+use miden_protocol::account::AccountId;
+
+/// Returns `true` if the error chain contains either of the two account-state
+/// errors that the runtime self-heal can recover.
+///
+/// Two reasons we walk the typed error chain instead of string-matching the
+/// Display:
+///
+/// 1. Upstream's `AddTransactionError::IncorrectAccountInitialCommitment` has
+///    `#[error("incorrect account initial commitment")]` (lowercase, with
+///    spaces — see miden-client `rpc/errors/node/transaction.rs:21-22`). A
+///    PascalCase string-match never fires. Typed downcast is correct.
+///
+/// 2. A miden-client upgrade that rewords either message would silently
+///    disable our retry. Typed matching breaks loudly at the compile boundary
+///    when the variant moves or renames.
+pub fn is_recoverable_account_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|e| {
+        // Direct ClientError::AccountDataNotFound
+        if let Some(client_err) = e.downcast_ref::<ClientError>() {
+            if matches!(client_err, ClientError::AccountDataNotFound(_)) {
+                return true;
+            }
+            // RpcError chain: ClientError::RpcError(RpcError) wrapping the
+            // node-side IncorrectAccountInitialCommitment.
+            if let ClientError::RpcError(rpc_err) = client_err {
+                if rpc_error_is_incorrect_initial_commitment(rpc_err) {
+                    return true;
+                }
+            }
+        }
+        // Bare RpcError in the chain (some call sites unwrap ClientError).
+        if let Some(rpc_err) = e.downcast_ref::<RpcError>() {
+            if rpc_error_is_incorrect_initial_commitment(rpc_err) {
+                return true;
+            }
+        }
+        // Last-resort string match — kept as a belt-and-braces fallback for
+        // any error path we miss. Matches both the original PascalCase token
+        // (in case a tool surfaces the enum variant name directly) AND the
+        // lowercase Display form. Covered by tests.
+        let s = format!("{e}");
+        s.contains("account data wasn't found")
+            || s.contains("incorrect account initial commitment")
+            || s.contains("IncorrectAccountInitialCommitment")
+    })
+}
+
+fn rpc_error_is_incorrect_initial_commitment(rpc_err: &RpcError) -> bool {
+    rpc_err
+        .endpoint_error()
+        .map(|endpoint_err| {
+            matches!(
+                endpoint_err,
+                EndpointError::AddTransaction(
+                    AddTransactionError::IncorrectAccountInitialCommitment,
+                )
+            )
+        })
+        .unwrap_or(false)
+}
+
+/// Force-refresh a single account from the Miden node into the proxy's
+/// local sqlite. Upstream's `import_account_by_id` calls
+/// `add_account(..., overwrite=true)` (`account/mod.rs:230,248`), so
+/// this works whether the local row is missing OR present-but-stale.
+///
+/// Errors are mapped into anyhow with the original ClientError text so
+/// callers can `is_recoverable_account_error` against a returned heal
+/// failure (e.g., the account turns out to be Private — that surfaces
+/// as `ClientError::AccountIsPrivate` and the heal cannot proceed).
+pub async fn reimport_account(
+    client: &MidenClient,
+    account_id: AccountId,
+    label: &'static str,
+) -> anyhow::Result<()> {
+    let result = client
+        .with(move |client| {
+            Box::new(async move {
+                match client.import_account_by_id(account_id).await {
+                    Ok(()) => Ok(()),
+                    Err(err) => Err(anyhow::Error::msg(format!(
+                        "import_account_by_id({account_id}) failed: {err}"
+                    ))),
+                }
+            })
+        })
+        .await;
+    match result {
+        Ok(()) => {
+            tracing::info!(account = label, account_id = %account_id, "reimported from node");
+            metrics::counter!(
+                "miden_account_reimport_total",
+                "account" => label,
+                "outcome" => "ok",
+            )
+            .increment(1);
+            Ok(())
+        }
+        Err(err) => {
+            tracing::warn!(
+                account = label,
+                account_id = %account_id,
+                err = %err,
+                "account reimport failed"
+            );
+            metrics::counter!(
+                "miden_account_reimport_total",
+                "account" => label,
+                "outcome" => "failed",
+            )
+            .increment(1);
+            Err(err)
+        }
+    }
+}
+
+/// Re-import every account in `bridge_accounts.toml`. Per-account
+/// failures are logged but NOT propagated — callers want this to be
+/// best-effort idempotent before retrying a submission. The locally-
+/// only accounts (e.g. `wallet_hardhat`, `service`) that aren't
+/// network-deployed will fail here with `AccountNotFoundOnChain` and
+/// that's fine: if the next submission succeeds, those accounts get
+/// deployed implicitly by the tx.
+pub async fn reimport_known_accounts(client: &MidenClient, accounts: &AccountsConfig) {
+    let targets: Vec<(&'static str, AccountId)> = {
+        let mut v = vec![
+            ("service", accounts.service.0),
+            ("bridge", accounts.bridge.0),
+            ("wallet_hardhat", accounts.wallet_hardhat.0),
+        ];
+        if let Some(g) = &accounts.ger_manager {
+            v.push(("ger_manager", g.0));
+        }
+        if let Some(f) = &accounts.faucet_eth {
+            v.push(("faucet_eth", f.0));
+        }
+        if let Some(f) = &accounts.faucet_agg {
+            v.push(("faucet_agg", f.0));
+        }
+        v
+    };
+    for (label, id) in targets {
+        let _ = reimport_account(client, id, label).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Belt-and-braces string-fallback path — covers errors that propagate
+    /// up as anyhow strings, not typed downcastable values. This is the
+    /// shape `service.rs:396` actually surfaces today.
+    #[test]
+    fn recoverable_error_match_account_data_not_found_string() {
+        let err = anyhow::Error::msg(
+            "account data wasn't found for account id 0xe9a21e616d9ed59016d481c7001393",
+        );
+        assert!(is_recoverable_account_error(&err));
+    }
+
+    #[test]
+    fn recoverable_error_match_incorrect_initial_commitment_pascalcase_string() {
+        // The PascalCase variant name appears in some debug formatting
+        // chains; keep the fallback resilient to both forms.
+        let err = anyhow::Error::msg("submission rejected: IncorrectAccountInitialCommitment");
+        assert!(is_recoverable_account_error(&err));
+    }
+
+    #[test]
+    fn recoverable_error_match_incorrect_initial_commitment_lowercase_string() {
+        // The upstream Display form is lowercase + spaces (see
+        // miden-client `rpc/errors/node/transaction.rs:21-22`).
+        // This is what the production proxy log actually contains.
+        let err = anyhow::Error::msg("rpc error: (incorrect account initial commitment)");
+        assert!(is_recoverable_account_error(&err));
+    }
+
+    #[test]
+    fn recoverable_error_rejects_unrelated() {
+        let err = anyhow::Error::msg("some other rpc error: connection refused");
+        assert!(!is_recoverable_account_error(&err));
+    }
+
+    /// Typed downcast path — guards against an upstream rewording silently
+    /// disabling the retry. If `AddTransactionError::IncorrectAccountInitialCommitment`
+    /// ever moves or gets renamed, this stops compiling. The test relies on
+    /// `rpc_error_is_incorrect_initial_commitment` walking a real `RpcError`
+    /// constructed below.
+    #[test]
+    fn typed_downcast_catches_incorrect_initial_commitment() {
+        use miden_client::rpc::{GrpcError, RpcEndpoint};
+        let endpoint_err = EndpointError::AddTransaction(
+            AddTransactionError::IncorrectAccountInitialCommitment,
+        );
+        let rpc_err = RpcError::RequestError {
+            endpoint: RpcEndpoint::SubmitProvenTx,
+            error_kind: GrpcError::InvalidArgument,
+            endpoint_error: Some(endpoint_err),
+            source: None,
+        };
+        assert!(
+            rpc_error_is_incorrect_initial_commitment(&rpc_err),
+            "rpc_error_is_incorrect_initial_commitment must match the canonical AddTransaction(IncorrectAccountInitialCommitment) value"
+        );
+
+        let client_err = ClientError::RpcError(rpc_err);
+        let anyhow_err = anyhow::Error::new(client_err);
+        assert!(
+            is_recoverable_account_error(&anyhow_err),
+            "is_recoverable_account_error must catch RpcError-wrapped IncorrectAccountInitialCommitment via typed downcast"
+        );
+    }
+}

--- a/src/account_recovery.rs
+++ b/src/account_recovery.rs
@@ -241,9 +241,8 @@ mod tests {
     #[test]
     fn typed_downcast_catches_incorrect_initial_commitment() {
         use miden_client::rpc::{GrpcError, RpcEndpoint};
-        let endpoint_err = EndpointError::AddTransaction(
-            AddTransactionError::IncorrectAccountInitialCommitment,
-        );
+        let endpoint_err =
+            EndpointError::AddTransaction(AddTransactionError::IncorrectAccountInitialCommitment);
         let rpc_err = RpcError::RequestError {
             endpoint: RpcEndpoint::SubmitProvenTx,
             error_kind: GrpcError::InvalidArgument,

--- a/src/account_recovery.rs
+++ b/src/account_recovery.rs
@@ -73,17 +73,17 @@ pub fn is_recoverable_account_error(err: &anyhow::Error) -> bool {
             }
             // RpcError chain: ClientError::RpcError(RpcError) wrapping the
             // node-side IncorrectAccountInitialCommitment.
-            if let ClientError::RpcError(rpc_err) = client_err {
-                if rpc_error_is_incorrect_initial_commitment(rpc_err) {
-                    return true;
-                }
+            if let ClientError::RpcError(rpc_err) = client_err
+                && rpc_error_is_incorrect_initial_commitment(rpc_err)
+            {
+                return true;
             }
         }
         // Bare RpcError in the chain (some call sites unwrap ClientError).
-        if let Some(rpc_err) = e.downcast_ref::<RpcError>() {
-            if rpc_error_is_incorrect_initial_commitment(rpc_err) {
-                return true;
-            }
+        if let Some(rpc_err) = e.downcast_ref::<RpcError>()
+            && rpc_error_is_incorrect_initial_commitment(rpc_err)
+        {
+            return true;
         }
         // Last-resort string match — kept as a belt-and-braces fallback for
         // any error path we miss. Matches both the original PascalCase token

--- a/src/accounts_config.rs
+++ b/src/accounts_config.rs
@@ -182,9 +182,8 @@ fn write_config_atomic(config_path: &std::path::Path, config_toml: &str) -> anyh
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => {
-            return Err(e).with_context(|| {
-                format!("failed to clear stale temp file {}", tmp.display())
-            });
+            return Err(e)
+                .with_context(|| format!("failed to clear stale temp file {}", tmp.display()));
         }
     }
 
@@ -197,7 +196,12 @@ fn write_config_atomic(config_path: &std::path::Path, config_toml: &str) -> anyh
     let file = fs::OpenOptions::new()
         .write(true)
         .open(&tmp)
-        .with_context(|| format!("failed to reopen temp config file {} for fsync", tmp.display()))?;
+        .with_context(|| {
+            format!(
+                "failed to reopen temp config file {} for fsync",
+                tmp.display()
+            )
+        })?;
     file.sync_all()
         .with_context(|| format!("failed to fsync temp config file {}", tmp.display()))?;
     drop(file);
@@ -347,7 +351,12 @@ mod tests {
     #[test]
     fn load_rejects_truncated_file_then_atomic_save_heals_it() {
         let dir = tempdir().unwrap();
-        save_config(full_cfg(), &NetworkId::Testnet, Some(dir.path().to_path_buf())).unwrap();
+        save_config(
+            full_cfg(),
+            &NetworkId::Testnet,
+            Some(dir.path().to_path_buf()),
+        )
+        .unwrap();
 
         let path = dir.path().join("bridge_accounts.toml");
         let body = fs::read_to_string(&path).unwrap();
@@ -365,7 +374,12 @@ mod tests {
 
         // Re-save via the atomic path and confirm it loads cleanly with all
         // optional fields intact (i.e. not silently defaulted to None).
-        save_config(full_cfg(), &NetworkId::Testnet, Some(dir.path().to_path_buf())).unwrap();
+        save_config(
+            full_cfg(),
+            &NetworkId::Testnet,
+            Some(dir.path().to_path_buf()),
+        )
+        .unwrap();
         let healed = load_config(Some(dir.path().to_path_buf())).unwrap();
         assert!(
             healed.ger_manager.is_some(),
@@ -383,10 +397,19 @@ mod tests {
     fn atomic_save_overwrites_stale_tmp_file_from_prior_crash() {
         let dir = tempdir().unwrap();
         let stale_tmp = dir.path().join("bridge_accounts.toml.new");
-        fs::write(&stale_tmp, b"this is garbage left over from a crashed run\n").unwrap();
+        fs::write(
+            &stale_tmp,
+            b"this is garbage left over from a crashed run\n",
+        )
+        .unwrap();
         assert!(stale_tmp.exists());
 
-        save_config(full_cfg(), &NetworkId::Testnet, Some(dir.path().to_path_buf())).unwrap();
+        save_config(
+            full_cfg(),
+            &NetworkId::Testnet,
+            Some(dir.path().to_path_buf()),
+        )
+        .unwrap();
 
         // Temp file must be gone (consumed by the rename) and the real config
         // must load successfully.

--- a/src/accounts_config.rs
+++ b/src/accounts_config.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use miden_protocol::account::AccountId;
 use miden_protocol::address::NetworkId;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -151,8 +152,65 @@ pub fn save_config(
     let on_disk = AccountsConfigOnDisk::from_config(&config, net_id);
     let config_toml = toml::to_string(&on_disk)?;
     let config_path = config_path(miden_store_dir)?;
-    fs::write(config_path.clone(), config_toml)?;
+    write_config_atomic(&config_path, &config_toml)?;
     Ok(config_path)
+}
+
+/// Atomically replace `config_path` with `config_toml`.
+///
+/// Writes to a sibling temp file in the same directory, fsync's it, then
+/// renames it into place. The rename is atomic on POSIX when source and
+/// destination are on the same filesystem — which is guaranteed here by
+/// constructing the temp path with `with_extension` on the target path.
+///
+/// Motivation: a non-atomic `fs::write` can leave `bridge_accounts.toml`
+/// truncated if the process is OOMKilled (or the host loses power) mid-write.
+/// On the next start, `load_config` would silently deserialize the partial
+/// file: fields like `ger_manager` are `#[serde(default)]` and would become
+/// `None`, causing GER injection to fall back to the wrong account and fail
+/// with `AccountDataNotFound`. Bali hit this failure mode after two OOMKills
+/// in four days.
+fn write_config_atomic(config_path: &std::path::Path, config_toml: &str) -> anyhow::Result<()> {
+    // Sibling temp file on the same mount as the target — required for the
+    // rename below to be atomic rather than degenerate to copy-then-unlink.
+    let tmp = config_path.with_extension("toml.new");
+
+    // Best-effort cleanup of any stragglers from a previously crashed run.
+    // We don't care if it doesn't exist; only surface errors that aren't
+    // NotFound so we don't mask the real failure below.
+    match fs::remove_file(&tmp) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!("failed to clear stale temp file {}", tmp.display())
+            });
+        }
+    }
+
+    fs::write(&tmp, config_toml)
+        .with_context(|| format!("failed to write temp config file {}", tmp.display()))?;
+
+    // fsync the file contents before renaming so that a crash between the
+    // write and the rename can't expose pre-fsync (zero-filled) contents
+    // after the rename completes.
+    let file = fs::OpenOptions::new()
+        .write(true)
+        .open(&tmp)
+        .with_context(|| format!("failed to reopen temp config file {} for fsync", tmp.display()))?;
+    file.sync_all()
+        .with_context(|| format!("failed to fsync temp config file {}", tmp.display()))?;
+    drop(file);
+
+    fs::rename(&tmp, config_path).with_context(|| {
+        format!(
+            "failed to rename temp config {} -> {}",
+            tmp.display(),
+            config_path.display()
+        )
+    })?;
+
+    Ok(())
 }
 
 pub fn load_config(miden_store_dir: Option<PathBuf>) -> anyhow::Result<AccountsConfig> {
@@ -267,5 +325,93 @@ mod tests {
             loaded.bridge.0,
             AccountId::from_hex(TEST_ACCOUNT_HEX).unwrap()
         );
+    }
+
+    fn full_cfg() -> AccountsConfig {
+        AccountsConfig {
+            service: dummy(),
+            bridge: dummy(),
+            faucet_eth: Some(dummy()),
+            faucet_agg: Some(dummy()),
+            wallet_hardhat: dummy(),
+            ger_manager: Some(dummy()),
+        }
+    }
+
+    /// Simulates a mid-write OOMKill by truncating the on-disk file to half
+    /// its length. `load_config` must surface the corruption as an error
+    /// rather than deserialising a partial TOML — otherwise `#[serde(default)]`
+    /// fields like `ger_manager` would silently fall back to `None`, which is
+    /// the exact failure path that hurt Bali after two OOMKills in four days.
+    /// After the corruption, a fresh `save_config` must heal the file.
+    #[test]
+    fn load_rejects_truncated_file_then_atomic_save_heals_it() {
+        let dir = tempdir().unwrap();
+        save_config(full_cfg(), &NetworkId::Testnet, Some(dir.path().to_path_buf())).unwrap();
+
+        let path = dir.path().join("bridge_accounts.toml");
+        let body = fs::read_to_string(&path).unwrap();
+        // Truncate to half length — guaranteed to slice mid-key or mid-value
+        // because every field name + bech32 value is longer than a few bytes.
+        let half = body.len() / 2;
+        fs::write(&path, &body[..half]).unwrap();
+
+        let truncated_load = load_config(Some(dir.path().to_path_buf()));
+        assert!(
+            truncated_load.is_err(),
+            "expected truncated TOML to fail to load; got Ok({:?})",
+            truncated_load.ok()
+        );
+
+        // Re-save via the atomic path and confirm it loads cleanly with all
+        // optional fields intact (i.e. not silently defaulted to None).
+        save_config(full_cfg(), &NetworkId::Testnet, Some(dir.path().to_path_buf())).unwrap();
+        let healed = load_config(Some(dir.path().to_path_buf())).unwrap();
+        assert!(
+            healed.ger_manager.is_some(),
+            "atomic save must round-trip ger_manager; got None which would silently \
+             trigger the AccountDataNotFound regression"
+        );
+        assert!(healed.faucet_eth.is_some());
+        assert!(healed.faucet_agg.is_some());
+    }
+
+    /// A stale `bridge_accounts.toml.new` left over from a crashed prior run
+    /// must not block the next save. `write_config_atomic` should clean it up
+    /// and rewrite cleanly.
+    #[test]
+    fn atomic_save_overwrites_stale_tmp_file_from_prior_crash() {
+        let dir = tempdir().unwrap();
+        let stale_tmp = dir.path().join("bridge_accounts.toml.new");
+        fs::write(&stale_tmp, b"this is garbage left over from a crashed run\n").unwrap();
+        assert!(stale_tmp.exists());
+
+        save_config(full_cfg(), &NetworkId::Testnet, Some(dir.path().to_path_buf())).unwrap();
+
+        // Temp file must be gone (consumed by the rename) and the real config
+        // must load successfully.
+        assert!(
+            !stale_tmp.exists(),
+            "stale temp file should have been removed or renamed away"
+        );
+        let loaded = load_config(Some(dir.path().to_path_buf())).unwrap();
+        assert!(loaded.ger_manager.is_some());
+    }
+
+    /// Belt-and-braces: confirm the atomic save never leaves the target file
+    /// in a partial state. After a successful save, the target's contents must
+    /// exactly match what `toml::to_string` produced for the on-disk config.
+    #[test]
+    fn atomic_save_produces_complete_file_contents() {
+        let dir = tempdir().unwrap();
+        let cfg = full_cfg();
+        let expected = toml::to_string(&AccountsConfigOnDisk::from_config(
+            &cfg,
+            &NetworkId::Testnet,
+        ))
+        .unwrap();
+        save_config(cfg, &NetworkId::Testnet, Some(dir.path().to_path_buf())).unwrap();
+        let actual = fs::read_to_string(dir.path().join("bridge_accounts.toml")).unwrap();
+        assert_eq!(actual, expected);
     }
 }

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -521,14 +521,44 @@ async fn publish_claim_internal(
     })
 }
 
-/// Publish a claim using a fresh miden-client instance (Igor's approach).
+/// Publish a claim through the long-lived `MidenClient` event loop.
 ///
-/// Creates a new client per call to avoid stale account state from the
-/// long-lived MidenClient's background sync loop. After faucet creation
-/// or prior CLAIMs, the service account's state drifts in the long-lived
-/// client, causing `IncorrectAccountInitialCommitment` errors. Recording
-/// of the ClaimEvent happens before the result is sent back so the event
-/// is in the store even if the HTTP caller disconnects.
+/// All Miden submissions — claim publishes and aggoracle `insert_ger` pushes
+/// alike — funnel through `MidenClient::with(...)`, which serialises every
+/// request through a `mpsc::channel::<Request>(1)` (see `miden_client.rs:126`).
+/// That FIFO serialisation is what makes this design correct on bali:
+///
+///   - **No concurrent submissions for the same account.** The Miden node
+///     rejects a second tx that builds atop the same `init_commitment` as a
+///     pending mempool tx with `AddTransactionError::IncorrectAccountInitialCommitment`
+///     (`code: 'Client specified an invalid argument', message: "transaction
+///     conflicts with current mempool state"`). The bali production incident
+///     fired this 189 times over 2026-05-11 → 2026-05-14 because the previous
+///     fresh-per-call code path raced aggoracle's `insert_ger` against
+///     claim publishes on the same `bridge`/`service` account. The channel-of-1
+///     makes that race structurally impossible.
+///
+///   - **Single in-memory account cache.** Building a fresh `Client` against
+///     the same `store.sqlite3` produced a divergent in-memory commitment
+///     cache between the two clients (the long-lived one's cache stayed at
+///     the pre-claim commitment until its next `sync_state()` tick, ~5s
+///     later). Routing through the long-lived client eliminates the second
+///     cache entirely.
+///
+///   - **TOCTOU safety for first-bridge faucet creation** (Cantina #1
+///     colliding-network refusal, `e6a33ae`) and any future per-resource
+///     check inside `publish_claim_internal` rely on the surrounding
+///     `with()` mutex, as documented at `find_or_create_faucet`.
+///
+/// Recording of the `ClaimEvent` happens inside the same closure, before the
+/// caller receives a response, so the event is durable in the store even if
+/// the HTTP client disconnects (cancellation-safe).
+///
+/// Race-safe ordering: write the txn+log at `latest_block + 1` BEFORE bumping
+/// `latest_block_number`. See the matching comment in `bridge_out.rs::on_post_sync`:
+/// advancing the counter first leaves a window where `eth_blockNumber` returns
+/// N but no log exists at block N yet, so aggsender / bridge-service skip the
+/// event entirely.
 #[allow(clippy::too_many_arguments)]
 pub async fn publish_claim(
     params: claimAssetCall,
@@ -540,163 +570,52 @@ pub async fn publish_claim(
     txn_hash: alloy::primitives::TxHash,
     txn_envelope: alloy::consensus::TxEnvelope,
     signer: alloy::primitives::Address,
-    store_dir: std::path::PathBuf,
-    node_url: String,
     reject_zero_padding: bool,
     expected_mints: Option<Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
-    api_key: Option<String>,
 ) -> anyhow::Result<PublishClaimTxn> {
     let result = Arc::new(OnceLock::<PublishClaimTxn>::new());
     let result_inner = result.clone();
-
-    if node_url.is_empty() {
-        // Test path: use the existing MidenClient.
-        //
-        // Race-safe ordering: write the txn+log at (current_latest + 1) BEFORE
-        // bumping `latest_block_number`. See the matching comment in
-        // `bridge_out.rs::on_post_sync`: advancing the counter first leaves a
-        // window where `eth_blockNumber` returns N but no log exists at block N
-        // yet, so aggsender / bridge-service skip the event entirely.
-        let result_test = result.clone();
-        client
-            .with(move |client| {
-                Box::new(async move {
-                    let value = publish_claim_internal(
-                        params,
-                        client,
-                        &accounts.0,
-                        &*store,
-                        latest_block_num,
-                        reject_zero_padding,
-                        expected_mints.as_ref(),
-                    )
-                    .await?;
-                    let block_num = store.get_latest_block_number().await? + 1;
-                    let block_hash = block_state.get_block_hash(block_num);
-                    store
-                        .txn_begin(
-                            txn_hash,
-                            crate::store::TxnEntry {
-                                id: Some(value.txn_id),
-                                envelope: txn_envelope,
-                                signer,
-                                expires_at: Some(value.expires_at),
-                                logs: vec![value.log.clone()],
-                            },
-                        )
-                        .await?;
-                    store
-                        .txn_commit(txn_hash, Ok(()), block_num, block_hash)
-                        .await?;
-                    store.set_latest_block_number(block_num).await?;
-                    tracing::info!(
-                        eth_tx = %txn_hash,
-                        block_num,
-                        "ClaimEvent recorded (cancellation-safe)"
-                    );
-                    let _ = result_test.set(value);
-                    Ok(())
-                })
-            })
-            .await?;
-        return result
-            .get()
-            .cloned()
-            .ok_or_else(|| anyhow::anyhow!("publish_claim: result not set"));
-    }
-
-    let keystore = client.get_keystore();
-    let store_path = store_dir.join("store.sqlite3");
-
-    // Production path: fresh client per call (Igor's approach).
-    let store_clone = store.clone();
-    let accounts_inner = accounts.0.clone();
-    let expected_mints_clone = expected_mints.clone();
-    let join_result = tokio::task::spawn_blocking(move || {
-        let rt = tokio::runtime::Runtime::new()?;
-        rt.block_on(async {
-            use ::miden_client::DebugMode;
-            use ::miden_client::builder::ClientBuilder;
-            use ::miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-            // Resolve via the same helper `MidenClient::new` uses, so shortcut
-            // strings ("devnet" / "testnet") map to the same Endpoint across both
-            // code paths. See RD-856 — an asymmetric URL parse was how the fresh
-            // client ended up dialing the wrong hostname in the first place.
-            let ep = crate::miden_client::parse_node_url(&node_url)
-                .map_err(|e| anyhow::anyhow!("invalid node URL {node_url}: {e}"))?;
-            tracing::info!(
-                node_url = %node_url,
-                resolved = %ep,
-                "publish_claim: building fresh Miden client to dial node"
-            );
-            // Build the gRPC client through the shared helper so the optional
-            // bearer-auth `api_key` (RD-856) is applied identically to the
-            // long-lived MidenClient path. Without the helper this fresh-per-call
-            // builder would silently skip the auth header.
-            let rpc = crate::miden_client::build_rpc_client(&ep, 10_000, api_key.as_deref());
-            let mut client = ClientBuilder::new()
-                .rpc(rpc)
-                .sqlite_store(store_path)
-                .authenticator(keystore)
-                .in_debug_mode(DebugMode::Enabled)
-                .build()
-                .await
-                .map_err(|e| {
-                    anyhow::anyhow!(
-                        "publish_claim: failed to build Miden client for {node_url}: {e}"
-                    )
-                })?;
-            client.sync_state().await?;
-
-            let value = publish_claim_internal(
-                params,
-                &mut client,
-                &accounts_inner,
-                &*store_clone,
-                latest_block_num,
-                reject_zero_padding,
-                expected_mints_clone.as_ref(),
-            )
-            .await?;
-
-            // Record the ClaimEvent — cancellation-safe.
-            // Race-safe ordering: write the txn+log at (current_latest + 1)
-            // BEFORE bumping `latest_block_number`. See `bridge_out.rs::on_post_sync`
-            // for the SIGPIPE/cursor-advance rationale.
-            let block_num = store_clone.get_latest_block_number().await? + 1;
-            let block_hash = block_state.get_block_hash(block_num);
-            store_clone
-                .txn_begin(
-                    txn_hash,
-                    crate::store::TxnEntry {
-                        id: Some(value.txn_id),
-                        envelope: txn_envelope,
-                        signer,
-                        expires_at: Some(value.expires_at),
-                        logs: vec![value.log.clone()],
-                    },
+    client
+        .with(move |client| {
+            Box::new(async move {
+                let value = publish_claim_internal(
+                    params,
+                    client,
+                    &accounts.0,
+                    &*store,
+                    latest_block_num,
+                    reject_zero_padding,
+                    expected_mints.as_ref(),
                 )
                 .await?;
-            store_clone
-                .txn_commit(txn_hash, Ok(()), block_num, block_hash)
-                .await?;
-            store_clone.set_latest_block_number(block_num).await?;
-            tracing::info!(
-                eth_tx = %txn_hash,
-                block_num,
-                "ClaimEvent recorded (cancellation-safe)"
-            );
-
-            let _ = result_inner.set(value);
-            Ok::<_, anyhow::Error>(())
+                let block_num = store.get_latest_block_number().await? + 1;
+                let block_hash = block_state.get_block_hash(block_num);
+                store
+                    .txn_begin(
+                        txn_hash,
+                        crate::store::TxnEntry {
+                            id: Some(value.txn_id),
+                            envelope: txn_envelope,
+                            signer,
+                            expires_at: Some(value.expires_at),
+                            logs: vec![value.log.clone()],
+                        },
+                    )
+                    .await?;
+                store
+                    .txn_commit(txn_hash, Ok(()), block_num, block_hash)
+                    .await?;
+                store.set_latest_block_number(block_num).await?;
+                tracing::info!(
+                    eth_tx = %txn_hash,
+                    block_num,
+                    "ClaimEvent recorded (cancellation-safe)"
+                );
+                let _ = result_inner.set(value);
+                Ok(())
+            })
         })
-    })
-    .await
-    .map_err(|e| anyhow::anyhow!("claim spawn_blocking: {e}"))?;
-
-    join_result?;
-
+        .await?;
     result
         .get()
         .cloned()

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -573,6 +573,77 @@ pub async fn publish_claim(
     reject_zero_padding: bool,
     expected_mints: Option<Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
 ) -> anyhow::Result<PublishClaimTxn> {
+    // Submit with runtime self-heal, mirroring the pattern in
+    // `src/ger.rs::insert_ger`. If the inner Miden submission rejects with
+    // `AccountDataNotFound` (local sqlite row missing — typically after a
+    // `--reset-miden-store`) or `IncorrectAccountInitialCommitment` (local
+    // commitment stale vs. the node), reimport every account from
+    // `bridge_accounts.toml` and retry the publish once. Defense in depth
+    // alongside the structural fix in `e3e3e2a` that routes through
+    // `MidenClient::with(...)` and eliminates mempool-conflict IAIC.
+    //
+    // The claim flow touches several accounts (`bridge` for the CLAIM note,
+    // `service` and dynamically-created faucets for first-bridge token
+    // registration), so we reimport the whole bridge_accounts set rather
+    // than guess which account was the culprit from the error message.
+    // `reimport_known_accounts` is best-effort and idempotent — accounts
+    // not on chain (e.g. `wallet_hardhat`) fail benignly.
+    match attempt_publish_claim(
+        params.clone(),
+        client,
+        accounts.clone(),
+        store.clone(),
+        block_state.clone(),
+        latest_block_num,
+        txn_hash,
+        txn_envelope.clone(),
+        signer,
+        reject_zero_padding,
+        expected_mints.clone(),
+    )
+    .await
+    {
+        Ok(value) => Ok(value),
+        Err(err) if crate::account_recovery::is_recoverable_account_error(&err) => {
+            tracing::warn!(
+                err = %err,
+                eth_tx = %txn_hash,
+                "publish_claim: recoverable account error, reimporting known accounts and retrying"
+            );
+            crate::account_recovery::reimport_known_accounts(client, &accounts.0).await;
+            attempt_publish_claim(
+                params,
+                client,
+                accounts,
+                store,
+                block_state,
+                latest_block_num,
+                txn_hash,
+                txn_envelope,
+                signer,
+                reject_zero_padding,
+                expected_mints,
+            )
+            .await
+        }
+        Err(err) => Err(err),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn attempt_publish_claim(
+    params: claimAssetCall,
+    client: &MidenClient,
+    accounts: crate::AccountsConfig,
+    store: Arc<dyn Store>,
+    block_state: std::sync::Arc<crate::block_state::BlockState>,
+    latest_block_num: BlockNumber,
+    txn_hash: alloy::primitives::TxHash,
+    txn_envelope: alloy::consensus::TxEnvelope,
+    signer: alloy::primitives::Address,
+    reject_zero_padding: bool,
+    expected_mints: Option<Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
+) -> anyhow::Result<PublishClaimTxn> {
     let result = Arc::new(OnceLock::<PublishClaimTxn>::new());
     let result_inner = result.clone();
     client

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -94,6 +94,73 @@ pub struct GerInsertResult {
     pub is_new: bool,
 }
 
+/// Submit the actual UpdateGerNote Miden transaction. Factored out of
+/// `insert_ger` so the caller can run it twice — once eagerly, then again
+/// after `reimport_account` if the first attempt failed with a recoverable
+/// account-state error.
+///
+/// Use the long-lived MidenClient. The dedicated ger_manager account
+/// (separate from the service account that the NTX builder constantly
+/// mutates via claim processing) keeps the account state stable across
+/// GER submissions, so we don't need a fresh client per call.
+///
+/// Fresh-client-per-GER was removed because it shared the main sqlite
+/// and advanced the sync cursor past blocks where bridge NTX consumes
+/// the UpdateGerNote. The main client's subsequent sync_nullifiers only
+/// queries [current_cursor, tip], so those consumption events were never
+/// discovered and `NoteFilter::Consumed` returned nothing in restore.
+async fn submit_update_ger_note(
+    miden_client: &MidenClient,
+    accounts: crate::AccountsConfig,
+    ger_bytes: [u8; 32],
+) -> anyhow::Result<()> {
+    let inner_accounts = accounts.0.clone();
+    miden_client
+        .with(move |client| {
+            Box::new(async move {
+                client.sync_state().await?;
+                let ger_manager_id = inner_accounts
+                    .ger_manager
+                    .as_ref()
+                    .map(|a| a.0)
+                    .unwrap_or(inner_accounts.service.0);
+                let bridge_id = inner_accounts.bridge.0;
+                let ger = ExitRoot::new(ger_bytes);
+                let note = UpdateGerNote::create(ger, ger_manager_id, bridge_id, client.rng())?;
+                tracing::info!(
+                    note_id = %note.id(),
+                    ger = %hex::encode(ger_bytes),
+                    "UpdateGerNote created"
+                );
+                let tx_request = TransactionRequestBuilder::new()
+                    .own_output_notes(vec![note])
+                    .build()?;
+                let tx_id = client
+                    .submit_new_transaction(ger_manager_id, tx_request)
+                    .await?;
+                tracing::info!(
+                    tx_id = %tx_id,
+                    ger = %hex::encode(ger_bytes),
+                    "UpdateGerNote submitted, waiting for commit..."
+                );
+
+                let committed = crate::miden_client::wait_for_transaction_commit(
+                    client,
+                    tx_id,
+                    30,
+                    std::time::Duration::from_secs(1),
+                )
+                .await?;
+                if !committed {
+                    anyhow::bail!("UpdateGerNote tx {tx_id} not committed after 30s");
+                }
+                tracing::info!(tx_id = %tx_id, "UpdateGerNote transaction committed");
+                Ok(())
+            })
+        })
+        .await
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn insert_ger(
     ger_bytes: [u8; 32],
@@ -125,61 +192,36 @@ pub async fn insert_ger(
             "GER injection: submitting to Miden..."
         );
 
-        // Use the long-lived MidenClient. The dedicated ger_manager account
-        // (separate from the service account that the NTX builder constantly
-        // mutates via claim processing) keeps the account state stable across
-        // GER submissions, so we don't need a fresh client per call.
-        //
-        // Fresh-client-per-GER was removed because it shared the main sqlite
-        // and advanced the sync cursor past blocks where bridge NTX consumes
-        // the UpdateGerNote. The main client's subsequent sync_nullifiers only
-        // queries [current_cursor, tip], so those consumption events were never
-        // discovered and `NoteFilter::Consumed` returned nothing in restore.
-        let inner_accounts = accounts.0.clone();
-        miden_client
-            .with(move |client| {
-                Box::new(async move {
-                    client.sync_state().await?;
-                    let ger_manager_id = inner_accounts
-                        .ger_manager
-                        .as_ref()
-                        .map(|a| a.0)
-                        .unwrap_or(inner_accounts.service.0);
-                    let bridge_id = inner_accounts.bridge.0;
-                    let ger = ExitRoot::new(ger_bytes);
-                    let note = UpdateGerNote::create(ger, ger_manager_id, bridge_id, client.rng())?;
-                    tracing::info!(
-                        note_id = %note.id(),
-                        ger = %hex::encode(ger_bytes),
-                        "UpdateGerNote created"
-                    );
-                    let tx_request = TransactionRequestBuilder::new()
-                        .own_output_notes(vec![note])
-                        .build()?;
-                    let tx_id = client
-                        .submit_new_transaction(ger_manager_id, tx_request)
-                        .await?;
-                    tracing::info!(
-                        tx_id = %tx_id,
-                        ger = %hex::encode(ger_bytes),
-                        "UpdateGerNote submitted, waiting for commit..."
-                    );
-
-                    let committed = crate::miden_client::wait_for_transaction_commit(
-                        client,
-                        tx_id,
-                        30,
-                        std::time::Duration::from_secs(1),
-                    )
-                    .await?;
-                    if !committed {
-                        anyhow::bail!("UpdateGerNote tx {tx_id} not committed after 30s");
-                    }
-                    tracing::info!(tx_id = %tx_id, "UpdateGerNote transaction committed");
-                    Ok(())
-                })
-            })
-            .await?;
+        // Submit with runtime self-heal: if the Miden submission rejects
+        // with AccountDataNotFound (local sqlite missing the account row)
+        // OR IncorrectAccountInitialCommitment (local commitment stale vs
+        // the node's view), reimport the ger_manager account from the
+        // live Miden node and retry once. See `src/account_recovery.rs`
+        // for the analysis — this is the actual bali production cure.
+        match submit_update_ger_note(miden_client, accounts.clone(), ger_bytes).await {
+            Ok(()) => {}
+            Err(err) if crate::account_recovery::is_recoverable_account_error(&err) => {
+                tracing::warn!(
+                    err = %err,
+                    ger = %hex::encode(ger_bytes),
+                    "GER injection: recoverable account error, reimporting ger_manager and retrying"
+                );
+                let ger_manager_id = accounts
+                    .0
+                    .ger_manager
+                    .as_ref()
+                    .map(|a| a.0)
+                    .unwrap_or(accounts.0.service.0);
+                crate::account_recovery::reimport_account(
+                    miden_client,
+                    ger_manager_id,
+                    "ger_manager",
+                )
+                .await?;
+                submit_update_ger_note(miden_client, accounts.clone(), ger_bytes).await?;
+            }
+            Err(err) => return Err(err),
+        }
 
         // Race-safe ordering: write the log at (current_latest + 1) BEFORE
         // bumping `latest_block_number`. See the matching comment in

--- a/src/init.rs
+++ b/src/init.rs
@@ -8,7 +8,7 @@ use miden_client::crypto::FeltRng;
 use miden_client::keystore::{FilesystemKeyStore, Keystore};
 use miden_client::transaction::TransactionRequestBuilder;
 use miden_protocol::account::auth::{AuthScheme, AuthSecretKey};
-use miden_protocol::account::{Account, AccountId};
+use miden_protocol::account::{Account, AccountId, AccountStorageMode};
 use miden_protocol::address::NetworkId;
 use miden_protocol::note::NoteType;
 use miden_standards::account::auth::AuthSingleSig;
@@ -126,8 +126,29 @@ async fn add_wallet(
     client: &mut MidenClientLib,
     keystore: Arc<FilesystemKeyStore>,
 ) -> anyhow::Result<Account> {
+    // Public storage mode is REQUIRED for the proxy's infrastructure accounts
+    // (service, ger_manager, wallet_hardhat) so a missing local sqlite row can
+    // be recovered via `Client::import_account_by_id` from the live Miden
+    // node. Private accounts (the AccountBuilder default) cannot be
+    // recovered — their full state lives ONLY in the proxy's sqlite. The
+    // regression that put bali in this state was commit dbe5c2d (Apr 2026),
+    // which folded `add_public_wallet` into `add_wallet` during the 0.14.x
+    // migration and dropped the explicit storage_mode call. Bali ran with
+    // Private accounts for ~20 days until the proxy's sqlite lost the
+    // ger_manager row, after which every aggoracle GER push rejected with
+    // `AccountDataNotFound` and `--reset-miden-store --restore` could not
+    // bring it back.
+    //
+    // We use `Public` rather than `Network` because the latter is
+    // testnet/devnet-only on current upstream — local miden-node builds
+    // (and any production node not running with network-tx enabled) reject
+    // Network deployments with `Network transactions may not be submitted
+    // by users yet`. Public gives us the recovery property (state on-chain,
+    // import-by-id works) without the network-tx-builder semantics, which
+    // the proxy doesn't use anyway.
     let (auth_component, key_pair) = create_auth_component(client)?;
     let account = Account::builder(client.rng().draw_word().into())
+        .storage_mode(AccountStorageMode::Public)
         .with_component(BasicWallet)
         .with_auth_component(auth_component)
         .build()?;

--- a/src/l1_info_tree_indexer.rs
+++ b/src/l1_info_tree_indexer.rs
@@ -117,23 +117,46 @@ impl L1InfoTreeIndexer {
                 "L1InfoTreeIndexer starting"
             );
 
-            // Start at L1 head — we don't backfill historic events. The race
-            // we're closing only matters for GERs injected from now on; older
-            // injections in the store either already have roots populated
-            // (resolved at the time) or are already orphaned and not
-            // recoverable cheaply. Backfill is a separate concern.
-            let mut last_processed: u64 = match provider.get_block_number().await {
+            // Resume from the persisted cursor if we have one, else start at
+            // current L1 head. The persisted cursor closes the gap that
+            // stranded GERs every time the proxy restarted (OOMKills,
+            // planned deploys): historic `UpdateL1InfoTree` events emitted
+            // during downtime are now indexed on the next boot and the
+            // orphan ger_entries rows from that window get their (M, R)
+            // filled in by the indexer's `set_ger_exit_roots` UPSERT.
+            //
+            // Fresh deployments (cursor = 0) start at head — same behaviour
+            // as before persistence. Pre-existing deployments inherit a 0
+            // cursor on first boot after the migration; treat 0 as "no
+            // cursor recorded yet" and fall back to head to avoid a
+            // multi-million-block backfill on the first boot.
+            let head = provider.get_block_number().await.unwrap_or_else(|e| {
+                tracing::error!(error = %e, "L1InfoTreeIndexer: failed to fetch initial L1 block; starting at 0");
+                0
+            });
+            let stored = match self.store.get_l1_indexer_cursor().await {
                 Ok(n) => n,
                 Err(e) => {
                     tracing::error!(
                         error = %e,
-                        "L1InfoTreeIndexer: failed to fetch initial L1 block, starting at 0"
+                        "L1InfoTreeIndexer: failed to load persisted cursor; falling back to L1 head"
                     );
                     0
                 }
             };
+            let mut last_processed: u64 = if stored == 0 {
+                head
+            } else {
+                // Re-process a small reorg window so we don't miss reorg'd
+                // events. Sepolia 64 blocks ≈ 12 minutes, well inside what
+                // `get_logs` can chunk through quickly via max_range.
+                const REORG_MARGIN: u64 = 64;
+                stored.saturating_sub(REORG_MARGIN)
+            };
             tracing::info!(
                 start_block = last_processed,
+                stored_cursor = stored,
+                l1_head = head,
                 "L1InfoTreeIndexer cursor initialized"
             );
 
@@ -228,6 +251,20 @@ impl L1InfoTreeIndexer {
         metrics::counter!("l1_info_tree_indexer_pairs_indexed_total").increment(indexed as u64);
 
         *last_processed = to;
+
+        // Persist the cursor so a restart resumes from here instead of
+        // jumping back to L1 head. Failure to persist is logged but does
+        // not abort the loop — we'd rather keep indexing on a transient
+        // DB blip than wedge the service.
+        if let Err(e) = self.store.set_l1_indexer_cursor(to).await {
+            tracing::warn!(
+                error = %e,
+                cursor = to,
+                "L1InfoTreeIndexer: failed to persist cursor; continuing in-memory"
+            );
+            metrics::counter!("l1_info_tree_indexer_cursor_persist_errors_total").increment(1);
+        }
+
         Ok(())
     }
 

--- a/src/l1_info_tree_indexer.rs
+++ b/src/l1_info_tree_indexer.rs
@@ -81,6 +81,15 @@ pub struct L1InfoTreeIndexer {
     store: Arc<dyn Store>,
     poll_interval: Duration,
     max_range: u64,
+    /// Optional operator override: force the indexer to start polling from
+    /// this L1 block on the next boot, ignoring any persisted cursor.
+    /// Used to backfill historic orphan GERs whose `UpdateL1InfoTree` events
+    /// predate the persisted cursor (e.g. bali's 27 NULL-roots rows from
+    /// blocks 95k-130k). Operator passes via `--l1-indexer-from-block <N>`
+    /// or env `L1_INDEXER_FROM_BLOCK`. After the backfill completes the
+    /// cursor advances forward normally; remove the flag for subsequent
+    /// boots.
+    from_block_override: Option<u64>,
 }
 
 impl L1InfoTreeIndexer {
@@ -91,7 +100,17 @@ impl L1InfoTreeIndexer {
             store,
             poll_interval: DEFAULT_POLL_INTERVAL,
             max_range: DEFAULT_MAX_RANGE,
+            from_block_override: None,
         }
+    }
+
+    /// Operator override for the indexer start block. Overrides both the
+    /// persisted cursor and the L1-head fallback for one boot. After that
+    /// boot's first persisted cursor write, the override stops mattering
+    /// and the normal resume-from-cursor path takes over.
+    pub fn with_from_block_override(mut self, from_block: u64) -> Self {
+        self.from_block_override = Some(from_block);
+        self
     }
 
     /// Spawn the indexer as a tokio task. Returns a oneshot sender for graceful
@@ -144,7 +163,22 @@ impl L1InfoTreeIndexer {
                     0
                 }
             };
-            let mut last_processed: u64 = if stored == 0 {
+            // Resolve start block:
+            //   1. Operator override (`--l1-indexer-from-block <N>`) wins
+            //      unconditionally — used to backfill historic orphan GERs
+            //      whose events predate the persisted cursor.
+            //   2. Else persisted cursor minus reorg margin, if non-zero.
+            //   3. Else current L1 head (fresh deployment).
+            let mut last_processed: u64 = if let Some(forced) = self.from_block_override {
+                tracing::warn!(
+                    from_block = forced,
+                    stored_cursor = stored,
+                    l1_head = head,
+                    "L1InfoTreeIndexer: operator override active — starting from forced block. \
+                     Remove --l1-indexer-from-block after this boot's backfill completes."
+                );
+                forced.saturating_sub(1)
+            } else if stored == 0 {
                 head
             } else {
                 // Re-process a small reorg window so we don't miss reorg'd
@@ -157,6 +191,7 @@ impl L1InfoTreeIndexer {
                 start_block = last_processed,
                 stored_cursor = stored,
                 l1_head = head,
+                from_block_override = ?self.from_block_override,
                 "L1InfoTreeIndexer cursor initialized"
             );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod account_recovery;
 pub mod accounts_config;
 pub mod address_mapper;
 pub mod block_state;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -52,6 +52,24 @@ fn log_filter() -> anyhow::Result<EnvFilter> {
         // without needing a rebuild.
         "miden_agglayer_service::service::debug=off",
         "miden_agglayer_service::service_send_raw_txn::debug=off",
+        // SECURITY: clamp the alloy/reqwest HTTP transport crates to `info`. The
+        // upstream `ReqwestTransport` emits a DEBUG event on every L1 RPC call that
+        // includes the full `url` field, which for our Sepolia archival endpoint
+        // contains the `?apiKey=<SECRET>` query string. The org logs to a SIEM, so
+        // any operator who flips `RUST_LOG=debug` would leak the credential. We add
+        // these as target-specific directives AFTER the env-derived filter — they
+        // take precedence over a bare `RUST_LOG=debug` because target-specific
+        // directives win on specificity in `tracing_subscriber::EnvFilter`,
+        // regardless of insertion order.
+        //
+        // If you ever need raw alloy transport tracing locally, do it explicitly
+        // and only with a non-production L1 endpoint:
+        //   RUST_LOG='info,my_target=debug,alloy_transport_http=debug' ...
+        // and accept that the URL (with any query params) will be logged.
+        "alloy_transport_http=info",
+        "alloy_transport=info",
+        "alloy_rpc_client=info",
+        "reqwest=info",
     ];
     let mut filter = env_or_default_filter();
     for directive in directives {
@@ -70,4 +88,149 @@ pub fn setup_tracing() -> anyhow::Result<()> {
     }));
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    //! Regression tests for the L1-RPC apiKey leak that prompted these directives.
+    //!
+    //! See the "SECURITY" comment in `log_filter` above. The fix relies on
+    //! target-specific directives winning over a bare `RUST_LOG=debug` because
+    //! `tracing_subscriber::EnvFilter` ranks directives by specificity, not by
+    //! insertion order. These tests pin that behaviour so a future refactor can't
+    //! silently regress the apiKey leak.
+    //!
+    //! Sample of the original leak (from bali pod `miden-agglayer-0`, redacted):
+    //!     DEBUG alloy_transport_http: received response from server, status: 200 OK
+    //!       url: https://rpc.eu-central-1.gateway.fm/v4/ethereum/archival/sepolia
+    //!       ?apiKey=<REDACTED> method_names: eth_blockNumber
+
+    use std::sync::{Arc, Mutex};
+
+    use tracing::Subscriber;
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+    use tracing_subscriber::registry::LookupSpan;
+
+    /// Capture layer that records `(target, level)` for every event reaching it.
+    #[derive(Clone, Default)]
+    struct CaptureLayer {
+        seen: Arc<Mutex<Vec<(String, tracing::Level)>>>,
+    }
+
+    impl<S> Layer<S> for CaptureLayer
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+    {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            let meta = event.metadata();
+            self.seen
+                .lock()
+                .unwrap()
+                .push((meta.target().to_string(), *meta.level()));
+        }
+    }
+
+    /// Build the production filter under a forced `RUST_LOG=debug` and run `f`
+    /// against a `Registry` that captures every event. This mirrors what the
+    /// real binary would do if an operator set `RUST_LOG=debug` on the pod.
+    fn with_debug_filter<F: FnOnce(&CaptureLayer)>(f: F) {
+        // SAFETY: tests in this module are single-threaded w.r.t. RUST_LOG.
+        // Cargo runs `#[test]` fns in parallel by default but each test owns
+        // its own subscriber instance via `with_default`, so the only shared
+        // state is the env var. We restore it at the end.
+        let prev = std::env::var("RUST_LOG").ok();
+        // SAFETY: setting env vars is unsafe on some platforms (Rust 1.84+).
+        unsafe {
+            std::env::set_var("RUST_LOG", "debug");
+        }
+
+        let filter = super::log_filter().expect("log_filter must build");
+        let capture = CaptureLayer::default();
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(capture.clone().with_filter(filter));
+
+        tracing::subscriber::with_default(subscriber, || f(&capture));
+
+        // SAFETY: see above.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("RUST_LOG", v),
+                None => std::env::remove_var("RUST_LOG"),
+            }
+        }
+    }
+
+    /// The leak target. No DEBUG-or-lower event from `alloy_transport_http`
+    /// must ever reach a subscriber, even under `RUST_LOG=debug`.
+    #[test]
+    fn logging_alloy_transport_http_debug_is_dropped_even_with_rust_log_debug() {
+        with_debug_filter(|capture| {
+            tracing::debug!(
+                target: "alloy_transport_http",
+                url = "https://rpc.example/v4/ethereum/archival/sepolia?apiKey=<REDACTED>",
+                "received response from server",
+            );
+            tracing::trace!(
+                target: "alloy_transport_http",
+                url = "https://rpc.example/v4/ethereum/archival/sepolia?apiKey=<REDACTED>",
+                "trace event that must not leak either",
+            );
+
+            let seen = capture.seen.lock().unwrap();
+            let leaked: Vec<_> = seen
+                .iter()
+                .filter(|(t, _)| t == "alloy_transport_http")
+                .collect();
+            assert!(
+                leaked.is_empty(),
+                "alloy_transport_http events reached subscriber: {leaked:?} — apiKey leak regression!",
+            );
+        });
+    }
+
+    /// The sibling transport crates use the same convention. Clamp them too.
+    /// `tracing::debug!` requires the target to be a string literal (the callsite
+    /// is generated at compile time), so the targets are unrolled rather than
+    /// looped.
+    #[test]
+    fn logging_alloy_transport_siblings_clamped_to_info() {
+        with_debug_filter(|capture| {
+            tracing::debug!(target: "alloy_transport", "debug must be dropped");
+            tracing::info!(target: "alloy_transport", "info is allowed");
+            tracing::debug!(target: "alloy_rpc_client", "debug must be dropped");
+            tracing::info!(target: "alloy_rpc_client", "info is allowed");
+            tracing::debug!(target: "reqwest", "debug must be dropped");
+            tracing::info!(target: "reqwest", "info is allowed");
+
+            let seen = capture.seen.lock().unwrap();
+            for (target, level) in seen.iter() {
+                if matches!(target.as_str(), "alloy_transport" | "alloy_rpc_client" | "reqwest") {
+                    assert!(
+                        *level <= tracing::Level::INFO,
+                        "{target} event at {level:?} leaked through filter",
+                    );
+                }
+            }
+        });
+    }
+
+    /// Sanity check: own-crate DEBUG events still surface under `RUST_LOG=debug`,
+    /// so the clamp didn't accidentally silence our own diagnostics.
+    #[test]
+    fn logging_own_crate_debug_still_surfaces() {
+        with_debug_filter(|capture| {
+            tracing::debug!(
+                target: "miden_agglayer_service::claim_watcher",
+                "own-crate debug must still reach subscriber",
+            );
+
+            let seen = capture.seen.lock().unwrap();
+            assert!(
+                seen.iter().any(|(t, l)| t == "miden_agglayer_service::claim_watcher"
+                    && *l == tracing::Level::DEBUG),
+                "own-crate debug event was suppressed by clamp — directive too broad. seen={seen:?}",
+            );
+        });
+    }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -147,8 +147,8 @@ mod tests {
 
         let filter = super::log_filter().expect("log_filter must build");
         let capture = CaptureLayer::default();
-        let subscriber = tracing_subscriber::Registry::default()
-            .with(capture.clone().with_filter(filter));
+        let subscriber =
+            tracing_subscriber::Registry::default().with(capture.clone().with_filter(filter));
 
         tracing::subscriber::with_default(subscriber, || f(&capture));
 
@@ -205,7 +205,10 @@ mod tests {
 
             let seen = capture.seen.lock().unwrap();
             for (target, level) in seen.iter() {
-                if matches!(target.as_str(), "alloy_transport" | "alloy_rpc_client" | "reqwest") {
+                if matches!(
+                    target.as_str(),
+                    "alloy_transport" | "alloy_rpc_client" | "reqwest"
+                ) {
                     assert!(
                         *level <= tracing::Level::INFO,
                         "{target} event at {level:?} leaked through filter",
@@ -227,8 +230,9 @@ mod tests {
 
             let seen = capture.seen.lock().unwrap();
             assert!(
-                seen.iter().any(|(t, l)| t == "miden_agglayer_service::claim_watcher"
-                    && *l == tracing::Level::DEBUG),
+                seen.iter()
+                    .any(|(t, l)| t == "miden_agglayer_service::claim_watcher"
+                        && *l == tracing::Level::DEBUG),
                 "own-crate debug event was suppressed by clamp — directive too broad. seen={seen:?}",
             );
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,17 @@ struct Command {
     #[arg(long, env = "GER_L1_ADDRESS")]
     ger_l1_address: Option<String>,
 
+    /// Operator override for the L1 InfoTree indexer's start block. When
+    /// set, the indexer ignores the persisted cursor and forces a forward
+    /// walk from this L1 block on the next boot — used to back-fill
+    /// historic `UpdateL1InfoTree` events whose `ger_entries` rows landed
+    /// with NULL `(M, R)` (the STATE C orphans pattern seen on bali, 27
+    /// rows from proxy blocks 95k-130k). After the back-fill completes
+    /// and the cursor advances forward, remove the flag for subsequent
+    /// boots — it serves no purpose once the cursor has moved past it.
+    #[arg(long, env = "L1_INDEXER_FROM_BLOCK")]
+    l1_indexer_from_block: Option<u64>,
+
     /// Enable Miden VM debug mode (verbose execution traces). Disable in production.
     #[arg(long, env = "MIDEN_DEBUG")]
     miden_debug: bool,
@@ -495,11 +506,15 @@ async fn main() -> anyhow::Result<()> {
     {
         match ger_addr_str.parse::<alloy::primitives::Address>() {
             Ok(ger_addr) => {
-                let indexer = miden_agglayer_service::l1_info_tree_indexer::L1InfoTreeIndexer::new(
-                    l1_rpc_url,
-                    ger_addr,
-                    state.store.clone(),
-                );
+                let mut indexer =
+                    miden_agglayer_service::l1_info_tree_indexer::L1InfoTreeIndexer::new(
+                        l1_rpc_url,
+                        ger_addr,
+                        state.store.clone(),
+                    );
+                if let Some(from_block) = command.l1_indexer_from_block {
+                    indexer = indexer.with_from_block_override(from_block);
+                }
                 match indexer.spawn() {
                     Ok(shutdown_tx) => {
                         // The indexer runs for the lifetime of the tokio

--- a/src/main.rs
+++ b/src/main.rs
@@ -478,21 +478,6 @@ async fn main() -> anyhow::Result<()> {
     // can mark it Landed once it sees the bridge consume it.
     state.expected_mints = expected_mints_handle;
     state.miden_store_dir = miden_store_dir.clone().unwrap_or_default();
-    // The fresh `MidenClient` built per `publish_claim` in `src/claim.rs` must connect to
-    // the SAME node URL as `MidenClient::new` — that's what `command.miden_node` feeds.
-    // This used to read an independent `MIDEN_NODE_URL` env var with a `http://miden-node:57291`
-    // fallback; when the env var wasn't set by the deployment, fresh-client builds
-    // unconditionally failed with `dns error: Name or service not known` on the fallback
-    // hostname, while the persistent sync loop (which reads `command.miden_node`) kept
-    // working fine. Claims silently never landed. See RD-856.
-    state.miden_node_url = command
-        .miden_node
-        .clone()
-        .unwrap_or_else(|| "http://localhost:57291".to_string());
-    tracing::info!(
-        miden_node_url = %state.miden_node_url,
-        "fresh-client `publish_claim` path will dial this Miden node URL"
-    );
     state.miden_api_key = command.miden_api_key;
 
     // L1 InfoTree indexer — eliminates the RD-862 GER decomposition race by

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,10 +333,9 @@ async fn main() -> anyhow::Result<()> {
             // migrations are now part of the deploy artifact (compiled into
             // the binary via `include_str!`) so the proxy and its schema
             // can't drift out of sync.
-            let report =
-                miden_agglayer_service::store::migrator::run_migrations(_db_url)
-                    .await
-                    .context("running embedded DB migrations on startup")?;
+            let report = miden_agglayer_service::store::migrator::run_migrations(_db_url)
+                .await
+                .context("running embedded DB migrations on startup")?;
             tracing::info!(
                 applied = report.applied.len(),
                 already_present = report.already_present.len(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -658,6 +658,7 @@ mod hardening_tests {
                 .to_string(),
             l1_rpc_url: None,
             ger_l1_address: None,
+            l1_indexer_from_block: None,
             miden_debug: false,
             cors_allowed_origins: cors,
             admin_api_key: admin,

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,6 +316,22 @@ async fn main() -> anyhow::Result<()> {
     let store: Arc<dyn Store> = if let Some(_db_url) = &command.database_url {
         #[cfg(feature = "postgres")]
         {
+            // Run embedded SQL migrations BEFORE the connection pool opens.
+            // This replaces the `agglayer-migrate` one-shot service that
+            // hardcoded the migration list in docker-compose.e2e.yml — new
+            // migrations are now part of the deploy artifact (compiled into
+            // the binary via `include_str!`) so the proxy and its schema
+            // can't drift out of sync.
+            let report =
+                miden_agglayer_service::store::migrator::run_migrations(_db_url)
+                    .await
+                    .context("running embedded DB migrations on startup")?;
+            tracing::info!(
+                applied = report.applied.len(),
+                already_present = report.already_present.len(),
+                "DB migrations complete"
+            );
+
             let pg = miden_agglayer_service::store::postgres::PgStore::new(_db_url).await?;
             Arc::new(pg)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -404,6 +404,14 @@ async fn main() -> anyhow::Result<()> {
         command.miden_debug,
     )?;
 
+    // Self-heal is RUNTIME-only, not startup-only. See `src/account_recovery.rs`
+    // — when a Miden submission inside `insert_ger` or `publish_claim` returns
+    // an `AccountDataNotFound` or `IncorrectAccountInitialCommitment` error,
+    // the caller reimports the affected account from the live Miden node and
+    // retries once. We deliberately do NOT brick the proxy at startup over
+    // locally-deployed-but-not-yet-network-tracked accounts (e.g. service,
+    // wallet_hardhat) — those are healthy until first use, at which point
+    // their initial `submit_new_transaction` deploys them on-chain.
     // Run restore if requested
     if command.restore {
         let result =

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -59,6 +59,24 @@ pub async fn restore(
 ) -> anyhow::Result<RestoreResult> {
     tracing::info!("=== RESTORE: starting state reconstruction ===");
 
+    // Phase 0: Re-import every bridge_accounts.toml account from the live
+    // Miden node into the local sqlite. Without this, `--reset-miden-store
+    // --restore` is a footgun: reset wipes the sqlite, restore's Phase 1
+    // calls `sync_state()` which only syncs deltas for already-tracked
+    // accounts (not new imports), and the proxy comes back with zero
+    // local rows for any account → every subsequent submission fails
+    // with `AccountDataNotFound`. This is the regression chain that
+    // locked bali into 20 days of stuck deposits after an operator ran
+    // the recovery flags.
+    //
+    // Best-effort: per-account failures are logged + counted but do not
+    // abort restore. Locally-deployed-but-not-network-tracked accounts
+    // (`service`, `wallet_hardhat`) will return `AccountNotFoundOnChain`
+    // here and that's fine — they're healthy until first use.
+    tracing::info!("Phase 0: re-importing bridge accounts from Miden node...");
+    crate::account_recovery::reimport_known_accounts(miden_client, accounts).await;
+    tracing::info!("Phase 0 complete: bridge account reimport pass done");
+
     // Phase 1: Sync miden state
     tracing::info!("Phase 1: syncing miden state...");
     let block_num = sync_miden_block(miden_client, store).await?;

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -376,11 +376,8 @@ async fn publish_and_record_claim(
         txn_hash,
         txn_envelope,
         signer,
-        service.miden_store_dir.clone(),
-        service.miden_node_url.clone(),
         service.reject_zero_padding_addresses,
         Some(service.expected_mints.clone()),
-        service.miden_api_key.clone(),
     )
     .await?;
     tracing::info!(

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -63,10 +63,10 @@ pub struct ServiceState {
     pub l1_rpc_url: Option<String>,
     /// L1 GER contract address
     pub ger_l1_address: Option<String>,
-    /// Miden client store directory (for building fresh clients)
+    /// Miden client store directory (used by recovery commands; the long-lived
+    /// `MidenClient` owns the sqlite handle so production submission paths do
+    /// not need to re-derive this).
     pub miden_store_dir: PathBuf,
-    /// Miden node URL (for building fresh clients)
-    pub miden_node_url: String,
     /// CORS-allowed origins (R11). `None` = no cross-origin requests permitted (the
     /// safe default in production); `Some(list)` = explicit allowlist; the special
     /// single-entry `vec!["*"]` is reserved for dev-only wildcards.
@@ -128,7 +128,6 @@ impl ServiceState {
             l1_rpc_url: None,
             ger_l1_address: None,
             miden_store_dir: PathBuf::new(),
-            miden_node_url: String::new(),
             cors_allowed_origins: None,
             admin_api_key: None,
             allowed_signers: None,

--- a/src/store/migrator.rs
+++ b/src/store/migrator.rs
@@ -1,0 +1,245 @@
+//! In-process Postgres migrator. Runs at proxy startup before `PgStore`
+//! opens the connection pool.
+//!
+//! ## Why
+//!
+//! Until this module existed, schema migrations were applied by a
+//! separate `agglayer-migrate` one-shot docker-compose service that
+//! hardcoded the migration list in its `command:` block. New
+//! migrations required editing both the SQL file AND the compose
+//! file. That footgun was the proximate cause of `005_l1_indexer_cursor.sql`
+//! shipping unwired in an earlier iteration of this branch. Production
+//! presumably had the same shape (init container or k8s Job with a
+//! hardcoded list) — so the proxy could ship a migration its DB
+//! never received.
+//!
+//! ## Design
+//!
+//! - Migrations are embedded into the binary via `include_str!`. The
+//!   list is alphabetically ordered (`001_…`, `002_…`, etc.) so
+//!   downstream tools and operators can grep the binary for them.
+//! - A `schema_migrations(name, checksum, applied_at)` tracking table
+//!   is created on first run if absent.
+//! - On every startup the migrator:
+//!     1. Acquires a SERIALIZABLE-level Postgres advisory lock so two
+//!        pods racing on startup don't double-apply.
+//!     2. For each migration in order: if absent → apply the file +
+//!        INSERT row + commit; if present with matching checksum →
+//!        skip; if present with MISMATCHING checksum → return Err
+//!        (loud: a previously-applied migration was edited, which is
+//!        a deployment bug, not something we can paper over).
+//!     3. Releases the advisory lock.
+//! - Idempotent: re-running is safe. Empty DB or fully-migrated DB
+//!   both converge.
+//!
+//! ## Caller contract
+//!
+//! `main.rs` calls `run_migrations(&db_url).await?` immediately after
+//! parsing `--database-url` and before constructing `PgStore`. Errors
+//! propagate up and abort startup. The InMemoryStore code path (when
+//! `--database-url` is unset) does not need migrations.
+
+use anyhow::{Context, Result};
+use sha3::{Digest, Keccak256};
+use tokio_postgres::{Client, NoTls};
+
+/// Compile-time embedded list of `(filename, sql)`. KEEP THIS IN
+/// LEXICOGRAPHIC ORDER. New migrations are added at the end.
+const MIGRATIONS: &[(&str, &str)] = &[
+    (
+        "001_initial.sql",
+        include_str!("../../migrations/001_initial.sql"),
+    ),
+    (
+        "002_faucet_registry.sql",
+        include_str!("../../migrations/002_faucet_registry.sql"),
+    ),
+    (
+        "003_unclaimable_claims.sql",
+        include_str!("../../migrations/003_unclaimable_claims.sql"),
+    ),
+    (
+        "004_claim_watcher.sql",
+        include_str!("../../migrations/004_claim_watcher.sql"),
+    ),
+    (
+        "005_l1_indexer_cursor.sql",
+        include_str!("../../migrations/005_l1_indexer_cursor.sql"),
+    ),
+];
+
+/// Postgres advisory-lock key. Arbitrary 64-bit int; just needs to be
+/// stable across all proxy instances so they serialise.
+const ADVISORY_LOCK_KEY: i64 = 0x1729_2026_0518_0001_u64 as i64;
+
+/// Result of one migrator run, suitable for structured logging.
+#[derive(Debug, Clone, Default)]
+pub struct MigrationReport {
+    pub applied: Vec<String>,
+    pub already_present: Vec<String>,
+}
+
+/// Connect to `db_url`, apply any pending migrations from the embedded
+/// list, return a report. Errors abort proxy startup.
+pub async fn run_migrations(db_url: &str) -> Result<MigrationReport> {
+    let (client, connection) = tokio_postgres::connect(db_url, NoTls)
+        .await
+        .context("connecting to Postgres for migrations")?;
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            tracing::error!(error = %e, "migrator: postgres connection task ended with error");
+        }
+    });
+    let result = run_migrations_with_client(&client).await;
+    drop(client);
+    result
+}
+
+/// Inner: takes an already-connected client so tests can pass a
+/// pg_temporary or testcontainer client.
+async fn run_migrations_with_client(client: &Client) -> Result<MigrationReport> {
+    ensure_schema_migrations_table(client).await?;
+
+    // Take the advisory lock; held for the rest of this connection's
+    // lifetime (released on drop).
+    client
+        .execute(&format!("SELECT pg_advisory_lock({ADVISORY_LOCK_KEY})"), &[])
+        .await
+        .context("acquiring advisory lock")?;
+
+    let mut report = MigrationReport::default();
+
+    for (name, sql) in MIGRATIONS {
+        let checksum = compute_checksum(sql);
+        let row = client
+            .query_opt(
+                "SELECT checksum FROM schema_migrations WHERE name = $1",
+                &[name],
+            )
+            .await
+            .with_context(|| format!("looking up migration {name}"))?;
+
+        match row {
+            None => {
+                // Apply
+                tracing::info!(migration = %name, "applying migration");
+                client
+                    .batch_execute(sql)
+                    .await
+                    .with_context(|| format!("applying migration {name}"))?;
+                client
+                    .execute(
+                        "INSERT INTO schema_migrations (name, checksum) VALUES ($1, $2)",
+                        &[name, &checksum.as_str()],
+                    )
+                    .await
+                    .with_context(|| format!("recording applied migration {name}"))?;
+                report.applied.push((*name).into());
+            }
+            Some(existing) => {
+                let recorded: &str = existing.get(0);
+                if recorded != checksum {
+                    anyhow::bail!(
+                        "migration {name} previously applied with checksum {recorded} \
+                         but the file currently embedded checksums to {checksum}. \
+                         A previously-applied migration was modified — this is a \
+                         deployment bug and not something the proxy will paper over. \
+                         Either revert the edit, or rename to a new migration file \
+                         that supersedes it."
+                    );
+                }
+                report.already_present.push((*name).into());
+            }
+        }
+    }
+
+    // Release the advisory lock explicitly (it'd release on disconnect
+    // anyway, but being explicit makes the intent obvious).
+    client
+        .execute(&format!("SELECT pg_advisory_unlock({ADVISORY_LOCK_KEY})"), &[])
+        .await
+        .context("releasing advisory lock")?;
+
+    tracing::info!(
+        applied = report.applied.len(),
+        already_present = report.already_present.len(),
+        applied_names = ?report.applied,
+        "migration run complete"
+    );
+    Ok(report)
+}
+
+async fn ensure_schema_migrations_table(client: &Client) -> Result<()> {
+    client
+        .batch_execute(
+            "CREATE TABLE IF NOT EXISTS schema_migrations (
+                name        TEXT PRIMARY KEY,
+                checksum    TEXT NOT NULL,
+                applied_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+            );",
+        )
+        .await
+        .context("creating schema_migrations table")
+}
+
+fn compute_checksum(sql: &str) -> String {
+    let mut hasher = Keccak256::new();
+    hasher.update(sql.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migration_list_is_lexicographically_sorted() {
+        let names: Vec<&str> = MIGRATIONS.iter().map(|(n, _)| *n).collect();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(
+            names, sorted,
+            "MIGRATIONS list must be in lexicographic order"
+        );
+    }
+
+    #[test]
+    fn migration_names_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for (name, _) in MIGRATIONS {
+            assert!(seen.insert(*name), "duplicate migration name: {name}");
+        }
+    }
+
+    #[test]
+    fn checksum_is_deterministic_and_changes_with_content() {
+        let c1 = compute_checksum("CREATE TABLE x();");
+        let c2 = compute_checksum("CREATE TABLE x();");
+        let c3 = compute_checksum("CREATE TABLE y();");
+        assert_eq!(c1, c2);
+        assert_ne!(c1, c3);
+        assert_eq!(c1.len(), 64); // sha256 hex
+    }
+
+    /// Live-Postgres integration test. Skipped unless DATABASE_URL is set,
+    /// which `make e2e-up` provides via the agglayer-postgres container.
+    ///
+    /// Run with `DATABASE_URL=host=127.0.0.1 port=5434 user=agglayer password=agglayer dbname=agglayer_store cargo test --features postgres migrator::tests::live -- --nocapture`.
+    #[tokio::test]
+    #[ignore = "requires live Postgres"]
+    async fn live_run_migrations_is_idempotent() {
+        let db_url = std::env::var("DATABASE_URL")
+            .expect("set DATABASE_URL to run this test");
+        let r1 = run_migrations(&db_url).await.expect("first run");
+        let r2 = run_migrations(&db_url).await.expect("second run");
+        // Second run must apply nothing.
+        assert!(r2.applied.is_empty(), "second run applied: {:?}", r2.applied);
+        assert_eq!(
+            r2.already_present.len(),
+            MIGRATIONS.len(),
+            "second run did not see all migrations as already-present"
+        );
+        // First run applied at least 0; if the DB was fresh it applied all.
+        assert!(r1.applied.len() + r1.already_present.len() == MIGRATIONS.len());
+    }
+}

--- a/src/store/migrator.rs
+++ b/src/store/migrator.rs
@@ -103,7 +103,10 @@ async fn run_migrations_with_client(client: &Client) -> Result<MigrationReport> 
     // Take the advisory lock; held for the rest of this connection's
     // lifetime (released on drop).
     client
-        .execute(&format!("SELECT pg_advisory_lock({ADVISORY_LOCK_KEY})"), &[])
+        .execute(
+            &format!("SELECT pg_advisory_lock({ADVISORY_LOCK_KEY})"),
+            &[],
+        )
         .await
         .context("acquiring advisory lock")?;
 
@@ -156,7 +159,10 @@ async fn run_migrations_with_client(client: &Client) -> Result<MigrationReport> 
     // Release the advisory lock explicitly (it'd release on disconnect
     // anyway, but being explicit makes the intent obvious).
     client
-        .execute(&format!("SELECT pg_advisory_unlock({ADVISORY_LOCK_KEY})"), &[])
+        .execute(
+            &format!("SELECT pg_advisory_unlock({ADVISORY_LOCK_KEY})"),
+            &[],
+        )
         .await
         .context("releasing advisory lock")?;
 
@@ -228,12 +234,15 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires live Postgres"]
     async fn live_run_migrations_is_idempotent() {
-        let db_url = std::env::var("DATABASE_URL")
-            .expect("set DATABASE_URL to run this test");
+        let db_url = std::env::var("DATABASE_URL").expect("set DATABASE_URL to run this test");
         let r1 = run_migrations(&db_url).await.expect("first run");
         let r2 = run_migrations(&db_url).await.expect("second run");
         // Second run must apply nothing.
-        assert!(r2.applied.is_empty(), "second run applied: {:?}", r2.applied);
+        assert!(
+            r2.applied.is_empty(),
+            "second run applied: {:?}",
+            r2.applied
+        );
         assert_eq!(
             r2.already_present.len(),
             MIGRATIONS.len(),

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -7,6 +7,8 @@
 
 pub mod memory;
 #[cfg(feature = "postgres")]
+pub mod migrator;
+#[cfg(feature = "postgres")]
 pub mod postgres;
 #[cfg(all(test, feature = "postgres"))]
 mod postgres_tests;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -133,6 +133,18 @@ pub trait Store: Send + Sync + 'static {
     /// Increment block number by 1 and return the new value.
     async fn advance_block_number(&self) -> anyhow::Result<u64>;
 
+    // === L1 indexer cursor (RD-862 follow-up) ===
+    /// Last successfully-polled L1 block. Returns 0 if the indexer has
+    /// never persisted a cursor on this deployment.
+    async fn get_l1_indexer_cursor(&self) -> anyhow::Result<u64> {
+        Ok(0)
+    }
+    /// Persist the last-processed L1 block. Called after each successful
+    /// batch so a restart resumes from here instead of jumping to L1 head.
+    async fn set_l1_indexer_cursor(&self, _block: u64) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     // === Synthetic logs ===
     async fn add_log(&self, log: SyntheticLog) -> anyhow::Result<()>;
     async fn get_logs(

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -92,6 +92,34 @@ impl Store for PgStore {
         Ok(val as u64)
     }
 
+    async fn get_l1_indexer_cursor(&self) -> anyhow::Result<u64> {
+        let client = self.pool.get().await?;
+        let row = client
+            .query_opt(
+                "SELECT last_processed FROM l1_indexer_state WHERE id = 1",
+                &[],
+            )
+            .await?;
+        match row {
+            Some(r) => {
+                let val: i64 = r.get(0);
+                Ok(val as u64)
+            }
+            None => Ok(0),
+        }
+    }
+
+    async fn set_l1_indexer_cursor(&self, block: u64) -> anyhow::Result<()> {
+        let client = self.pool.get().await?;
+        client
+            .execute(
+                "UPDATE l1_indexer_state SET last_processed = $1, updated_at = now() WHERE id = 1",
+                &[&(block as i64)],
+            )
+            .await?;
+        Ok(())
+    }
+
     // ── Logs ─────────────────────────────────────────────────────
 
     async fn add_log(&self, log: SyntheticLog) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary

Supersedes #44 with a clean, hand-picked commit history.

Closes the bali production incident (Marti's L1→L2 deposit stuck ~20 days as of 2026-05-18) and structurally prevents the bug class.

## What's broken on bali (verified via Loki + code archaeology + local repro)

| When | Event |
|------|-------|
| 2026-04-13 | Commit `dbe5c2d` accidentally dropped `.storage_mode(AccountStorageMode::Network/Public)` from `add_wallet` during the 0.14.x migration. All accounts deployed from this point default to `Private` (no on-chain copy). |
| 2026-04-23 | Bali deployed via the buggy code path. `ger_manager`, `bridge`, `service` accounts all Private. |
| 2026-05-11 16:14:51Z | First `incorrect account initial commitment` (IAIC) log line on bali. Recurred 189 times through 2026-05-14 from concurrent claim + GER submissions racing the `bridge` account's mempool slot. |
| 2026-05-14 18:45:18Z | Operator ran `--reset-miden-store --restore` to recover. `--reset` wiped `store.sqlite3`; `--restore` Phase 1 only called `sync_state()` — does **not** re-import bridge accounts. `latest_account_headers` came back empty. |
| 2026-05-14 onwards | Every aggoracle `insertGlobalExitRoot` push fails with `AccountDataNotFound`. Backlog grows. |

## What v0.4.0 ships

### Cure for the active failure mode

- **`fix(init): use AccountStorageMode::Public for add_wallet`** — restores the dropped storage_mode call. Future deployments are recoverable from a local sqlite loss.
- **`feat(self-heal): runtime retry on AccountDataNotFound + IAIC`** — typed-downcast catch on `ClientError`/`AddTransactionError`, `import_account_by_id` from node, retry once. Covers both error types via the same code path. 5 unit tests pin the typed match against canonical upstream variants.
- **`feat(restore): import bridge accounts in Phase 0 of --restore`** — `--reset-miden-store --restore` now re-imports bridge accounts before `sync_state()`. End-to-end repro: `scripts/e2e-reset-restore-recovery.sh`.

### Structural prevention of the root-cause race

- **`feat(claim): route publish_claim through long-lived MidenClient`** — eliminates the dual-sqlite-handle race. Every Miden submission funnels through the long-lived client's `mpsc::channel(1)`. At most one in-flight submission ⇒ structurally impossible to produce two mempool-conflicting txs from the proxy.
- **`fix(claim): wrap publish_claim with self-heal retry`** — closes the asymmetry where only the GER path had the safety net.
- **`feat(indexer): persistent cursor + resume on restart`** — closes the gap that produced bali's 27 historic STATE-C orphans.

### Defensive hardening + operational fixes

- **`fix(logging): clamp alloy http transport to info`** — stops `RUST_LOG=debug` from logging the Sepolia archival `?apiKey=<SECRET>` query string in every L1 RPC line. Active SIEM credential leak.
- **`fix(accounts-config): atomic write for bridge_accounts.toml`** — fsync + rename. Prevents OOM-mid-write corruption.
- **`feat(startup): in-process DB migrator`** — embeds migrations via `include_str!` + checksum-verified `schema_migrations` + advisory lock. Replaces the `agglayer-migrate` compose service that was a deploy-time footgun (new migrations had to be wired into compose by hand).
- **`feat(indexer): --l1-indexer-from-block override`** — operator backfill flag for bali's 27 historic STATE-C orphans (cosmetic; non-blocking).
- **`fix(dockerfile): COPY migrations dir into builder context`** — without it the build fails at `include_str!`.

## Test surface

```
cargo test --lib --features postgres   →   179 passed; 1 ignored (live-PG)
cargo clippy --all-targets             →   0 warnings
cargo build --release --features postgres → 0 errors
```

E2E repro scripts (in `scripts/`):
- `e2e-account-self-heal.sh` (MODE=`expect_failure` / `expect_self_heal` — proves bug on main AND cure on this branch, same script)
- `e2e-reset-restore-recovery.sh` (operator-faithful reset+restore cure)
- `e2e-iaic-mempool-conflict.sh` (concurrent-load IAIC induction; requires fixture, see script header)

Multi-pass evidence from earlier runs and the regression sweep are not committed to the repo (kept local in `../repro/v0.3.0-evidence/`); happy to share out of band if you want to see them.

## Bali deployment caveat

v0.4.0's runtime self-heal **cannot** recover bali's current `ger_manager` because that account is Private (created pre-`dbe5c2d`-fix). `import_account_by_id` returns `AccountIsPrivate` on Private accounts. Bali specifically needs a **full redeploy** with fresh Public accounts + aggkit reconfig. Procedure documented in `docs/REDEPLOY_RUNBOOK_BALI.md`.

All FUTURE deployments (and any other proxy redeployed off v0.4.0) self-heal on this bug class without operator intervention.

## Why v0.4.0 and not v0.3.1?

The `v0.3.0` tag was pushed earlier today against a slightly different commit (`bb529f3`). Per org policy, force-updating a published tag is off the table. v0.4.0 sidesteps the ambiguity cleanly.

## Test plan
- [ ] Review the 13 substantive commits + 1 fmt commit
- [ ] Confirm bali redeploy procedure with SRE
- [ ] Merge → tag v0.4.0 → docker image push
- [ ] Bali redeploy (per `docs/REDEPLOY_RUNBOOK_BALI.md`)
- [ ] Aggkit reconfig pointing at new bridge account IDs
- [ ] Verify Marti's deposit `cnt=1130654` flips `ready_for_claim=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)