### PR TITLE
feat(monitor): unknown wrapper detection + erased-B2AGG quarantine (Cantina MA#4 + MA#18)

### DIFF
--- a/migrations/006_unbridgeable_bridge_outs.sql
+++ b/migrations/006_unbridgeable_bridge_outs.sql
@@ -1,0 +1,44 @@
+-- Cantina MA#18: log of L2→L1 B2AGG bridge-outs that aggkit observed consumed
+-- by the bridge account but could NOT translate into a synthetic BridgeEvent.
+--
+-- The on-chain consumption already advanced the LET frontier (the funds are
+-- effectively burned on L2), but aggkit failed to parse the note or resolve
+-- its faucet, so no BridgeEvent log was written. From aggsender's
+-- perspective the bridge-out never happened — without operator intervention,
+-- the user's funds are stranded.
+--
+-- Rows here are the positive quarantine handle that lets an operator (and a
+-- future recovery endpoint) reconstruct the missing leaf: the note_id is the
+-- on-chain B2AGG that was consumed, and the JSON `note_dump` captures
+-- everything we knew about it at quarantine time so a rescue path can
+-- re-derive the BridgeEvent fields if and when the underlying parse bug or
+-- registry gap is fixed.
+--
+-- Mirror of `unclaimable_claims` (migration 003), with note_id as the
+-- primary key instead of global_index because erased B2AGGs by definition
+-- never reached the deposit-counter stage that would assign a global_index.
+--
+-- Recovery design (NOT IMPLEMENTED YET — see PR body for full sketch):
+--   1. Operator inspects this table to identify stranded B2AGGs.
+--   2. If the underlying cause is fixable (e.g. faucet now registered, parse
+--      bug patched), operator calls a recovery RPC that re-runs
+--      process_consumed_note against the original note_dump and, on
+--      success, emits the synthetic BridgeEvent + deletes the row.
+--   3. If unfixable (truly erased contents, faucet permanently unknown), the
+--      operator escalates via the L1 fork-choice path (drop the cert, fork
+--      the LET, or accept the leak).
+CREATE TABLE IF NOT EXISTS unbridgeable_bridge_outs (
+    note_id         TEXT PRIMARY KEY,
+    bridge_account  TEXT NOT NULL,
+    reason          TEXT NOT NULL,
+    detail          TEXT NOT NULL,
+    note_dump       TEXT NOT NULL,
+    observed_block  BIGINT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_unbridgeable_bridge_outs_reason
+    ON unbridgeable_bridge_outs (reason);
+
+CREATE INDEX IF NOT EXISTS idx_unbridgeable_bridge_outs_bridge_account
+    ON unbridgeable_bridge_outs (bridge_account);

--- a/src/bridge_out.rs
+++ b/src/bridge_out.rs
@@ -350,7 +350,22 @@ impl BridgeOutScanner {
             match parse_b2agg_storage(details.storage()) {
                 Ok(v) => v,
                 Err(e) => {
+                    // Cantina MA#18 — erased / malformed B2AGG storage. The
+                    // bridge consumed the note (LET frontier advanced on-chain),
+                    // but aggkit cannot reconstruct destination_network /
+                    // destination_address to form the BridgeEvent. Pre-fix the
+                    // failure surfaced only via the LET-divergence symptom
+                    // monitor (Cantina #9); a positive quarantine row gives
+                    // operators a concrete per-note handle for recovery.
                     tracing::error!("B2AGG note {note_id_str}: failed to parse storage: {e:#}");
+                    self.quarantine_unbridgeable_b2agg(
+                        &note_id_str,
+                        note,
+                        block_number,
+                        crate::store::UnbridgeableBridgeOutReason::StorageParseFailed,
+                        format!("parse_b2agg_storage failed: {e:#}"),
+                    )
+                    .await;
                     return false;
                 }
             };
@@ -404,6 +419,17 @@ impl BridgeOutScanner {
         // Get the fungible asset
         let Some(fungible_asset) = details.assets().iter_fungible().next() else {
             tracing::warn!("B2AGG note {note_id_str} has no fungible asset, skipping");
+            // Cantina MA#18 — bridge consumed an empty B2AGG. Quarantine so
+            // an operator can decide whether the LET advance was legitimate
+            // (zero-amount probe) or attacker-induced.
+            self.quarantine_unbridgeable_b2agg(
+                &note_id_str,
+                note,
+                block_number,
+                crate::store::UnbridgeableBridgeOutReason::NoFungibleAsset,
+                "iter_fungible returned None".to_string(),
+            )
+            .await;
             return false;
         };
         let faucet_id = fungible_asset.faucet_id();
@@ -439,6 +465,20 @@ impl BridgeOutScanner {
                          next tick will re-observe it"
                     );
                 }
+                // Cantina MA#18 — positive quarantine in addition to the
+                // mark_note_processed B8 already does. mark_note_processed
+                // prevents the infinite re-scan loop but leaves no
+                // forensic trail; the quarantine row gives operators a
+                // structured record of every B8 hit, including the faucet
+                // id that needs registering.
+                self.quarantine_unbridgeable_b2agg(
+                    &note_id_str,
+                    note,
+                    block_number,
+                    crate::store::UnbridgeableBridgeOutReason::UnknownFaucet,
+                    format!("resolve_faucet_origin(faucet_id={faucet_id}) failed: {e:#}"),
+                )
+                .await;
                 return false;
             }
         };
@@ -446,6 +486,17 @@ impl BridgeOutScanner {
             Ok(v) => v,
             Err(e) => {
                 tracing::error!("B2AGG note {note_id_str}: {e:#}");
+                // Cantina MA#18 — amount × 10^scale overflowed u128.
+                // Practically impossible for legitimate amounts, but a
+                // malicious B2AGG could trigger it.
+                self.quarantine_unbridgeable_b2agg(
+                    &note_id_str,
+                    note,
+                    block_number,
+                    crate::store::UnbridgeableBridgeOutReason::AmountOverflow,
+                    format!("reverse_scale_amount failed: {e:#}"),
+                )
+                .await;
                 return false;
             }
         };
@@ -500,11 +551,133 @@ impl BridgeOutScanner {
                     error = %e,
                     "atomic B2AGG commit failed; transaction rolled back, no state advanced"
                 );
+                // Cantina MA#18 — atomic commit failed mid-write. The store
+                // rolled back, so a retry on the next tick may succeed; the
+                // quarantine row gives operators visibility into commit-side
+                // flakiness without losing the leaf-recovery handle if the
+                // failure is persistent.
+                self.quarantine_unbridgeable_b2agg(
+                    &note_id_str,
+                    note,
+                    block_number,
+                    crate::store::UnbridgeableBridgeOutReason::AtomicCommitFailed,
+                    format!("commit_b2agg_event_atomic failed: {e}"),
+                )
+                .await;
                 false
             }
         }
     }
 
+    /// Cantina MA#18 — record a quarantine row for a B2AGG that was observed
+    /// consumed by the bridge but skipped by the indexer.
+    ///
+    /// The on-chain LET frontier has already advanced; without this row the
+    /// failure surfaces only as a `bridge_let_divergence_total` symptom and an
+    /// operator has no per-note handle to drive recovery. The quarantine row
+    /// captures `(note_id, reason, detail, note_dump)` so a future recovery
+    /// RPC can re-attempt synthesis once the underlying cause (parse bug,
+    /// missing faucet, etc) is fixed.
+    ///
+    /// Best-effort: a quarantine-write failure must not panic or surface
+    /// from `process_consumed_note` — the caller's contract is that
+    /// returning `false` is the only side effect a skip path produces.
+    /// Quarantine errors are logged and the metric still fires.
+    async fn quarantine_unbridgeable_b2agg(
+        &self,
+        note_id_str: &str,
+        note: &InputNoteRecord,
+        observed_block: u64,
+        reason: crate::store::UnbridgeableBridgeOutReason,
+        detail: String,
+    ) {
+        // Bound the detail field so a flood of malformed notes can't
+        // bloat individual rows. The Postgres column has no length cap;
+        // bound here so the bound is enforced regardless of backend.
+        const MAX_DETAIL: usize = 4096;
+        let detail = if detail.len() > MAX_DETAIL {
+            format!("{}…[truncated {} bytes]", &detail[..MAX_DETAIL], detail.len() - MAX_DETAIL)
+        } else {
+            detail
+        };
+
+        let note_dump = dump_note_for_quarantine(note);
+        metrics::counter!(
+            "bridge_out_quarantined_erased_b2agg_total",
+            "reason" => reason.as_str()
+        )
+        .increment(1);
+
+        let entry = crate::store::UnbridgeableBridgeOut {
+            note_id: note_id_str.to_string(),
+            bridge_account: self.bridge_account_id,
+            reason,
+            detail,
+            note_dump,
+            observed_block,
+        };
+
+        match self.store.record_unbridgeable_bridge_out(entry).await {
+            Ok(true) => {
+                tracing::warn!(
+                    target: "bridge_out::quarantine",
+                    note_id = %note_id_str,
+                    reason = reason.as_str(),
+                    "Cantina MA#18: B2AGG quarantined — operator handle persisted"
+                );
+            }
+            Ok(false) => {
+                // Already quarantined; idempotent — no spam.
+                tracing::debug!(
+                    target: "bridge_out::quarantine",
+                    note_id = %note_id_str,
+                    reason = reason.as_str(),
+                    "Cantina MA#18: B2AGG already quarantined (idempotent skip)"
+                );
+            }
+            Err(e) => {
+                tracing::error!(
+                    target: "bridge_out::quarantine",
+                    note_id = %note_id_str,
+                    reason = reason.as_str(),
+                    error = %e,
+                    "Cantina MA#18: failed to record quarantine row — \
+                     metric still fired but recovery handle is lost"
+                );
+            }
+        }
+    }
+}
+
+/// Render a note's key forensic fields as a JSON-like string suitable for
+/// the `note_dump` quarantine column. Captures: script root (so an operator
+/// can confirm this was a B2AGG, not some other wrapper), the storage felts
+/// (so a fixed parser can re-derive destination_network + destination_address),
+/// and the asset list (so the operator knows what's stranded).
+///
+/// Kept simple text rather than `serde_json::to_string` to avoid pulling
+/// serde into the bridge_out hot path and to keep the format human-readable
+/// in psql.
+fn dump_note_for_quarantine(note: &InputNoteRecord) -> String {
+    use std::fmt::Write as _;
+    let details = note.details();
+    let script_root_hex = hex::encode(details.script().root().as_bytes());
+    let storage_items: Vec<String> = details
+        .storage()
+        .items()
+        .iter()
+        .map(|f| format!("{}", f.as_canonical_u64()))
+        .collect();
+    let assets: Vec<String> = details
+        .assets()
+        .iter_fungible()
+        .map(|fa| format!("{{faucet={}, amount={}}}", fa.faucet_id(), fa.amount()))
+        .collect();
+    let mut out = String::with_capacity(256);
+    let _ = write!(out, "{{\"script_root\":\"0x{script_root_hex}\",");
+    let _ = write!(out, "\"storage_items\":[{}],", storage_items.join(","));
+    let _ = write!(out, "\"fungible_assets\":[{}]}}", assets.join(","));
+    out
 }
 
 #[async_trait::async_trait]
@@ -1550,6 +1723,171 @@ mod tests {
         // the gate. The pure-helper test pins the exact decision; this just
         // exercises the wiring end-to-end without a downstream panic.
         let _ = scanner.process_consumed_note(&note, 100).await;
+    }
+
+    // CANTINA MA#18 — UNBRIDGEABLE B2AGG QUARANTINE TESTS
+    // ============================================================================================
+
+    /// Build a B2AGG note with INVALID storage (only 1 felt) so
+    /// `parse_b2agg_storage` returns Err. Bridge-consumed so it passes the
+    /// MA#3 gate and reaches the storage-parse skip site in
+    /// `process_consumed_note`.
+    fn build_erased_b2agg_note(consumer_account: AccountId) -> miden_client::store::InputNoteRecord {
+        use miden_client::store::InputNoteState;
+        use miden_client::store::input_note_states::ConsumedExternalNoteState;
+        use miden_protocol::Felt;
+        use miden_protocol::Word;
+        use miden_protocol::block::BlockNumber;
+        use miden_protocol::note::{NoteAssets, NoteDetails, NoteRecipient, NoteStorage};
+
+        // 1 felt: too short for parse_b2agg_storage (which requires ≥6).
+        // This simulates an "erased" B2AGG — the bridge consumed it on-chain
+        // (LET advanced) but the indexer cannot reconstruct the destination.
+        let storage = NoteStorage::new(vec![Felt::new(0)]).unwrap();
+        let script = B2AggNote::script();
+        let recipient = NoteRecipient::new(Word::default(), script, storage);
+        let assets = NoteAssets::new(vec![]).unwrap();
+        let details = NoteDetails::new(assets, recipient);
+
+        let state = InputNoteState::ConsumedExternal(ConsumedExternalNoteState {
+            nullifier_block_height: BlockNumber::from(0u32),
+            consumer_account: Some(consumer_account),
+            consumed_tx_order: None,
+        });
+
+        miden_client::store::InputNoteRecord::new(details, None, state)
+    }
+
+    /// Cantina MA#18 — wiring repro. A B2AGG with un-parseable storage
+    /// (the "erased" case) that the bridge consumed MUST land a positive
+    /// quarantine row so an operator has a concrete handle to investigate /
+    /// rescue. Pre-MA#18 this skipped silently and only surfaced as a LET
+    /// divergence symptom (Cantina #9).
+    #[tokio::test]
+    async fn ma18_erased_b2agg_quarantined_on_storage_parse_failure() {
+        use crate::block_state::BlockState;
+        use crate::store::UnbridgeableBridgeOutReason;
+        use crate::store::memory::InMemoryStore;
+        use std::sync::Arc as StdArc;
+
+        let store: StdArc<dyn crate::store::Store> = StdArc::new(InMemoryStore::new());
+        let block_state = StdArc::new(BlockState::new());
+        let bridge_id = AccountId::from_hex("0x3d7c9747558851900f8206226dfbea").unwrap();
+
+        let scanner = BridgeOutScanner::new(store.clone(), block_state, 7, bridge_id);
+        let note = build_erased_b2agg_note(bridge_id);
+        let note_id_str = note.id().to_string();
+
+        let advanced = scanner.process_consumed_note(&note, 42).await;
+        assert!(!advanced, "erased note must NOT signal block advance");
+
+        let row = store
+            .get_unbridgeable_bridge_out(&note_id_str)
+            .await
+            .unwrap()
+            .expect("quarantine row must be present");
+        assert_eq!(row.note_id, note_id_str);
+        assert_eq!(row.bridge_account, bridge_id);
+        assert_eq!(row.reason, UnbridgeableBridgeOutReason::StorageParseFailed);
+        assert_eq!(row.observed_block, 42);
+        assert!(
+            row.note_dump.contains("script_root"),
+            "note_dump must capture script_root for forensic inspection, got: {}",
+            row.note_dump
+        );
+        assert!(
+            row.note_dump.contains("storage_items"),
+            "note_dump must capture storage_items so a fixed parser can re-derive fields"
+        );
+        assert!(
+            !row.detail.is_empty(),
+            "detail must capture the underlying parse error"
+        );
+    }
+
+    /// Cantina MA#18 — quarantine writes are idempotent by note_id. Multiple
+    /// sync ticks observing the same erased note must NOT duplicate rows.
+    /// Pre-fix duplicate inserts would either error or bloat the table on
+    /// every tick.
+    #[tokio::test]
+    async fn ma18_quarantine_is_idempotent_per_note_id() {
+        use crate::block_state::BlockState;
+        use crate::store::memory::InMemoryStore;
+        use std::sync::Arc as StdArc;
+
+        let store: StdArc<dyn crate::store::Store> = StdArc::new(InMemoryStore::new());
+        let block_state = StdArc::new(BlockState::new());
+        let bridge_id = AccountId::from_hex("0x3d7c9747558851900f8206226dfbea").unwrap();
+
+        let scanner = BridgeOutScanner::new(store.clone(), block_state, 7, bridge_id);
+        let note = build_erased_b2agg_note(bridge_id);
+        let note_id_str = note.id().to_string();
+
+        // First observation — quarantine row written.
+        let _ = scanner.process_consumed_note(&note, 1).await;
+        let first = store
+            .get_unbridgeable_bridge_out(&note_id_str)
+            .await
+            .unwrap()
+            .expect("first quarantine row");
+        let first_block = first.observed_block;
+
+        // Second observation — quarantine row UNCHANGED.
+        let _ = scanner.process_consumed_note(&note, 2).await;
+        let second = store
+            .get_unbridgeable_bridge_out(&note_id_str)
+            .await
+            .unwrap()
+            .expect("quarantine row must persist");
+        assert_eq!(
+            second.observed_block, first_block,
+            "first-write-wins: observed_block must not be overwritten by later ticks"
+        );
+    }
+
+    /// Cantina MA#18 — a non-skip path (e.g. MA#3 reclaim by user) must NOT
+    /// generate a quarantine row. Quarantine fires only when the bridge
+    /// consumed the note (LET advanced) AND we couldn't translate it.
+    /// Reclaim by user is normal flow — no LET advance, no quarantine.
+    #[tokio::test]
+    async fn ma18_user_reclaim_does_not_quarantine() {
+        use crate::block_state::BlockState;
+        use crate::store::memory::InMemoryStore;
+        use std::sync::Arc as StdArc;
+
+        let store: StdArc<dyn crate::store::Store> = StdArc::new(InMemoryStore::new());
+        let block_state = StdArc::new(BlockState::new());
+        let bridge_id = AccountId::from_hex("0x3d7c9747558851900f8206226dfbea").unwrap();
+        let user_id = AccountId::from_hex("0x3d7c9747558851900f8206226dfbeb").unwrap();
+
+        let scanner = BridgeOutScanner::new(store.clone(), block_state, 7, bridge_id);
+        let note = build_b2agg_note_with_consumer(Some(user_id));
+        let note_id_str = note.id().to_string();
+
+        let _ = scanner.process_consumed_note(&note, 1).await;
+
+        assert!(
+            store
+                .get_unbridgeable_bridge_out(&note_id_str)
+                .await
+                .unwrap()
+                .is_none(),
+            "user-reclaim must not produce a quarantine row — the LET did not advance"
+        );
+    }
+
+    /// Cantina MA#18 — pin the `as_str()` mapping. The textual `reason`
+    /// column is the load-bearing key for any future recovery RPC; the
+    /// strings MUST stay stable or operator queries will silently miss
+    /// rows.
+    #[test]
+    fn ma18_reason_str_mapping_stable() {
+        use crate::store::UnbridgeableBridgeOutReason as R;
+        assert_eq!(R::StorageParseFailed.as_str(), "storage_parse_failed");
+        assert_eq!(R::NoFungibleAsset.as_str(), "no_fungible_asset");
+        assert_eq!(R::UnknownFaucet.as_str(), "unknown_faucet");
+        assert_eq!(R::AmountOverflow.as_str(), "amount_overflow");
+        assert_eq!(R::AtomicCommitFailed.as_str(), "atomic_commit_failed");
     }
 
     /// Cantina MA#4 — wiring repro for the unknown-wrapper detector. Pins

--- a/src/bridge_out.rs
+++ b/src/bridge_out.rs
@@ -504,6 +504,7 @@ impl BridgeOutScanner {
             }
         }
     }
+
 }
 
 #[async_trait::async_trait]
@@ -635,6 +636,45 @@ impl SyncListener for BridgeOutScanner {
                         note_id = %note.id(),
                         "Cantina #4: MINT note observed with no decodable \
                          NetworkAccountTarget attachment — forged via NoAuth"
+                    );
+                }
+            }
+
+            // Cantina MA#4 — unknown bridge-out wrapper detection. The bridge
+            // account has no on-chain assertion that the note consumed must
+            // be the canonical B2AGG script — any MASM body that calls
+            // `bridge_out::bridge_out` from a transaction the bridge consumes
+            // will advance the LET frontier and BURN funds. Pre-fix the
+            // indexer silently dropped every non-B2AGG script root in
+            // `is_b2agg_note`, so an alternate wrapper would create an
+            // invisible exit. Detect post-hoc: notes consumed by the bridge
+            // account whose script root is in neither the B2AGG-out set nor
+            // the CLAIM-in set are the MA#4 signature.
+            if note.consumer_account() == Some(self.bridge_account_id) {
+                let b2agg_root_bytes = B2AggNote::script_root().as_bytes();
+                let claim_root_bytes = claim_root.as_bytes();
+                let observed_bytes = script_root.as_bytes();
+                use crate::unknown_wrapper_detector::{
+                    BridgeConsumerScript, classify_bridge_consumer_script,
+                };
+                if matches!(
+                    classify_bridge_consumer_script(
+                        observed_bytes,
+                        b2agg_root_bytes,
+                        claim_root_bytes,
+                    ),
+                    BridgeConsumerScript::Unknown
+                ) {
+                    metrics::counter!("bridge_unknown_wrapper_consumed_total").increment(1);
+                    tracing::warn!(
+                        target: "bridge_out::unknown_wrapper",
+                        note_id = %note.id(),
+                        observed_script_root = %hex::encode(observed_bytes),
+                        bridge = %self.bridge_account_id,
+                        "Cantina MA#4: bridge account consumed a note whose script \
+                         root matches neither the canonical B2AGG bridge-out wrapper \
+                         nor the CLAIM script — alternate wrapper has produced an \
+                         on-chain LET advance that the indexer cannot translate"
                     );
                 }
             }
@@ -1510,5 +1550,40 @@ mod tests {
         // the gate. The pure-helper test pins the exact decision; this just
         // exercises the wiring end-to-end without a downstream panic.
         let _ = scanner.process_consumed_note(&note, 100).await;
+    }
+
+    /// Cantina MA#4 — wiring repro for the unknown-wrapper detector. Pins
+    /// that the predicate correctly distinguishes the canonical B2AGG and
+    /// CLAIM roots from any other 32-byte root. The wiring inside
+    /// `on_post_sync` is exercised by the e2e tests (full client+sync stack
+    /// required); this test pins the pure decision the wiring depends on.
+    #[test]
+    fn ma4_classify_bridge_consumer_script_pins_known_set() {
+        use crate::unknown_wrapper_detector::{
+            BridgeConsumerScript, classify_bridge_consumer_script,
+        };
+        // Use the real B2AGG + CLAIM roots so a future MASM regen that
+        // changes either is caught here.
+        let b2agg = B2AggNote::script_root().as_bytes();
+        let claim = miden_base_agglayer::claim_script().root().as_bytes();
+        assert_ne!(b2agg, claim, "B2AGG and CLAIM must have distinct roots");
+
+        // Known roots — the bridge legitimately consumes both.
+        assert_eq!(
+            classify_bridge_consumer_script(b2agg, b2agg, claim),
+            BridgeConsumerScript::KnownB2Agg
+        );
+        assert_eq!(
+            classify_bridge_consumer_script(claim, b2agg, claim),
+            BridgeConsumerScript::KnownClaim
+        );
+
+        // Arbitrary other root — the MA#4 signature. Pre-fix this slipped
+        // through silently.
+        let foreign = [0xCCu8; 32];
+        assert_eq!(
+            classify_bridge_consumer_script(foreign, b2agg, claim),
+            BridgeConsumerScript::Unknown
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod store;
 #[cfg(test)]
 pub mod test_helpers;
 pub mod twin_note_detector;
+pub mod unknown_wrapper_detector;
 
 pub const COMPONENT: &str = "miden-agglayer";
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -99,6 +99,14 @@ pub fn init_metrics() {
          must investigate before more funds are stranded."
     );
     describe_counter!(
+        "bridge_out_quarantined_erased_b2agg_total",
+        "B2AGG note observed consumed by the bridge but skipped by the \
+         indexer because the note contents were unparseable or referenced \
+         an unknown faucet (Cantina MA#18). A row was written to the \
+         quarantine table so operators have a concrete handle for a \
+         future recovery flow."
+    );
+    describe_counter!(
         "rpc_claim_ger_not_seen_total",
         "Claim submission rejected because the referenced GER was not \
          yet in `has_seen_ger` (C6). Caller should retry after the GER \

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -91,6 +91,14 @@ pub fn init_metrics() {
          Quarantined to prevent silent re-loop on every sync tick."
     );
     describe_counter!(
+        "bridge_unknown_wrapper_consumed_total",
+        "Bridge account consumed a note whose script root is neither the \
+         canonical B2AGG bridge-out wrapper nor the CLAIM script (Cantina \
+         MA#4). The on-chain LET frontier has advanced; aggkit cannot \
+         synthesise a BridgeEvent for an unrecognised wrapper. Operator \
+         must investigate before more funds are stranded."
+    );
+    describe_counter!(
         "rpc_claim_ger_not_seen_total",
         "Claim submission rejected because the referenced GER was not \
          yet in `has_seen_ger` (C6). Caller should retry after the GER \

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1,6 +1,6 @@
 //! In-memory Store implementation — wraps HashMap/RwLock data structures.
 
-use super::{FaucetEntry, Store, TxnData, TxnEntry, UnclaimableClaim};
+use super::{FaucetEntry, Store, TxnData, TxnEntry, UnbridgeableBridgeOut, UnclaimableClaim};
 use crate::log_synthesis::{
     GerEntry, L2_GLOBAL_EXIT_ROOT_ADDRESS, LogFilter, SyntheticLog, UPDATE_HASH_CHAIN_VALUE_TOPIC,
 };
@@ -51,6 +51,9 @@ pub struct InMemoryStore {
     // Unclaimable claims — first-write wins per global_index (RD-860).
     unclaimable: RwLock<HashMap<U256, UnclaimableClaim>>,
 
+    // Unbridgeable bridge-outs — first-write wins per note_id (Cantina MA#18).
+    unbridgeable_bridge_outs: RwLock<HashMap<String, UnbridgeableBridgeOut>>,
+
     // Address mappings
     address_mappings: RwLock<HashMap<Address, AccountId>>,
 
@@ -85,6 +88,7 @@ impl InMemoryStore {
             nonces: RwLock::new(HashMap::new()),
             claimed: RwLock::new(HashSet::new()),
             unclaimable: RwLock::new(HashMap::new()),
+            unbridgeable_bridge_outs: RwLock::new(HashMap::new()),
             address_mappings: RwLock::new(HashMap::new()),
             processed_notes: RwLock::new(HashSet::new()),
             deposit_counter: RwLock::new(0),
@@ -519,6 +523,30 @@ impl Store for InMemoryStore {
         global_index: &U256,
     ) -> anyhow::Result<Option<UnclaimableClaim>> {
         Ok(self.unclaimable.read().get(global_index).cloned())
+    }
+
+    // ── Unbridgeable bridge-outs (Cantina MA#18) ─────────────────
+
+    async fn record_unbridgeable_bridge_out(
+        &self,
+        entry: UnbridgeableBridgeOut,
+    ) -> anyhow::Result<bool> {
+        use std::collections::hash_map::Entry;
+        let mut map = self.unbridgeable_bridge_outs.write();
+        match map.entry(entry.note_id.clone()) {
+            Entry::Occupied(_) => Ok(false),
+            Entry::Vacant(slot) => {
+                slot.insert(entry);
+                Ok(true)
+            }
+        }
+    }
+
+    async fn get_unbridgeable_bridge_out(
+        &self,
+        note_id: &str,
+    ) -> anyhow::Result<Option<UnbridgeableBridgeOut>> {
+        Ok(self.unbridgeable_bridge_outs.read().get(note_id).cloned())
     }
 
     // ── Address mappings ─────────────────────────────────────────

--- a/src/store/migrator.rs
+++ b/src/store/migrator.rs
@@ -66,6 +66,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "005_l1_indexer_cursor.sql",
         include_str!("../../migrations/005_l1_indexer_cursor.sql"),
     ),
+    (
+        "006_unbridgeable_bridge_outs.sql",
+        include_str!("../../migrations/006_unbridgeable_bridge_outs.sql"),
+    ),
 ];
 
 /// Postgres advisory-lock key. Arbitrary 64-bit int; just needs to be

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -84,6 +84,86 @@ impl UnclaimableReason {
     }
 }
 
+/// Record of a B2AGG bridge-out that aggkit observed consumed by the bridge
+/// but could NOT translate into a synthetic `BridgeEvent` (Cantina MA#18).
+///
+/// The on-chain consumption already advanced the LET frontier — funds are
+/// effectively burned on L2 — but aggkit failed to parse or process the
+/// note. Without this quarantine row, the failure was only surfaced as a
+/// symptom by the LET-divergence monitor (Cantina #9); operators had no
+/// concrete handle for an individual stranded B2AGG.
+///
+/// `note_id` is the primary key because erased B2AGGs by definition never
+/// reached the deposit-counter stage that would assign a `global_index`.
+/// `note_dump` captures everything we knew about the note at quarantine
+/// time so a future recovery RPC can re-attempt the BridgeEvent
+/// synthesis once the underlying cause is fixed (faucet registered, parse
+/// bug patched, etc).
+#[derive(Debug, Clone)]
+pub struct UnbridgeableBridgeOut {
+    pub note_id: String,
+    pub bridge_account: AccountId,
+    pub reason: UnbridgeableBridgeOutReason,
+    /// Free-form diagnostic (the exact error message from the skip site).
+    /// Bounded by the caller; the column has no length cap in Postgres but
+    /// callers should keep it under 4 KiB so a flood of bad notes cannot
+    /// fill the table beyond bounded growth.
+    pub detail: String,
+    /// JSON-ish dump of the note for later forensic inspection. Today we
+    /// capture script root + storage felts + asset metadata — enough for an
+    /// operator to identify the depositor and decide on a recovery path.
+    pub note_dump: String,
+    /// The aggkit synthetic block number at which the consumption was
+    /// observed. Useful for cross-referencing with the LET-divergence
+    /// monitor that fires in the same on_post_sync tick.
+    pub observed_block: u64,
+}
+
+/// Why an observed-consumed B2AGG could not be translated into a
+/// synthetic BridgeEvent. Each variant maps 1:1 to a skip-return path in
+/// `process_consumed_note`.
+///
+/// Variant set is closed today; future skip paths must add their own
+/// variant + map back via `as_str()` so the Postgres column value remains
+/// machine-parseable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnbridgeableBridgeOutReason {
+    /// `parse_b2agg_storage` errored — the storage section was missing,
+    /// truncated, or contained limb values that overflowed u32. "Erased
+    /// note" in the Cantina MA#18 sense.
+    StorageParseFailed,
+    /// The B2AGG carried no fungible asset — the bridge consumed an empty
+    /// note. Pre-MA#18 this skipped silently; now quarantined so we have a
+    /// row to investigate.
+    NoFungibleAsset,
+    /// The B2AGG's faucet is not in aggkit's registry (B8). Already had a
+    /// metric (`bridge_out_unknown_faucet_total`) and a mark-processed
+    /// step, but no quarantine row — this adds one so the operator has a
+    /// concrete handle.
+    UnknownFaucet,
+    /// `reverse_scale_amount` overflowed u128 — the on-chain amount × 10^scale
+    /// can't fit. Practically impossible for legitimate ERC-20 amounts but
+    /// kept as a distinct skip path so a malicious B2AGG that triggers it
+    /// is auditable.
+    AmountOverflow,
+    /// The atomic store commit failed mid-write (transaction rolled back,
+    /// nothing persisted). Quarantine so a retry path or operator can
+    /// re-attempt without missing the leaf.
+    AtomicCommitFailed,
+}
+
+impl UnbridgeableBridgeOutReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::StorageParseFailed => "storage_parse_failed",
+            Self::NoFungibleAsset => "no_fungible_asset",
+            Self::UnknownFaucet => "unknown_faucet",
+            Self::AmountOverflow => "amount_overflow",
+            Self::AtomicCommitFailed => "atomic_commit_failed",
+        }
+    }
+}
+
 /// Full transaction data returned from the store.
 #[derive(Debug, Clone)]
 pub struct TxnData {
@@ -292,6 +372,34 @@ pub trait Store: Send + Sync + 'static {
     /// processed since genesis). Used by the Cantina #9 LET-divergence monitor
     /// to compare against the bridge account's `let_num_leaves` storage slot.
     async fn get_deposit_count(&self) -> anyhow::Result<u64>;
+
+    /// Record a B2AGG bridge-out that was observed consumed by the bridge but
+    /// could NOT be translated into a synthetic BridgeEvent (Cantina MA#18).
+    ///
+    /// Idempotent by `note_id` — multiple sync ticks observing the same
+    /// erased note must not duplicate rows; the first record wins. Returns
+    /// `true` if this was a new insert (not a duplicate).
+    ///
+    /// Default impl is a no-op so InMemoryStore in tests that don't care
+    /// about quarantine state still compiles; the real impls (memory + pg)
+    /// override below.
+    async fn record_unbridgeable_bridge_out(
+        &self,
+        _entry: UnbridgeableBridgeOut,
+    ) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+
+    /// Look up an unbridgeable B2AGG by `note_id`. `None` if not quarantined.
+    ///
+    /// Default impl returns `None` so stores without the quarantine table
+    /// (e.g. legacy deployments before migration 006) don't crash readers.
+    async fn get_unbridgeable_bridge_out(
+        &self,
+        _note_id: &str,
+    ) -> anyhow::Result<Option<UnbridgeableBridgeOut>> {
+        Ok(None)
+    }
 
     // === Claim watcher ===
     //

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -3,7 +3,10 @@
 //! Requires the `postgres` feature flag and a running PostgreSQL instance
 //! with the schema from `migrations/001_initial.sql` applied.
 
-use super::{FaucetEntry, Store, TxnData, TxnEntry, UnclaimableClaim, UnclaimableReason};
+use super::{
+    FaucetEntry, Store, TxnData, TxnEntry, UnbridgeableBridgeOut, UnbridgeableBridgeOutReason,
+    UnclaimableClaim, UnclaimableReason,
+};
 use crate::bridge_address::get_bridge_address;
 use crate::log_synthesis::{
     GerEntry, L2_GLOBAL_EXIT_ROOT_ADDRESS, LogFilter, SyntheticLog, UPDATE_HASH_CHAIN_VALUE_TOPIC,
@@ -1081,6 +1084,81 @@ impl Store for PgStore {
             amount: U256::from_str_radix(amount_hex.trim_start_matches("0x"), 16)?,
             reason,
             eth_tx_hash: eth_tx_hex.parse()?,
+        }))
+    }
+
+    // ── Unbridgeable bridge-outs (Cantina MA#18) ─────────────────
+
+    async fn record_unbridgeable_bridge_out(
+        &self,
+        entry: UnbridgeableBridgeOut,
+    ) -> anyhow::Result<bool> {
+        let client = self.pool.get().await?;
+        let bridge_account = entry.bridge_account.to_hex();
+        let reason = entry.reason.as_str();
+        let observed_block = entry.observed_block as i64;
+
+        // First-write wins: ON CONFLICT DO NOTHING so repeated sync ticks
+        // observing the same erased note don't error or duplicate rows.
+        let rows = client
+            .query(
+                "INSERT INTO unbridgeable_bridge_outs \
+                 (note_id, bridge_account, reason, detail, note_dump, observed_block) \
+                 VALUES ($1, $2, $3, $4, $5, $6) \
+                 ON CONFLICT (note_id) DO NOTHING \
+                 RETURNING note_id",
+                &[
+                    &entry.note_id,
+                    &bridge_account,
+                    &reason,
+                    &entry.detail,
+                    &entry.note_dump,
+                    &observed_block,
+                ],
+            )
+            .await?;
+        Ok(!rows.is_empty())
+    }
+
+    async fn get_unbridgeable_bridge_out(
+        &self,
+        note_id: &str,
+    ) -> anyhow::Result<Option<UnbridgeableBridgeOut>> {
+        let client = self.pool.get().await?;
+        let rows = client
+            .query(
+                "SELECT note_id, bridge_account, reason, detail, note_dump, observed_block \
+                 FROM unbridgeable_bridge_outs WHERE note_id = $1",
+                &[&note_id],
+            )
+            .await?;
+        let Some(row) = rows.into_iter().next() else {
+            return Ok(None);
+        };
+        let note_id_col: String = row.get(0);
+        let bridge_account_hex: String = row.get(1);
+        let reason_str: String = row.get(2);
+        let detail: String = row.get(3);
+        let note_dump: String = row.get(4);
+        let observed_block: i64 = row.get(5);
+
+        let reason = match reason_str.as_str() {
+            "storage_parse_failed" => UnbridgeableBridgeOutReason::StorageParseFailed,
+            "no_fungible_asset" => UnbridgeableBridgeOutReason::NoFungibleAsset,
+            "unknown_faucet" => UnbridgeableBridgeOutReason::UnknownFaucet,
+            "amount_overflow" => UnbridgeableBridgeOutReason::AmountOverflow,
+            "atomic_commit_failed" => UnbridgeableBridgeOutReason::AtomicCommitFailed,
+            other => anyhow::bail!("unknown unbridgeable_bridge_outs.reason value: {other}"),
+        };
+
+        Ok(Some(UnbridgeableBridgeOut {
+            note_id: note_id_col,
+            bridge_account: AccountId::from_hex(&bridge_account_hex)
+                .map_err(|e| anyhow::anyhow!("decoding bridge_account from db row: {e}"))?,
+            reason,
+            detail,
+            note_dump,
+            observed_block: u64::try_from(observed_block)?,
         }))
     }
 

--- a/src/unknown_wrapper_detector.rs
+++ b/src/unknown_wrapper_detector.rs
@@ -1,0 +1,171 @@
+//! Unknown bridge-out wrapper detection — Cantina MA#4 monitor.
+//!
+//! Cantina MA#4 reports that `BridgeOutScanner` only treats notes whose script
+//! root matches `B2AggNote::script_root()` as bridge-out signals. The bridge
+//! account, however, has no on-chain restriction on which script bodies it
+//! will accept — any note that calls `bridge_out::bridge_out` from inside a
+//! transaction the bridge consumes will advance the on-chain LET frontier and
+//! BURN funds. If an attacker (or any future legitimate but unrecognised
+//! wrapper) crafts an alternate MASM script that does this, the bridge
+//! consumes it, the LET advances, BURN is emitted — but aggkit's indexer
+//! silently filters the note out at `is_b2agg_note`, never emits a synthetic
+//! `BridgeEvent`, and the assets are effectively burned on L2 with no
+//! corresponding L1 exit ticket.
+//!
+//! We cannot prevent the on-chain consumption (the gate would have to live in
+//! the bridge MASM, not in aggkit). What we CAN do is detect it: every note
+//! consumed by `bridge_account_id` whose script root is NOT in the set of
+//! known-legitimate roots is an "unknown wrapper" candidate. Emit a
+//! `bridge_unknown_wrapper_consumed_total` counter and a structured `warn`
+//! log naming the unknown script root so an operator can investigate before
+//! more funds are stranded.
+//!
+//! The set of "known-legitimate roots consumed by the bridge" is two:
+//!   * `B2AggNote::script_root()` — the canonical bridge-out wrapper.
+//!   * `miden_base_agglayer::claim_script().root()` — CLAIM notes are
+//!     consumed by the bridge as a precondition to MINT emission (bridge-IN,
+//!     not bridge-OUT, but still a legitimate bridge-account consumption).
+//!
+//! Anything else consumed by the bridge is the MA#4 signature.
+//!
+//! This module exposes:
+//! - The pure predicate `classify_bridge_consumer_script` so the detection
+//!   logic is unit-testable in isolation.
+//! - The `BridgeConsumerScript` enum the caller uses to drive alerts.
+//!
+//! The actual periodic check lives in `bridge_out.rs::on_post_sync`: after
+//! the existing per-note loop, every note whose `consumer_account ==
+//! bridge_account_id` AND whose script root is unknown increments
+//! `bridge_unknown_wrapper_consumed_total` and logs at `warn`.
+
+/// Outcome of checking a single bridge-account-consumed note's script root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeConsumerScript {
+    /// Note is a recognised B2AGG bridge-out wrapper. Normal flow.
+    KnownB2Agg,
+    /// Note is a recognised CLAIM consumed by the bridge to trigger a MINT.
+    /// Normal flow (bridge-IN, not bridge-OUT, but legitimate bridge
+    /// consumption).
+    KnownClaim,
+    /// Note was consumed by the bridge account but its script root is in
+    /// neither set above — the Cantina MA#4 signature. Operator must
+    /// investigate before the LET advance becomes permanent.
+    Unknown,
+}
+
+/// Classify a bridge-account-consumed note's script root.
+///
+/// Pure (no I/O, no metrics) so it can be unit-tested directly. The caller
+/// in `bridge_out::on_post_sync` first filters to notes where
+/// `consumer_account == bridge_account_id`; this predicate then decides
+/// whether the script root is known.
+///
+/// `known_b2agg_root` and `known_claim_root` are passed in (rather than
+/// computed inside) so the unit tests can pin the predicate against
+/// well-known fixed values without depending on the upstream MASM crate's
+/// behaviour at test time.
+pub fn classify_bridge_consumer_script(
+    observed_root: [u8; 32],
+    known_b2agg_root: [u8; 32],
+    known_claim_root: [u8; 32],
+) -> BridgeConsumerScript {
+    if observed_root == known_b2agg_root {
+        BridgeConsumerScript::KnownB2Agg
+    } else if observed_root == known_claim_root {
+        BridgeConsumerScript::KnownClaim
+    } else {
+        BridgeConsumerScript::Unknown
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Cantina MA#4 — repro+regression. The detection predicate must pin
+    /// three states cleanly:
+    /// - `KnownB2Agg`: observed root matches the canonical B2AGG wrapper.
+    /// - `KnownClaim`: observed root matches the CLAIM script consumed by
+    ///   the bridge to trigger MINTs.
+    /// - `Unknown`: anything else — the MA#4 signature.
+    ///
+    /// Pre-fix this predicate did not exist; `BridgeOutScanner` filtered all
+    /// non-B2AGG notes silently in `is_b2agg_note`, so an alternate wrapper
+    /// that called `bridge_out::bridge_out` from a different script body
+    /// would advance the on-chain LET with no aggkit observation.
+    #[test]
+    fn ma4_classify_bridge_consumer_script_branches() {
+        let b2agg = [0xAAu8; 32];
+        let claim = [0xBBu8; 32];
+
+        // 1. Known B2AGG — canonical bridge-out wrapper.
+        assert_eq!(
+            classify_bridge_consumer_script(b2agg, b2agg, claim),
+            BridgeConsumerScript::KnownB2Agg
+        );
+
+        // 2. Known CLAIM — bridge consumes CLAIM to mint.
+        assert_eq!(
+            classify_bridge_consumer_script(claim, b2agg, claim),
+            BridgeConsumerScript::KnownClaim
+        );
+
+        // 3. Unknown — the MA#4 signature. Any other 32-byte script root
+        // consumed by the bridge is an invisible exit risk.
+        let foreign = [0xCCu8; 32];
+        assert_eq!(
+            classify_bridge_consumer_script(foreign, b2agg, claim),
+            BridgeConsumerScript::Unknown
+        );
+
+        // Edge: all zeros — also Unknown unless one of the known roots
+        // happens to be all-zero (it never is for non-trivial MASM).
+        assert_eq!(
+            classify_bridge_consumer_script([0u8; 32], b2agg, claim),
+            BridgeConsumerScript::Unknown
+        );
+    }
+
+    /// Pin that the predicate doesn't accidentally collapse the two known
+    /// roots into one bucket. If B2AGG and CLAIM ever shared a script root
+    /// (they don't; the MASM bodies are distinct) this predicate would
+    /// still need to distinguish them so the metric label is correct.
+    #[test]
+    fn ma4_classify_distinguishes_b2agg_from_claim() {
+        let b2agg = [0x01u8; 32];
+        let claim = [0x02u8; 32];
+        assert_eq!(
+            classify_bridge_consumer_script(b2agg, b2agg, claim),
+            BridgeConsumerScript::KnownB2Agg
+        );
+        assert_eq!(
+            classify_bridge_consumer_script(claim, b2agg, claim),
+            BridgeConsumerScript::KnownClaim
+        );
+        // Swap argument order to ensure we don't depend on positional luck.
+        assert_eq!(
+            classify_bridge_consumer_script(b2agg, claim, b2agg),
+            BridgeConsumerScript::KnownClaim,
+            "predicate must classify against the role each root plays, \
+             not its argument position"
+        );
+    }
+
+    /// If a future bridge variant adds a third legitimate script root (e.g.
+    /// a separate "force-claim" wrapper), this predicate WILL flag it as
+    /// `Unknown` until the call site is updated to pass a third known root
+    /// and the predicate is extended. That's intentional — fail-loud is
+    /// better than silent acceptance of unrecognised wrappers, which is
+    /// exactly the MA#4 condition.
+    #[test]
+    fn ma4_new_wrapper_must_be_explicitly_recognised() {
+        let b2agg = [0xAAu8; 32];
+        let claim = [0xBBu8; 32];
+        let new_wrapper = [0xDDu8; 32];
+        assert_eq!(
+            classify_bridge_consumer_script(new_wrapper, b2agg, claim),
+            BridgeConsumerScript::Unknown,
+            "any unrecognised wrapper consumed by the bridge MUST be flagged"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes 2 Cantina Miden-Agglayer findings:
- **MA#4 (Low)** — adds a post-hoc monitor predicate detecting bridge-account consumed notes with non-B2AGG / non-CLAIM script roots (`bridge_unknown_wrapper_consumed_total`)
- **MA#18 (Low)** — adds a positive quarantine row (`unbridgeable_bridge_outs`) for erased B2AGGs so operator intervention has a concrete handle (was previously only surfaced via the LET-divergence symptom monitor, Cantina #9)

## Base

Originally branched from `fix/cantina-ma3-reclaim-gate` (PR #63) since all three touch `src/bridge_out.rs`. PR #63 has now merged into `main` (squash-merge SHA `2d46142`), so this PR targets `main` directly. The MA#3 reclaim-gate is the first commit in our history visible via `git log b883762`; it is preserved in `main` via the squash merge.

## Commits

- `7e1fbd5 feat(monitor): unknown bridge-out wrapper detection (Cantina MA#4)` — new `unknown_wrapper_detector` module + wiring in `on_post_sync` + metric registration.
- `ea770c7 feat(bridge-out): quarantine erased B2AGGs + operator-recovery hook (Cantina MA#18)` — migration 006, `UnbridgeableBridgeOut` types, in-memory + Postgres impls, `quarantine_unbridgeable_b2agg` helper wired into all five B2AGG skip sites.

## Recovery flow (DESIGN ONLY for MA#18)

The MA#18 quarantine table is the load-bearing piece. The operator-facing recovery RPC is intentionally out of scope for this PR (touches auth, rate-limit, audit surface). The intended future flow is documented in the MA#18 commit body and the migration SQL:

1. Operator inspects `unbridgeable_bridge_outs` to identify stranded B2AGGs.
2. For each row, if the underlying cause is fixable (faucet now registered, parse bug patched), a recovery RPC re-runs `process_consumed_note` against the stored `note_dump` and emits the synthetic `BridgeEvent`.
3. If unfixable, operator escalates via the L1 fork-choice path (drop the cert, fork the LET, or accept the leak).

The existing `unclaimable_claims` table (RD-860, migration 003) follows the same pattern — quarantine row exists with no automated retry path — so MA#18 matches house style.

## Test plan

- [x] `cargo test --lib bridge_out` — 20 tests pass including 5 new (`ma4_classify_bridge_consumer_script_pins_known_set`, `ma18_erased_b2agg_quarantined_on_storage_parse_failure`, `ma18_quarantine_is_idempotent_per_note_id`, `ma18_user_reclaim_does_not_quarantine`, `ma18_reason_str_mapping_stable`).
- [x] `cargo test --lib unknown_wrapper_detector` — 3 tests pass (pure predicate, three branches + foreign-wrapper regression).
- [x] `cargo test --lib` — full 190-test suite passes.
- [x] `cargo clippy --features postgres --all-targets -- -D warnings` — clean.
- [x] `cargo check --features postgres` — clean.
- [ ] Full e2e regression (running separately).

## Cantina links

- https://cantina.xyz/code/c338caaf-fb92-403b-b3e8-2294541f29f4/findings/4
- https://cantina.xyz/code/c338caaf-fb92-403b-b3e8-2294541f29f4/findings/18

Generated with Claude Code.
