### PR TITLE
docs: agglayer operations — monitoring, runbook, diagnostics

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,56 @@
+# miden-agglayer — operations
+
+Operational reference for running miden-agglayer in a production-like
+deployment (bali is the current reference cluster).
+
+Audience: SRE on call for the bali Miden testnet, or anyone bringing up a
+similarly-shaped deployment elsewhere.
+
+## What's in this directory
+
+| Doc | Use it when… |
+|---|---|
+| [`monitoring.md`](./monitoring.md) | You want to know what to scrape, what to alert on, and what "healthy" vs "stuck" looks like end to end. |
+| [`runbook.md`](./runbook.md) | A specific failure mode is firing (IAIC, AccountDataNotFound, GER backlog, stuck claim, ClaimSettler dry, indexer drift) and you need step-by-step recovery. |
+| [`diagnostics.md`](./diagnostics.md) | You don't yet know what's wrong — you need the read-only inspection playbook (Loki queries, SQL snapshots, account introspection, single-deposit tracing). |
+
+## What's already documented elsewhere
+
+These existing docs cover specific incidents and design notes — link out
+to them rather than re-stating their contents:
+
+- [`../POSTMORTEM_2026-05-11_IAIC_TO_ADNF.md`](../POSTMORTEM_2026-05-11_IAIC_TO_ADNF.md) — the IAIC →
+  AccountDataNotFound chain that ran the bali bridge for ~20 days. Anyone
+  triaging "mempool conflict" or "account data wasn't found" symptoms
+  should read this first.
+- [`../REDEPLOY_RUNBOOK_BALI.md`](../REDEPLOY_RUNBOOK_BALI.md) — the v0.4.1 deploy + recovery
+  runbook for bali specifically. The redeploy procedure documented there
+  is the cure for the postmortem's failure mode on the existing bali
+  cluster.
+- [`../ger-decomposition.md`](../ger-decomposition.md) — design notes on the GER decomposition
+  problem and the `UseUpdateExitRoot` aggoracle mode that is the
+  permanent fix (RD-862).
+- [`../ger-note-screening-bypass.md`](../ger-note-screening-bypass.md) — design notes on the split
+  `execute → prove → submit` flow that GER injection uses to bypass the
+  miden-client NoteScreener.
+- [`../../README.md`](../../README.md) — service-level overview, CLI flags,
+  ClaimSettler env vars, recovery flags (`--reset-miden-store`,
+  `--unlock-miden-accounts`, `--restore`, `--init`).
+- The [`miden-bali-debug` skill](../../.claude/skills/miden-bali-debug/SKILL.md) (if checked
+  out) — read-only diagnostic agent that automates Phases 0-7 of
+  `diagnostics.md`.
+
+## Conventions
+
+- All command examples assume the bali cluster
+  (`dev-gateway-eks` / `outpost-testnet-miden-testnet` namespace,
+  pod `miden-agglayer-0`, image `gatewayfm/miden-agglayer:0.4.1` or
+  later). Adapt cluster context, namespace, and pod name for other
+  deployments.
+- Placeholders are written as `<placeholder>` and need operator input
+  before the command will run. Anything labelled `<TODO: ...>` is
+  unverified — confirm with the on-call before relying on it.
+- Destructive commands (`--reset-miden-store`, `--init`, SQL UPDATE) are
+  always called out with their blast radius and the rollback path.
+- The diagnostic skill is read-only by contract — it never executes
+  recovery actions, even when one is obvious.

--- a/docs/operations/diagnostics.md
+++ b/docs/operations/diagnostics.md
@@ -1,0 +1,384 @@
+# miden-agglayer diagnostics
+
+The read-only playbook: what to inspect, in what order, to localise a
+failure before reaching for [`runbook.md`](./runbook.md). Pair this with
+the [`miden-bali-debug` skill](../../.claude/skills/miden-bali-debug/SKILL.md)
+when you want the snapshot collected for you.
+
+## Read-only contract
+
+Everything in this doc is non-mutating:
+
+- `kubectl`: `get`, `describe`, `logs`, `port-forward` only.
+- SQL: `SELECT` / `\d` only — never `UPDATE`, `INSERT`, `DELETE`, `ALTER`,
+  `TRUNCATE`.
+- JSON-RPC: `eth_*` reads (`eth_blockNumber`, `eth_getLogs`, `eth_call`)
+  and `zkevm_get*` reads.
+
+If at any point you need a mutating action, **stop, write down what you
+saw, switch to runbook.md**.
+
+## Accounts at a glance — what to inspect and where
+
+miden-agglayer's bridging surface involves five distinct account classes
+on each side. Knowing where each lives is the prerequisite to tracing a
+single deposit or withdrawal.
+
+| Class | Side | Role | How to look it up |
+|---|---|---|---|
+| **Bridge contract** | L1 | `polygonZkEVMBridge` — receives `bridgeAsset()` for L1→L2 deposits and finalises `claimAsset()` for L2→L1 withdrawals. | `BRIDGE_ADDRESS` env on the proxy pod (bali: `0x1348947e282138d8f377b467f7d9c2eb0f335d1f`, source: `miden/bali-l1-deposit.sh`). |
+| **L1 GER contract** | L1 | `polygonZkEVMGlobalExitRoot` — emits `UpdateL1InfoTree` events; the L1InfoTreeIndexer scrapes this. | `L1_GER_ADDRESS` env (bali: `0x2968d6d736178f8fe7393cc33c87f29d9c287e78`). |
+| **RollupManager** | L1 | Receives `claimAsset()` post-cert; ClaimSettler talks to this. | `ROLLUP_MANAGER_ADDRESS` env (bali: `0xe2ef6215adc132df6913c8dd16487abf118d1764`). |
+| **ger_manager** | L2 (Miden) | Receives `UpdateGerNote` notes injected by the proxy on each `insertGlobalExitRoot`/`updateExitRoot` call. | `bridge_accounts.toml` inside the pod at `--miden-store-dir/bridge_accounts.toml`. Account IDs are 30-hex (15 bytes). |
+| **bridge** | L2 (Miden) | Mints wrapped assets via `mint_and_send` on CLAIM; consumes B2AGG notes for withdrawals. | Same `bridge_accounts.toml`. |
+| **Faucet(s)** | L2 (Miden) | Owned by `bridge`, hold per-asset supply. Listed in the `faucet_registry` table (migration 002). | `SELECT * FROM faucet_registry;` against the proxy DB. |
+| **Aggsender signer** | L1 + L2 | Submits AggLayer certificates. | aggkit config — `<TODO: confirm aggsender pubkey location for bali>`. |
+| **Aggoracle signer** | L1 (read) → L2 (write) | Calls `insertGlobalExitRoot`/`updateExitRoot` on the proxy. | aggkit config. |
+| **ClaimSettler signer** | L1 (write) | Auto-claims settled L2→L1 transfers. | `CLAIM_SETTLER_PRIVATE_KEY` env on the proxy pod. **Never log or echo this.** Derive the public address from logs only. |
+| **Claim sponsor** | L2 (write) | Submits CLAIM notes on the proxy for L1→L2 deposits. | aggkit / claimsponsor config. |
+
+To inspect an L1 account: `cast` against the Sepolia RPC.
+
+```bash
+cast balance <address> --rpc-url "$SEPOLIA_RPC_URL"
+cast nonce   <address> --rpc-url "$SEPOLIA_RPC_URL"
+cast code    <address> --rpc-url "$SEPOLIA_RPC_URL"   # contract presence check
+```
+
+To inspect a Miden account: the proxy exposes none of this directly via
+JSON-RPC. The two read-only options:
+
+- Read the cached state via the proxy DB tables — `address_mappings`,
+  `faucet_registry`, `bridge_accounts.toml` (the file).
+- Use `miden-cli` from a separate workstation against the same
+  miden-node RPC. **Do not run `miden-cli` from inside the proxy pod** —
+  it would contend with the live `MidenClient` on the same sqlite file.
+
+`<TODO: Max — confirm a sanctioned bali miden-cli setup, ideally pointed
+at rpc.testnet.miden.io with a read-only store_dir, and add the invocation
+here.>`
+
+## 1. Sanity (always run first)
+
+```bash
+kubectl config current-context           # must equal the cluster you think you're on
+kubectl get pods -n outpost-testnet-miden-testnet
+```
+
+Expect: `miden-agglayer-0` `Running`, restart count low (single digits
+over the last week, ideally 0-1 attributable to deploys).
+
+If context is wrong: **stop**. If restart count is high, the data-layer
+queries below may be chasing a downstream effect of a pod-layer cause.
+
+## 2. Pod fingerprint
+
+```bash
+kubectl -n outpost-testnet-miden-testnet describe pod miden-agglayer-0 \
+  | grep -E 'Image|Args|Reason|Started|Restart Count|Limits|Requests'
+```
+
+Capture and reason about:
+
+- **`Image`** — pre-v0.3.0 (`:0.2.1` or earlier) is the postmortem-class
+  baseline; the proxy is missing the IAIC fix, the Phase 0 restore
+  reimport, and the runtime self-heal.
+- **`Args`** — `--reset-miden-store`, `--restore`, `--unlock-miden-accounts`,
+  `--init` should NEVER be live in steady state. If any of them is set,
+  the pod is in a recovery sequence — wait for it to finish before
+  trusting any data.
+- **`Environment`** — `L1_RPC_URL`, `L1_GER_ADDRESS`, `DATABASE_URL`,
+  `BRIDGE_ADDRESS` must all be set. `CLAIM_SETTLER_ENABLED=true` enables
+  the L2→L1 auto-claim path; if `false`, withdrawals require manual
+  claim on L1.
+- **`Last State.Reason`** — `OOMKilled` is a tell that the indexer
+  cursor may have rolled back to current L1 head on the latest restart.
+- **`Limits.memory`** — flag for bump if OOMs are recurring.
+
+## 3. Log signals
+
+```bash
+kubectl logs miden-agglayer-0 -n outpost-testnet-miden-testnet --tail=20000 \
+  | grep -E 'L1InfoTreeIndexer|GER injection|GER already seen|exit roots don|incorrect account initial commitment|account data wasn|UpdateGerNote|insertGlobalExitRoot|updateExitRoot|OOMKilled|reimport|bridge_invariant|claim_watcher'
+```
+
+Translate patterns to verdicts via this decision table:
+
+| Pattern | Verdict |
+|---|---|
+| `L1InfoTreeIndexer polled (no events), from: N, to: N, head: N` | Indexer alive + caught up. |
+| `from: M, to: M, head: N` with `N >> M` | Indexer falling behind — runbook section E.2. |
+| `GER injection: submitting to Miden... ger: <hex>` followed by no `UpdateGerNote transaction committed` for that hex within 30s | Miden submission stuck or failed silently — chase by GER hex. |
+| `account data wasn't found for account id 0x<id>` | Miden-store divergence (missing account). Runbook A. |
+| `incorrect account initial commitment` | Miden-store divergence (stale commitment) OR mempool conflict (read the gRPC tail). Runbook A. |
+| `transaction conflicts with current mempool state` | Pure mempool conflict — should be impossible on v0.3.0+. If observed, regression. Runbook A.3. |
+| `L1 exit roots don't match injected GER, storing without roots` | RD-862 race fired — orphan stored. Confirms `UseUpdateExitRoot=false` mode. |
+| `GER already seen, skipping duplicate` | Dedup poison: the combined hash already has `is_injected=TRUE` with whatever roots are in `ger_entries` (possibly NULL). |
+| `reimporting ger_manager` followed by `reimported from node` | Self-heal fired on a recoverable error. Expected once per pod restart on bali; multiple firings in steady state = chronic divergence. |
+| `bridge_invariant_violation: <kind>` | Cantina hard-page metric incremented. Runbook D. |
+| `claim_watcher synthesised ClaimEvent` in steady state (not just at startup) | The `eth_sendRawTransaction` path failed to record a CLAIM; watcher cleaned up after it. Sustained = `service_send_raw_txn` is broken. |
+
+## 4. Trace a single L1→L2 deposit
+
+You need:
+
+- `deposit_cnt` (decimal, from bridge-service or the depositor's `cast
+  receipt` output).
+- Optionally the user's destination address (Miden AccountId 30-hex or
+  Eth-mapped 20-byte).
+
+### 4.1 Did bridge-service see the deposit?
+
+Port-forward the bridge DB (see runbook preamble), then:
+
+```sql
+SELECT deposit_cnt, network_id, dest_net, ready_for_claim, block_id,
+       encode(orig_addr, 'hex') AS orig,
+       encode(dest_addr, 'hex') AS dest,
+       amount
+FROM sync.deposit
+WHERE network_id = 0 AND deposit_cnt = <cnt>;
+```
+
+Expect a row with `network_id=0` (L1 origin), `dest_net=<your rollup id>`
+(bali: 73 historically, 76 post-relaunch — confirm against current
+deployment).
+
+- No row: bridge-service hasn't ingested the L1 event. Either bridge-service
+  is behind on L1 sync, or the deposit transaction reverted on L1.
+  Verify with `cast receipt <tx-hash> --rpc-url $SEPOLIA_RPC_URL`.
+- `ready_for_claim = false`: no covering GER on bridge-service yet —
+  jump to 4.2.
+- `ready_for_claim = true`: the deposit is ready to be claimed on L2 —
+  jump to 4.3.
+
+### 4.2 Has the covering GER reached the proxy?
+
+```sql
+-- against the proxy DB
+SELECT count(*) FROM ger_entries WHERE block_number > (
+  SELECT block_number FROM ger_entries
+  WHERE block_number <= (
+    SELECT block_id FROM sync.deposit WHERE network_id=0 AND deposit_cnt=<cnt>
+  )
+  ORDER BY block_number DESC LIMIT 1
+) AND is_injected;
+```
+
+A non-zero result means at least one newer GER has been injected on L2,
+which should be sufficient to cover the deposit (exit trees are
+append-only — see [`../ger-decomposition.md`](../ger-decomposition.md)).
+
+If zero, the proxy hasn't injected a GER newer than the deposit's L1
+block. Cross-reference with proxy logs around the deposit's timestamp.
+
+### 4.3 Has the CLAIM landed on L2?
+
+```sql
+-- against the proxy DB
+SELECT global_index, created_at FROM claimed_indices ORDER BY created_at DESC LIMIT 20;
+```
+
+Compute the expected `global_index` from `(network_id, deposit_cnt)`:
+
+```
+global_index = (1 << 64) | (network_id << 32) | deposit_cnt
+```
+
+(`<TODO: confirm exact bit layout against
+src/service_send_raw_txn.rs claim-flow code — the postmortem shows
+`global_index=18446744073710679244` which decodes to network/cnt values
+that should match this formula>`.)
+
+If the global_index appears in `claimed_indices`, the CLAIM was
+processed. To verify the on-chain receipt:
+
+```sql
+SELECT tx_hash, status, signer, block_number, miden_tx_id
+FROM transactions
+WHERE tx_hash IN (
+  SELECT transaction_hash FROM synthetic_logs
+  WHERE topics[1] = '0x1df3f2a973a00d6635911755c260704e95e8a5876997546798770f76396fda4d'
+  ORDER BY block_number DESC LIMIT 20
+);
+```
+
+(`0x1df3f2a9...` is the `ClaimEvent` topic — also exported by
+`miden/bali-l2-status.sh`.)
+
+### 4.4 Did the user's balance actually change?
+
+Miden balance inspection from outside the pod requires miden-cli, which
+is out of scope for this doc — see the accounts table above. As a proxy
+check, look up the `address_mappings` table:
+
+```sql
+SELECT * FROM address_mappings WHERE lower(eth_address) = lower('<dest_address>');
+```
+
+If the row is missing, the proxy zero-padded the destination
+(`address_mapper_zero_padding_fallback_total` should have incremented at
+claim time) — the user's balance increased on a synthesised Miden
+account they don't control. **Page Max** before any remediation.
+
+## 5. Trace a single L2→L1 withdrawal
+
+You need the user's `BridgeEvent` log block + log_index, or the
+`deposit_count` reported by the L2 proxy.
+
+### 5.1 Did the proxy see the B2AGG note?
+
+```sql
+SELECT * FROM bridge_out_processed WHERE deposit_count = <n>;
+```
+
+If absent, `BridgeOutScanner` (`src/bridge_out.rs`) hasn't processed it.
+Possible causes:
+
+- Note's faucet missing from registry — `bridge_out_unknown_faucet_total`
+  incremented. The note is quarantined by design.
+- Note destination is invalid (zero address / EVM precompile range) —
+  `bridge_out_invalid_destination_total` incremented. Refused.
+- Self-targeted destination_network — `bridge_out_self_targeted_total`
+  incremented. **Hard fault** — page Max.
+
+### 5.2 Did the synthetic `BridgeEvent` log emit?
+
+Using the running JSON-RPC (default port-forward 8546):
+
+```bash
+# Topic hash for BridgeEvent
+TOPIC=0x501781209a1f8899323b96b4ef08b168df93e0a90c673d1e4cce39366cb62f9b
+
+curl -sS http://localhost:8546 \
+  -H 'content-type: application/json' \
+  --data "{
+    \"jsonrpc\": \"2.0\", \"id\": 1,
+    \"method\": \"eth_getLogs\",
+    \"params\": [{
+      \"fromBlock\": \"0x0\",
+      \"toBlock\":   \"latest\",
+      \"topics\":    [\"$TOPIC\"]
+    }]
+  }" | jq '.result | length'
+```
+
+For the at-a-glance dump (all three event types in one pass), use
+`miden/bali-l2-status.sh` from the local checkout.
+
+### 5.3 Did aggsender pick the event up + build a certificate?
+
+`<TODO: confirm aggsender log signatures + cert lifecycle queries
+against the bali aggsender setup. The aggsender pod and its REST API
+URL need to land in this section.>`
+
+### 5.4 Did ClaimSettler claim on L1?
+
+ClaimSettler logs at INFO when it submits an L1 claim:
+
+```logql
+{namespace="outpost-testnet-miden-testnet", container="miden-agglayer"}
+  |~ "ClaimSettler.*submitted|ClaimSettler.*claimed"
+```
+
+If no log, check:
+
+```bash
+# Is ClaimSettler enabled?
+kubectl -n outpost-testnet-miden-testnet describe pod miden-agglayer-0 \
+  | grep -E 'CLAIM_SETTLER_ENABLED|CLAIM_SETTLER_WATCH_ADDRESSES'
+
+# Does the signer have ETH?
+SIGNER=$(kubectl logs miden-agglayer-0 -n outpost-testnet-miden-testnet \
+  | grep -m1 'ClaimSettler: signing as' | grep -oE '0x[0-9a-fA-F]{40}')
+cast balance "$SIGNER" --rpc-url "$SEPOLIA_RPC_URL"
+```
+
+## 6. Proxy DB snapshot — health overview
+
+Run the queries from
+[`../../.claude/skills/miden-bali-debug/queries/01-proxy-health.sql`](../../.claude/skills/miden-bali-debug/queries/01-proxy-health.sql).
+Sanity checks on the output:
+
+- `total - injected` should be a small handful (a few in-flight GERs
+  waiting for Miden commit). A large gap = aggoracle is pushing faster
+  than Miden is committing, or every Miden submission is failing — see
+  log signals in section 3.
+- `injected AND mainnet_exit_root IS NULL` = STATE-C orphans. Pre-RD-862
+  legacy on bali (~27 historic). Should not be growing on a
+  `UseUpdateExitRoot=true` cluster — if it is, the aggkit config flag
+  isn't actually enabled.
+- `service_state.latest_block_number` should equal or be one ahead of
+  the maximum `ger_entries.block_number`. A larger gap means the proxy
+  is producing synthetic blocks (every 12s) but not landing GERs.
+- `transactions.status` distribution — `success` should dominate;
+  sustained `failed` rows are the leading indicator of failure mode A.
+
+## 7. Bridge-service DB snapshot
+
+Run [`../../.claude/skills/miden-bali-debug/queries/02-bridge-state.sql`](../../.claude/skills/miden-bali-debug/queries/02-bridge-state.sql).
+
+Cross-cluster invariants:
+
+- `stuck` count should be flat or shrinking. Growing = either proxy
+  isn't emitting GERs (failure mode E) or bridge-service isn't ingesting
+  them (sync gap).
+- `max(sync.exit_root.id)` for the rollup network should advance every
+  time the proxy injects a new GER. Plateaued = bridge-service has lost
+  L2 sync.
+- `matchable` count (rollup-side GER rows that join `mt.root[n=0]`)
+  should equal the total rollup-side count, or the gap should match the
+  number of unresolved GERs on the proxy. Larger gap = GERs that
+  bridge-service has but cannot validate; investigate per-row.
+
+## 8. Single-GER deep dive
+
+Given a GER hex, the full lifecycle in 4 lookups:
+
+```sql
+-- 1) Proxy: did we store it? With which roots? Injected?
+SELECT encode(ger_hash,'hex'), encode(mainnet_exit_root,'hex'),
+       encode(rollup_exit_root,'hex'), is_injected, block_number,
+       to_timestamp(timestamp)
+FROM ger_entries WHERE ger_hash = decode('<hex>', 'hex');
+
+-- 2) Bridge-service: did it ingest the synthetic event?
+SELECT id, block_id, network_id,
+       encode(exit_roots[1],'hex') AS m,
+       encode(exit_roots[2],'hex') AS r
+FROM sync.exit_root WHERE global_exit_root = decode('<hex>', 'hex');
+
+-- 3) Proxy logs: lifecycle
+--    {namespace="...", container="miden-agglayer"} |~ "<ger-hex>"
+
+-- 4) Miden-side: was the UpdateGerNote actually committed?
+SELECT tx_hash, miden_tx_id, status, block_number
+FROM transactions
+WHERE tx_hash IN (
+  SELECT transaction_hash FROM synthetic_logs
+  WHERE topics[1] = '0xda61aa7823fcd807e37b95aabcbe17f03a6f3efd514176444dae191d27fd66b3'
+    AND topics[2] = '<ger-hex-32-byte-padded>'
+);
+```
+
+(`0xda61aa78...` is the `UpdateL1InfoTree` topic, mirrored by the proxy
+as the GER injection synthetic log.)
+
+## 9. When to bring in higher-level help
+
+Hand off — capture the snapshot first — when any of:
+
+- Cantina hard-page metric increments (runbook D).
+- ClaimSettler submitted but `cast receipt` shows the L1 claim reverted
+  (`status: 0`) — implies on-chain bridge-state corruption.
+- bridge_accounts.toml differs between the running pod and what version
+  control has — implies the recovery flow ran `--init` accidentally.
+- `address_mapper_zero_padding_fallback_total` rate spikes during a
+  high-volume deposit window — implies a user is sending to an unmapped
+  destination and may not be able to spend the resulting wrapped asset.
+- Aggsender unable to build certificates against an otherwise-healthy
+  proxy — issue is in aggkit / agglayer rather than here.
+
+For all of these, post the snapshot block from
+`miden-bali-debug`'s output format (skill docs §"Output format") into
+the incident ticket.

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1,0 +1,235 @@
+# Monitoring miden-agglayer
+
+This doc describes what is exposed by the service, what to scrape, what
+to alert on, and how to translate a Prometheus / Loki snapshot into a
+verdict on whether bridging is flowing in each direction.
+
+## 1. Endpoints exposed by the service
+
+The service binds a single HTTP listener on `--port` (default `8546`) and
+mounts:
+
+| Path | Purpose |
+|---|---|
+| `POST /` | JSON-RPC. Bridge tooling (aggoracle, aggsender, bridge-service, claim sponsor) talks here. |
+| `GET /health` | Returns `{"status":"ok"}` once the service has finished startup. Use as a Kubernetes readiness + liveness probe. |
+| `GET /metrics` | Prometheus exposition. All metrics described below come from here. |
+
+See `src/metrics.rs` for the authoritative list of metric names and the
+inline documentation on what each one means.
+
+## 2. Prometheus metrics catalogue
+
+Counters and one histogram, grouped by purpose. All metric names are
+unprefixed in the exposition (no `miden_agglayer_` prefix in source —
+add one via `relabel_configs` if your global registry needs it).
+
+### Throughput — "is the service doing useful work?"
+
+| Metric | What it counts |
+|---|---|
+| `rpc_requests_total{method=...}` | JSON-RPC requests by method. Strong proxy for upstream tooling liveness. |
+| `claims_processed_total` | L1→L2 claim notes successfully submitted to Miden. |
+| `ger_injections_total` | UpdateGerNote notes successfully committed on Miden. |
+| `bridge_outs_total` | L2→L1 B2AGG notes detected + emitted as `BridgeEvent` synthetic logs. |
+| `rpc_request_duration_seconds` | Histogram. Per-method latency; use `_bucket` for tail-latency SLOs. |
+
+If `rpc_requests_total{method="eth_sendRawTransaction"}` is climbing but
+`claims_processed_total` + `ger_injections_total` are flat, every tx is
+failing pre-submit — go straight to the runbook section on "no
+submissions landing".
+
+### Self-heal / divergence — Miden-client store health
+
+| Metric | Meaning | Severity |
+|---|---|---|
+| `miden_client_build_errors_total` | Failed attempts to build the Miden gRPC connection. Sustained non-zero rate = miden-node down or DNS broken. | warning |
+| `miden_client_restarts_total` | Background event-loop thread restarted after a crash. Each tick = a closure panicked. | warning |
+| `miden_sync_errors_total{kind=...}` | Sync errors by kind. Spikes correlate with miden-node reorgs / restarts. | warning |
+| `miden_locked_accounts_detected_total` | Set at startup if any managed account is `locked` in the miden-client sqlite. Indicates stale-lock divergence — see runbook `"--unlock-miden-accounts"`. | page if non-zero on startup |
+
+### Bridge invariants — Cantina audit findings, hard-page metrics
+
+These exist to satisfy the Cantina audit's "you must page before this
+ever silently wedges the bridge" requirement. Treat each one as a
+hard-page criterion at any non-zero rate.
+
+| Metric | What it means | Cantina ref |
+|---|---|---|
+| `bridge_burn_serial_collision_total` | A BURN note's serial number was reused for a different leaf. `mint_and_send` token_supply is at risk of exhaustion. | Cantina #5 |
+| `bridge_twin_note_detected_total` | Second on-chain note with a previously-observed NoteId but different metadata — B2AGG reclaim attack signature. | Cantina #6 |
+| `bridge_mint_target_mismatch_total` | MINT note consumed by a faucet other than its `NetworkAccountTarget`. Claimant about to receive the wrong wrapped asset. | Cantina #2 |
+| `bridge_faucet_ownership_drift_total{kind=drift\|renounced}` | Faucet owner storage slot moved away from the configured bridge AccountId. `renounced` wedges the faucet permanently. | Cantina #4 |
+| `bridge_forged_mint_total` | MINT note on chain that does not correspond to any aggkit-recorded claim. Forged via NoAuth bridge note authorship. | Cantina #4 |
+| `bridge_out_self_targeted_total` | B2AGG whose `destination_network` equals our `network_id`. Each one is a poison leaf that wedges the bridge. | Cantina #13 |
+
+### Drift detection — Local Exit Tree consistency
+
+| Metric | Meaning |
+|---|---|
+| `bridge_let_divergence_total{kind=on_chain_ahead}` | A private B2AGG was consumed on chain that we never observed — local LET is behind. |
+| `bridge_let_divergence_total{kind=aggkit_ahead}` | Aggkit's LET is ahead of what we can reconstruct from on-chain data — likely local state corruption. |
+| `bridge_expected_mint_stale_total` | A MINT NoteId we predicted hasn't landed within the retry threshold (`Cantina #7` — batch-dedup censorship via metadata-distinct twin). |
+
+### Backpressure / dedup signals — operational, not security
+
+| Metric | Use |
+|---|---|
+| `bridge_out_invalid_destination_total` | B2AGG with zero-address / EVM-precompile destination. We refuse to forward to bridge-service. Steady non-zero rate = upstream client bug. |
+| `bridge_out_unknown_faucet_total` | B2AGG referencing a faucet not in our registry. Quarantined to prevent silent re-loop. Investigate any non-zero rate. |
+| `address_mapper_zero_padding_fallback_total` | We had no explicit eth→Miden mapping and fell back to zero-padding the trailing 16 bytes. Account existence is NOT verified — alert on unusual rates. |
+| `rpc_claim_ger_not_seen_total` | Claim submission was rejected because the GER it referenced was not yet in our store. Cheap, retry-friendly. A sustained spike means claim sponsor and aggoracle are out of sync. |
+| `rpc_claim_ger_wait_short_circuit_total` | A claim's GER-propagation wait completed instantly because the GER was already injected. Saves ~12s per claim — useful as a positive-side health signal. |
+| `claim_watcher_synthesised_total` | ClaimWatcher synthesised a ClaimEvent for a consumed CLAIM that wasn't recorded by the normal path. Normal during crash recovery; spikes during steady state = `eth_sendRawTransaction` path is broken. |
+| `claim_watcher_already_recorded_total` | ClaimWatcher saw a CLAIM that was already in the store. Use to monitor dedup rate. |
+| `claim_watcher_storage_decode_total` | ClaimWatcher couldn't decode on-chain CLAIM note storage. Should be zero; any non-zero rate is a parser / schema-drift bug. |
+| `claim_watcher_unrecoverable_total` | Consumed CLAIM that can't be synthesised at all. Page if rate spikes. |
+| `store_envelope_decode_errors_total` | Tx envelope row in PgStore that won't decode. Either schema drift or DB corruption — investigate immediately. |
+| `store_errors_total` | Generic catch-all for any store operation that returned an error. |
+
+## 3. Suggested Prometheus alert rules
+
+These are starter rules. Tune thresholds per cluster after a week of
+baseline observation.
+
+```yaml
+# <TODO: confirm Prometheus rule file path on bali — likely
+# kube-prometheus-stack PrometheusRule CRD in observability namespace>
+groups:
+- name: miden-agglayer.bridge-safety
+  rules:
+  # ---- Hard-page Cantina findings (any non-zero rate) -----------------
+  - alert: MidenAgglayerBridgeInvariantViolation
+    expr: |
+      sum by (cluster, pod) (
+        increase(bridge_burn_serial_collision_total[5m])
+        + increase(bridge_twin_note_detected_total[5m])
+        + increase(bridge_mint_target_mismatch_total[5m])
+        + increase(bridge_faucet_ownership_drift_total[5m])
+        + increase(bridge_forged_mint_total[5m])
+        + increase(bridge_out_self_targeted_total[5m])
+      ) > 0
+    for: 0m
+    labels: { severity: critical }
+    annotations:
+      summary: "Bridge invariant violation on {{ $labels.pod }}"
+      runbook_url: "https://github.com/gateway-fm/miden-agglayer/blob/main/docs/operations/runbook.md#bridge-invariant-violation"
+
+  # ---- Account divergence (the postmortem-class failure) --------------
+  - alert: MidenAgglayerAccountDivergence
+    expr: |
+      rate({namespace="outpost-testnet-miden-testnet", container="miden-agglayer"}
+        |~ "account data wasn't found|incorrect account initial commitment" [5m]) > 0
+    for: 5m
+    labels: { severity: critical }
+    annotations:
+      summary: "Miden-store account divergence — bridge will not advance until cured"
+      runbook_url: "https://github.com/gateway-fm/miden-agglayer/blob/main/docs/operations/runbook.md#accountdatanotfound--iaic"
+
+  # ---- Bridge stalled (no new GER for >1h) ----------------------------
+  - alert: MidenAgglayerGerInjectionStalled
+    expr: |
+      rate(ger_injections_total[15m]) == 0
+        and on (pod) (rate(rpc_requests_total{method="eth_sendRawTransaction"}[15m]) > 0)
+    for: 1h
+    labels: { severity: high }
+    annotations:
+      summary: "Aggoracle is still pushing but no GER has injected for 1h"
+
+  # ---- Claim throughput stalled while deposits pile up ----------------
+  - alert: MidenAgglayerClaimThroughputDry
+    expr: |
+      rate(claims_processed_total[15m]) == 0
+        and on (pod) (rate(rpc_claim_ger_not_seen_total[15m]) > 0.1)
+    for: 30m
+    labels: { severity: high }
+    annotations:
+      summary: "Claims are being rejected for missing GER — aggoracle is behind"
+
+  # ---- ClaimWatcher quarantine spike ----------------------------------
+  - alert: MidenAgglayerClaimWatcherUnrecoverable
+    expr: rate(claim_watcher_unrecoverable_total[10m]) > 0
+    for: 10m
+    labels: { severity: high }
+    annotations:
+      summary: "ClaimWatcher is quarantining consumed CLAIM notes — parser/schema bug"
+
+  # ---- Locked accounts on startup -------------------------------------
+  - alert: MidenAgglayerLockedAccountsOnStartup
+    expr: miden_locked_accounts_detected_total > 0
+    for: 1m
+    labels: { severity: high }
+    annotations:
+      summary: "Managed account(s) locked in miden-client sqlite"
+      runbook_url: "https://github.com/gateway-fm/miden-agglayer/blob/main/docs/operations/runbook.md#stale-account-lock"
+```
+
+`<TODO: confirm Max — should the cluster label come from `cluster` (kube-prometheus-stack default) or a custom relabel?>`
+
+## 4. Loki queries — fast triage
+
+The diagnostic skill (`miden-bali-debug`) is the canonical source for
+these. Reproduced here for operators who don't have the skill checked
+out.
+
+```logql
+# Bridge invariant violations (any one of the Cantina hard-page metrics
+# logs a structured ERROR with the violation kind alongside the counter
+# increment).
+{namespace="outpost-testnet-miden-testnet", container="miden-agglayer"}
+  |~ "bridge_invariant_violation|burn_serial_collision|twin_note_detected|mint_target_mismatch|faucet_ownership_drift|forged_mint|self_targeted_b2agg"
+
+# Account divergence (the postmortem class)
+{namespace="outpost-testnet-miden-testnet", container="miden-agglayer"}
+  |~ "account data wasn't found|incorrect account initial commitment|AccountIsPrivate|AccountNotFoundOnChain"
+
+# Self-heal events — should fire once per pod restart for normal recoveries
+{namespace="outpost-testnet-miden-testnet", container="miden-agglayer"}
+  |~ "reimporting ger_manager|reimported from node|reimport_known_accounts"
+
+# Indexer position — confirm cursor advancing
+{namespace="outpost-testnet-miden-testnet", container="miden-agglayer"}
+  |~ "L1InfoTreeIndexer polled|cursor advanced|batch processed"
+
+# GER lifecycle for a specific GER hash (substitute the hex)
+{namespace="outpost-testnet-miden-testnet", container="miden-agglayer"}
+  |~ "<ger-hex-without-0x-prefix>"
+  |~ "insertGlobalExitRoot|updateExitRoot|UpdateGerNote|exit roots don|is_injected"
+
+# Claim flow for a specific globalIndex (decimal, as logged)
+{namespace="outpost-testnet-miden-testnet", container="miden-agglayer"}
+  |~ "globalIndex=<dec>|global_index=<dec>"
+```
+
+## 5. Grafana dashboards
+
+`<TODO: Max to paste current Grafana URLs.>` Until then, the key panels
+to assemble are:
+
+- Throughput row: `rate(rpc_requests_total[5m])` by method,
+  `rate(claims_processed_total[5m])`,
+  `rate(ger_injections_total[5m])`,
+  `rate(bridge_outs_total[5m])`.
+- Latency row: `histogram_quantile(0.99, ...rpc_request_duration_seconds_bucket)`
+  by method.
+- Bridge-safety row: stacked rate of all Cantina hard-page metrics —
+  ideal display is "must be flat at zero".
+- Divergence row: `miden_client_restarts_total`,
+  `miden_sync_errors_total`, `miden_locked_accounts_detected_total`,
+  `store_envelope_decode_errors_total`.
+- Backlog row (overlay with bridge-service Postgres exporter): count of
+  `sync.deposit WHERE network_id=0 AND ready_for_claim=false` vs count of
+  `ger_entries WHERE is_injected` — divergence here is the most direct
+  user-impact signal.
+
+## 6. Healthy vs stuck — at-a-glance reference
+
+| Signal | Healthy | Stuck |
+|---|---|---|
+| `eth_sendRawTransaction` rate | > 0, broadly steady | > 0 but `claims_processed_total` / `ger_injections_total` flat → every tx failing pre-submit |
+| L1InfoTreeIndexer cursor | Within ~1 block of L1 head | Falling behind by >100 blocks → L1 RPC slow / hung |
+| `bridge-service.sync.deposit WHERE network_id=0 AND ready_for_claim=true` count | Climbing in step with new L1 deposits | Plateaued — either aggoracle isn't pushing or proxy isn't emitting GERs |
+| `ger_entries WHERE is_injected AND mainnet_exit_root IS NULL` ("STATE-C orphans") | Stable / shrinking (operator backfill running) | Climbing — RD-862 race firing, no `UseUpdateExitRoot` flag |
+| Loki rate of `incorrect account initial commitment` | Zero | Any non-zero rate — see postmortem |
+| Pod restart count over 24h | 0-1 (deploys only) | Multiple — check `Last State.Reason` for `OOMKilled` |
+| `miden_locked_accounts_detected_total` on latest startup | 0 | > 0 — surgical unlock required |

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -1,0 +1,435 @@
+# miden-agglayer operations runbook
+
+Step-by-step recovery procedures for the failure modes we know about.
+For pre-fix snapshot collection (logs / SQL / pod state), use
+[`diagnostics.md`](./diagnostics.md) first. The runbook assumes you
+already have a verdict.
+
+## How to use this doc
+
+1. Identify the failure mode (most recently fired alert; or the verdict
+   block from the diagnostic skill).
+2. Jump to the matching section.
+3. Read the **blast radius** + **rollback** lines before executing.
+4. Note that anything labelled `<TODO: ...>` requires confirmation from
+   Max before running on bali — the underlying behaviour hasn't been
+   confirmed in this revision of the doc.
+
+## Common preamble — port-forwards + secrets
+
+Most procedures need at least one of:
+
+```bash
+# Proxy DB
+kubectl -n outpost-testnet-miden-testnet port-forward svc/miden-agglayer-db 15434:5432 &
+
+# Bridge-service DB
+kubectl -n outpost-testnet-miden-testnet port-forward svc/bridge-db 15435:5432 &
+
+# Service JSON-RPC
+kubectl -n outpost-testnet-miden-testnet port-forward svc/miden-agglayer 8546:8546 &
+
+# Verify all listeners came up
+ss -tlnp | grep -E ':(8546|1543[45])'
+```
+
+Read the DB passwords from secrets — never paste them into chat:
+
+```bash
+export PROXY_PG_PASSWORD="$(
+  kubectl -n outpost-testnet-miden-testnet get secret miden-agglayer-secret \
+    -o jsonpath='{.data.database_url}' \
+  | base64 -d | grep -oP 'password=\K[^ ]+')"
+
+# Bridge-service password lives in 1Password.
+# <TODO: confirm 1Password item name with Max>
+```
+
+`kubectl exec`-free SQL via docker:
+
+```bash
+docker run --rm --network host -e PGPASSWORD="$PROXY_PG_PASSWORD" postgres:17-alpine \
+  psql -h 127.0.0.1 -p 15434 -U agglayer -d agglayer_store -c "<query>"
+```
+
+---
+
+## Failure mode A — AccountDataNotFound / IAIC
+
+Symptoms in logs:
+
+- `account data wasn't found for account id 0x<id>`, OR
+- `incorrect account initial commitment`, OR
+- gRPC tail `transaction conflicts with current mempool state`.
+
+In Prometheus: `MidenAgglayerAccountDivergence` alert firing; recently:
+no fresh rows in `transactions` with `status='success'`.
+
+Background: see [`../POSTMORTEM_2026-05-11_IAIC_TO_ADNF.md`](../POSTMORTEM_2026-05-11_IAIC_TO_ADNF.md).
+Both symptoms map to the same class of fault — local miden-client store
+diverged from on-chain state.
+
+### A.1 Is it just a stale lock?
+
+`miden_locked_accounts_detected_total > 0` at last startup, or startup
+logs include:
+
+```
+src/main.rs: startup diagnostic: 1 managed account(s) are LOCKED in miden-client
+```
+
+Surgical unlock — preserves all local state (milliseconds), no
+re-sync needed:
+
+```bash
+kubectl -n outpost-testnet-miden-testnet patch statefulset miden-agglayer \
+  --type='json' \
+  -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--unlock-miden-accounts"}]'
+
+kubectl -n outpost-testnet-miden-testnet rollout status statefulset miden-agglayer --watch
+
+# Expect "unlocked N row(s)" then the pod exits cleanly.
+
+# Remove the flag and let the pod restart normally
+kubectl -n outpost-testnet-miden-testnet patch statefulset miden-agglayer \
+  --type='json' \
+  -p='[{"op":"remove","path":"/spec/template/spec/containers/0/args/<index-of-flag>"}]'
+```
+
+**Blast radius:** writes to `latest_account_headers` +
+`historical_account_headers` in miden-client sqlite. Reversible — locks
+are recovered from the node on the next sync if they were correct.
+
+**Rollback:** none needed. The flag is idempotent; re-running it is safe.
+
+### A.2 Full miden-store reset
+
+Required when `--unlock-miden-accounts` doesn't clear the symptom — the
+local sqlite has structurally diverged.
+
+> **READ FIRST:** the runbook for this on bali specifically is
+> [`../REDEPLOY_RUNBOOK_BALI.md`](../REDEPLOY_RUNBOOK_BALI.md). It captures the v0.4.1 version
+> requirement, GER state assertions, and the cure-event log signatures
+> we expect after redeploy. Follow that doc on bali; this section is the
+> generic procedure for other clusters.
+
+Procedure:
+
+```bash
+# 1. Confirm the pod image is at least v0.3.0 (Phase 0 reimport in
+#    restore.rs is required for AccountDataNotFound recovery to work).
+kubectl -n <namespace> describe pod <pod> | grep Image:
+
+# 2. Add the recovery flags. Order matters: --reset wipes sqlite, then
+#    --restore reimports accounts + replays state from the node + L1.
+kubectl -n <namespace> patch statefulset miden-agglayer \
+  --type='json' \
+  -p='[
+    {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--reset-miden-store"},
+    {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--restore"}
+  ]'
+
+kubectl -n <namespace> rollout status statefulset miden-agglayer --watch
+
+# 3. Expected boot log sequence:
+#    INFO recovery.rs: reset_miden_store: deleted .../store.sqlite3
+#    INFO restore.rs: === RESTORE: starting state reconstruction ===
+#    INFO Phase 0: re-importing bridge accounts from Miden node...
+#    INFO Phase 0 complete: bridge account reimport pass done
+#    INFO Phase 1: sync_miden_block ...
+#    INFO === RESTORE: complete ===
+#    Then pod exits (return Ok). Kubernetes restarts it without the
+#    recovery flags by virtue of step 4.
+
+# 4. CRITICAL — remove the flags before the pod restarts again, otherwise
+#    every restart loops through reset+restore and never serves traffic.
+kubectl -n <namespace> patch statefulset miden-agglayer \
+  --type='json' \
+  -p='[
+    {"op":"remove","path":"/spec/template/spec/containers/0/args/<index-of-restore>"},
+    {"op":"remove","path":"/spec/template/spec/containers/0/args/<index-of-reset>"}
+  ]'
+
+# 5. Watch for the first successful GER inject post-recovery:
+kubectl -n <namespace> logs -f <pod> | grep -E 'UpdateGerNote transaction committed|account data wasn'
+```
+
+**Blast radius:** deletes `store.sqlite3` (+ WAL/SHM) in the pod's
+PersistentVolume. Keystore + `bridge_accounts.toml` are preserved
+explicitly by `recovery::reset_miden_store`. The proxy's PgStore and
+all on-chain state are untouched.
+
+**Caveat:** Phase 0 reimport requires accounts to be `Public` storage
+mode. The bali infrastructure accounts deployed before commit `34d4316`
+(pre-v0.3.0) are `Private` — for those, `import_account_by_id` returns
+`AccountIsPrivate` and the reimport silently fails for that account.
+This is the case bali is in today — `<TODO: confirm with Max whether
+bali's accounts have been redeployed as Public yet; if not, full reset
+is not a safe option and the only recourse is the v0.4.1 redeploy
+documented in REDEPLOY_RUNBOOK_BALI.md>`.
+
+**Rollback:** none. If `restore` left the system worse, you must
+escalate to Max + Igor for a manual rebuild of bridge_accounts.toml
+against fresh accounts.
+
+### A.3 The IAIC variant (mempool conflict, not store divergence)
+
+If the gRPC tail is literally `transaction conflicts with current mempool
+state` and not `incorrect account initial commitment` alone, the cause is
+mempool serialisation, not local cache lag. This class of error was
+**closed structurally in v0.3.0** by routing all submissions through the
+`MidenClient` channel-of-1 — so on any v0.3.0+ deployment, observing a
+fresh IAIC means something has reintroduced a parallel-submit path.
+
+If a fresh IAIC fires on a v0.3.0+ deployment:
+
+1. Capture a 30-minute Loki window around the first occurrence.
+2. Look for two concurrent `submit_proven_transaction` calls in the same
+   timestamp bucket — that's the regression signature.
+3. Open an incident ticket and **page the maintainer** before redeploying.
+   A self-heal will mask the regression but not fix it.
+
+---
+
+## Failure mode B — Stuck L1→L2 deposit (no claim arriving on L2)
+
+User report: "I sent ETH on Sepolia, the bridge-service shows my deposit
+but no balance has appeared on Miden."
+
+Use the trace in [`diagnostics.md` section 4](./diagnostics.md#4-trace-a-single-l1l2-deposit)
+to localise the wedge to one of:
+
+- **Bridge-service hasn't marked the deposit `ready_for_claim`.** Cause:
+  bridge-service hasn't ingested a GER that covers the deposit yet. Look
+  at proxy `ger_entries` — is there a recent injected row? If not, see
+  failure mode E.
+- **Bridge-service is `ready_for_claim=true` but no CLAIM has landed on
+  the proxy.** Cause: claim sponsor / ClaimTxManager isn't picking the
+  deposit up. Check claim sponsor logs in
+  `<TODO: confirm aggkit claimsponsor pod name on bali — likely aggkit-0>`.
+- **CLAIM submission keeps failing on the proxy.** Cause: failure mode A
+  is firing — go fix that first.
+- **CLAIM committed on Miden but the user's balance didn't change.**
+  Cause: address mapping fell back to zero-padding for an address that
+  doesn't exist on Miden (counter
+  `address_mapper_zero_padding_fallback_total` incremented). The mint
+  happened to a synthesised account that nobody can spend. **Page Max**
+  before proceeding — this needs a deliberate decision on whether to
+  re-issue.
+
+For the recovery cure that unsticks marti's deposits specifically, the
+v0.4.1 redeploy in [`../REDEPLOY_RUNBOOK_BALI.md`](../REDEPLOY_RUNBOOK_BALI.md) is the procedure of
+record.
+
+---
+
+## Failure mode C — Stuck L2→L1 withdrawal (no claim landing on L1)
+
+User report: "I burned my Miden balance via a B2AGG note, the L2 logs
+show `BridgeEvent`, but I never received ETH on Sepolia."
+
+Trace via [`diagnostics.md` section 5](./diagnostics.md#5-trace-a-single-l2l1-withdrawal).
+Possible wedges:
+
+1. **`BridgeEvent` not emitted on L2.** The `BridgeOutScanner`
+   (`src/bridge_out.rs`) didn't see the B2AGG note. Check
+   `bridge_outs_total` rate. Cross-check the `bridge_out_processed`
+   table for the user's deposit_count — if absent, the scanner never
+   processed it. Likely cause: the note's faucet isn't in our
+   registry (`bridge_out_unknown_faucet_total` incremented) — quarantine
+   is by design but the deposit is permanently stuck until the registry
+   is updated.
+2. **AggLayer certificate not built.** Look in aggsender logs for the
+   `BridgeEvent` block — does aggsender pick up the event?
+   `<TODO: confirm aggsender pod name and logs path on bali>`.
+3. **Certificate built but ClaimSettler hasn't auto-claimed on L1.**
+   Inspect ClaimSettler config: `CLAIM_SETTLER_ENABLED=true`,
+   `CLAIM_SETTLER_WATCH_ADDRESSES` covers the destination address, the
+   signer L1 balance is sufficient.
+
+### C.1 ClaimSettler signer is dry
+
+Signer address is logged at startup as
+`ClaimSettler: signing as <address>`. Check balance:
+
+```bash
+cast balance <signer_address> --rpc-url "$SEPOLIA_RPC_URL"
+```
+
+Top-up procedure: `<TODO: confirm bali claimsponsor funding source with
+Max — likely the gateway-treasury 1Password "Sepolia faucet" entry>`.
+
+**Blast radius:** L1 ETH spend, irreversible.
+
+---
+
+## Failure mode D — Bridge invariant violation (Cantina hard-page metrics)
+
+If any of these counters increment, the safe action is to **stop processing
+new claims and bridge-outs** until the cause is understood:
+
+- `bridge_burn_serial_collision_total`
+- `bridge_twin_note_detected_total`
+- `bridge_mint_target_mismatch_total`
+- `bridge_faucet_ownership_drift_total{kind=renounced}`
+- `bridge_forged_mint_total`
+
+### D.1 Stop the world
+
+There is **no clean "pause" flag**. The least-bad approximation:
+
+```bash
+# Scale the StatefulSet to 0 — refuses all JSON-RPC, breaks the
+# aggoracle / aggsender / claim sponsor loop until restored.
+kubectl -n <namespace> scale statefulset miden-agglayer --replicas=0
+```
+
+**Blast radius:** all bridging halts in both directions. Aggsender will
+queue events; aggoracle will retry. This is the right action for a
+suspected exploit. Do not unwind without explicit go from Max + Igor.
+
+**Rollback:**
+
+```bash
+kubectl -n <namespace> scale statefulset miden-agglayer --replicas=1
+```
+
+### D.2 Capture evidence
+
+Before any further action, snapshot the proxy DB:
+
+```bash
+# <TODO: confirm pg_dump RBAC permissions and S3 destination bucket>
+PGPASSWORD="$PROXY_PG_PASSWORD" pg_dump -h 127.0.0.1 -p 15434 \
+  -U agglayer -d agglayer_store \
+  -F c -f bali-agglayer-store-$(date -u +%Y%m%dT%H%M%SZ).pgdump
+```
+
+Snapshot the relevant Loki window:
+
+```logql
+{namespace="outpost-testnet-miden-testnet", container="miden-agglayer"}
+  |~ "bridge_invariant_violation"
+```
+
+Open an incident ticket with the metric name + violation kind + the
+NoteId / AccountId mentioned in the WARN/ERROR log line.
+
+---
+
+## Failure mode E — Aggoracle pushed a GER but it didn't land
+
+Symptoms:
+
+- bridge-service log shows aggoracle calling `insertGlobalExitRoot`
+  (or `updateExitRoot`) against the proxy,
+- proxy `ger_entries` does **not** show a corresponding row, OR shows
+  the row with `is_injected=FALSE`.
+
+### E.1 Step 1: which RPC method did aggoracle use?
+
+Check the aggkit config:
+
+```bash
+kubectl -n <namespace> get configmap aggkit-config -o yaml | grep UseUpdateExitRoot
+```
+
+If `UseUpdateExitRoot = false`, aggoracle is using the legacy
+`insertGlobalExitRoot(combinedGER)` path, which **must** be paired with
+the L1InfoTreeIndexer to backfill the two roots. Confirm
+`L1_RPC_URL` + `L1_GER_ADDRESS` (or `--l1-rpc-url` / `--l1-ger-address`)
+are set on the proxy pod. If they aren't, the proxy stores `(NULL, NULL)`
+roots permanently (the failure documented in [`../ger-decomposition.md`](../ger-decomposition.md)).
+
+Fix: set the env vars + restart, OR flip `UseUpdateExitRoot = true` and
+restart aggkit (preferred — closes the race entirely, see RD-862).
+
+### E.2 Step 2: indexer falling behind?
+
+```bash
+kubectl logs <pod> -n <namespace> --tail=2000 \
+  | grep 'L1InfoTreeIndexer polled' | tail -5
+```
+
+If `head` is many blocks ahead of `to`, the indexer is behind L1. Causes
+to consider:
+
+- L1 RPC slow / rate-limited (Infura quota burnt).
+- The pod OOMKilled recently — each restart resets the cursor to current
+  L1 head and forgets the in-progress window (`<TODO: confirm whether
+  the v0.4.0 cursor persistence in migration 005 has fully closed this
+  failure mode>`).
+- L1 reorg backed up the indexer's reverification logic.
+
+### E.3 Step 3: Miden submission failing?
+
+If the GER row in `ger_entries` has `is_injected=FALSE` and the proxy
+keeps trying:
+
+```logql
+{namespace="<ns>", container="miden-agglayer"}
+  |~ "UpdateGerNote.*failed|NoteScreener|FetchAssetWitnessFailed|RootNotInStore"
+```
+
+The NoteScreener bypass design (see [`../ger-note-screening-bypass.md`](../ger-note-screening-bypass.md))
+should handle the `RootNotInStore` class. If you see
+`FetchAssetWitnessFailed` repeating *after* the split-submit path, the
+bypass has regressed — escalate.
+
+---
+
+## Failure mode F — STATE-C orphan backfill (historic poisoned GERs)
+
+The 27 race-poisoned GER rows on bali — `is_injected=TRUE`,
+`mainnet_exit_root IS NULL`, `rollup_exit_root IS NULL` — exist from the
+pre-`UseUpdateExitRoot` era. They are **not blocking current bridging**
+(see ger-decomposition.md: newer GERs supersede older ones), so the
+backfill is cosmetic.
+
+To clean them up:
+
+1. Find the earliest orphan's L1 block (the indexer needs to walk back
+   to before the orphan was injected to re-emit the matching
+   `UpdateL1InfoTree`). Use 30 days before today as a safe lower bound.
+2. Patch the StatefulSet with `--l1-indexer-from-block=<N>` and wait for
+   the indexer cursor to walk past current head.
+3. Remove the flag.
+4. Verify: `SELECT count(*) FROM ger_entries WHERE is_injected AND mainnet_exit_root IS NULL;` returns 0.
+
+Full procedure is in
+[`../REDEPLOY_RUNBOOK_BALI.md` step 4](../REDEPLOY_RUNBOOK_BALI.md#step-4--clean-up-the-27-historic-state-c-orphans-optional)
+and is identical for any cluster.
+
+---
+
+## Failure mode G — Stale account lock
+
+`miden_locked_accounts_detected_total > 0` at startup; no other
+divergence symptoms. See section A.1 above for the `--unlock-miden-accounts`
+procedure.
+
+---
+
+## Procedures we deliberately do NOT document
+
+These need explicit case-by-case authorisation; copy-paste recovery
+would be dangerous.
+
+- **`--init` re-run on a deployed cluster.** Mints new on-chain
+  infrastructure accounts and overwrites `bridge_accounts.toml`. Any
+  asset balance held by the old accounts is unrecoverable. Only safe on
+  greenfield deployments. Max owns the decision.
+- **Manual SQL UPDATE against `ger_entries`.** The race-orphan backfill
+  is preferred (failure mode F). A direct UPDATE bypasses the proof that
+  the (mainnet, rollup) pair is consistent with the combined hash, which
+  is the only safety property keeping bridge-service from accepting
+  forged roots.
+- **PgStore restore from `pg_dump`.** Splices live on-chain state with a
+  stale snapshot of synthetic state. Likely to break the deterministic
+  hash chain. Use the in-process `--restore` flag instead — it rebuilds
+  from authoritative sources.
+- **Manual `kubectl exec` against the running miden-agglayer pod to run
+  miden-client CLI.** The pod's miden-client sqlite is locked by the
+  long-lived `MidenClient` event loop; concurrent access from a CLI
+  invocation will corrupt it. Use a separate diagnostic pod or local
+  copy via `kubectl cp` of a snapshot.


### PR DESCRIPTION
Fixes RD-932.

## Summary

Fills the operational-doc gap identified in the RD-932 brief and the
2026-05-27 reconciliation comment. Adds four files under
`docs/operations/`:

- `README.md` — index + pointers to existing postmortem / redeploy
  docs / GER design notes.
- `monitoring.md` — endpoints (`/health`, `/metrics`, JSON-RPC), full
  Prometheus metrics catalogue grouped by purpose (throughput,
  self-heal/divergence, Cantina hard-page bridge invariants, drift
  detection, backpressure/dedup signals), starter `PrometheusRule`
  alerts, Loki triage queries, Grafana dashboard sketch, and a
  healthy-vs-stuck reference table.
- `runbook.md` — step-by-step recovery for the known failure modes:
  AccountDataNotFound / IAIC (sections A.1-A.3), stuck L1→L2 deposit
  (B), stuck L2→L1 withdrawal (C, including ClaimSettler dry signer),
  bridge invariant violation / Cantina hard-page metric (D —
  stop-the-world procedure + evidence capture), GER injection stalls
  (E), STATE-C orphan backfill (F), stale account lock (G). Every
  destructive command has a blast-radius callout and a rollback path.
  Cross-links to `POSTMORTEM_2026-05-11_IAIC_TO_ADNF.md` and
  `REDEPLOY_RUNBOOK_BALI.md` for incident context.
- `diagnostics.md` — read-only inspection playbook mirroring the
  `miden-bali-debug` skill's contract: accounts catalogue (L1 + L2,
  with how-to-inspect for each), pod-fingerprint checks, log-signal
  decision tree, end-to-end single-deposit (§4) and single-withdrawal
  (§5) traces with JSON-RPC / SQL queries, single-GER lifecycle
  lookup (§8), and explicit escalation criteria (§9).

The new docs interlink and respect the read-only / destructive
boundary established by the diagnostic skill.

## TODO placeholders requiring Max's input

Each `<TODO: ...>` in the diff is a real unknown the author couldn't
confirm. Listed here so they can be cleared in a follow-up:

1. `monitoring.md` — Prometheus rule file path on bali
   (kube-prometheus-stack PrometheusRule CRD location).
2. `monitoring.md` — whether `cluster` label needs a custom
   `relabel_configs` for the alert expressions.
3. `monitoring.md` — Grafana dashboard URLs.
4. `runbook.md` (A.2) — whether bali's bridge infrastructure accounts
   have been redeployed as `Public` storage mode yet. Affects whether
   `--reset-miden-store --restore` is a safe option, or whether
   `REDEPLOY_RUNBOOK_BALI.md` (v0.4.1 redeploy) is the only path.
5. `runbook.md` — 1Password item name for the bridge-service DB
   password.
6. `runbook.md` (B) — claim sponsor / aggkit pod name on bali.
7. `runbook.md` (C) — aggsender pod name + REST API URL for cert
   lifecycle queries.
8. `runbook.md` (C.1) — 1Password / treasury source for topping up the
   ClaimSettler signer on Sepolia.
9. `runbook.md` (D.2) — pg_dump RBAC permissions and S3 destination
   bucket for incident-evidence snapshots.
10. `runbook.md` (E.2) — whether v0.4.0 migration `005_l1_indexer_cursor.sql`
    has fully closed the OOM-rolls-back-the-cursor failure mode.
11. `diagnostics.md` — sanctioned `miden-cli` setup pointed at
    `rpc.testnet.miden.io` with a read-only `store_dir`, plus invocation.
12. `diagnostics.md` (4.3) — exact bit layout of `global_index` (the
    formula written needs cross-check against `service_send_raw_txn.rs`
    claim flow).
13. `diagnostics.md` (5.3) — aggsender certificate lifecycle queries on
    bali (pod name, REST API URL, log signatures).
14. `diagnostics.md` — aggsender pubkey location for bali (accounts
    catalogue entry).

## Out of scope (deliberately not addressed)

- The 27 historic STATE-C orphans on bali. The runbook references the
  backfill procedure already documented in `REDEPLOY_RUNBOOK_BALI.md`
  step 4 — re-stating it here would duplicate the source of truth.
- `--init` re-run on a deployed cluster. Documented explicitly as
  "deliberately NOT documented" in `runbook.md` because copy-paste
  recovery here would be unsafe.
- Bridge-service / aggkit-internal recovery procedures. Scope here is
  the miden-agglayer surface only.

## Test plan

- [ ] Max reads through the four docs end-to-end and confirms accuracy.
- [ ] Resolve each `<TODO: ...>` placeholder above, either inline in a
      follow-up commit on this PR or in a follow-up PR.
- [ ] Optional: dry-run the `--unlock-miden-accounts` procedure on a
      non-bali test cluster to confirm the command sequence is exact.
- [ ] Optional: render each doc in GitHub's markdown preview to confirm
      every relative link resolves.