### PR TITLE
fix: close 3 small Cantina findings (MA#8, MA#22, MA#26)

### DIFF
--- a/src/address_mapper.rs
+++ b/src/address_mapper.rs
@@ -49,21 +49,40 @@ pub async fn resolve_address(
     address: Address,
     config: &AccountsConfig,
 ) -> anyhow::Result<AccountId> {
-    resolve_address_with_policy(store, address, config, false).await
+    resolve_address_with_policy(store, address, config, false, false).await
 }
 
 /// Same as `resolve_address` but allows the caller to disable the
 /// zero-padding fallback (production posture). When `reject_zero_padding`
 /// is `true`, addresses that aren't in the store mapping fail with a
 /// clear error rather than falling through to the structural reconstruction.
+///
+/// Cantina MA#8 — `reject_hardhat_alias`: when `true`, the special-case
+/// remap of the well-known Hardhat default-account address
+/// (`0xf39f...2266`) to `config.wallet_hardhat` is disabled. The alias is
+/// useful for local dev (the Hardhat default signer becomes a valid
+/// Miden bridge destination without an explicit mapping) but is
+/// dangerous in production: any deposit on L1 with that destination
+/// would be silently rerouted into the operator-owned `wallet_hardhat`
+/// account. Gated by `--require-hardening` at the caller layer.
 pub async fn resolve_address_with_policy(
     store: &dyn crate::store::Store,
     address: Address,
     config: &AccountsConfig,
     reject_zero_padding: bool,
+    reject_hardhat_alias: bool,
 ) -> anyhow::Result<AccountId> {
-    // 1. Hardhat special case
+    // 1. Hardhat special case (dev convenience) — gated by policy in production.
     if address == HARDHAT_ADDRESS {
+        if reject_hardhat_alias {
+            ::metrics::counter!("address_mapper_hardhat_alias_rejected_total").increment(1);
+            anyhow::bail!(
+                "Hardhat default-account alias is disabled in this deployment \
+                 (MA#8). The Hardhat address {address} would have been rerouted \
+                 to wallet_hardhat — set --disable-hardhat-alias=false or add \
+                 an explicit store mapping for legitimate use."
+            );
+        }
         return Ok(config.wallet_hardhat.0);
     }
     // 2. Check existing mapping from store
@@ -144,11 +163,11 @@ mod tests {
         let zero_padded = address!("0x000000003d7c9747558851900f8206226dfbea00");
 
         // Default policy (reject = false): fallback succeeds.
-        let r = resolve_address_with_policy(&store, zero_padded, &cfg, false).await;
+        let r = resolve_address_with_policy(&store, zero_padded, &cfg, false, false).await;
         assert!(r.is_ok());
 
         // Strict policy (reject = true): fallback refused with clear error.
-        let r = resolve_address_with_policy(&store, zero_padded, &cfg, true).await;
+        let r = resolve_address_with_policy(&store, zero_padded, &cfg, true, false).await;
         let err = r.unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("fallback disabled"));
@@ -171,7 +190,81 @@ mod tests {
             .unwrap();
 
         // With strict policy, the mapping still resolves.
-        let r = resolve_address_with_policy(&store, mapped_addr, &cfg, true).await;
+        let r = resolve_address_with_policy(&store, mapped_addr, &cfg, true, false).await;
+        assert_eq!(r.unwrap(), target);
+    }
+
+    /// Cantina MA#8 — the Hardhat default-account alias must be
+    /// rejectable in production. Pre-fix the remap fired
+    /// unconditionally on every claim, so a deposit on L1 with the
+    /// well-known Hardhat address as destination would always land in
+    /// `wallet_hardhat`. With `reject_hardhat_alias = true` the
+    /// resolver refuses the remap and the caller gets a clear error.
+    #[tokio::test]
+    async fn ma8_reject_hardhat_alias_when_policy_set() {
+        use crate::store::memory::InMemoryStore;
+        let store = InMemoryStore::new();
+        let cfg = test_accounts_config();
+        let hardhat = Address::new([
+            0xf3, 0x9f, 0xd6, 0xe5, 0x1a, 0xad, 0x88, 0xf6, 0xf4, 0xce, 0x6a, 0xb8, 0x82, 0x72,
+            0x79, 0xcf, 0xff, 0xb9, 0x22, 0x66,
+        ]);
+
+        // Dev posture: alias still works.
+        let r = resolve_address_with_policy(&store, hardhat, &cfg, false, false).await;
+        assert_eq!(r.unwrap(), cfg.wallet_hardhat.0);
+
+        // Hardened posture: alias refused with a Cantina MA#8 error.
+        let r = resolve_address_with_policy(&store, hardhat, &cfg, false, true).await;
+        let err = r.unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Hardhat default-account alias is disabled"),
+            "expected MA#8 error message, got: {msg}"
+        );
+    }
+
+    /// Cantina MA#8 — with the alias disabled and no explicit mapping,
+    /// the Hardhat address (which is not zero-padded) cannot be
+    /// resolved by any other branch, so resolution must error. This
+    /// pins the "no silent rerouting" guarantee: a production deposit
+    /// targeting `0xf39f...2266` is refused outright instead of
+    /// landing in `wallet_hardhat`.
+    #[tokio::test]
+    async fn ma8_disabled_alias_no_silent_fallback() {
+        use crate::store::memory::InMemoryStore;
+        let store = InMemoryStore::new();
+        let cfg = test_accounts_config();
+        let hardhat = Address::new([
+            0xf3, 0x9f, 0xd6, 0xe5, 0x1a, 0xad, 0x88, 0xf6, 0xf4, 0xce, 0x6a, 0xb8, 0x82, 0x72,
+            0x79, 0xcf, 0xff, 0xb9, 0x22, 0x66,
+        ]);
+
+        // Alias disabled, no store mapping, address is not zero-padded →
+        // resolution must error.
+        let r = resolve_address_with_policy(&store, hardhat, &cfg, false, true).await;
+        assert!(r.is_err());
+    }
+
+    /// Cantina MA#8 — non-Hardhat addresses must be unaffected by the
+    /// alias-rejection flag. Only the single special-case remap is gated.
+    #[tokio::test]
+    async fn ma8_non_hardhat_address_unaffected_by_alias_policy() {
+        use crate::Store;
+        use crate::store::memory::InMemoryStore;
+        let store = InMemoryStore::new();
+        let cfg = test_accounts_config();
+        let mapped_addr = address!("0xabcdef1234567890abcdef1234567890abcdef12");
+        let target = AccountId::from_hex("0x3d7c9747558851900f8206226dfbea").unwrap();
+        store
+            .set_address_mapping(mapped_addr, target)
+            .await
+            .unwrap();
+
+        // With alias rejected (and zero-padding allowed), the explicit
+        // mapping still resolves cleanly — the MA#8 policy doesn't
+        // touch the store-mapping path.
+        let r = resolve_address_with_policy(&store, mapped_addr, &cfg, false, true).await;
         assert_eq!(r.unwrap(), target);
     }
 

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -297,6 +297,7 @@ async fn create_claim(
     store: &dyn Store,
     rng: &mut impl FeltRng,
     reject_zero_padding: bool,
+    reject_hardhat_alias: bool,
 ) -> anyhow::Result<Note> {
     let sender = accounts.service.0;
 
@@ -305,6 +306,7 @@ async fn create_claim(
         params.destinationAddress,
         accounts,
         reject_zero_padding,
+        reject_hardhat_alias,
     )
     .await?;
 
@@ -350,6 +352,7 @@ async fn publish_claim_internal(
     store: &dyn Store,
     latest_block_num: BlockNumber,
     reject_zero_padding: bool,
+    reject_hardhat_alias: bool,
     expected_mints: Option<&Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
     // Opt-in local prover used as a fallback when the remote prover
     // configured on the surrounding `MidenClient` fails. `None` when
@@ -388,6 +391,7 @@ async fn publish_claim_internal(
         store,
         client.rng(),
         reject_zero_padding,
+        reject_hardhat_alias,
     )
     .await?;
     let claim_note_id = claim_note.id().to_string();
@@ -632,6 +636,7 @@ pub async fn publish_claim(
     txn_envelope: alloy::consensus::TxEnvelope,
     signer: alloy::primitives::Address,
     reject_zero_padding: bool,
+    reject_hardhat_alias: bool,
     expected_mints: Option<Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
 ) -> anyhow::Result<PublishClaimTxn> {
     // Submit with runtime self-heal, mirroring the pattern in
@@ -660,6 +665,7 @@ pub async fn publish_claim(
         txn_envelope.clone(),
         signer,
         reject_zero_padding,
+        reject_hardhat_alias,
         expected_mints.clone(),
     )
     .await
@@ -683,6 +689,7 @@ pub async fn publish_claim(
                 txn_envelope,
                 signer,
                 reject_zero_padding,
+                reject_hardhat_alias,
                 expected_mints,
             )
             .await
@@ -703,6 +710,7 @@ async fn attempt_publish_claim(
     txn_envelope: alloy::consensus::TxEnvelope,
     signer: alloy::primitives::Address,
     reject_zero_padding: bool,
+    reject_hardhat_alias: bool,
     expected_mints: Option<Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
 ) -> anyhow::Result<PublishClaimTxn> {
     // Snapshot the opt-in local-prover fallback BEFORE entering the
@@ -725,6 +733,7 @@ async fn attempt_publish_claim(
                     &*store,
                     latest_block_num,
                     reject_zero_padding,
+                    reject_hardhat_alias,
                     expected_mints.as_ref(),
                     local_prover_fallback,
                 )

--- a/src/log_synthesis.rs
+++ b/src/log_synthesis.rs
@@ -170,14 +170,25 @@ impl LogFilter {
             // Without the topic filter guard, queries by address only (like aggkit's
             // L2BridgeSyncer) would receive UpdateHashChainValue logs that they can't
             // decode, causing "input too short" errors.
+            //
+            // Cantina MA#26 — passthrough is intentionally NARROWED to
+            // `UpdateHashChainValue` only. Synthetic `BridgeEvent` logs are
+            // emitted at the bridge contract address (see
+            // `Store::record_bridge_event` and bridge_out.rs), so a caller
+            // querying by the bridge address sees them via the normal
+            // address-match path — no passthrough required. Previously
+            // `BRIDGE_EVENT_TOPIC` was lumped into the passthrough list,
+            // which leaked BridgeEvent logs to consumers querying a
+            // DIFFERENT address but with BridgeEvent in their topic filter
+            // (e.g. a misconfigured indexer pointed at the wrong rollup's
+            // bridge address). Address-aware filtering is the correct
+            // semantic for BridgeEvent: if the address doesn't match,
+            // the log is not for this caller.
             let is_passthrough = if !matches_addr {
                 let topic0 = log.topics.first().map(|t| t.to_lowercase());
                 let is_passthrough_topic = topic0
                     .as_ref()
-                    .map(|t| {
-                        t == &UPDATE_HASH_CHAIN_VALUE_TOPIC.to_lowercase()
-                            || t == &BRIDGE_EVENT_TOPIC.to_lowercase()
-                    })
+                    .map(|t| t == &UPDATE_HASH_CHAIN_VALUE_TOPIC.to_lowercase())
                     .unwrap_or(false);
 
                 // Only passthrough if the query's topic filter explicitly includes
@@ -401,4 +412,90 @@ mod tests {
 
     // LogStore-based tests (ger dedup, hash chain, log add/query, bridge event roundtrip)
     // have been moved to src/store/memory.rs tests.
+
+    /// Cantina MA#26 regression — a BridgeEvent log emitted at the bridge
+    /// contract address MUST NOT be returned to a caller filtering by a
+    /// DIFFERENT address even when the caller's topic filter explicitly
+    /// includes BRIDGE_EVENT_TOPIC. Pre-fix the passthrough fall-through
+    /// would let the log slip out, exposing cross-rollup bridge state to
+    /// indexers that asked for a different address.
+    #[test]
+    fn ma26_bridge_event_address_aware_filter() {
+        let log = SyntheticLog {
+            address: "0x000000000000000000000000000000000000bee5".to_string(),
+            topics: vec![BRIDGE_EVENT_TOPIC.to_string()],
+            data: "0x".to_string(),
+            block_number: 100,
+            block_hash: [0u8; 32],
+            transaction_hash: "0xabc".to_string(),
+            transaction_index: 0,
+            log_index: 0,
+            removed: false,
+        };
+
+        // Caller filters by a different address but explicitly asks for
+        // BridgeEvent in topic0. Must NOT match.
+        let filter = LogFilter {
+            from_block: Some("0x0".to_string()),
+            to_block: Some("0x200".to_string()),
+            address: Some(AddressFilter::Single(
+                "0x000000000000000000000000000000000000dead".to_string(),
+            )),
+            topics: Some(vec![Some(TopicFilter::Single(
+                BRIDGE_EVENT_TOPIC.to_string(),
+            ))]),
+            ..Default::default()
+        };
+        assert!(
+            !filter.matches(&log, 500),
+            "BridgeEvent must be address-filtered; passthrough is GER-only"
+        );
+
+        // Same caller filtering by the actual bridge address still matches.
+        let filter_correct_addr = LogFilter {
+            from_block: Some("0x0".to_string()),
+            to_block: Some("0x200".to_string()),
+            address: Some(AddressFilter::Single(
+                "0x000000000000000000000000000000000000bee5".to_string(),
+            )),
+            topics: Some(vec![Some(TopicFilter::Single(
+                BRIDGE_EVENT_TOPIC.to_string(),
+            ))]),
+            ..Default::default()
+        };
+        assert!(filter_correct_addr.matches(&log, 500));
+    }
+
+    /// Cantina MA#26 — UpdateHashChainValue passthrough remains intact.
+    /// Aggkit's L2BridgeSyncer queries by bridge address but legitimately
+    /// needs GER updates emitted at L2_GLOBAL_EXIT_ROOT_ADDRESS; this is
+    /// the case the passthrough was added for, and the narrowed semantic
+    /// must preserve it.
+    #[test]
+    fn ma26_update_hash_chain_value_passthrough_preserved() {
+        let log = SyntheticLog {
+            address: L2_GLOBAL_EXIT_ROOT_ADDRESS.to_string(),
+            topics: vec![UPDATE_HASH_CHAIN_VALUE_TOPIC.to_string()],
+            data: "0x".to_string(),
+            block_number: 100,
+            block_hash: [0u8; 32],
+            transaction_hash: "0xabc".to_string(),
+            transaction_index: 0,
+            log_index: 0,
+            removed: false,
+        };
+
+        let filter = LogFilter {
+            from_block: Some("0x0".to_string()),
+            to_block: Some("0x200".to_string()),
+            address: Some(AddressFilter::Single(
+                "0x000000000000000000000000000000000000bee5".to_string(),
+            )),
+            topics: Some(vec![Some(TopicFilter::Single(
+                UPDATE_HASH_CHAIN_VALUE_TOPIC.to_string(),
+            ))]),
+            ..Default::default()
+        };
+        assert!(filter.matches(&log, 500));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,16 @@ struct Command {
     #[arg(long, env = "REJECT_ZERO_PADDING_ADDRESSES", default_value_t = false)]
     reject_zero_padding_addresses: bool,
 
+    /// Disable the built-in Hardhat default-account alias (Cantina MA#8).
+    /// When set, the special-case remap of the well-known Hardhat address
+    /// (`0xf39f...2266`) to `wallet_hardhat` is refused. Production
+    /// deployments MUST set this flag — otherwise an L1 deposit targeting
+    /// the Hardhat default-account address would be silently routed into
+    /// the operator's `wallet_hardhat` account. Enforced as a
+    /// `--require-hardening` invariant.
+    #[arg(long, env = "DISABLE_HARDHAT_ALIAS", default_value_t = false)]
+    disable_hardhat_alias: bool,
+
     /// Production hardening invariant. When set, refuse to start if any of
     /// the following hardening flags are at their fail-open defaults:
     /// - `--admin-api-key` unset (admin endpoints accept any caller)
@@ -216,6 +226,18 @@ fn check_hardening_invariants(command: &Command) -> Result<(), Vec<String>> {
                 .to_string(),
         );
     }
+    // Cantina MA#8 — the Hardhat default-account alias is unsafe in
+    // production. With `--require-hardening` set, the operator MUST
+    // also pass `--disable-hardhat-alias` (env `DISABLE_HARDHAT_ALIAS`).
+    if !command.disable_hardhat_alias {
+        reasons.push(
+            "  - --disable-hardhat-alias is unset (Cantina MA#8: the well-known \
+             Hardhat default-account address `0xf39f...2266` would be silently \
+             remapped to `wallet_hardhat` on every claim). Set \
+             DISABLE_HARDHAT_ALIAS=true to refuse the remap in production."
+                .to_string(),
+        );
+    }
     if reasons.is_empty() {
         Ok(())
     } else {
@@ -253,6 +275,7 @@ impl std::fmt::Debug for Command {
             .field("cors_allowed_origins", &self.cors_allowed_origins)
             .field("allowed_signers", &self.allowed_signers)
             .field("require_hardening", &self.require_hardening)
+            .field("disable_hardhat_alias", &self.disable_hardhat_alias)
             .field(
                 "miden_api_key",
                 &self.miden_api_key.as_ref().map(|_| "[REDACTED]"),
@@ -544,6 +567,7 @@ async fn main() -> anyhow::Result<()> {
     state.rate_limit_per_second = command.rate_limit_per_second;
     state.rate_limit_burst = command.rate_limit_burst;
     state.reject_zero_padding_addresses = command.reject_zero_padding_addresses;
+    state.reject_hardhat_alias = command.disable_hardhat_alias;
     // Cantina #7: share the BridgeOutScanner's expected-MINT tracker so
     // `publish_claim_internal` can record the CLAIM NoteId and the scanner
     // can mark it Landed once it sees the bridge consume it.
@@ -782,6 +806,11 @@ mod hardening_tests {
             rate_limit_burst: miden_agglayer_service::service::DEFAULT_RATE_LIMIT_BURST,
             reject_zero_padding_addresses: false,
             require_hardening: require,
+            // Cantina MA#8 — tests default the alias to disabled so the
+            // pre-existing hardening tests below only flex the flag they
+            // care about. The dedicated `hardening_flags_hardhat_alias`
+            // test below pins the new invariant in isolation.
+            disable_hardhat_alias: true,
             miden_api_key: None,
             miden_prover_url: prover_url,
             miden_prover_timeout_secs: 120,
@@ -792,7 +821,8 @@ mod hardening_tests {
     /// When --require-hardening is false, no invariant is enforced.
     #[test]
     fn hardening_disabled_passes_with_open_defaults() {
-        let c = cmd(false, None, None, None);
+        let mut c = cmd(false, None, None, None);
+        c.disable_hardhat_alias = false;
         assert!(check_hardening_invariants(&c).is_ok());
     }
 
@@ -846,5 +876,38 @@ mod hardening_tests {
         let reasons = check_hardening_invariants(&c).unwrap_err();
         assert_eq!(reasons.len(), 1);
         assert!(reasons[0].contains("--miden-prover-url"));
+    }
+
+    /// Cantina MA#8 — `--require-hardening` MUST require
+    /// `--disable-hardhat-alias` to be set. Otherwise an operator
+    /// thinks they're running a hardened build but the Hardhat default
+    /// address is still being remapped to `wallet_hardhat` on every
+    /// claim.
+    #[test]
+    fn hardening_flags_hardhat_alias_when_unset() {
+        let mut c = cmd(
+            true,
+            Some("strong-admin-key".into()),
+            Some(vec![alloy::primitives::Address::ZERO]),
+            Some(vec!["https://app.example.com".into()]),
+        );
+        c.disable_hardhat_alias = false;
+        let reasons = check_hardening_invariants(&c).unwrap_err();
+        assert_eq!(reasons.len(), 1);
+        assert!(
+            reasons[0].contains("--disable-hardhat-alias"),
+            "expected MA#8 invariant, got: {}",
+            reasons[0]
+        );
+    }
+
+    /// Cantina MA#8 — when `--require-hardening` is OFF, the hardhat
+    /// invariant is not enforced. Operators can run dev-mode with the
+    /// alias on (current default) or off.
+    #[test]
+    fn hardening_disabled_does_not_enforce_hardhat_alias() {
+        let mut c = cmd(false, None, None, None);
+        c.disable_hardhat_alias = false;
+        assert!(check_hardening_invariants(&c).is_ok());
     }
 }

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -592,8 +592,16 @@ pub async fn wait_for_transaction_commit(
             continue;
         }
 
+        // Cantina MA#22 — scope the store scan to the txn we're actually
+        // waiting on. Previously this used `TransactionFilter::All`, which
+        // forces the underlying sqlite query to return EVERY known
+        // transaction (committed, uncommitted, expired, foreign) on every
+        // 1s poll. On a hot path (claim publish, faucet ops, GER inject,
+        // init) this scales O(transactions_in_store) per poll, per call —
+        // wasted CPU, wasted memory, slower commit observation. The
+        // `Ids(...)` filter pushes the equality check into the SQL query.
         let txns = client
-            .get_transactions(miden_client::store::TransactionFilter::All)
+            .get_transactions(miden_client::store::TransactionFilter::Ids(vec![txn_id]))
             .await?;
         if txns.iter().any(|t| {
             t.id == txn_id

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -384,6 +384,7 @@ async fn publish_and_record_claim(
         txn_envelope,
         signer,
         service.reject_zero_padding_addresses,
+        service.reject_hardhat_alias,
         Some(service.expected_mints.clone()),
     )
     .await?;

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -103,6 +103,14 @@ pub struct ServiceState {
     /// reconstruction. Production posture; default false for backward
     /// compatibility with aggsender / aggoracle / hardhat dev flows.
     pub reject_zero_padding_addresses: bool,
+    /// Reject the Hardhat default-account alias remap (Cantina MA#8).
+    /// When `true`, the special-case remap of the well-known Hardhat
+    /// address (`0xf39f...2266`) to `wallet_hardhat` is disabled. Required
+    /// for production deployments — otherwise any L1 deposit targeting
+    /// the Hardhat address is silently routed into the operator-owned
+    /// wallet account. Enforced as a `--require-hardening` invariant in
+    /// `main.rs::check_hardening_invariants`.
+    pub reject_hardhat_alias: bool,
     /// Cantina #7 expected-MINT tracker, shared with the `BridgeOutScanner`.
     /// `publish_claim_internal` records each submitted CLAIM's NoteId here;
     /// the scanner ticks it each sync, marking entries Landed once it
@@ -143,6 +151,7 @@ impl ServiceState {
             rate_limit_per_second: crate::service::DEFAULT_RATE_LIMIT_PER_SECOND,
             rate_limit_burst: crate::service::DEFAULT_RATE_LIMIT_BURST,
             reject_zero_padding_addresses: false,
+            reject_hardhat_alias: false,
             expected_mints: Arc::new(crate::expected_mint_tracker::ExpectedMintTracker::new()),
             miden_api_key: None,
         }


### PR DESCRIPTION
## Summary

Closes 3 of 4 small Cantina Miden-Agglayer findings. MA#20 is dropped from this PR per the invasiveness clause — see "Dropped" section below.

- **MA#8 (Low)** — Hardhat alias gated by `--require-hardening` (new `--disable-hardhat-alias` flag; `--require-hardening` now refuses to start unless the alias is disabled).
- **MA#22 (Info)** — `wait_for_transaction_commit` switched to `TransactionFilter::Ids(vec![txn_id])` so the equality check is pushed into the underlying sqlite query instead of returning the full transaction set on every 1s poll.
- **MA#26 (Info)** — `LogFilter::matches` is now address-aware for `BridgeEvent`. The passthrough is narrowed to `UpdateHashChainValue` only (the original aggkit `L2BridgeSyncer` use-case); BridgeEvent is emitted at the bridge contract address so a caller filtering by the bridge address sees them via the normal address-match path.

## Test plan

- [x] `cargo check --lib`
- [x] `cargo check --tests`
- [x] `cargo test --lib` (170 / 170 pass)
- [x] `cargo test --bins hardening` (6 / 6 pass — including 2 new MA#8 hardening invariants)
- [x] `cargo test --lib log_synthesis` (7 / 7 pass — including 2 new MA#26 regression tests)
- [x] `cargo test --lib address_mapper` (8 / 8 pass — including 3 new MA#8 alias-policy tests)
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Full e2e regression (running separately by the orchestrator).

## New tests

- `log_synthesis::tests::ma26_bridge_event_address_aware_filter`
- `log_synthesis::tests::ma26_update_hash_chain_value_passthrough_preserved`
- `address_mapper::tests::ma8_reject_hardhat_alias_when_policy_set`
- `address_mapper::tests::ma8_disabled_alias_no_silent_fallback`
- `address_mapper::tests::ma8_non_hardhat_address_unaffected_by_alias_policy`
- `hardening_tests::hardening_flags_hardhat_alias_when_unset`
- `hardening_tests::hardening_disabled_does_not_enforce_hardhat_alias`

## Dropped from this PR

- **MA#20 (Info)** — `sanitize_store_dir` reject absolute paths. Dropped because the literal fix (extend the component-walk check to reject both `ParentDir` AND `RootDir`) would break the default startup path: `config_path` constructs the default store dir as `$HOME/.miden` (absolute), and rejecting all absolute paths would also break operators passing `--miden-store-dir /srv/agglayer`. Implementing this safely requires reshaping `--miden-store-dir` to be a relative path joined against a known safe base, which is a refactor that exceeds the scope of a "small fix" PR. Filed for separate follow-up.

## Operator-facing changes

A new CLI flag is added: `--disable-hardhat-alias` (env `DISABLE_HARDHAT_ALIAS`, default `false`).

When `--require-hardening` is set, operators MUST also set `--disable-hardhat-alias=true`, otherwise startup fails loudly with:

```
--require-hardening is set but the following invariants are not satisfied:
  - --disable-hardhat-alias is unset (Cantina MA#8: the well-known
    Hardhat default-account address `0xf39f...2266` would be silently
    remapped to `wallet_hardhat` on every claim). Set
    DISABLE_HARDHAT_ALIAS=true to refuse the remap in production.
```

A new metric `address_mapper_hardhat_alias_rejected_total` is emitted on every refused alias resolution, so operators can alert on misconfigured callers that still target the Hardhat default address.

## Cantina links

- https://cantina.xyz/code/c338caaf-fb92-403b-b3e8-2294541f29f4/findings/8
- https://cantina.xyz/code/c338caaf-fb92-403b-b3e8-2294541f29f4/findings/22
- https://cantina.xyz/code/c338caaf-fb92-403b-b3e8-2294541f29f4/findings/26

Generated with Claude Code.
