### PR TITLE
ger_entries: demote race-path WARN to DEBUG + populate L1 block/timestamp

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -6,3 +6,10 @@ extend-exclude = ["*.lock", "dist", "target", "fixtures"]
 # Test fixture for constant_time_eq() — `abd` is intentionally a one-byte
 # variant of `abc`, not a typo of `and`/`bad`.
 abd = "abd"
+
+[default.extend-identifiers]
+# Short commit-SHA fragment referenced in postmortems, runbooks, and one
+# source comment. typos-cli's word splitter sees `dbe5c2d` as `dbe` + digits
+# and flags `dbe` as a typo of `be`. Allowlist the specific identifier
+# rather than the bare word so unrelated occurrences of `dbe` still surface.
+dbe5c2d = "dbe5c2d"

--- a/scripts/e2e-account-self-heal.sh
+++ b/scripts/e2e-account-self-heal.sh
@@ -124,7 +124,7 @@ ger_state() {
 
 depo() {
   # jq's `//` operator treats boolean `false` as null-equivalent, which
-  # would mis-report a deposit that's genuinely NOT ready as "<missing>".
+  # would incorrectly report a deposit that's genuinely NOT ready as "<missing>".
   # Use an explicit existence check + tostring so we distinguish:
   #   "true"      → deposit ready_for_claim is true
   #   "false"     → deposit indexed but not ready (the bug-state we want to see)

--- a/src/l1_info_tree_indexer.rs
+++ b/src/l1_info_tree_indexer.rs
@@ -37,11 +37,13 @@
 //!
 //! Either ordering converges to a resolved entry. No race window.
 
+use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::Address;
 use alloy::providers::{Provider, ProviderBuilder};
 use alloy::rpc::types::{Filter, Log};
 use alloy::sol_types::SolEvent;
 use sha3::{Digest, Keccak256};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -247,9 +249,21 @@ impl L1InfoTreeIndexer {
         let logs: Vec<Log> = provider.get_logs(&filter).await?;
         let log_count = logs.len();
 
+        // Per-poll cache: one `eth_getBlockByNumber` per *unique* L1 block in
+        // the batch, used to populate the L1 timestamp written to
+        // `ger_entries.timestamp`. Events from the same block share an RPC
+        // roundtrip, so a steady-state poll that sees 0–1 unique blocks per
+        // tick costs nothing extra in the common case.
+        let mut block_timestamps: HashMap<u64, u64> = HashMap::new();
+
         let mut indexed = 0usize;
         for log in logs {
-            match self.process_log(&log).await {
+            let block_number = log.block_number.unwrap_or(0);
+            let timestamp = self
+                .resolve_block_timestamp(provider, block_number, &mut block_timestamps)
+                .await;
+
+            match self.process_log(&log, block_number, timestamp).await {
                 Ok(true) => indexed += 1,
                 Ok(false) => {}
                 Err(e) => {
@@ -258,7 +272,7 @@ impl L1InfoTreeIndexer {
                     // poison log forever.
                     tracing::warn!(
                         error = %e,
-                        block = log.block_number.unwrap_or(0),
+                        block = block_number,
                         tx = ?log.transaction_hash,
                         "L1InfoTreeIndexer: failed to index log"
                     );
@@ -303,7 +317,12 @@ impl L1InfoTreeIndexer {
         Ok(())
     }
 
-    async fn process_log(&self, log: &Log) -> anyhow::Result<bool> {
+    async fn process_log(
+        &self,
+        log: &Log,
+        block_number: u64,
+        timestamp: u64,
+    ) -> anyhow::Result<bool> {
         // Both event signatures have the same shape: two indexed bytes32.
         // Topic 0 = event sig hash, topic 1 = mainnetExitRoot, topic 2 = rollupExitRoot.
         let topics = log.topics();
@@ -329,7 +348,7 @@ impl L1InfoTreeIndexer {
         let combined = combined_ger(&mainnet, &rollup);
 
         self.store
-            .set_ger_exit_roots(&combined, mainnet, rollup)
+            .set_ger_exit_roots(&combined, mainnet, rollup, block_number, timestamp)
             .await?;
 
         // INFO-level so test runs show every pair indexed in real time
@@ -341,10 +360,55 @@ impl L1InfoTreeIndexer {
             mainnet = %hex::encode(mainnet),
             rollup = %hex::encode(rollup),
             combined = %hex::encode(combined),
-            block = log.block_number.unwrap_or(0),
+            block = block_number,
+            timestamp,
             "L1InfoTreeIndexer: indexed exit-root pair"
         );
         Ok(true)
+    }
+
+    /// Resolve the L1 block timestamp for a given block number, using and
+    /// updating the per-poll cache. Returns 0 if the block is unknown
+    /// (block_number == 0) or if the RPC lookup fails — the indexer's
+    /// upsert path keeps the row writable in that case, and the next
+    /// successful poll will overwrite with the real timestamp.
+    async fn resolve_block_timestamp<P: Provider>(
+        &self,
+        provider: &P,
+        block_number: u64,
+        cache: &mut HashMap<u64, u64>,
+    ) -> u64 {
+        if block_number == 0 {
+            return 0;
+        }
+        if let Some(&ts) = cache.get(&block_number) {
+            return ts;
+        }
+        match provider
+            .get_block_by_number(BlockNumberOrTag::Number(block_number))
+            .await
+        {
+            Ok(Some(block)) => {
+                let ts = block.header.timestamp;
+                cache.insert(block_number, ts);
+                ts
+            }
+            Ok(None) => {
+                tracing::debug!(
+                    block = block_number,
+                    "L1InfoTreeIndexer: get_block_by_number returned None; timestamp left as 0 (will be overwritten on next observation)"
+                );
+                0
+            }
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    block = block_number,
+                    "L1InfoTreeIndexer: get_block_by_number failed; timestamp left as 0 (will be overwritten on next observation)"
+                );
+                0
+            }
+        }
     }
 }
 

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -498,9 +498,17 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         tracing::debug!(target: concat!(module_path!(), "::debug"), "insertGlobalExitRoot call params: {params:?}");
         let ger_bytes: [u8; 32] = params.root.0;
 
-        // Resolve exit root components from L1, since insertGlobalExitRoot
-        // only carries the combined hash. Without these, bridge-service
-        // cannot mark deposits as ready_for_claim.
+        // Best-effort resolve `(mainnet, rollup)` from L1 via view calls on
+        // the GER contract. This is the RD-862 race path: under deposit load
+        // L1 has usually advanced past the pair that produced the combined
+        // hash before we get here, so the keccak check fails. That's fine —
+        // the `L1InfoTreeIndexer` (see `l1_info_tree_indexer.rs`) reads
+        // `UpdateL1InfoTree` events directly and backfills the components
+        // via `set_ger_exit_roots` UPSERT. Bridge-service's subsequent
+        // `zkevm_getExitRootsByGER` poll picks up the resolved entry, so
+        // an `(None, None)` outcome here is non-fatal. Logged at debug
+        // because the indexer guarantees convergence — a stuck deposit
+        // would surface elsewhere (indexer cursor stalled, store error).
         let (mainnet_root, rollup_root) = match (&service.l1_rpc_url, &service.ger_l1_address) {
             (Some(l1_rpc), Some(ger_addr)) => {
                 match ger::fetch_l1_exit_roots(l1_rpc, ger_addr).await {
@@ -509,14 +517,17 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
                         if computed == ger_bytes {
                             (Some(m), Some(r))
                         } else {
-                            tracing::warn!(
-                                "L1 exit roots don't match injected GER (L1 may have advanced), storing without roots"
+                            tracing::debug!(
+                                "L1 exit roots don't match injected GER (L1 may have advanced); \
+                                 indexer will backfill via set_ger_exit_roots"
                             );
                             (None, None)
                         }
                     }
                     Err(e) => {
-                        tracing::warn!("failed to fetch L1 exit roots: {e:#}");
+                        tracing::debug!(
+                            "failed to fetch L1 exit roots ({e:#}); indexer will backfill"
+                        );
                         (None, None)
                     }
                 }

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -236,6 +236,8 @@ impl Store for InMemoryStore {
         ger: &[u8; 32],
         mainnet_exit_root: [u8; 32],
         rollup_exit_root: [u8; 32],
+        l1_block_number: u64,
+        l1_timestamp: u64,
     ) -> anyhow::Result<()> {
         let mut seen = self.seen_gers.write();
         let entry = seen.entry(*ger).or_insert(GerEntry {
@@ -246,6 +248,10 @@ impl Store for InMemoryStore {
         });
         entry.mainnet_exit_root = Some(mainnet_exit_root);
         entry.rollup_exit_root = Some(rollup_exit_root);
+        // Mirror the PgStore semantics: indexer is authoritative for L1
+        // origin metadata, so overwrite unconditionally on every call.
+        entry.block_number = l1_block_number;
+        entry.timestamp = l1_timestamp;
         Ok(())
     }
 
@@ -650,6 +656,41 @@ impl Store for InMemoryStore {
 mod tests {
     use super::*;
     use crate::log_synthesis::{CLAIM_EVENT_TOPIC, TopicFilter};
+
+    #[tokio::test]
+    async fn set_ger_exit_roots_persists_l1_block_and_timestamp() {
+        // Before this change, both columns were hardcoded to 0 in PgStore and
+        // ignored in InMemoryStore. The indexer is the authoritative writer
+        // for L1 origin metadata, so the InMemoryStore — which mirrors
+        // PgStore semantics for tests — must round-trip them.
+        let store = InMemoryStore::new();
+        let ger = [0x11u8; 32];
+        let mainnet = [0x22u8; 32];
+        let rollup = [0x33u8; 32];
+
+        // First write: fresh entry — block + ts land as given.
+        store
+            .set_ger_exit_roots(&ger, mainnet, rollup, 10_900_000, 1_779_300_000)
+            .await
+            .unwrap();
+        let entry = store.get_ger_entry(&ger).await.unwrap().unwrap();
+        assert_eq!(entry.mainnet_exit_root, Some(mainnet));
+        assert_eq!(entry.rollup_exit_root, Some(rollup));
+        assert_eq!(entry.block_number, 10_900_000);
+        assert_eq!(entry.timestamp, 1_779_300_000);
+
+        // Second write at a later L1 block (same GER hash): indexer is
+        // authoritative, so the new L1 origin metadata overwrites the old.
+        // This is the "L2 path wrote the row first with stale values; later
+        // indexer poll corrects it" convergence the docstring describes.
+        store
+            .set_ger_exit_roots(&ger, mainnet, rollup, 10_900_005, 1_779_300_060)
+            .await
+            .unwrap();
+        let entry = store.get_ger_entry(&ger).await.unwrap().unwrap();
+        assert_eq!(entry.block_number, 10_900_005);
+        assert_eq!(entry.timestamp, 1_779_300_060);
+    }
 
     #[tokio::test]
     async fn test_block_number() {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -162,11 +162,21 @@ pub trait Store: Send + Sync + 'static {
     async fn mark_ger_seen(&self, ger: &[u8; 32], entry: GerEntry) -> anyhow::Result<bool>;
     async fn get_latest_ger(&self) -> anyhow::Result<Option<[u8; 32]>>;
     async fn get_ger_entry(&self, ger: &[u8; 32]) -> anyhow::Result<Option<GerEntry>>;
+    /// Set the `(mainnet, rollup)` decomposition and L1 origin metadata for a
+    /// GER. Called by `L1InfoTreeIndexer` after observing the source
+    /// `UpdateL1InfoTree` / `UpdateGlobalExitRoot` event on L1, so the
+    /// `l1_block_number` / `l1_timestamp` here are the L1 block where the
+    /// event was emitted (the authoritative source for `zkevm_getExitRootsByGER`).
+    /// UPSERTs: on conflict, all four columns are overwritten — the indexer's
+    /// L1-sourced view supersedes any earlier hardcoded-0 row that may have
+    /// been left by an L2-side write path that didn't know the L1 origin yet.
     async fn set_ger_exit_roots(
         &self,
         ger: &[u8; 32],
         mainnet_exit_root: [u8; 32],
         rollup_exit_root: [u8; 32],
+        l1_block_number: u64,
+        l1_timestamp: u64,
     ) -> anyhow::Result<()>;
     async fn is_ger_injected(&self, ger: &[u8; 32]) -> anyhow::Result<bool>;
     async fn mark_ger_injected(&self, ger: [u8; 32]) -> anyhow::Result<()>;

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -337,6 +337,8 @@ impl Store for PgStore {
         ger: &[u8; 32],
         mainnet_exit_root: [u8; 32],
         rollup_exit_root: [u8; 32],
+        l1_block_number: u64,
+        l1_timestamp: u64,
     ) -> anyhow::Result<()> {
         let client = self.pool.get().await?;
         let mainnet = mainnet_exit_root.to_vec();
@@ -344,11 +346,19 @@ impl Store for PgStore {
         client
             .execute(
                 "INSERT INTO ger_entries (ger_hash, mainnet_exit_root, rollup_exit_root, block_number, timestamp)
-                 VALUES ($1, $2, $3, 0, 0)
+                 VALUES ($1, $2, $3, $4, $5)
                  ON CONFLICT (ger_hash) DO UPDATE
                  SET mainnet_exit_root = EXCLUDED.mainnet_exit_root,
-                     rollup_exit_root = EXCLUDED.rollup_exit_root",
-                &[&ger.as_slice(), &mainnet, &rollup],
+                     rollup_exit_root  = EXCLUDED.rollup_exit_root,
+                     block_number      = EXCLUDED.block_number,
+                     timestamp         = EXCLUDED.timestamp",
+                &[
+                    &ger.as_slice(),
+                    &mainnet,
+                    &rollup,
+                    &(l1_block_number as i64),
+                    &(l1_timestamp as i64),
+                ],
             )
             .await?;
         Ok(())


### PR DESCRIPTION
## Summary

Two related cleanups to the GER (Global Exit Root) write path. Both came out of an audit triggered by a single `WARN` line on bali; turns out the WARN is harmless _and_ the metadata columns it concerns are silently zero.

### 1. Demote `service_send_raw_txn.rs` race WARN to DEBUG (commit 1)

The legacy `fetch_l1_exit_roots` path used inside `handle_send_raw_transaction`'s `insertGlobalExitRoot` branch races L1 view calls (RD-862). Under deposit load the L1 GER contract has typically advanced past the `(mainnet, rollup)` pair that produced the combined hash by the time we get here, so the keccak check fails and we fall through with `(None, None)`.

This used to be a real problem. It isn't anymore: `L1InfoTreeIndexer` (added in PR #41) reads `UpdateL1InfoTree` events directly and backfills via `set_ger_exit_roots` UPSERT, so bridge-service's subsequent `zkevm_getExitRootsByGER` resolves regardless of which path won the race.

Verified live on bali (`outpost-testnet-miden-testnet`): **157 / 157 rows have both roots populated, zero unresolved**. The architecture works; the WARN was just yelling about it.

### 2. Populate `ger_entries.block_number` + `timestamp` from the L1 source (commit 2)

While poking at point 1, noticed that **every row** in the live `ger_entries` table has `block_number=0, timestamp=0`. Both columns are `NOT NULL` and documented as L1 origin metadata (what `zkevm_getExitRootsByGER` returns), but they were never being set:

- `Store::set_ger_exit_roots` (indexer's UPSERT) had `VALUES (..., 0, 0)` literally in the SQL — even though the indexer knew the L1 block from the log event.
- `commit_ger_event_atomic` (L2-side write path) passes its L2 block/timestamp, but the indexer's 1s poll almost always wins the insert, so `ON CONFLICT DO NOTHING` keeps the `0, 0`.

Fixes:

- Add `l1_block_number` and `l1_timestamp` params to `Store::set_ger_exit_roots`. PgStore now writes them on INSERT and overwrites them on conflict (indexer is authoritative for L1 origin metadata).
- `L1InfoTreeIndexer` pulls `block_number` from the eth_getLogs envelope and looks up `block.timestamp` via `eth_getBlockByNumber`, cached per L1 block within each poll — so multiple events from the same block share one RPC call. Steady-state polls with 0–1 unique blocks pay at most one extra roundtrip.
- Lookup failures fall back to `0` at debug level; next observation overwrites via UPSERT.

## Test plan

- [x] `cargo check --bins`, `cargo check --tests` — clean
- [x] `cargo test --lib` — **165 passed, 0 failed** (164 pre-existing + 1 new)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --tests --no-deps -- -D warnings` — clean
- [x] New unit test `set_ger_exit_roots_persists_l1_block_and_timestamp` exercises:
  - Fresh insert populates both columns
  - Later upsert (later L1 block) overwrites — locks in the "indexer corrects a stale row" convergence
- [ ] Deploy to bali; verify next `UpdateL1InfoTree` poll lands a row with non-zero block/ts (existing 157 rows will get rewritten as the indexer re-observes their source blocks — operators can force a backfill replay via the existing `--l1-indexer-from-block` flag if needed)

## Out of scope

- Removing the legacy `fetch_l1_exit_roots` view-call path entirely. The indexer makes it redundant, but the deletion is a separate refactor — this PR only stops it from emitting a misleading WARN.
- Backfilling the 157 existing `0, 0` rows on bali. They'll naturally get rewritten as the indexer re-observes events; for an immediate fix, set `--l1-indexer-from-block` to the earliest affected block and let it replay.