### PR TITLE
fix(security): harden --miden-store-dir containment (Cantina MA#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ make build
 |------|---------|---------|-------------|
 | `--port` | | `8546` | JSON-RPC HTTP port |
 | `--miden-node` | | `http://localhost:57291` | Miden node gRPC URL (or `devnet`/`testnet`) |
-| `--miden-store-dir` | | `$HOME/.miden` | Directory for miden-client data |
+| `--miden-store-dir` | `MIDEN_STORE_BASE` (containment) | `$HOME/.miden` | Directory for miden-client data. Absolute paths are accepted (deployments rely on it); `..` traversal and symlink-escape are rejected. Set `MIDEN_STORE_BASE` to require the store dir to live inside a fixed root — see note below. |
 | `--chain-id` | `CHAIN_ID` | `2` | EVM chain ID for `eth_chainId` |
 | `--network-id` | `NETWORK_ID` | `1` | Rollup network ID from RollupManager |
 | `--l1-rpc-url` | `L1_RPC_URL` | | L1 RPC URL (enables GER verification + claim forwarding) |
@@ -138,6 +138,16 @@ make build
 | `--init` | | | Initialize accounts config, then exit |
 | `--reset-miden-store` | | | Wipe miden-client sqlite before startup (preserves keystore + config) — see [Recovery](#recovery) |
 | `--unlock-miden-accounts` | | | Clear stale `locked` flags in miden-client sqlite, then exit — see [Recovery](#recovery) |
+
+> **Store-directory containment (`MIDEN_STORE_BASE`).** `--miden-store-dir`
+> always rejects `..` traversal and, for an existing directory, resolves
+> symlinks and re-checks. Absolute paths are allowed by design — every
+> deployment passes one (`/var/lib/miden-agglayer-service`, the `$HOME/.miden`
+> default). For defence-in-depth when the store dir may come from a
+> less-trusted source, set `MIDEN_STORE_BASE=/var/lib/miden-agglayer-service`
+> (or your chosen root): the resolved store directory must then live inside it,
+> and anything escaping the base — absolutely or via symlink — is rejected at
+> startup. Unset = unchanged behaviour. (Cantina MA#20.)
 
 ### ClaimSettler env vars
 

--- a/src/accounts_config.rs
+++ b/src/accounts_config.rs
@@ -3,7 +3,7 @@ use miden_protocol::account::AccountId;
 use miden_protocol::address::NetworkId;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt::{Display, Formatter};
-use std::path::{Component, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::{env, fs};
 
 #[derive(Debug, Clone, Deserialize)]
@@ -102,8 +102,29 @@ impl AccountsConfigOnDisk {
     }
 }
 
-/// Reject paths containing parent-directory (`..`) traversal components.
-fn sanitize_store_dir(dir: &PathBuf) -> anyhow::Result<PathBuf> {
+/// Optional containment root for the store directory.
+///
+/// `--miden-store-dir` is an operator-supplied flag, so an absolute path is a
+/// legitimate and required input — every deployment (Dockerfile, compose, the
+/// e2e suite, the documented operator invocations) passes one, and the default
+/// is the absolute `$HOME/.miden`. Rejecting absolute paths outright would
+/// break all of them, so we do NOT.
+///
+/// Instead, defence-in-depth is opt-in: when `MIDEN_STORE_BASE` is set, the
+/// resolved store directory MUST live inside it, so a store dir injected from
+/// a less-trusted source (e.g. a templated env var) can't escape the area the
+/// operator intended. Unset = unchanged behaviour.
+fn store_base_from_env() -> Option<PathBuf> {
+    env::var_os("MIDEN_STORE_BASE")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+}
+
+/// Validate the store directory: reject `..` traversal (lexical and
+/// post-symlink-resolution) and, when a containment `base` is configured,
+/// reject any directory that escapes it. Absolute paths are allowed by design
+/// (see [`store_base_from_env`]).
+fn sanitize_store_dir(dir: &PathBuf, base: Option<&Path>) -> anyhow::Result<PathBuf> {
     for component in dir.components() {
         if matches!(component, Component::ParentDir) {
             anyhow::bail!(
@@ -116,17 +137,37 @@ fn sanitize_store_dir(dir: &PathBuf) -> anyhow::Result<PathBuf> {
     // Canonicalize when the directory already exists on disk so that any
     // symlink-based traversal is also resolved. When it does not yet exist
     // (first run / --init), the lexical check above is sufficient.
-    if dir.exists() {
-        let canonical = dir.canonicalize()?;
+    let resolved = if dir.exists() {
+        let canonical = dir
+            .canonicalize()
+            .with_context(|| format!("failed to canonicalize store directory {dir:?}"))?;
         // After resolving symlinks, re-verify there are no `..` segments.
         for component in canonical.components() {
             if matches!(component, Component::ParentDir) {
                 anyhow::bail!("path traversal detected after canonicalization: {canonical:?}");
             }
         }
-        return Ok(canonical);
+        canonical
+    } else {
+        dir.clone()
+    };
+
+    // Opt-in containment: when MIDEN_STORE_BASE is configured the store dir
+    // must live inside it. The `resolved` form above means this also catches
+    // an existing dir that symlinks out of the base.
+    if let Some(base) = base {
+        let canonical_base = base.canonicalize().with_context(|| {
+            format!("MIDEN_STORE_BASE {base:?} does not exist or is not accessible")
+        })?;
+        if !resolved.starts_with(&canonical_base) {
+            anyhow::bail!(
+                "store directory {resolved:?} escapes the configured MIDEN_STORE_BASE \
+                 {canonical_base:?}"
+            );
+        }
     }
-    Ok(dir.clone())
+
+    Ok(resolved)
 }
 
 fn config_path(miden_store_dir_opt: Option<PathBuf>) -> anyhow::Result<PathBuf> {
@@ -135,7 +176,8 @@ fn config_path(miden_store_dir_opt: Option<PathBuf>) -> anyhow::Result<PathBuf> 
         let base_dir = env::home_dir().unwrap_or(current_dir);
         base_dir.join(".miden")
     });
-    let safe_dir = sanitize_store_dir(&miden_store_dir)?;
+    let base = store_base_from_env();
+    let safe_dir = sanitize_store_dir(&miden_store_dir, base.as_deref())?;
     Ok(safe_dir.join("bridge_accounts.toml"))
 }
 
@@ -254,6 +296,11 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Absolute paths are allowed BY DESIGN (Cantina MA#20): `--miden-store-dir`
+    /// is an operator-supplied flag and every deployment passes an absolute
+    /// path (`/var/lib/miden-agglayer-service`, the `$HOME/.miden` default,
+    /// etc). Containment is the opt-in `MIDEN_STORE_BASE` mechanism, exercised
+    /// by the `containment_*` tests below — not a blanket absolute-path ban.
     #[test]
     fn allows_clean_absolute_path() {
         let good = Some(PathBuf::from("/tmp/miden-test-store"));
@@ -261,6 +308,62 @@ mod tests {
         assert!(result.is_ok());
         let path = result.unwrap();
         assert!(path.ends_with("bridge_accounts.toml"));
+    }
+
+    #[test]
+    fn containment_allows_dir_inside_base() {
+        let base = tempdir().unwrap();
+        let inside = base.path().join("store");
+        // Not-yet-created dir under the base is accepted (first-run / --init).
+        let ok = sanitize_store_dir(&inside, Some(base.path()));
+        assert!(ok.is_ok(), "dir under base must be allowed: {ok:?}");
+    }
+
+    #[test]
+    fn containment_rejects_dir_outside_base() {
+        let base = tempdir().unwrap();
+        let outside = PathBuf::from("/var/lib/somewhere-else");
+        let result = sanitize_store_dir(&outside, Some(base.path()));
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("escapes the configured"),
+            "expected containment-escape error"
+        );
+    }
+
+    #[test]
+    fn containment_rejects_symlink_escape() {
+        // A dir that exists but symlinks out of the base must be rejected once
+        // canonicalized, even though its lexical path sits under the base.
+        let base = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let link = base.path().join("escape");
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+        let result = sanitize_store_dir(&link, Some(base.path()));
+        assert!(
+            result.is_err(),
+            "symlink escaping the base must be rejected; got {result:?}"
+        );
+    }
+
+    #[test]
+    fn no_base_allows_absolute_outside_any_root() {
+        // With no containment configured, behaviour is unchanged: a clean
+        // absolute path is accepted (only `..` / symlink-`..` are rejected).
+        let result = sanitize_store_dir(&PathBuf::from("/var/lib/miden-agglayer-service"), None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn rejects_parent_dir_traversal_with_base() {
+        let base = tempdir().unwrap();
+        let bad = base.path().join("..").join("etc");
+        let result = sanitize_store_dir(&bad, Some(base.path()));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("path traversal"));
     }
 
     #[test]


### PR DESCRIPTION
## Cantina MA#20 — `sanitize_store_dir` blocks `..` but not absolute paths

`sanitize_store_dir` rejected `..` traversal but accepted any absolute path for `--miden-store-dir`. The literal "reject `Component::RootDir`" fix was dropped from #64 because it broke the default `$HOME/.miden` and the `allows_clean_absolute_path` test.

### Why not "relative-only"

`--miden-store-dir` is **operator-supplied** and **every deployment passes an absolute path**:

| Source | Value |
|---|---|
| `Dockerfile` | `/var/lib/miden-agglayer-service` |
| `docker-compose.e2e.yml` | `/var/lib/miden-agglayer-service` |
| `scripts/e2e-restore.sh`, `scripts/e2e-reset-restore-recovery.sh` | `/var/lib/miden-agglayer-service` |
| README operator examples | `/var/lib/miden` |
| default | `$HOME/.miden` |

A relative-only redesign would break production, the Docker image, and the entire E2E suite. Since the flag is operator-controlled (not attacker-reachable), "absolute path" is not a privilege boundary — so we keep absolute paths and add **opt-in** containment instead.

### Change

`sanitize_store_dir`:
- keeps the lexical `..` rejection;
- keeps canonicalize + post-symlink-resolution `..` re-check for existing dirs;
- **adds opt-in `MIDEN_STORE_BASE` containment** — when set, the resolved store dir must live *inside* the base. Because the comparison is against the canonicalized path, this also rejects an existing dir that **symlinks out** of the base;
- absolute paths remain allowed by design.

Set `MIDEN_STORE_BASE=/var/lib/miden-agglayer-service` (or your chosen root) for defence-in-depth when the store dir may originate from a less-trusted source (e.g. a templated env var). Unset = unchanged behaviour, so this is fully backward-compatible.

### Tests

`cargo test --lib accounts_config` → **15/15 green**, including 5 new:
- `containment_allows_dir_inside_base`
- `containment_rejects_dir_outside_base`
- `containment_rejects_symlink_escape`
- `no_base_allows_absolute_outside_any_root`
- `rejects_parent_dir_traversal_with_base`

`cargo check --all-targets`, `cargo clippy --lib --tests`, `cargo fmt --check` all clean.

### Follow-ups
- Cantina reply on MA#20 must correct comment `313a48ef` (currently over-promises that it will reject `RootDir`) and cite this PR's merge SHA.
- Audit-finding disposition logged to Linear/Aikido per ISO 27001 / Vanta change-management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
