### PR TITLE
fix(network-id): validate u32 truncation in service_send_raw_txn

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -384,14 +384,22 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    // Cantina #13 — BridgeOutScanner needs to know our local network id so it can
-    // refuse to emit synthetic BridgeEvents for self-targeted poison leaves.
-    let bridge_out_local_network_id = u32::try_from(command.network_id).map_err(|_| {
+    // Cantina #13 / RD-703 — narrow the operator-supplied `--network-id`
+    // (parsed as `u64` for CLI backward compat) to `u32` exactly once, here
+    // at startup. The Solidity bridge contract types `originNetwork`,
+    // `destinationNetwork`, and the on-chain `networkID()` return as
+    // `uint32`, and BridgeOutScanner / ServiceState / claimAsset comparisons
+    // are all `u32`. A `u64` value that doesn't fit `u32` is operator
+    // misconfiguration — fail loudly here rather than silently truncate at
+    // a later use site (the prior `as u32` cast in `service_send_raw_txn.rs`
+    // would spuriously accept claims targeting `network_id & 0xFFFFFFFF`).
+    let local_network_id_u32 = u32::try_from(command.network_id).map_err(|_| {
         anyhow::anyhow!(
-            "--network-id ({}) does not fit in u32; B2AGG destination_network is u32-sized",
+            "--network-id ({}) does not fit in u32; bridge destinationNetwork / originNetwork are u32-sized",
             command.network_id
         )
     })?;
+    let bridge_out_local_network_id = local_network_id_u32;
     let bridge_out_scanner = Arc::new(BridgeOutScanner::new(
         store.clone(),
         block_state.clone(),
@@ -460,7 +468,7 @@ async fn main() -> anyhow::Result<()> {
         client,
         accounts,
         command.chain_id,
-        command.network_id,
+        local_network_id_u32,
         store,
         block_state,
     );

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -135,7 +135,14 @@ async fn handle_claim_asset(
     signer: Address,
 ) -> anyhow::Result<TxHash> {
     // Only claims where destinationNetwork matches our network_id are processed.
-    if params.destinationNetwork != service.network_id as u32 {
+    //
+    // RD-703 — `service.network_id` is `u32` (validated at startup in
+    // `main.rs` via `u32::try_from(command.network_id)`), matching the
+    // Solidity bridge's `uint32 destinationNetwork`. No silent `as u32` cast
+    // here: any operator value that does not fit `u32` is rejected loudly
+    // at startup rather than truncating into a comparison that would
+    // spuriously accept the wrong network.
+    if params.destinationNetwork != service.network_id {
         anyhow::bail!(
             "claim targets destinationNetwork {} but this proxy only handles network {}",
             params.destinationNetwork,

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -55,8 +55,16 @@ pub struct ServiceState {
     pub miden_client: Arc<MidenClient>,
     pub accounts: AccountsConfig,
     pub chain_id: u64,
-    /// Rollup network ID from RollupManager (used for bridge's networkID() call)
-    pub network_id: u64,
+    /// Rollup network ID from RollupManager (used for bridge's `networkID()` call).
+    ///
+    /// Stored as `u32` because the Solidity bridge contract types
+    /// `originNetwork` / `destinationNetwork` as `uint32` (see
+    /// `claimAssetCall` in `src/claim.rs`) and the on-chain `networkID()`
+    /// return is `uint32`. The CLI flag is parsed as `u64` for backward
+    /// compat but validated and narrowed at startup in `main.rs` via
+    /// `u32::try_from`; reaching this struct with anything beyond `u32::MAX`
+    /// is therefore impossible (RD-703).
+    pub network_id: u32,
     pub store: Arc<dyn Store>,
     pub block_state: Arc<BlockState>,
     /// L1 RPC URL for resolving exit roots from the L1 GER contract
@@ -114,7 +122,7 @@ impl ServiceState {
         miden_client: MidenClient,
         accounts: AccountsConfig,
         chain_id: u64,
-        network_id: u64,
+        network_id: u32,
         store: Arc<dyn Store>,
         block_state: Arc<BlockState>,
     ) -> Self {


### PR DESCRIPTION
## Summary

Closes the residual silent `as u32` cast in `service_send_raw_txn.rs:138` (RD-703). The reconciliation comment on the ticket noted that `BridgeOutScanner` was already guarded in `main.rs:389-394` via `u32::try_from(command.network_id)`, but the `claimAsset` destination-network comparison still cast `service.network_id as u32` silently. An operator who configured `--network-id` > `u32::MAX` (or whose deploy automation widened it accidentally) would have the proxy spuriously accept claims targeting `network_id & 0xFFFFFFFF` — wrong network, silent acceptance.

### Changes

- `src/service_state.rs` — `ServiceState::network_id` is now `u32` (matches the Solidity `uint32 destinationNetwork` / `originNetwork` and on-chain `networkID()` return). Comment block explains the invariant.
- `src/main.rs` — narrow `command.network_id` (`u64`, kept for CLI backward compat) once at startup via `u32::try_from`, reusing the same narrowed value for both `BridgeOutScanner` and `ServiceState::new`. Out-of-range is a loud `anyhow::bail!` at startup, not a runtime truncation.
- `src/service_send_raw_txn.rs` — the comparison drops `as u32`; the in-line comment now points to RD-703.

The CLI surface is unchanged (`--network-id` / `NETWORK_ID` still parse as `u64`); only the internal storage type narrows.

Fixes RD-703.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` — 165 / 165 passing
- [ ] Reviewer: confirm no operator currently sets `NETWORK_ID` above `u32::MAX` on bali / mainnet (`make e2e-l1-to-l2` runs with `network_id = 1` so the happy path is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)