### PR TITLE
ci(release): drop `:latest` tag — Docker Hub immutability rolled back every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,14 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+          # NOTE: `:latest` is intentionally NOT pushed. The Docker Hub
+          # repository has tag-immutability enabled on `:latest`, so every
+          # release-workflow run that tried to push it failed (v0.2.0,
+          # v0.2.1, v0.3.0, v0.4.0 first attempt) and the multi-tag buildx
+          # push rolled back the version-specific manifests with it,
+          # leaving Docker Hub without the released image. If a moving
+          # `:latest` pointer is ever wanted, remove the immutability rule
+          # on Docker Hub first, then re-add `type=raw,value=latest` here.
 
       - name: Build and push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0


### PR DESCRIPTION
## Summary

Removes `type=raw,value=latest` from `release.yml` so the workflow stops trying to push `:latest` on tag push.

## Why

Every release-workflow run since v0.2.0 has failed at the `:latest` push step because Docker Hub has tag-immutability enabled on `:latest`. Earlier I (and the v0.3.0 release notes) assumed only the `:latest` step was failing while the version tag still got through — but the v0.4.0 release (run 26108752860) showed the truth via post-run Docker Hub inspection: **nothing** persisted. The buildx multi-tag push rolls back the version-specific manifests when the `:latest` manifest is rejected.

So every "successful" release we thought we had pushed to Docker Hub since v0.2.0 may need verification too. v0.4.0 is definitely not there right now.

## Test plan
- [ ] Merge
- [ ] Delete + re-create `v0.4.0` tag at new main HEAD (which contains both the v0.4.0 code and this workflow fix)
- [ ] Watch the release workflow succeed
- [ ] Verify `gatewayfm/miden-agglayer:0.4.0` is on Docker Hub
- [ ] Verify `gatewayfm/miden-agglayer:0.4` is also pushed

If `:latest` is ever wanted, the immutability rule on Docker Hub needs to be removed first, then `type=raw,value=latest` re-added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)