### PR TITLE
fix(eth_getLogs): emit over-range error in aggsender-parseable format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3370,6 +3370,7 @@ dependencies = [
  "miden-standards",
  "miden-tx",
  "parking_lot",
+ "regex",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ path = "src/bin/check_burn_root.rs"
 
 [dev-dependencies]
 tempfile = "3.10"
+# Used only by `r5_oversize_error_matches_aggsender_parser` to mirror aggkit's
+# `ParseMaxRangeFromError` regex verbatim and pin the error-format contract.
+regex = "1.10"
 
 [profile.dev.package."*"]
 opt-level = 1

--- a/src/service_get_logs.rs
+++ b/src/service_get_logs.rs
@@ -89,8 +89,14 @@ pub fn validate_getlogs_filter(filter: &LogFilter, current_block: u64) -> Result
     // Saturate so a `from` that exceeds `to` doesn't underflow into a giant span.
     let span = to.saturating_sub(from).saturating_add(1);
     if span > MAX_GETLOGS_BLOCK_RANGE {
+        // Format chosen to match aggkit's `ParseMaxRangeFromError` reMaxRange regex
+        // `block range too large, max range:\s*(\d+)` so aggsender's reactive-chunking
+        // fallback can extract the limit and split the request automatically. See
+        // `aggkit/common/errors.go` and `aggkit/claimsync/agglayer_bridge_l2_reader.go`.
+        // The regression test `r5_oversize_error_matches_aggsender_parser` below pins
+        // this contract — do not change the format without updating that test.
         return Err(format!(
-            "eth_getLogs block range too large: {span} > {MAX_GETLOGS_BLOCK_RANGE} (paginate)"
+            "eth_getLogs block range too large, max range: {MAX_GETLOGS_BLOCK_RANGE} (got {span}, paginate)"
         ));
     }
     #[allow(clippy::collapsible_if)]
@@ -158,6 +164,61 @@ mod tests {
         // Accepts: tip-only query (default `latest`/`latest` resolves to current_block).
         let tip = LogFilter::default();
         assert!(validate_getlogs_filter(&tip, 100).is_ok());
+    }
+
+    /// Regression test for an interop bug we hit on the post-relaunch Bali rollup
+    /// 2026-05-20: aggsender's `ParseMaxRangeFromError` parser couldn't extract the
+    /// limit from the agglayer's "X > Y (paginate)" error format, so its reactive
+    /// chunked-fallback never fired and the bridge-out cert build was stuck retrying
+    /// forever. The fix was to rewrite the error string to the canonical
+    /// "max range: N" shape that aggsender's `reMaxRange` regex matches.
+    ///
+    /// This test locks the contract: a regex copy-pasted from
+    /// `aggkit/common/errors.go:12` (and verified in `aggkit/common/errors_test.go`)
+    /// MUST find a numeric capture in the over-range error string. If anyone ever
+    /// reverts the format, this test fails before the change ships.
+    #[test]
+    fn r5_oversize_error_matches_aggsender_parser() {
+        use regex::Regex;
+        // Copied verbatim from `aggkit/common/errors.go:12` — the regex aggsender
+        // uses to detect "split this into chunks of N blocks" hints. If this regex
+        // ever changes upstream we want a test failure; do not "fix" it by relaxing
+        // here. See [[agglayer-getlogs-error-format-mismatch]] in the gateway memory.
+        let re_max_range = Regex::new(r"block range too large, max range:\s*(\d+)").unwrap();
+
+        // Trigger the over-range path with a realistic ratio (matches what aggsender
+        // sends on a fresh-deployment cold-start scan: from=0, to=cluster's L2 head).
+        let oversize = LogFilter {
+            from_block: Some("0x0".into()),
+            to_block: Some("0xd2a7d".into()), // 862_653 — typical cold-start ceiling
+            ..Default::default()
+        };
+        let err = validate_getlogs_filter(&oversize, 1_000_000)
+            .expect_err("oversize range must be rejected");
+
+        // 1. Bare error string must match the parser regex.
+        let caps_bare = re_max_range
+            .captures(&err)
+            .unwrap_or_else(|| panic!("agglayer error format diverged from aggsender parser; aggsender's reactive chunking will silently fail. err={err}"));
+        let parsed_max: u64 = caps_bare[1].parse().unwrap();
+        assert_eq!(
+            parsed_max, MAX_GETLOGS_BLOCK_RANGE,
+            "parsed max range ({parsed_max}) must equal the agglayer cap ({MAX_GETLOGS_BLOCK_RANGE})"
+        );
+
+        // 2. Wrapped error (the actual shape aggsender sees: an err chain wrapped
+        // multiple levels deep by gRPC/Go wrappers) must ALSO match. This is the
+        // string aggsender actually parses — its parser does `.error()` on the
+        // root err, getting the fully unwrapped concatenation. Confirm our format
+        // is parseable even when prefixed with the wrapping aggsender adds.
+        let wrapped = format!(
+            "error getting certificate build params: error generating build params: \
+             error getting unset claims for block range: {err}"
+        );
+        let caps_wrapped = re_max_range.captures(&wrapped).unwrap_or_else(|| {
+            panic!("wrapped error did not match parser regex (caller wrapping broke contract): {wrapped}")
+        });
+        assert_eq!(&caps_wrapped[1], &caps_bare[1]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The `MAX_GETLOGS_BLOCK_RANGE` over-range error was emitted as `"block range too large: <span> > <max> (paginate)"`, which doesn't match any of aggkit's `ParseMaxRangeFromError` regexes. Aggsender's reactive chunked-fallback never fired, and bridge-out cert builds spun in an infinite retry loop on any rollup with >10k L2 blocks at aggsender startup — i.e. every fresh deployment.
- Reword the error to `"block range too large, max range: <max> (got <span>, paginate)"`, matching aggkit's `reMaxRange` regex at [`aggkit/common/errors.go:12`](https://github.com/agglayer/aggkit/blob/main/common/errors.go).
- Add `r5_oversize_error_matches_aggsender_parser` regression test that copies aggkit's regex verbatim and asserts the agglayer's over-range error parses to the expected limit, in both bare and realistically-wrapped forms.

## How it was found

Running the L2→L1 bridge-out test against the post-relaunch Bali testnet 2026-05-20. Aggsender's cold-start scan from block 1 → 862k immediately tripped the agglayer's 10k cap; the reactive-chunking fallback couldn't extract the limit; the cert-build retry loop never converged. See the test docstring for the full repro narrative.

## Orthogonal mitigation

Setting `[AggSender] UnsetClaimsMaxLogBlockRange = 10000` in the aggkit configmap triggers proactive chunking and bypasses the error-parse path entirely. That's the right setting for production runs regardless of this fix, but doesn't remove the need to make the reactive path actually work for operators who haven't opted in.

## Test plan

- [x] `cargo test --release --lib service_get_logs::tests::` passes (5 tests, including the new one)
- [x] Verified the test FAILS on the old error format (with an actionable panic) and PASSES on the new one — i.e. it actually catches the regression
- [ ] Once merged + image rebuilt + deployed, bridge-out cert build should converge on next aggsender trigger