### PR TITLE
docs: document FungibleAsset::MAX_AMOUNT ceiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,54 @@ src/
 └── main.rs                 # CLI entry point (clap)
 ```
 
+### Bridge amount ceiling
+
+Every L1 → Miden deposit is scaled from the L1 `uint256` wei amount down
+to a Miden fungible-asset amount (an 8-decimal `Felt`). The maximum
+representable Miden value is the protocol-level fungible-asset cap
+[`miden_client::asset::FungibleAsset::MAX_AMOUNT`][miden-max] —
+`2^63 − 2^31 ≈ 9.223 × 10^18` Miden base units. For the default 18 → 8
+decimal layout this corresponds to approximately **9.22 billion ETH per
+single deposit**, well above any realistic single-deposit value.
+
+This ceiling supersedes the earlier `u32::MAX` (~42.94 ETH) limit that
+was reported under [RD-702][rd-702]. The cap is now enforced by
+`EthAmount::scale_to_token_amount` (used inside `scale_claim_amount` at
+`src/claim.rs`), not by an intermediate `u32` truncation — see the
+boundary regression in
+[`cantina_12_amount_cap_pins_fungible_asset_max`][cantina-12]
+(`src/claim.rs:838-867`) and the above-old-ceiling acceptance test
+[`accepts_amount_above_old_u32_ceiling`][accepts] (`src/claim.rs:802-807`).
+Both will fail loud if a future refactor tightens or loosens the cap.
+
+The flow is:
+
+1. `claimAsset()` arrives over `eth_sendRawTransaction` with a `uint256
+   amount` (wei).
+2. `scale_claim_amount` (in `src/claim.rs`) divides by `10^scale`
+   (where `scale = origin_token_decimals − miden_decimals`, usually
+   `18 − 8 = 10`), truncating sub-unit wei.
+3. `EthAmount::scale_to_token_amount` rejects the scaled value if it
+   exceeds `FungibleAsset::MAX_AMOUNT`.
+4. On rejection, `scale_claim_amount` returns
+   `claim amount is not representable on Miden: <inner error>`. That
+   error bubbles out of `publish_claim` as an `anyhow::Error`, the JSON-RPC
+   handler maps it to a standard EVM error response, and the
+   `try_claim` lock is released by the RAII drop guard so the caller
+   may resubmit a smaller deposit. No CLAIM note is written, no Miden
+   transaction is submitted, and the eth tx hash is not recorded as
+   successful in the store.
+
+Cantina #12 (see the source comment on the regression test) also bounds
+the upstream MASM verifier's safe range; values that would land in the
+`[2^123, 2^128)` MASM gap are rejected at this same step before any
+note is built.
+
+[miden-max]: https://github.com/0xMiden/miden-base
+[rd-702]: https://linear.app/gatewayfm/issue/RD-702
+[cantina-12]: src/claim.rs
+[accepts]: src/claim.rs
+
 ## Prerequisites
 
 - [Rust](https://rustup.rs) (1.90+, nightly for Docker builds)


### PR DESCRIPTION
## Summary

Documents the new bridge amount ceiling in README.md. RD-702 originally
described a "~42 ETH per-tx" `u32::MAX` truncation limit — that ceiling
no longer applies. The real cap is now
`miden_client::asset::FungibleAsset::MAX_AMOUNT = 2^63 − 2^31`, enforced
inside `EthAmount::scale_to_token_amount` via `scale_claim_amount`
(`src/claim.rs`). For the default 18 → 8 decimal layout this maps to
~9.22 billion ETH per single deposit — comfortably above any realistic
single-deposit value.

The new README section covers:

- The numeric ceiling and how it derives from the Miden fungible-asset
  primitive
- The U256 → scale → `Felt` flow through `scale_claim_amount` /
  `EthAmount::scale_to_token_amount`
- The two pinning regression tests by name + file location:
  - `accepts_amount_above_old_u32_ceiling` at `src/claim.rs:802-807`
  - `cantina_12_amount_cap_pins_fungible_asset_max` at `src/claim.rs:838-867`
- The RPC behaviour when an inbound `claimAsset.amount` exceeds the cap:
  `scale_claim_amount` returns `claim amount is not representable on
  Miden: <inner>`, no CLAIM note is built, no Miden tx is submitted, the
  `try_claim` lock is released by the RAII drop guard, the eth tx hash
  is not recorded as successful, and the caller may retry with a
  smaller deposit
- The Cantina #12 MASM `[2^123, 2^128)` gap and how it is rejected at
  the same step before any note is built

Code-only change is purely doc: no source files touched.

Refs RD-702.

## Test plan

- [x] `make lint` (`cargo fmt --check` + `taplo fmt --check` + `typos` + `cargo clippy -D warnings`) — clean
- [x] Cross-checked the file:line and test names cited in the new section against `src/claim.rs` HEAD
- [ ] Reviewer: confirm the RPC error UX summary matches the path
  bubbling through `service_send_raw_txn::publish_and_record_claim` ↔
  `claim::publish_claim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)