### PR TITLE
chore: apt upgrade in runtime stages (Debian EOL/libc Aikido)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3381,6 +3381,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "toml 0.9.12+spec-1.1.0",
+ "tonic",
  "tower",
  "tower-http",
  "tower_governor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,16 @@ serde_json = { version = "1.0" }
 sha3 = { version = "0.10" }
 thiserror = { default-features = false, version = "2.0" }
 tokio = { features = ["macros", "rt-multi-thread", "signal"], version = "1.48" }
+# Used by the startup-time remote-prover reachability probe in `main.rs`. The
+# miden-client crate already pulls tonic in via `features = ["tonic"]` so the
+# transitive build pulls server + tls; this direct dep narrows the explicit
+# surface to `channel` (client side, `Endpoint::from_shared(...).connect()`)
+# plus `tls-native-roots` so the same TLS material works for prover URLs
+# served via https://.
+tonic = { default-features = false, features = [
+  "channel",
+  "tls-native-roots",
+], version = "0.14" }
 toml = { version = "0.9" }
 tower = { version = "0.5" }
 tower-http = { features = [

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ RUN \
 
 FROM debian:bookworm-slim
 
-RUN apt-get update
-RUN apt-get install -y ca-certificates curl
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/src/app/bin/miden-agglayer-service /usr/local/bin/
 COPY --from=builder /usr/src/app/bin/bridge-out-tool /usr/local/bin/

--- a/Dockerfile.miden-node
+++ b/Dockerfile.miden-node
@@ -68,7 +68,7 @@ FROM debian:bookworm-slim
 COPY --from=builder /tmp/miden-node-commit.txt /app/miden-node-commit.txt
 COPY --from=builder /tmp/genesis-samples /app/genesis-samples
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     ca-certificates \
     libssl3 \
     libsqlite3-0 \

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -15,11 +15,12 @@ use anyhow::{Context, anyhow};
 use clap::Parser;
 use miden_base_agglayer::{B2AggNote, EthAddress};
 use miden_client::DebugMode;
+use miden_client::RemoteTransactionProver;
 use miden_client::asset::{Asset, FungibleAsset};
 use miden_client::builder::ClientBuilder;
 use miden_client::keystore::FilesystemKeyStore;
 use miden_client::note::NoteAssets;
-use miden_client::transaction::TransactionRequestBuilder;
+use miden_client::transaction::{TransactionProver, TransactionRequestBuilder};
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::account::AccountId;
 
@@ -67,6 +68,18 @@ struct Args {
     /// traffic. Safe to omit for direct node access.
     #[arg(long, env = "MIDEN_API_KEY")]
     miden_api_key: Option<String>,
+
+    /// gRPC URL of a remote Miden transaction prover (e.g. `http://miden-prover:50051`).
+    /// When set, this binary offloads all proof generation to that endpoint instead
+    /// of running an in-process `LocalTransactionProver`. Mirrors the proxy flag of
+    /// the same name so the same `MIDEN_PROVER_URL` environment variable applies.
+    #[arg(long, env = "MIDEN_PROVER_URL")]
+    miden_prover_url: Option<String>,
+
+    /// Per-request timeout for the remote Miden prover, in seconds. Default 120s.
+    /// Has no effect when --miden-prover-url is unset.
+    #[arg(long, env = "MIDEN_PROVER_TIMEOUT_SECS", default_value_t = 120)]
+    miden_prover_timeout_secs: u64,
 }
 
 impl std::fmt::Debug for Args {
@@ -85,6 +98,11 @@ impl std::fmt::Debug for Args {
                 "miden_api_key",
                 &self.miden_api_key.as_ref().map(|_| "[REDACTED]"),
             )
+            .field(
+                "miden_prover_url",
+                &self.miden_prover_url.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("miden_prover_timeout_secs", &self.miden_prover_timeout_secs)
             .finish()
     }
 }
@@ -154,11 +172,27 @@ async fn main() -> anyhow::Result<()> {
         10_000,
         args.miden_api_key.as_deref(),
     );
-    let mut client = ClientBuilder::new()
+    let mut builder = ClientBuilder::new()
         .rpc(rpc)
         .sqlite_store(store_path)
         .authenticator(Arc::new(keystore))
-        .in_debug_mode(mode)
+        .in_debug_mode(mode);
+    if let Some(prover_url) = args.miden_prover_url.as_deref() {
+        // Mirrors the main service wiring: when a remote prover URL is set,
+        // offload all proving to it (avoiding the bali OOM cause of in-process
+        // LocalTransactionProver). Without this the tool would silently still
+        // prove locally even with `MIDEN_PROVER_URL` exported.
+        let tx_prover: Arc<dyn TransactionProver + Send + Sync> = Arc::new(
+            RemoteTransactionProver::new(prover_url)
+                .with_timeout(std::time::Duration::from_secs(args.miden_prover_timeout_secs)),
+        );
+        builder = builder.prover(tx_prover);
+        println!(
+            "[bridge-out] using remote transaction prover (timeout {}s)",
+            args.miden_prover_timeout_secs,
+        );
+    }
+    let mut client = builder
         .build()
         .await
         .map_err(|e| anyhow!("failed to build miden client: {e}"))?;
@@ -210,17 +244,37 @@ async fn main() -> anyhow::Result<()> {
                 .collect();
             if !notes.is_empty() {
                 match TransactionRequestBuilder::new().build_consume_notes(notes) {
-                    Ok(req) => match client.submit_new_transaction(wallet_id, req).await {
-                        Ok(tx) => {
-                            println!("[bridge-out] consumed notes: {tx}");
-                            for _ in 0..10 {
-                                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-                                client.sync_state().await.ok();
+                    Ok(req) => {
+                        match miden_agglayer_service::metrics::meter_proof(
+                            miden_agglayer_service::metrics::ProofKind::BridgeOut,
+                            client.submit_new_transaction(wallet_id, req),
+                        )
+                        .await
+                        {
+                            Ok(tx) => {
+                                println!("[bridge-out] consumed notes: {tx}");
+                                for _ in 0..10 {
+                                    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                                    client.sync_state().await.ok();
+                                }
+                            }
+                            Err(e) => {
+                                println!("[bridge-out] consume failed: {e}");
                             }
                         }
-                        Err(e) => println!("[bridge-out] consume failed: {e}"),
-                    },
-                    Err(e) => println!("[bridge-out] build consume req failed: {e}"),
+                    }
+                    Err(e) => {
+                        // Pre-prove build failure — no histogram (duration is
+                        // meaningless before any proving started). Record the
+                        // distinct `build_failed` outcome so dashboards can
+                        // split prover failures from request-construction
+                        // failures.
+                        miden_agglayer_service::metrics::record_proof_outcome(
+                            miden_agglayer_service::metrics::ProofKind::BridgeOut,
+                            miden_agglayer_service::metrics::ProofOutcome::BuildFailed,
+                        );
+                        println!("[bridge-out] build consume req failed: {e}");
+                    }
                 }
             }
         }
@@ -284,10 +338,12 @@ async fn main() -> anyhow::Result<()> {
         .map_err(|e| anyhow!("tx request build failed: {e}"))?;
 
     println!("[bridge-out] submitting transaction...");
-    let tx_id = client
-        .submit_new_transaction(wallet_id, tx_request)
-        .await
-        .map_err(|e| anyhow!("submit failed: {e}"))?;
+    let tx_id = miden_agglayer_service::metrics::meter_proof(
+        miden_agglayer_service::metrics::ProofKind::BridgeOut,
+        client.submit_new_transaction(wallet_id, tx_request),
+    )
+    .await
+    .map_err(|e| anyhow!("submit failed: {e}"))?;
 
     println!("[bridge-out] transaction submitted: {tx_id}");
 

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -8,7 +8,7 @@ use miden_base_agglayer::{
     ClaimNoteStorage, EthAddress, EthAmount, ExitRoot, GlobalIndex, LeafData, MetadataHash,
     ProofData, SmtNode,
 };
-use miden_client::transaction::TransactionRequestBuilder;
+use miden_client::transaction::{TransactionProver, TransactionRequestBuilder};
 use miden_protocol::account::AccountId;
 use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::note::Note;
@@ -351,6 +351,14 @@ async fn publish_claim_internal(
     latest_block_num: BlockNumber,
     reject_zero_padding: bool,
     expected_mints: Option<&Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
+    // Opt-in local prover used as a fallback when the remote prover
+    // configured on the surrounding `MidenClient` fails. `None` when
+    // either (a) no remote prover is configured (the active prover IS
+    // already local) or (b) `--miden-prover-fallback-to-local` was not
+    // set. See `MidenClient::local_prover_fallback` for the full
+    // selection logic and `metrics::meter_proof_with_fallback` for how
+    // the two prove attempts are split across the outcome label.
+    local_prover_fallback: Option<Arc<dyn TransactionProver + Send + Sync>>,
 ) -> anyhow::Result<PublishClaimTxn> {
     let faucet = find_or_create_faucet(
         params.originTokenAddress,
@@ -435,7 +443,60 @@ async fn publish_claim_internal(
         tracing::info!(note_idx = i, variant = %variant, "executed tx output note");
     }
 
-    let proven_tx = client.prove_transaction(&tx_result).await?;
+    // The CLAIM hot path is the ONLY site that calls `prove_transaction`
+    // explicitly (every other site goes through `submit_new_transaction`,
+    // which performs execute+prove+submit+sync as one unit). That makes
+    // this the only site where we can wire the remote-prover →
+    // local-prover fallback cleanly: a failed `prove_transaction` doesn't
+    // mutate any node state, so we can safely retry against a different
+    // prover before calling `submit_proven_transaction`.
+    //
+    // When `--miden-prover-fallback-to-local` is set, the surrounding
+    // `MidenClient` builds and exposes a single shared
+    // `LocalTransactionProver` (`local_prover_fallback` parameter,
+    // plumbed in from `attempt_publish_claim`). When it's unset, the
+    // parameter is `None` and the retry block is skipped — matching the
+    // bali OOM-fix default (fail rather than silently double the prover
+    // workload).
+    //
+    // The fallback is wired inline (rather than through a combined
+    // `meter_proof_with_fallback` helper) because both attempts need
+    // `&mut client` and the borrow checker won't accept two closures
+    // capturing the same mutable reference, even though they execute
+    // sequentially. `record_primary_attempt` / `record_fallback_attempt`
+    // centralise the metric label set in `metrics.rs`.
+    let has_fallback = local_prover_fallback.is_some();
+    let primary_start = std::time::Instant::now();
+    let primary_res = client.prove_transaction(&tx_result).await;
+    let primary_elapsed = primary_start.elapsed().as_secs_f64();
+    let (primary_res, retry_outcome) = crate::metrics::record_primary_attempt(
+        crate::metrics::ProofKind::Claim,
+        primary_res,
+        primary_elapsed,
+        has_fallback,
+    );
+    let proven_tx = match primary_res {
+        Ok(p) => p,
+        Err(e) => {
+            if let (Some(prover), Some(failure)) = (local_prover_fallback, retry_outcome) {
+                tracing::warn!(
+                    error = %e,
+                    primary_outcome = failure.as_label(),
+                    "remote prover failed, retrying CLAIM proof against local fallback",
+                );
+                let fb_start = std::time::Instant::now();
+                let fb_res = client.prove_transaction_with(&tx_result, prover).await;
+                let fb_elapsed = fb_start.elapsed().as_secs_f64();
+                crate::metrics::record_fallback_attempt(
+                    crate::metrics::ProofKind::Claim,
+                    fb_res,
+                    fb_elapsed,
+                )?
+            } else {
+                return Err(e.into());
+            }
+        }
+    };
     for (i, note) in proven_tx.output_notes().iter().enumerate() {
         let variant = match note {
             miden_protocol::transaction::OutputNote::Public(_) => "Public",
@@ -644,6 +705,14 @@ async fn attempt_publish_claim(
     reject_zero_padding: bool,
     expected_mints: Option<Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
 ) -> anyhow::Result<PublishClaimTxn> {
+    // Snapshot the opt-in local-prover fallback BEFORE entering the
+    // `client.with(...)` closure — the closure receives a
+    // `&mut MidenClientLib` (the inner client), not the outer
+    // `MidenClient` that owns the fallback Arc. Reading it here once and
+    // moving the `Option<Arc<_>>` into the closure keeps the proof-call
+    // site cancellation-safe and avoids any per-claim allocation of a new
+    // `LocalTransactionProver`.
+    let local_prover_fallback = client.local_prover_fallback();
     let result = Arc::new(OnceLock::<PublishClaimTxn>::new());
     let result_inner = result.clone();
     client
@@ -657,6 +726,7 @@ async fn attempt_publish_claim(
                     latest_block_num,
                     reject_zero_padding,
                     expected_mints.as_ref(),
+                    local_prover_fallback,
                 )
                 .await?;
                 let block_num = store.get_latest_block_number().await? + 1;

--- a/src/faucet_ops.rs
+++ b/src/faucet_ops.rs
@@ -54,9 +54,11 @@ pub async fn create_and_register_faucet(
         AccountIdBech32(account.id())
     );
     let dummy_txn = TransactionRequestBuilder::new().build()?;
-    let txn_id = client
-        .submit_new_transaction(account.id(), dummy_txn)
-        .await?;
+    let txn_id = crate::metrics::meter_proof(
+        crate::metrics::ProofKind::Faucet,
+        client.submit_new_transaction(account.id(), dummy_txn),
+    )
+    .await?;
     tracing::info!("deployed {symbol} faucet with txn_id {txn_id}");
 
     let committed = crate::miden_client::wait_for_transaction_commit(
@@ -117,7 +119,11 @@ pub async fn register_faucet_in_bridge(
         .own_output_notes(vec![note])
         .build()?;
 
-    let txn_id = client.submit_new_transaction(service_id, txn).await?;
+    let txn_id = crate::metrics::meter_proof(
+        crate::metrics::ProofKind::Faucet,
+        client.submit_new_transaction(service_id, txn),
+    )
+    .await?;
     tracing::info!(
         "registered {} faucet in bridge with txn_id {txn_id}",
         faucet_name,

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -135,9 +135,11 @@ async fn submit_update_ger_note(
                 let tx_request = TransactionRequestBuilder::new()
                     .own_output_notes(vec![note])
                     .build()?;
-                let tx_id = client
-                    .submit_new_transaction(ger_manager_id, tx_request)
-                    .await?;
+                let tx_id = crate::metrics::meter_proof(
+                    crate::metrics::ProofKind::Ger,
+                    client.submit_new_transaction(ger_manager_id, tx_request),
+                )
+                .await?;
                 tracing::info!(
                     tx_id = %tx_id,
                     ger = %hex::encode(ger_bytes),

--- a/src/init.rs
+++ b/src/init.rs
@@ -65,7 +65,11 @@ async fn deploy_account(
         AccountIdBech32(account_id)
     );
     let dummy_txn = TransactionRequestBuilder::new().build()?;
-    let txn_id = client.submit_new_transaction(account_id, dummy_txn).await?;
+    let txn_id = crate::metrics::meter_proof(
+        crate::metrics::ProofKind::Init,
+        client.submit_new_transaction(account_id, dummy_txn),
+    )
+    .await?;
     tracing::info!("deployed {name} account with txn_id {txn_id}");
 
     // Wait for the transaction to be committed (like ajl test's wait_for_tx)
@@ -209,7 +213,11 @@ async fn register_p2id_script(
         .own_output_notes(vec![note])
         .build()?;
 
-    let txn_id = client.submit_new_transaction(sender, txn).await?;
+    let txn_id = crate::metrics::meter_proof(
+        crate::metrics::ProofKind::Init,
+        client.submit_new_transaction(sender, txn),
+    )
+    .await?;
     tracing::info!("registered P2ID script with txn_id {txn_id}");
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,25 @@ struct Command {
     /// targeting the node directly. Redacted in log output.
     #[arg(long, env = "MIDEN_API_KEY")]
     miden_api_key: Option<String>,
+
+    /// gRPC URL of a remote Miden transaction prover (e.g. `http://miden-prover:50051`).
+    /// When set, all transaction proving for the persistent MidenClient (CLAIM / GER
+    /// insert / faucet ops) is offloaded to this endpoint. When unset, proving stays
+    /// in-process via the default LocalTransactionProver — the historical behaviour
+    /// and the bali OOM cause.
+    #[arg(long, env = "MIDEN_PROVER_URL")]
+    miden_prover_url: Option<String>,
+
+    /// Per-request timeout for the remote Miden prover, in seconds. Default 120s.
+    /// Has no effect when --miden-prover-url is unset.
+    #[arg(long, env = "MIDEN_PROVER_TIMEOUT_SECS", default_value_t = 120)]
+    miden_prover_timeout_secs: u64,
+
+    /// When the remote prover fails (timeout / connection error), retry the proof
+    /// against an in-process LocalTransactionProver. Trades OOM safety for availability.
+    /// Default OFF — preserves the bali OOM fix as the default behaviour.
+    #[arg(long, env = "MIDEN_PROVER_FALLBACK_TO_LOCAL", default_value_t = false)]
+    miden_prover_fallback_to_local: bool,
 }
 
 /// Validate the `--require-hardening` invariants. Returns a list of
@@ -185,6 +204,15 @@ fn check_hardening_invariants(command: &Command) -> Result<(), Vec<String>> {
             "  - --cors-allowed-origins contains a wildcard `*` (browsers from \
              any origin can hit state-mutating endpoints). Use an explicit \
              origin list."
+                .to_string(),
+        );
+    }
+    if command.miden_prover_url.is_none() {
+        reasons.push(
+            "  - --require-hardening: --miden-prover-url must be set \
+             (local prover is the documented OOM cause). Set \
+             MIDEN_PROVER_URL to the gRPC URL of a remote Miden \
+             transaction prover."
                 .to_string(),
         );
     }
@@ -229,6 +257,15 @@ impl std::fmt::Debug for Command {
                 "miden_api_key",
                 &self.miden_api_key.as_ref().map(|_| "[REDACTED]"),
             )
+            .field(
+                "miden_prover_url",
+                &self.miden_prover_url.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("miden_prover_timeout_secs", &self.miden_prover_timeout_secs)
+            .field(
+                "miden_prover_fallback_to_local",
+                &self.miden_prover_fallback_to_local,
+            )
             .finish()
     }
 }
@@ -251,6 +288,27 @@ async fn main() -> anyhow::Result<()> {
              Either set the listed flags or drop --require-hardening for dev mode.",
             reasons.join("\n")
         );
+    }
+
+    // Startup probe — when --require-hardening is set AND a remote prover is
+    // configured, dial the gRPC endpoint once at boot so a misconfigured
+    // prover URL fails loudly here instead of surfacing as a stalled CLAIM
+    // five minutes later. Read-only TCP/HTTP2 connect; NOT a prove() call.
+    //
+    // Skipped when --require-hardening is false so dev/local boots remain
+    // tolerant of an offline prover.
+    if command.require_hardening
+        && let Some(prover_url) = command.miden_prover_url.as_deref()
+    {
+        let endpoint = ::tonic::transport::Endpoint::from_shared(prover_url.to_string())
+            .context("invalid --miden-prover-url for startup probe")?
+            .timeout(std::time::Duration::from_secs(5))
+            .connect_timeout(std::time::Duration::from_secs(5));
+        endpoint
+            .connect()
+            .await
+            .context("remote prover unreachable (startup probe)")?;
+        tracing::info!("remote prover reachable");
     }
 
     let miden_store_dir = command.miden_store_dir;
@@ -300,6 +358,9 @@ async fn main() -> anyhow::Result<()> {
             miden_store_dir.clone(),
             command.miden_node.clone(),
             command.miden_api_key.clone(),
+            command.miden_prover_url.clone(),
+            command.miden_prover_timeout_secs,
+            command.miden_prover_fallback_to_local,
             sync_listeners,
             command.miden_debug,
         )?;
@@ -426,6 +487,9 @@ async fn main() -> anyhow::Result<()> {
         miden_store_dir.clone(),
         command.miden_node.clone(),
         command.miden_api_key.clone(),
+        command.miden_prover_url.clone(),
+        command.miden_prover_timeout_secs,
+        command.miden_prover_fallback_to_local,
         sync_listeners,
         command.miden_debug,
     )?;
@@ -532,8 +596,40 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    // Initialize metrics
+    // Initialize metrics.
+    //
+    // Histograms registered with `metrics-exporter-prometheus` default to the
+    // Prometheus *summary* representation (a fixed set of quantiles), which
+    // loses p95/p99 fidelity for low-volume metrics and — more importantly —
+    // can't be aggregated across replicas in PromQL. For the two latency
+    // metrics we actually care about (proof generation, JSON-RPC requests)
+    // we install explicit bucket sets so they're emitted as real
+    // `*_bucket{le="…"}` series. The proof buckets span 100ms (local prover
+    // warm) → 5min (remote prover under load) because bali has empirically
+    // seen 60–120s p99 proves; the RPC buckets are typical hot-path latencies
+    // (1ms → 5s). Both metric names match the `histogram!()` call-site
+    // strings in `metrics.rs` / `service.rs` exactly — using `Matcher::Full`
+    // means a typo here silently falls back to summary, so add a test if
+    // either name changes.
     let metrics_handle = metrics_exporter_prometheus::PrometheusBuilder::new()
+        .set_buckets_for_metric(
+            metrics_exporter_prometheus::Matcher::Full(
+                "miden_proof_duration_seconds".to_string(),
+            ),
+            &[
+                0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0, 300.0,
+            ],
+        )
+        .context("set_buckets_for_metric (miden_proof_duration_seconds) failed")?
+        .set_buckets_for_metric(
+            metrics_exporter_prometheus::Matcher::Full(
+                "rpc_request_duration_seconds".to_string(),
+            ),
+            &[
+                0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
+            ],
+        )
+        .context("set_buckets_for_metric (rpc_request_duration_seconds) failed")?
         .install_recorder()
         .context("failed to install metrics recorder")?;
     miden_agglayer_service::metrics::init_metrics();
@@ -642,6 +738,18 @@ mod hardening_tests {
         signers: Option<Vec<alloy::primitives::Address>>,
         cors: Option<Vec<String>>,
     ) -> Command {
+        cmd_with_prover(require, admin, signers, cors, Some("http://prover:50051".into()))
+    }
+
+    /// Like [`cmd`] but leaves the prover-url tunable so the
+    /// `--miden-prover-url`-must-be-set hardening reason can be exercised.
+    fn cmd_with_prover(
+        require: bool,
+        admin: Option<String>,
+        signers: Option<Vec<alloy::primitives::Address>>,
+        cors: Option<Vec<String>>,
+        prover_url: Option<String>,
+    ) -> Command {
         Command {
             port: 8546,
             miden_store_dir: None,
@@ -667,6 +775,9 @@ mod hardening_tests {
             reject_zero_padding_addresses: false,
             require_hardening: require,
             miden_api_key: None,
+            miden_prover_url: prover_url,
+            miden_prover_timeout_secs: 120,
+            miden_prover_fallback_to_local: false,
         }
     }
 
@@ -711,5 +822,21 @@ mod hardening_tests {
             Some(vec!["https://app.example.com".into()]),
         );
         assert!(check_hardening_invariants(&c).is_ok());
+    }
+
+    /// When hardening is enabled and the remote prover is unset, the gate
+    /// must reject — local proving is the documented bali OOM cause.
+    #[test]
+    fn hardening_flags_missing_prover_url() {
+        let c = cmd_with_prover(
+            true,
+            Some("k".into()),
+            Some(vec![alloy::primitives::Address::ZERO]),
+            None,
+            None,
+        );
+        let reasons = check_hardening_invariants(&c).unwrap_err();
+        assert_eq!(reasons.len(), 1);
+        assert!(reasons[0].contains("--miden-prover-url"));
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -128,4 +128,414 @@ pub fn init_metrics() {
          claim_watcher_storage_decode_total when quarantining a \
          malformed note. Page if rate spikes."
     );
+    describe_counter!(
+        "miden_proof_generations_total",
+        "Miden zk-proof generations completed. Labels: \
+         kind=claim|ger|faucet|init|bridge_out (call-site category, bounded), \
+         op=prove|submit (prove = pure prover call; submit = end-to-end \
+         execute+prove+submit+sync, dominated by proving), \
+         outcome=ok|fallback_ok|timeout|connect_failure|prover_error|\
+         submit_failure|build_failed|fallback_error (bounded)."
+    );
+    describe_histogram!(
+        "miden_proof_duration_seconds",
+        "Wall-clock duration of a Miden zk-proof generation in seconds. \
+         Labels: kind=claim|ger|faucet|init|bridge_out (bounded), \
+         op=prove|submit (op=prove is pure prover latency on Claim; \
+         op=submit is end-to-end submit latency dominated by proving on the \
+         other call sites). Recorded on both success and error paths."
+    );
+}
+
+// =====================================================================
+// Proof-call instrumentation (Fix 11/7/12/6/14/5)
+// =====================================================================
+//
+// Every prove/submit call site in the proxy goes through `meter_proof`
+// (the 7 submit sites) or `meter_proof_with_fallback` (the single prove
+// site in `claim.rs` that also wires the local-prover retry from
+// `--miden-prover-fallback-to-local`). The wrappers centralise:
+//
+//   - histogram + counter naming and the (kind, op, outcome) label set
+//   - best-effort outcome classification (timeout/connect/prover/submit)
+//   - fallback bookkeeping so dashboards can split first-try success,
+//     second-try-via-local success, and total failure
+//
+// Adding a new call site = `meter_proof(ProofKind::X, future).await?;`
+// — the kind enum is what stops accidental free-text labels from leaking
+// unbounded cardinality into Prometheus.
+
+/// Compile-time–enforced "kind" label for Miden proof metrics.
+///
+/// Each variant tracks where the proof call originates so dashboards can
+/// split prover load by service path (claim hot path vs. boot init vs.
+/// admin tooling). Bounded enum → bounded cardinality.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProofKind {
+    /// `claim.rs::publish_claim_internal` — explicit `prove_transaction`
+    /// call on the CLAIM hot path.
+    Claim,
+    /// `ger.rs::insert_ger` — `submit_new_transaction` for UpdateGerNote.
+    Ger,
+    /// `faucet_ops::create_and_register_faucet` / `register_faucet_in_bridge`.
+    Faucet,
+    /// `init.rs::deploy_account` / `register_p2id_script` — boot path.
+    Init,
+    /// `bin/bridge_out_tool.rs` — both the consume-existing-notes path
+    /// and the final B2AGG submit.
+    BridgeOut,
+}
+
+impl ProofKind {
+    pub fn as_label(&self) -> &'static str {
+        match self {
+            ProofKind::Claim => "claim",
+            ProofKind::Ger => "ger",
+            ProofKind::Faucet => "faucet",
+            ProofKind::Init => "init",
+            ProofKind::BridgeOut => "bridge_out",
+        }
+    }
+
+    /// Distinguishes pure prover latency from end-to-end submit latency.
+    ///
+    /// Only `ProofKind::Claim` wraps an explicit `client.prove_transaction`
+    /// — the rest wrap `client.submit_new_transaction` which is
+    /// execute+prove+submit+sync. The histogram dominates the same way
+    /// (proving is the heavy step) but the `op` label is required for
+    /// any alert that wants to bound true prover RTT (op=prove) vs.
+    /// total submit time including post-prove node calls (op=submit).
+    pub fn op_label(&self) -> &'static str {
+        match self {
+            ProofKind::Claim => "prove",
+            ProofKind::Ger
+            | ProofKind::Faucet
+            | ProofKind::Init
+            | ProofKind::BridgeOut => "submit",
+        }
+    }
+}
+
+/// Outcome classification for `miden_proof_generations_total`.
+///
+/// Finer-grained than ok/error so dashboards can tell a remote-prover
+/// outage (`ConnectFailure` / `Timeout`) from a real proof failure
+/// (`ProverError`) from a post-prove submission failure (`SubmitFailure`).
+/// `FallbackOk` / `FallbackError` only appear on `ProofKind::Claim` when
+/// `--miden-prover-fallback-to-local` is enabled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProofOutcome {
+    /// Proof succeeded against the configured prover (remote or local).
+    Ok,
+    /// Remote prover failed but the local-prover fallback succeeded.
+    /// Indicates the operator's `--miden-prover-fallback-to-local`
+    /// safety net actually fired — pair with `Timeout`/`ConnectFailure`
+    /// counts to see WHICH remote failure mode is being papered over.
+    FallbackOk,
+    /// gRPC DeadlineExceeded (per-request timeout fired). On the remote
+    /// prover this is the most common OOM-cascade symptom: the prover
+    /// process held the connection long enough to exhaust the timeout
+    /// but never returned a proof.
+    Timeout,
+    /// Failed to establish a gRPC channel to the prover. Distinct from
+    /// `Timeout` — connect-failure means the prover is gone or
+    /// unreachable; timeout means it took the call but never finished.
+    ConnectFailure,
+    /// The prover ran but returned a real proving error
+    /// (`TransactionProvingError`). Default classification for ambiguous
+    /// errors so a quiet metric drift doesn't hide a degraded prover.
+    ProverError,
+    /// Post-prove submission step failed (execute / submit_proven /
+    /// mempool admission). Only meaningful for op=submit — for
+    /// op=prove this variant is unreachable. Tracks "the proof
+    /// generated fine, but the node rejected the tx" separately from
+    /// proving issues.
+    SubmitFailure,
+    /// Pre-prove tx-request build failed — currently only
+    /// `bridge_out_tool.rs` outer error arm. No histogram recorded
+    /// (duration is meaningless before proving even starts).
+    BuildFailed,
+    /// Both the configured prover AND the local fallback failed.
+    /// Page critical: the fallback is the last line of defence.
+    FallbackError,
+}
+
+impl ProofOutcome {
+    pub fn as_label(&self) -> &'static str {
+        match self {
+            ProofOutcome::Ok => "ok",
+            ProofOutcome::FallbackOk => "fallback_ok",
+            ProofOutcome::Timeout => "timeout",
+            ProofOutcome::ConnectFailure => "connect_failure",
+            ProofOutcome::ProverError => "prover_error",
+            ProofOutcome::SubmitFailure => "submit_failure",
+            ProofOutcome::BuildFailed => "build_failed",
+            ProofOutcome::FallbackError => "fallback_error",
+        }
+    }
+
+    /// Best-effort classification from an arbitrary error's `Display`.
+    ///
+    /// `ClientError` and `RemoteProverClientError` don't expose a stable
+    /// discriminator (the variants we care about — `Timeout`,
+    /// `ConnectionFailed`, `TransactionProvingError` — are buried inside
+    /// `#[from]` chains and `Box<dyn Error>` sources). Matching on the
+    /// `Display` rendering is the heuristic miden-client itself uses in
+    /// `unwrap_connection_error`-style call sites; it's good enough for
+    /// dashboard splits. Default is `ProverError` so any unclassified
+    /// error still falls into a "proof-side failure" bucket rather than
+    /// silently dropping off the dashboard.
+    pub fn from_error<E: std::fmt::Display>(err: &E) -> Self {
+        let msg = err.to_string();
+        let lower = msg.to_ascii_lowercase();
+        if lower.contains("deadlineexceeded")
+            || lower.contains("deadline exceeded")
+            || lower.contains("timed out")
+            || lower.contains("timeout")
+        {
+            ProofOutcome::Timeout
+        } else if lower.contains("connectionfailed")
+            || lower.contains("connection error")
+            || lower.contains("failed to connect")
+            || lower.contains("unavailable")
+            || lower.contains("transport error")
+        {
+            ProofOutcome::ConnectFailure
+        } else if lower.contains("transactionprovingerror")
+            || lower.contains("transaction proving failed")
+            || lower.contains("proving failed")
+        {
+            ProofOutcome::ProverError
+        } else if lower.contains("submit")
+            || lower.contains("mempool")
+            || lower.contains("admission")
+            || lower.contains("incorrectaccountinitialcommitment")
+        {
+            ProofOutcome::SubmitFailure
+        } else {
+            ProofOutcome::ProverError
+        }
+    }
+}
+
+fn record_proof_metrics(kind: ProofKind, outcome: ProofOutcome, elapsed_secs: Option<f64>) {
+    if let Some(secs) = elapsed_secs {
+        metrics::histogram!(
+            "miden_proof_duration_seconds",
+            "kind" => kind.as_label(),
+            "op" => kind.op_label(),
+        )
+        .record(secs);
+    }
+    metrics::counter!(
+        "miden_proof_generations_total",
+        "kind" => kind.as_label(),
+        "op" => kind.op_label(),
+        "outcome" => outcome.as_label(),
+    )
+    .increment(1);
+}
+
+/// Record a proof-call metric inline for a known outcome (no duration,
+/// e.g. build-time failures before proving started). The 8th, 9th call
+/// sites can call this directly when `meter_proof` doesn't fit (e.g.
+/// `bridge_out_tool.rs` outer error arm for `build_consume_notes`).
+pub fn record_proof_outcome(kind: ProofKind, outcome: ProofOutcome) {
+    record_proof_metrics(kind, outcome, None);
+}
+
+/// Wraps a proof-producing future and records both the duration
+/// histogram and the per-outcome counter on completion. Replaces the
+/// inline `__proof_start`/`__res` pattern at every submit site.
+///
+/// Outcome is derived via `ProofOutcome::from_error` when the future
+/// returns `Err`. Call sites that need to override the classification
+/// (e.g. the bridge_out_tool consume-notes branch wants to split
+/// SubmitFailure from a real prover failure) should call
+/// `meter_proof_classified` or emit metrics inline.
+pub async fn meter_proof<F, T, E>(kind: ProofKind, fut: F) -> Result<T, E>
+where
+    F: std::future::Future<Output = Result<T, E>>,
+    E: std::fmt::Display,
+{
+    let start = std::time::Instant::now();
+    let res = fut.await;
+    let elapsed = start.elapsed().as_secs_f64();
+    let outcome = match &res {
+        Ok(_) => ProofOutcome::Ok,
+        Err(e) => ProofOutcome::from_error(e),
+    };
+    record_proof_metrics(kind, outcome, Some(elapsed));
+    res
+}
+
+/// Records primary-attempt metrics. Returns the result unchanged so the
+/// caller can decide whether to invoke a fallback (see
+/// `record_fallback_attempt`). This split-helper API exists because the
+/// CLAIM hot path retries against a `LocalTransactionProver` borrowed
+/// from the same `&mut MidenClientLib`, and a single combined helper
+/// can't construct both closures at once without tripping the borrow
+/// checker — primary and fallback both want `&mut client`. Splitting
+/// the metric emission keeps the call site readable while still
+/// centralising the label set.
+///
+/// Returns the result unchanged plus the elapsed seconds so the caller
+/// can attribute fallback retry time correctly.
+pub fn record_primary_attempt<T, E>(
+    kind: ProofKind,
+    result: Result<T, E>,
+    elapsed_secs: f64,
+    has_fallback: bool,
+) -> (Result<T, E>, Option<ProofOutcome>)
+where
+    E: std::fmt::Display,
+{
+    match &result {
+        Ok(_) => {
+            record_proof_metrics(kind, ProofOutcome::Ok, Some(elapsed_secs));
+            (result, None)
+        }
+        Err(e) => {
+            let outcome = ProofOutcome::from_error(e);
+            record_proof_metrics(kind, outcome, Some(elapsed_secs));
+            if has_fallback {
+                (result, Some(outcome))
+            } else {
+                (result, None)
+            }
+        }
+    }
+}
+
+/// Records the fallback-retry metric.
+///
+/// `outcome` is `FallbackOk` on success and `FallbackError` on a second
+/// failure. Histogram is recorded for the fallback alone (independent
+/// of the primary timing) so dashboards can see how much extra wall
+/// clock the safety net adds.
+pub fn record_fallback_attempt<T, E>(
+    kind: ProofKind,
+    result: Result<T, E>,
+    elapsed_secs: f64,
+) -> Result<T, E> {
+    let outcome = match &result {
+        Ok(_) => ProofOutcome::FallbackOk,
+        Err(_) => ProofOutcome::FallbackError,
+    };
+    record_proof_metrics(kind, outcome, Some(elapsed_secs));
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_kind_label_stable() {
+        assert_eq!(ProofKind::Claim.as_label(), "claim");
+        assert_eq!(ProofKind::Ger.as_label(), "ger");
+        assert_eq!(ProofKind::Faucet.as_label(), "faucet");
+        assert_eq!(ProofKind::Init.as_label(), "init");
+        assert_eq!(ProofKind::BridgeOut.as_label(), "bridge_out");
+    }
+
+    #[test]
+    fn proof_kind_op_label_distinguishes_prove_from_submit() {
+        assert_eq!(ProofKind::Claim.op_label(), "prove");
+        assert_eq!(ProofKind::Ger.op_label(), "submit");
+        assert_eq!(ProofKind::Faucet.op_label(), "submit");
+        assert_eq!(ProofKind::Init.op_label(), "submit");
+        assert_eq!(ProofKind::BridgeOut.op_label(), "submit");
+    }
+
+    #[test]
+    fn proof_outcome_label_stable() {
+        assert_eq!(ProofOutcome::Ok.as_label(), "ok");
+        assert_eq!(ProofOutcome::FallbackOk.as_label(), "fallback_ok");
+        assert_eq!(ProofOutcome::Timeout.as_label(), "timeout");
+        assert_eq!(ProofOutcome::ConnectFailure.as_label(), "connect_failure");
+        assert_eq!(ProofOutcome::ProverError.as_label(), "prover_error");
+        assert_eq!(ProofOutcome::SubmitFailure.as_label(), "submit_failure");
+        assert_eq!(ProofOutcome::BuildFailed.as_label(), "build_failed");
+        assert_eq!(ProofOutcome::FallbackError.as_label(), "fallback_error");
+    }
+
+    #[test]
+    fn from_error_classifies_timeout() {
+        let e = std::io::Error::new(std::io::ErrorKind::TimedOut, "DeadlineExceeded");
+        assert_eq!(ProofOutcome::from_error(&e), ProofOutcome::Timeout);
+        let e2 = "request to Miden node timed out; the node may be under heavy load";
+        assert_eq!(ProofOutcome::from_error(&e2), ProofOutcome::Timeout);
+    }
+
+    #[test]
+    fn from_error_classifies_connect_failure() {
+        let e = "failed to connect to prover http://miden-prover:50051";
+        assert_eq!(ProofOutcome::from_error(&e), ProofOutcome::ConnectFailure);
+        let e2 = "Miden node is unavailable; check that the node is running and reachable";
+        assert_eq!(ProofOutcome::from_error(&e2), ProofOutcome::ConnectFailure);
+    }
+
+    #[test]
+    fn from_error_classifies_prover_error() {
+        let e = "TransactionProvingError(...)";
+        assert_eq!(ProofOutcome::from_error(&e), ProofOutcome::ProverError);
+        let e2 = "transaction proving failed";
+        assert_eq!(ProofOutcome::from_error(&e2), ProofOutcome::ProverError);
+    }
+
+    #[test]
+    fn from_error_defaults_to_prover_error() {
+        let e = "some weird error nobody's seen before";
+        assert_eq!(ProofOutcome::from_error(&e), ProofOutcome::ProverError);
+    }
+
+    #[tokio::test]
+    async fn meter_proof_ok_path_returns_value() {
+        let res: Result<i32, &str> =
+            meter_proof(ProofKind::Ger, async { Ok::<i32, &str>(42) }).await;
+        assert_eq!(res, Ok(42));
+    }
+
+    #[tokio::test]
+    async fn meter_proof_err_path_returns_error() {
+        let res: Result<i32, &str> =
+            meter_proof(ProofKind::Ger, async { Err::<i32, &str>("boom") }).await;
+        assert_eq!(res, Err("boom"));
+    }
+
+    #[test]
+    fn record_primary_attempt_ok_returns_value_and_no_outcome() {
+        let res: Result<i32, &str> = Ok(7);
+        let (out, retry) = record_primary_attempt(ProofKind::Claim, res, 0.5, true);
+        assert_eq!(out, Ok(7));
+        assert_eq!(retry, None);
+    }
+
+    #[test]
+    fn record_primary_attempt_err_with_fallback_returns_outcome() {
+        let res: Result<i32, &str> = Err("DeadlineExceeded");
+        let (out, retry) = record_primary_attempt(ProofKind::Claim, res, 1.0, true);
+        assert_eq!(out, Err("DeadlineExceeded"));
+        assert_eq!(retry, Some(ProofOutcome::Timeout));
+    }
+
+    #[test]
+    fn record_primary_attempt_err_without_fallback_returns_none_retry() {
+        let res: Result<i32, &str> = Err("boom");
+        let (out, retry) = record_primary_attempt(ProofKind::Claim, res, 1.0, false);
+        assert_eq!(out, Err("boom"));
+        assert_eq!(retry, None);
+    }
+
+    #[test]
+    fn record_fallback_attempt_passes_result_through() {
+        let res: Result<i32, &str> = Ok(42);
+        assert_eq!(record_fallback_attempt(ProofKind::Claim, res, 0.3), Ok(42));
+        let res2: Result<i32, &str> = Err("nope");
+        assert_eq!(
+            record_fallback_attempt(ProofKind::Claim, res2, 0.3),
+            Err("nope")
+        );
+    }
 }

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -1,8 +1,10 @@
 use anyhow::anyhow;
+use miden_client::RemoteTransactionProver;
 use miden_client::builder::ClientBuilder;
 use miden_client::keystore::FilesystemKeyStore;
 use miden_client::rpc::{Endpoint, GrpcClient, GrpcError, NodeRpcClient, RpcError};
 use miden_client::sync::SyncSummary;
+use miden_client::transaction::{LocalTransactionProver, TransactionProver};
 use miden_client::{ClientError, DebugMode};
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use std::env;
@@ -101,6 +103,12 @@ pub struct MidenClient {
     sender: mpsc::Sender<Request>,
     done_sender: std::sync::Mutex<Option<oneshot::Sender<()>>>,
     alive: Arc<AtomicBool>,
+    /// Opt-in `LocalTransactionProver` used when the remote prover fails and
+    /// `--miden-prover-fallback-to-local` is set. `None` when fallback is
+    /// disabled (the default — preserves the bali OOM fix) OR when the
+    /// proxy is already proving locally (no remote prover configured, so
+    /// the active prover IS the local one and a "fallback" is meaningless).
+    local_prover_fallback: Option<Arc<dyn TransactionProver + Send + Sync>>,
     #[cfg(test)]
     call_count: Arc<AtomicUsize>,
 }
@@ -109,10 +117,14 @@ const fn assert_sync<T: Send + Sync>() {}
 const _: () = assert_sync::<MidenClient>();
 
 impl MidenClient {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         store_dir: Option<PathBuf>,
         node_url: Option<String>,
         api_key: Option<String>,
+        prover_url: Option<String>,
+        prover_timeout_secs: u64,
+        fallback_to_local: bool,
         sync_listeners: Vec<Arc<dyn SyncListener>>,
         debug_mode: bool,
     ) -> anyhow::Result<Self> {
@@ -122,6 +134,21 @@ impl MidenClient {
             .unwrap_or(Ok(Endpoint::localhost()))?;
         let keystore = Self::create_keystore(store_dir.clone())?;
         let keystore_for_run = keystore.clone();
+        let prover_url_for_run = prover_url.clone();
+
+        // Pre-construct the local-prover Arc once at boot so the proof-call
+        // hot path can clone it without re-initialising. Only meaningful when
+        // a remote prover IS configured AND the operator has opted in via
+        // `--miden-prover-fallback-to-local`; otherwise the active prover
+        // is already local (no remote configured) or the operator has
+        // explicitly chosen "fail rather than fall back to the bali OOM
+        // path" (the default).
+        let local_prover_fallback: Option<Arc<dyn TransactionProver + Send + Sync>> =
+            if fallback_to_local && prover_url.is_some() {
+                Some(Arc::new(LocalTransactionProver::default()))
+            } else {
+                None
+            };
 
         let (sender, receiver) = mpsc::channel::<Request>(1);
         let (done_sender, done_receiver) = oneshot::channel::<()>();
@@ -139,6 +166,8 @@ impl MidenClient {
                     store_dir.clone(),
                     node_endpoint.clone(),
                     api_key.clone(),
+                    prover_url_for_run.clone(),
+                    prover_timeout_secs,
                     keystore_for_run.clone(),
                     &mut receiver,
                     &mut done_receiver,
@@ -171,9 +200,23 @@ impl MidenClient {
             sender,
             done_sender,
             alive,
+            local_prover_fallback,
             #[cfg(test)]
             call_count: Arc::new(AtomicUsize::new(0)),
         })
+    }
+
+    /// Returns the opt-in `LocalTransactionProver` fallback if the operator
+    /// set `--miden-prover-fallback-to-local` AND a remote prover is
+    /// configured. `None` when the active prover is already local (no
+    /// remote configured) or fallback was not opted into.
+    ///
+    /// Callers (currently `claim.rs`) should attempt `prove_transaction`
+    /// against the configured prover first, then retry against this
+    /// `Arc` when the result is a `ClientError::TransactionProvingError`.
+    /// See `src/claim.rs::publish_claim_internal` for the canonical use.
+    pub fn local_prover_fallback(&self) -> Option<Arc<dyn TransactionProver + Send + Sync>> {
+        self.local_prover_fallback.clone()
     }
 
     /// Returns true if the background thread is connected and syncing.
@@ -224,6 +267,7 @@ impl MidenClient {
             sender,
             done_sender: std::sync::Mutex::new(Some(done_sender)),
             alive: Arc::new(AtomicBool::new(true)),
+            local_prover_fallback: None,
             call_count,
         }
     }
@@ -363,6 +407,8 @@ impl MidenClient {
         store_dir: PathBuf,
         node_endpoint: Endpoint,
         api_key: Option<String>,
+        prover_url: Option<String>,
+        prover_timeout_secs: u64,
         keystore: Arc<FilesystemKeyStore>,
         receiver: &mut mpsc::Receiver<Request>,
         done_receiver: &mut oneshot::Receiver<()>,
@@ -378,10 +424,33 @@ impl MidenClient {
             DebugMode::Disabled
         };
 
+        let tx_prover: Option<Arc<dyn TransactionProver + Send + Sync>> =
+            prover_url.as_deref().map(|url| {
+                Arc::new(
+                    RemoteTransactionProver::new(url)
+                        .with_timeout(Duration::from_secs(prover_timeout_secs)),
+                ) as _
+            });
+        if prover_url.is_some() {
+            // Deliberately NOT logging the URL itself — operators can audit
+            // MIDEN_PROVER_URL from the environment, ops logs must not
+            // contain it (the URL may include an auth-bearing path or be
+            // routed through an internal-only hostname we do not want
+            // captured in long-lived log indices).
+            tracing::info!(
+                target: crate::COMPONENT,
+                prover_url = "configured",
+                prover_timeout_secs,
+                "MidenClient using remote transaction prover",
+            );
+        } else {
+            tracing::info!(target: crate::COMPONENT, "MidenClient using local transaction prover (default)");
+        }
+
         let mut client;
         let mut backoff = BACKOFF_MIN;
         loop {
-            let build_result = ClientBuilder::new()
+            let mut builder = ClientBuilder::new()
                 .rpc(build_rpc_client(
                     &node_endpoint,
                     node_timeout_ms,
@@ -389,9 +458,11 @@ impl MidenClient {
                 ))
                 .sqlite_store(store_dir.join("store.sqlite3"))
                 .authenticator(keystore.clone())
-                .in_debug_mode(mode)
-                .build()
-                .await;
+                .in_debug_mode(mode);
+            if let Some(p) = tx_prover.clone() {
+                builder = builder.prover(p);
+            }
+            let build_result = builder.build().await;
 
             match build_result {
                 Ok(c) => {


### PR DESCRIPTION
## Summary
Adds `apt-get upgrade -y` to the `debian:bookworm-slim` runtime stages of both `Dockerfile` (miden-agglayer-service) and `Dockerfile.miden-node` so image rebuilds pull patched libc/openssl/curl on every build. Matches the established pattern in `cdk-proposer` and `privacy-proxy`.

## Aikido reference
- Issue group **18169693** — Debian Linux EOL (severity high in detail, low in listing)
- Affected images in this repo: `gatewayfm/miden-agglayer`, `gatewayfm/miden-node`

Indirectly also clears the `libc` finding (group 20995437) which pins to `libc 2.41-12+deb13u2` — bookworm-slim with `apt upgrade` pulls latest patched debu12 libc, lower-risk than a major OS bump to trixie.

## Test plan
- [ ] CI green
- [ ] Image builds and `miden-agglayer-service` / `miden-node` start as before
- [ ] Next Aikido scan no longer flags this repo under group 18169693