### PR TITLE
ci(release): drop moving :major.minor tag, retag as v0.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,15 +29,16 @@ jobs:
           images: gatewayfm/miden-agglayer
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-          # NOTE: `:latest` is intentionally NOT pushed. The Docker Hub
-          # repository has tag-immutability enabled on `:latest`, so every
-          # release-workflow run that tried to push it failed (v0.2.0,
-          # v0.2.1, v0.3.0, v0.4.0 first attempt) and the multi-tag buildx
-          # push rolled back the version-specific manifests with it,
-          # leaving Docker Hub without the released image. If a moving
-          # `:latest` pointer is ever wanted, remove the immutability rule
-          # on Docker Hub first, then re-add `type=raw,value=latest` here.
+          # NOTE: Only the exact `:{version}` tag is pushed. The Docker Hub
+          # repository has tag-immutability enabled across the board, so
+          # any *moving* tag fails on the second release that tries to
+          # update it. `:latest` killed v0.2.0, v0.2.1, v0.3.0, and v0.4.0
+          # first attempt; `:{major}.{minor}` (e.g. `:0.4`) killed v0.4.0
+          # second attempt because the first attempt had already written
+          # it before failing on `:latest`. Both moving patterns are now
+          # removed. If a moving pointer is ever wanted, remove the
+          # immutability rule on Docker Hub first, then re-add the
+          # corresponding `type=raw` / `type=semver` entry here.
 
       - name: Build and push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/docs/REDEPLOY_RUNBOOK_BALI.md
+++ b/docs/REDEPLOY_RUNBOOK_BALI.md
@@ -1,14 +1,20 @@
-# Bali v0.4.0 deploy + recovery runbook
+# Bali v0.4.1 deploy + recovery runbook
 
 Author: max.revitt@gateway.fm
 Audience: SRE on call for the bali Miden agglayer testnet
 Last-validated: 2026-05-19 against branch `feat/v0.4.0-self-heal`
                 (HEAD `d241b0b`).
 
+> **v0.4.1 vs v0.4.0:** code is identical. v0.4.1 is a re-tag that
+> drops the moving `:{major}.{minor}` (`:0.4`) tag from the release
+> workflow — both v0.4.0 release attempts failed at the Docker Hub
+> push because of tag immutability (`:latest` on attempt 1, `:0.4` on
+> attempt 2). The published image is `gatewayfm/miden-agglayer:0.4.1`.
+
 ## What this runbook is for
 
-Deploying `v0.4.0` of `gatewayfm/miden-agglayer` to the bali production
-proxy (`outpost-testnet-miden-testnet/miden-agglayer-0`). v0.4.0 fixes
+Deploying `v0.4.1` of `gatewayfm/miden-agglayer` to the bali production
+proxy (`outpost-testnet-miden-testnet/miden-agglayer-0`). v0.4.1 fixes
 the regression chain that has held bali's L1→L2 bridge in
 `AccountDataNotFound` failure for ~20 wall-days, plus the underlying
 race that triggered it. Two stuck deposits (marti's `cnt=1130654` and
@@ -26,7 +32,7 @@ kubectl -n outpost-testnet-miden-testnet describe pod miden-agglayer-0 \
 ```
 
 Expect: `Image: docker.io/gatewayfm/miden-agglayer:0.2.1`. If it's
-already v0.4.0 something is out of band and you should ask Max.
+already v0.4.1 something is out of band and you should ask Max.
 
 ```sql
 -- agglayer-store (kubectl port-forward svc/miden-agglayer-db 15434:5432)
@@ -50,25 +56,25 @@ WHERE network_id = 0 AND dest_net = 73 ORDER BY deposit_cnt;
 Expect `1127628..1127650 ready=true` (3 rows), `1130654 + 1131034
 ready=false` (2 rows). marti's `1130654` is one of the stuck.
 
-## Step 1 — build + push v0.4.0 image
+## Step 1 — build + push v0.4.1 image
 
 The `release.yml` GitHub Actions workflow auto-builds and pushes
-`gatewayfm/miden-agglayer:0.4.0` to Docker Hub on tag push. Local
+`gatewayfm/miden-agglayer:0.4.1` to Docker Hub on tag push. Local
 fallback (if CI is unavailable):
 
 ```bash
 cd ~/github/gateway/miden/miden-agglayer
 git checkout main  # after PR #45 merge
 docker buildx build --platform linux/amd64 \
-  -t gatewayfm/miden-agglayer:0.4.0 \
+  -t gatewayfm/miden-agglayer:0.4.1 \
   --push .
 ```
 
 Tag the commit:
 
 ```bash
-git tag -a v0.4.0 -m "v0.4.0 runtime self-heal + Public storage_mode + unified claim client + remote tx-prover + atomic config + in-process migrator + persistent indexer cursor"
-git push origin v0.4.0
+git tag -a v0.4.1 -m "v0.4.1 — same code as v0.4.0, re-tagged after dropping moving :major.minor tag from release workflow"
+git push origin v0.4.1
 ```
 
 Image digest from the push output — paste it into the StatefulSet
@@ -79,7 +85,7 @@ patch below.
 ```bash
 kubectl -n outpost-testnet-miden-testnet patch statefulset miden-agglayer \
   --type='json' \
-  -p='[{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"docker.io/gatewayfm/miden-agglayer:0.4.0"}]'
+  -p='[{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"docker.io/gatewayfm/miden-agglayer:0.4.1"}]'
 ```
 
 Watch the rollout:


### PR DESCRIPTION
## Summary
- Removes `type=semver,pattern={{major}}.{{minor}}` from `release.yml`. Docker Hub tag-immutability locked `:0.4` during v0.4.0 attempt #1 (which successfully pushed `:0.4.0` and `:0.4` before dying on `:latest`); attempt #2 then failed re-pushing `:0.4.0` itself. Killing the moving tag prevents the same trap on every future release.
- Bumps `docs/REDEPLOY_RUNBOOK_BALI.md` to v0.4.1. Code is identical to v0.4.0 — this is purely a re-tag to escape the registry deadlock.

## Test plan
- [ ] Merge this PR
- [ ] Tag `v0.4.1` at the resulting main HEAD and push — release workflow should push `gatewayfm/miden-agglayer:0.4.1` cleanly with no moving-tag fallout

🤖 Generated with [Claude Code](https://claude.com/claude-code)