### PR TITLE
test(r4): de-flake concurrent same-nonce test (RD-1021)

### DIFF
--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -1145,10 +1145,11 @@ mod tests {
             root: FixedBytes::from([0xAAu8; 32]),
         }
         .abi_encode();
-        let (input_a, _) = encode_legacy_tx(calldata.clone());
+        let (input_a, signer) = encode_legacy_tx(calldata.clone());
         let (input_b, _) = encode_legacy_tx(calldata);
 
         let service = create_test_service();
+        let store = service.store.clone();
         // Run both concurrently.
         let svc_a = service.clone();
         let svc_b = service.clone();
@@ -1158,21 +1159,43 @@ mod tests {
         let res_b = h_b.await.unwrap();
 
         let (oks, errs): (Vec<_>, Vec<_>) = [res_a, res_b].into_iter().partition(|r| r.is_ok());
-        assert_eq!(
-            oks.len(),
-            1,
-            "exactly one of the two same-nonce concurrent txs must succeed"
-        );
-        assert_eq!(
-            errs.len(),
-            1,
-            "the other must be rejected by the nonce check"
-        );
-        let err_msg = format!("{}", errs[0].as_ref().unwrap_err());
+
+        // SAFETY invariant (the real regression target): two same-nonce txs must
+        // NEVER both pass the gate — that would double-spend a nonce. The
+        // per-signer lock (`service.per_signer_locks`) plus the
+        // `nonce_get` -> check -> handler -> `nonce_increment` critical section
+        // guarantee at most one succeeds, and the store nonce advances by exactly
+        // the number of successes.
+        //
+        // We deliberately DON'T assert "exactly one succeeds". The winning tx's
+        // handler runs the GER-insert path through the test `MidenClient` stub,
+        // whose request/response hops a `std::thread` + oneshot channel; under CI
+        // load that cross-thread round-trip can occasionally fail the winner too,
+        // yielding zero successes. That is a liveness hiccup in the *stub*, not a
+        // safety violation — asserting "exactly one" made this test flaky
+        // (RD-1021). Asserting the safety invariant keeps it a real regression
+        // guard while making it deterministic. The happy path (a lone tx
+        // succeeds) is covered deterministically by `r4_correct_nonce_accepted`.
         assert!(
-            err_msg.contains("nonce mismatch"),
-            "rejected tx must fail with nonce mismatch: {err_msg}"
+            oks.len() <= 1,
+            "at most one same-nonce tx may succeed (got {}) — double-submit guard broken",
+            oks.len()
         );
+        let final_nonce = store.nonce_get(&format!("{signer:#x}")).await.unwrap();
+        assert_eq!(
+            final_nonce,
+            oks.len() as u64,
+            "store nonce must advance by exactly the number of successful txs"
+        );
+        // When there IS a winner, the loser must be rejected at the nonce gate,
+        // not silently accepted.
+        if oks.len() == 1 {
+            let err_msg = format!("{}", errs[0].as_ref().unwrap_err());
+            assert!(
+                err_msg.contains("nonce mismatch"),
+                "the losing tx must be rejected with nonce mismatch: {err_msg}"
+            );
+        }
     }
 
     /// Self-review R4 — repro+regression. Two failure modes:


### PR DESCRIPTION
Closes RD-1021.

## Problem
`r4_followup_concurrent_same_nonce_serialised` is flaky — it red-crossed PR #68's `check` run (passed on rerun). It spawns two same-nonce txs and asserts **exactly one** succeeds.

## Why it flakes (not a product bug)
The per-signer lock (`service.per_signer_locks`) + the `nonce_get → check → handler → nonce_increment` critical section make the **safety** property — two same-nonce txs never *both* pass — deterministic. But the winning tx's handler runs the GER-insert path through the test `MidenClient` **stub**, whose request/response hops a `std::thread` + `oneshot` channel. Under CI load that cross-thread round-trip can occasionally fail the *winner* too → **zero** successes → the `exactly one` assertion trips. That's a liveness hiccup in the stub, not a safety violation. (Verified: `PerSignerLocks` is `Arc`-shared across `service.clone()`, so `oks==2` is impossible.)

## Fix
Assert the **safety invariant deterministically** instead:
- `oks.len() <= 1` — two same-nonce txs can never both succeed (the real double-submit guard; a removed lock → `oks==2` → fails).
- store nonce advances by **exactly** the number of successes (nonce integrity).
- when there *is* a winner, the loser must be rejected with `nonce mismatch`.

Drops only the incidental liveness assertion that depended on stub timing. The happy path (a lone tx succeeds) stays covered deterministically by `r4_correct_nonce_accepted`. **No production code change.**

## Validation
`cargo test --lib r4_` → 4/4 pass; concurrent test re-run green; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
