### PR TITLE
chore(scripts): salvage v0.3.0 recovery/repro e2e scripts

### DIFF
--- a/scripts/e2e-account-reimport.sh
+++ b/scripts/e2e-account-reimport.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# ══════════════════════════════════════════════════════════════════════════════
+# e2e-account-reimport.sh — bali "missing GER manager account" repro/heal test
+#
+# Faithfully reproduces the bali production failure observed 2026-05-18:
+#   proxy returns `account data wasn't found for account id <ger_manager>`
+#   on every aggoracle insertGlobalExitRoot push, with this state:
+#     - bridge_accounts.toml intact
+#     - keystore/ intact
+#     - store.sqlite3 missing the ger_manager rows
+#
+# How: take a healthy stack, drop ger_manager rows from the proxy's local
+# sqlite (while leaving keystore + toml alone), restart the proxy, then push
+# one updateExitRoot via the recovery script. Assert the deposit STAYS stuck
+# and the proxy logs the exact bali error.
+#
+# The script supports two modes:
+#   MODE=expect_failure    (default) — repro on `main`, expects bug.
+#   MODE=expect_self_heal  — runs the same sequence and expects the fix
+#                             branch to recover automatically (no manual reset).
+#
+# Exit codes:
+#   0 — expected behaviour observed (bug repro'd in expect_failure mode, OR
+#       self-heal succeeded in expect_self_heal mode)
+#   1 — unexpected: bug did not repro / heal did not work
+#   2 — pre-flight failed
+#
+# Requires the stack to already be up (`make e2e-up`).
+# ══════════════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+MODE="${MODE:-expect_failure}"
+COMPOSE_FILE="$PROJECT_DIR/docker-compose.e2e.yml"
+ENV_FILE="$PROJECT_DIR/fixtures/.env"
+
+export MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-https://github.com/0xMiden/miden-node.git}"
+export MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-v0.14.10}"
+
+L1_RPC="${L1_RPC:-http://localhost:8545}"
+L2_RPC="${L2_RPC:-http://localhost:8546}"
+BRIDGE_SERVICE_URL="${BRIDGE_SERVICE_URL:-http://localhost:18080}"
+
+L1_BRIDGE_ADDRESS="${L1_BRIDGE_ADDRESS:-0xC8cbEBf950B9Df44d987c8619f092beA980fF038}"
+L1_GER_ADDRESS="${L1_GER_ADDRESS:-0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674}"
+L2_GER_ADDRESS="${L2_GER_ADDRESS:-0xa40D5f56745a118D0906a34E69aeC8C0Db1cB8fA}"
+SIGNER_KEY="${SIGNER_KEY:-0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625}"
+
+PROXY_CONTAINER="${PROXY_CONTAINER:-miden-agglayer-miden-agglayer-1}"
+SQLITE_PATH="${SQLITE_PATH:-/var/lib/miden-agglayer-service/store.sqlite3}"
+TOML_PATH="${TOML_PATH:-/var/lib/miden-agglayer-service/bridge_accounts.toml}"
+
+DEPOSIT_WEI="${DEPOSIT_WEI:-10000000000000}"
+RUN_SUFFIX="$(date +%s)"
+
+if [[ -t 1 ]]; then
+  R=$'\033[0;31m'; G=$'\033[0;32m'; Y=$'\033[0;33m'; C=$'\033[0;36m'; B=$'\033[1m'; N=$'\033[0m'
+else R=''; G=''; Y=''; C=''; B=''; N=''; fi
+
+# Safety: ALWAYS try to restart the proxy on exit, even on failure mid-Phase 2,
+# so a botched run doesn't leave the stack with the proxy down.
+PROXY_STOPPED=false
+cleanup() {
+  if [[ "$PROXY_STOPPED" == "true" ]]; then
+    echo "[cleanup] ensuring proxy is back up" >&2
+    docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" start miden-agglayer >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+ts()   { date +%H:%M:%S; }
+say()  { printf '%s[%s]%s %s\n' "$G" "$(ts)" "$N" "$*"; }
+step() { printf '\n%s[%s] %s%s%s\n' "$C" "$(ts)" "$B" "$*" "$N"; }
+warn() { printf '%s[%s] WARN:%s %s\n' "$Y" "$(ts)" "$N" "$*"; }
+fail() { printf '%s[%s] FAIL:%s %s\n' "$R" "$(ts)" "$N" "$*" >&2; exit 1; }
+pass() { printf '%s[%s] PASS:%s %s\n' "$G" "$(ts)" "$N" "$*"; }
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+command -v cast >/dev/null || { fail "cast (foundry) not in PATH"; }
+command -v jq >/dev/null   || { fail "jq not in PATH"; }
+docker inspect "$PROXY_CONTAINER" >/dev/null 2>&1 \
+  || fail "proxy container $PROXY_CONTAINER not found — is the stack up?"
+
+curl -sf "$L1_RPC" -X POST -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' >/dev/null \
+  || fail "L1 not reachable at $L1_RPC"
+curl -sf "$L2_RPC" -X POST -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' >/dev/null \
+  || fail "L2 proxy not reachable at $L2_RPC"
+
+# ── Phase 0 — resolve the ger_manager hex account id ──────────────────────────
+step "Phase 0 — resolving ger_manager account id"
+GER_MANAGER_HEX=$(
+  docker logs "$PROXY_CONTAINER" 2>&1 \
+    | grep -oE 'deploying ger_manager account 0x[0-9a-f]+' \
+    | head -1 | awk '{print $NF}' || true
+)
+if [[ -z "${GER_MANAGER_HEX:-}" ]]; then
+  fail "could not extract ger_manager hex id from proxy init logs — did init run on this stack?"
+fi
+say "    ger_manager hex id = $GER_MANAGER_HEX"
+
+GER_MANAGER_BECH32=$(docker exec "$PROXY_CONTAINER" awk -F'"' '/^ger_manager/{print $2}' "$TOML_PATH")
+say "    ger_manager bech32 = $GER_MANAGER_BECH32"
+
+# ── Phase 1 — baseline: confirm the stack is healthy before we break it ───────
+step "Phase 1 — baseline sanity (one L1→L2 deposit must reach ready_for_claim)"
+START_CNT=$(cast call "$L1_BRIDGE_ADDRESS" 'depositCount()(uint256)' --rpc-url "$L1_RPC")
+DEST_PRE="0x000000000000000000000000${RUN_SUFFIX: -8}deadbeef"
+DEST_PRE=$(echo "$DEST_PRE" | head -c 42)
+say "    baseline bridgeAsset cnt=$START_CNT dest=$DEST_PRE"
+cast send --rpc-url "$L1_RPC" \
+  --private-key "$SIGNER_KEY" "$L1_BRIDGE_ADDRESS" \
+  'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+  1 "$DEST_PRE" "$DEPOSIT_WEI" 0x0000000000000000000000000000000000000000 true 0x \
+  --value "$DEPOSIT_WEI" >/dev/null
+
+# Wait up to 30s for aggoracle to push a GER and bridge-service to flip
+DEADLINE=$((SECONDS + 45))
+while :; do
+  R_BASE=$(curl -s "$BRIDGE_SERVICE_URL/bridge?net_id=0&deposit_cnt=$START_CNT" \
+    | jq -r '.deposit.ready_for_claim // empty')
+  [[ "$R_BASE" == "true" ]] && break
+  (( SECONDS >= DEADLINE )) && fail "baseline deposit cnt=$START_CNT did not reach ready_for_claim in 45s — stack is already broken"
+  sleep 2
+done
+pass "baseline deposit cnt=$START_CNT reached ready_for_claim=true"
+
+# ── Phase 2 — surgical break: drop ger_manager rows from sqlite, keep keystore ──
+step "Phase 2 — reproducing bali's 'missing account' state"
+say "    stopping proxy"
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" stop miden-agglayer >/dev/null
+PROXY_STOPPED=true
+
+# Confirm ger_manager EXISTS before delete (proof we found the right row)
+EXISTS_BEFORE=$(
+  sudo sqlite3 "$PROJECT_DIR/.miden-agglayer-data/store.sqlite3" "SELECT count(*) FROM latest_account_headers WHERE id = '$GER_MANAGER_HEX';" \
+    2>/dev/null | tail -1
+)
+[[ "$EXISTS_BEFORE" == "1" ]] || fail "expected ger_manager row to exist pre-delete (got count=$EXISTS_BEFORE)"
+say "    confirmed ger_manager row exists in latest_account_headers (count=1)"
+
+# Delete every row that references this account id, across all relevant tables.
+# This mirrors the bali state: the keystore + toml stay, the sqlite state for this
+# one account is missing.
+say "    deleting ger_manager from sqlite (keystore + bridge_accounts.toml preserved)"
+sudo sqlite3 "$PROJECT_DIR/.miden-agglayer-data/store.sqlite3" <<EOSQL 2>&1 | sed 's/^/      sqlite: /' || true
+DELETE FROM latest_account_headers     WHERE id         = '$GER_MANAGER_HEX';
+DELETE FROM latest_account_assets      WHERE account_id = '$GER_MANAGER_HEX';
+DELETE FROM latest_account_storage     WHERE account_id = '$GER_MANAGER_HEX';
+DELETE FROM historical_account_headers WHERE account_id = '$GER_MANAGER_HEX';
+DELETE FROM historical_account_storage WHERE account_id = '$GER_MANAGER_HEX';
+DELETE FROM historical_account_assets  WHERE account_id = '$GER_MANAGER_HEX';
+EOSQL
+
+EXISTS_AFTER=$(
+  sudo sqlite3 "$PROJECT_DIR/.miden-agglayer-data/store.sqlite3" "SELECT count(*) FROM latest_account_headers WHERE id = '$GER_MANAGER_HEX';" \
+    2>/dev/null | tail -1
+)
+[[ "$EXISTS_AFTER" == "0" ]] || fail "delete failed (count_after=$EXISTS_AFTER)"
+say "    confirmed ger_manager row absent post-delete (count=0)"
+say "    keystore still has key file:"
+docker exec "$PROXY_CONTAINER" ls /var/lib/miden-agglayer-service/keystore/ 2>/dev/null | sed 's/^/      /' || true
+say "    bridge_accounts.toml still references ger_manager:"
+docker exec "$PROXY_CONTAINER" grep '^ger_manager' "$TOML_PATH" 2>/dev/null | sed 's/^/      /' || true
+
+say "    restarting proxy"
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" start miden-agglayer >/dev/null
+PROXY_STOPPED=false
+
+# Wait for healthy
+DEADLINE=$((SECONDS + 90))
+while :; do
+  HEALTH=$(docker inspect -f '{{.State.Health.Status}}' "$PROXY_CONTAINER" 2>/dev/null || echo "none")
+  [[ "$HEALTH" == "healthy" ]] && break
+  (( SECONDS >= DEADLINE )) && fail "proxy did not become healthy within 90s after restart"
+  sleep 2
+done
+pass "proxy restarted (healthy)"
+
+# ── Phase 3 — trigger a GER push and observe ─────────────────────────────────
+step "Phase 3 — pushing a GER via updateExitRoot (mirrors bali's aggoracle attempt)"
+LOGS_BEFORE_LINES=$(docker logs "$PROXY_CONTAINER" 2>&1 | wc -l)
+
+# Read CURRENT (M, R) from L1 and submit updateExitRoot.
+MAIN=$(cast call "$L1_GER_ADDRESS" "lastMainnetExitRoot()(bytes32)" --rpc-url "$L1_RPC")
+ROLL=$(cast call "$L1_GER_ADDRESS" "lastRollupExitRoot()(bytes32)"  --rpc-url "$L1_RPC")
+say "    M=$MAIN"
+say "    R=$ROLL"
+
+CAST_OUT=$(
+  cast send "$L2_GER_ADDRESS" "updateExitRoot(bytes32,bytes32)" "$ROLL" "$MAIN" \
+    --rpc-url "$L2_RPC" --private-key "$SIGNER_KEY" \
+    --legacy --gas-price 1000000000 --gas-limit 1000000 2>&1 || true
+)
+echo "$CAST_OUT" | sed 's/^/    /' | tail -10
+
+# Drop a stuck L1→L2 deposit so we can observe whether bridge-service flips it
+STUCK_CNT=$(cast call "$L1_BRIDGE_ADDRESS" 'depositCount()(uint256)' --rpc-url "$L1_RPC")
+say "    triggering a stuck deposit at cnt=$STUCK_CNT"
+cast send --rpc-url "$L1_RPC" --private-key "$SIGNER_KEY" "$L1_BRIDGE_ADDRESS" \
+  'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+  1 "$DEST_PRE" "$DEPOSIT_WEI" 0x0000000000000000000000000000000000000000 true 0x \
+  --value "$DEPOSIT_WEI" >/dev/null
+
+sleep 8  # let bridge-service ingest
+
+# ── Phase 4 — verdict ────────────────────────────────────────────────────────
+step "Phase 4 — verdict"
+ERR_LINE=$(docker logs "$PROXY_CONTAINER" 2>&1 \
+  | tail -n +$((LOGS_BEFORE_LINES + 1)) \
+  | grep -E "account data wasn't found for account id $GER_MANAGER_HEX" \
+  | head -1 || true)
+
+REIMPORT_LINE=$(docker logs "$PROXY_CONTAINER" 2>&1 \
+  | tail -n +$((LOGS_BEFORE_LINES + 1)) \
+  | grep -E "account missing from local store, importing from node|reimported account from node" \
+  | head -1 || true)
+
+STUCK_READY=$(curl -s "$BRIDGE_SERVICE_URL/bridge?net_id=0&deposit_cnt=$STUCK_CNT" \
+  | jq -r '.deposit.ready_for_claim // "indexed?"')
+
+say "    stuck deposit cnt=$STUCK_CNT ready_for_claim=$STUCK_READY"
+
+case "$MODE" in
+  expect_failure)
+    if [[ -n "$ERR_LINE" && "$STUCK_READY" != "true" ]]; then
+      pass "BUG REPRODUCED (expected on \`main\`):"
+      printf '      %s\n' "$ERR_LINE"
+      pass "deposit stayed stuck (ready=$STUCK_READY) — matches bali"
+      exit 0
+    fi
+    if [[ -z "$ERR_LINE" ]]; then
+      fail "expected 'account data wasn't found' in proxy logs but did not see it (got self-heal? maybe fix branch is checked out)"
+    else
+      fail "saw the error but deposit somehow flipped ready=$STUCK_READY"
+    fi
+    ;;
+  expect_self_heal)
+    if [[ "$STUCK_READY" == "true" ]]; then
+      pass "SELF-HEAL VERIFIED: stuck deposit flipped ready=true after restart"
+      if [[ -n "$REIMPORT_LINE" ]]; then
+        pass "and reimport log line present:"
+        printf '      %s\n' "$REIMPORT_LINE"
+      else
+        warn "no reimport log line found; verify the fix path emits a recognisable log"
+      fi
+      exit 0
+    fi
+    fail "expected self-heal — deposit cnt=$STUCK_CNT still ready=$STUCK_READY. error line: ${ERR_LINE:-<none>}"
+    ;;
+  *)
+    fail "unknown MODE=$MODE (use expect_failure or expect_self_heal)"
+    ;;
+esac

--- a/scripts/e2e-recover-l1-to-l2.sh
+++ b/scripts/e2e-recover-l1-to-l2.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# ══════════════════════════════════════════════════════════════════════════════
+# E2E reproducer + fix verifier for the bali L1→L2 backlog incident.
+#
+# Demonstrates, end-to-end against the local docker-compose stack:
+#
+#   PART A — THE BUG (race-poisoned GER, mimics what happened on bali)
+#     A1. Stop aggkit so backlog accumulates.
+#     A2. Make N stuck L1 deposits (ready_for_claim=false).
+#     A3. Submit `insertGlobalExitRoot(GARBAGE)` to the proxy. The proxy
+#         refetches L1, computes keccak(real_M ‖ real_R), sees it does NOT
+#         match GARBAGE, and stores the row as (mainnet=NULL, rollup=NULL,
+#         is_injected=TRUE). Postgres state is verified.
+#     A4. Re-submit the same GARBAGE → proxy logs "GER already seen, skipping
+#         duplicate" — DEDUP-POISONED, the entry is now permanently
+#         unresolvable via the insertGlobalExitRoot path.
+#     A5. Verify all N deposits are STILL stuck (synthetic log fired but
+#         bridge-service can't resolve (M, R) → can't advance index).
+#
+#   PART B — THE FIX (one-shot-ger-inject.sh with updateExitRoot)
+#     B1. Run `scripts/one-shot-ger-inject.sh` against current L1 state. The
+#         new path calls `updateExitRoot(R, M)` — proxy stores both roots
+#         from the call parameters with NO L1 refetch.
+#     B2. Verify postgres now has the freshly-injected GER row with non-NULL
+#         (mainnet, rollup) AND is_injected=TRUE.
+#     B3. Verify all N stuck deposits flipped to ready_for_claim=TRUE.
+#
+# WHY GARBAGE WORKS AS A RACE STAND-IN
+# ────────────────────────────────────
+# The RD-862 L1InfoTreeIndexer runs on the local stack — it would auto-heal
+# a real-race-poisoned row by UPSERTing (M, R) within ~1s of polling L1.
+# Bali is pre-RD-862, the indexer is NOT present, so the row stays poisoned.
+# A GARBAGE hash never corresponds to any L1 (M, R) pair the indexer would
+# ever observe → its row stays (NULL, NULL) here too, faithfully matching
+# the bali state.
+#
+# Requires: stack up (`make e2e-up`).
+# Exit codes: 0 = bug reproduced AND fix verified; non-zero = unexpected
+# state at any verification step.
+# ══════════════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+L1_RPC="${L1_RPC:-http://localhost:8545}"
+L2_RPC="${L2_RPC:-http://localhost:8546}"
+BRIDGE_SERVICE_URL="${BRIDGE_SERVICE_URL:-http://localhost:18080}"
+
+L1_BRIDGE_ADDRESS="${L1_BRIDGE_ADDRESS:-0xC8cbEBf950B9Df44d987c8619f092beA980fF038}"
+L1_GER_ADDRESS="${L1_GER_ADDRESS:-0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674}"
+L2_GER_ADDRESS="${L2_GER_ADDRESS:-0xa40D5f56745a118D0906a34E69aeC8C0Db1cB8fA}"
+
+# Aggoracle key — only signer the proxy's ALLOWED_SIGNERS permits.
+SIGNER_KEY="${SIGNER_KEY:-0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625}"
+
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-miden-agglayer}"
+COMPOSE_FILE="$PROJECT_DIR/docker-compose.e2e.yml"
+ENV_FILE="$PROJECT_DIR/fixtures/.env"
+
+# docker-compose.e2e.yml requires these at interpolation time even for
+# stop/start/ps — `make e2e-up` exports them, but ad-hoc compose calls
+# from this script need them set explicitly.
+export MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-https://github.com/0xMiden/miden-node.git}"
+export MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-v0.14.10}"
+
+# Distinguishable garbage hashes so re-runs don't collide with prior repros.
+RUN_SUFFIX="$(date +%s)"
+GARBAGE_HASH="0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef$(printf '%08x' "$((RUN_SUFFIX & 0xffffffff))")"
+
+N_DEPOSITS="${N_DEPOSITS:-3}"
+DEPOSIT_WEI="${DEPOSIT_WEI:-10000000000000}"
+
+# Bash colors only when stdout is a tty.
+if [[ -t 1 ]]; then
+  RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; CYAN=$'\033[0;36m'; BOLD=$'\033[1m'; NC=$'\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; CYAN=''; BOLD=''; NC=''
+fi
+
+ts()   { date +%H:%M:%S; }
+say()  { printf '%s[%s]%s %s\n' "$GREEN" "$(ts)" "$NC" "$*"; }
+step() { printf '\n%s[%s] %s%s%s\n' "$CYAN" "$(ts)" "$BOLD" "$*" "$NC"; }
+warn() { printf '%s[%s] WARN:%s %s\n' "$YELLOW" "$(ts)" "$NC" "$*"; }
+fail() { printf '%s[%s] FAIL:%s %s\n' "$RED" "$(ts)" "$NC" "$*" >&2; exit 1; }
+pass() { printf '%s[%s] PASS:%s %s\n' "$GREEN" "$(ts)" "$NC" "$*"; }
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+command -v cast >/dev/null   || fail "cast (foundry) not found"
+command -v jq >/dev/null     || fail "jq not found"
+command -v docker >/dev/null || fail "docker not found"
+
+curl -sf "$L1_RPC" -X POST -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' >/dev/null \
+  || fail "L1 (anvil) not reachable at $L1_RPC — is the stack up?"
+curl -sf "$L2_RPC" -X POST -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' >/dev/null \
+  || fail "L2 (proxy) not reachable at $L2_RPC — is the stack up?"
+curl -sf "$BRIDGE_SERVICE_URL/bridge?net_id=0&deposit_cnt=0" >/dev/null \
+  || fail "bridge-service not reachable at $BRIDGE_SERVICE_URL"
+
+PG_CONTAINER="${COMPOSE_PROJECT_NAME}-agglayer-postgres-1"
+docker inspect "$PG_CONTAINER" >/dev/null 2>&1 \
+  || fail "agglayer postgres container $PG_CONTAINER not found"
+
+pg() {
+  docker exec -i "$PG_CONTAINER" \
+    psql -U agglayer -d agglayer_store -At -F '|' -c "$1"
+}
+
+depo() {
+  curl -sf "$BRIDGE_SERVICE_URL/bridge?net_id=0&deposit_cnt=$1" \
+    | jq -r '.deposit | "\(.deposit_cnt)|\(.block_num)|\(.ready_for_claim)|\(.claim_tx_hash != "")"'
+}
+
+# ── Part A: induce the stuck state and poison a GER ───────────────────────────
+step "Part A — reproduce the bali bug locally"
+
+say "A1. Stopping aggkit so deposits stack up without GER updates from aggoracle"
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" stop aggkit >/dev/null
+
+say "A2. Reading current bridge depositCount to pick fresh slots for our $N_DEPOSITS deposits"
+START_CNT=$(cast call "$L1_BRIDGE_ADDRESS" 'depositCount()(uint256)' --rpc-url "$L1_RPC")
+say "    current depositCount = $START_CNT"
+
+DEPOSIT_CNTS=()
+# 40-hex-char destination: 24 zero-nibbles + 8 of RUN_SUFFIX + 8 of slot index.
+DEST_SUFFIX_HEX=$(printf '%08x' "$((RUN_SUFFIX & 0xffffffff))")
+for i in $(seq 0 $((N_DEPOSITS - 1))); do
+  CNT=$((START_CNT + i))
+  DEPOSIT_CNTS+=("$CNT")
+  DEST="0x000000000000000000000000${DEST_SUFFIX_HEX}$(printf '%08x' "$i")"
+  say "    bridgeAsset → deposit_cnt=$CNT  (dest=$DEST  amount=$DEPOSIT_WEI wei)"
+  cast send --rpc-url "$L1_RPC" \
+    --private-key "$SIGNER_KEY" \
+    "$L1_BRIDGE_ADDRESS" \
+    'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+    1 "$DEST" "$DEPOSIT_WEI" 0x0000000000000000000000000000000000000000 true 0x \
+    --value "$DEPOSIT_WEI" >/dev/null
+done
+
+say "A2. Waiting up to 30s for bridge-service to index all $N_DEPOSITS deposits"
+DEADLINE=$((SECONDS + 30))
+while :; do
+  ALL_INDEXED=true
+  for cnt in "${DEPOSIT_CNTS[@]}"; do
+    INFO=$(depo "$cnt" 2>/dev/null || echo '||')
+    [[ -z ${INFO%%|*} ]] && { ALL_INDEXED=false; break; }
+  done
+  $ALL_INDEXED && break
+  (( SECONDS >= DEADLINE )) && fail "deposits not indexed by bridge-service in 30s"
+  sleep 1
+done
+
+say "A2. Verifying all $N_DEPOSITS deposits are STUCK (ready_for_claim=false)"
+for cnt in "${DEPOSIT_CNTS[@]}"; do
+  IFS='|' read -r DCNT BLK READY CLAIMED <<<"$(depo "$cnt")"
+  [[ "$READY" == "false" ]] || fail "deposit_cnt=$cnt unexpectedly ready=$READY before any GER update"
+  printf '    cnt=%s blk=%s ready=%s claimed=%s\n' "$DCNT" "$BLK" "$READY" "$CLAIMED"
+done
+pass "all $N_DEPOSITS deposits in expected stuck state"
+
+step "A3. Poison a GER by submitting insertGlobalExitRoot(GARBAGE)"
+say "    GARBAGE = $GARBAGE_HASH"
+say "    (proxy will refetch (M, R) from L1, compute real combined, see mismatch,"
+say "     store row with NULL roots and is_injected=TRUE — this IS the bali bug)"
+
+cast send "$L2_GER_ADDRESS" 'insertGlobalExitRoot(bytes32)' "$GARBAGE_HASH" \
+  --rpc-url "$L2_RPC" \
+  --private-key "$SIGNER_KEY" \
+  --legacy \
+  --gas-price 1000000000 >/dev/null
+
+sleep 2
+
+say "A3. Verifying the poisoned row in agglayer_store.ger_entries"
+GARB_NO0X=${GARBAGE_HASH#0x}
+ROW=$(pg "SELECT encode(mainnet_exit_root, 'hex'), encode(rollup_exit_root, 'hex'), is_injected
+         FROM ger_entries WHERE ger_hash = decode('$GARB_NO0X', 'hex');")
+[[ -n "$ROW" ]] || fail "poisoned row not found in ger_entries — did the proxy reject the tx?"
+IFS='|' read -r MAIN_HEX ROLL_HEX IS_INJ <<<"$ROW"
+say "    mainnet_exit_root = ${MAIN_HEX:-<NULL>}"
+say "    rollup_exit_root  = ${ROLL_HEX:-<NULL>}"
+say "    is_injected       = $IS_INJ"
+
+if [[ -z "$MAIN_HEX" && -z "$ROLL_HEX" && "$IS_INJ" == "t" ]]; then
+  pass "BUG REPRODUCED: poisoned row has NULL roots AND is_injected=TRUE"
+else
+  fail "expected (NULL, NULL, t), got ($MAIN_HEX, $ROLL_HEX, $IS_INJ)"
+fi
+
+step "A4. Verifying dedup poison: re-submitting same GARBAGE is a no-op"
+PROXY_CONTAINER="${COMPOSE_PROJECT_NAME}-miden-agglayer-1"
+LOGS_BEFORE_LINES=$(docker logs "$PROXY_CONTAINER" 2>&1 | wc -l)
+
+cast send "$L2_GER_ADDRESS" 'insertGlobalExitRoot(bytes32)' "$GARBAGE_HASH" \
+  --rpc-url "$L2_RPC" \
+  --private-key "$SIGNER_KEY" \
+  --legacy \
+  --gas-price 1000000000 >/dev/null
+
+sleep 2
+
+# Look for the dedup-skip log AFTER our re-submit.
+DEDUP_LINE=$(docker logs "$PROXY_CONTAINER" 2>&1 \
+  | tail -n +$((LOGS_BEFORE_LINES + 1)) \
+  | grep -E "GER already seen|skipping duplicate" || true)
+if [[ -n "$DEDUP_LINE" ]]; then
+  pass "DEDUP POISON CONFIRMED: $DEDUP_LINE"
+else
+  warn "did not observe 'GER already seen' in proxy logs after re-submit"
+  warn "(may be filtered by log level; checking ger_entries.block_number stayed put instead)"
+fi
+
+step "A5. Verifying the $N_DEPOSITS deposits are STILL stuck after the poisoned GER"
+for cnt in "${DEPOSIT_CNTS[@]}"; do
+  IFS='|' read -r DCNT BLK READY CLAIMED <<<"$(depo "$cnt")"
+  [[ "$READY" == "false" ]] || fail "deposit_cnt=$cnt unexpectedly flipped to ready=$READY after garbage GER"
+  printf '    cnt=%s ready=%s (correctly still stuck)\n' "$DCNT" "$READY"
+done
+pass "BUG CONFIRMED: synthetic log fired but bridge-service can't resolve unmatched (M, R)"
+
+# ── Part B: apply the fix ─────────────────────────────────────────────────────
+step "Part B — apply the fix via one-shot-ger-inject.sh (updateExitRoot)"
+
+say "B1. Running scripts/one-shot-ger-inject.sh with current L1 (M, R)"
+ONESHOT_OUTPUT=$(
+  L1_RPC_URL="$L1_RPC" \
+  L1_GER_ADDRESS="$L1_GER_ADDRESS" \
+  L2_RPC_URL="$L2_RPC" \
+  SIGNER_KEY="$SIGNER_KEY" \
+  L2_GER_ADDRESS="$L2_GER_ADDRESS" \
+  "$SCRIPT_DIR/one-shot-ger-inject.sh" 2>&1
+)
+echo "$ONESHOT_OUTPUT" | sed 's/^/    /'
+echo "$ONESHOT_OUTPUT" | grep -q 'status .*1 ' \
+  || fail "one-shot tx did not report status=1"
+
+REAL_MAIN=$(echo "$ONESHOT_OUTPUT" | grep -oE 'mainnet[[:space:]]+0x[0-9a-fA-F]{64}' | head -1 | awk '{print $2}')
+REAL_ROLL=$(echo "$ONESHOT_OUTPUT" | grep -oE 'rollup[[:space:]]+0x[0-9a-fA-F]{64}'  | head -1 | awk '{print $2}')
+REAL_COMB=$(echo "$ONESHOT_OUTPUT" | grep -oE 'combined[[:space:]]+0x[0-9a-fA-F]{64}'| head -1 | awk '{print $2}')
+
+[[ -n "$REAL_MAIN" && -n "$REAL_ROLL" && -n "$REAL_COMB" ]] \
+  || fail "could not parse roots from one-shot output"
+
+say "    real mainnet  = $REAL_MAIN"
+say "    real rollup   = $REAL_ROLL"
+say "    real combined = $REAL_COMB"
+
+step "B2. Verifying ger_entries row for the freshly-injected GER"
+sleep 2
+COMB_NO0X=${REAL_COMB#0x}
+ROW=$(pg "SELECT encode(mainnet_exit_root, 'hex'), encode(rollup_exit_root, 'hex'), is_injected
+         FROM ger_entries WHERE ger_hash = decode('$COMB_NO0X', 'hex');")
+[[ -n "$ROW" ]] || fail "fresh GER row missing in ger_entries"
+IFS='|' read -r MAIN_HEX ROLL_HEX IS_INJ <<<"$ROW"
+say "    mainnet_exit_root = 0x${MAIN_HEX}"
+say "    rollup_exit_root  = 0x${ROLL_HEX}"
+say "    is_injected       = $IS_INJ"
+
+[[ "0x${MAIN_HEX}" == "${REAL_MAIN}" ]] \
+  || fail "stored mainnet root 0x${MAIN_HEX} != sent ${REAL_MAIN}"
+[[ "0x${ROLL_HEX}" == "${REAL_ROLL}" ]] \
+  || fail "stored rollup root 0x${ROLL_HEX} != sent ${REAL_ROLL}"
+[[ "$IS_INJ" == "t" ]] \
+  || fail "fresh GER not marked is_injected=TRUE"
+pass "FIX VERIFIED at proxy level: (M, R) stored from call params, no race"
+
+step "B3. Verifying all $N_DEPOSITS deposits flipped to ready_for_claim=TRUE"
+DEADLINE=$((SECONDS + 30))
+while :; do
+  ALL_READY=true
+  for cnt in "${DEPOSIT_CNTS[@]}"; do
+    IFS='|' read -r DCNT BLK READY CLAIMED <<<"$(depo "$cnt")"
+    if [[ "$READY" != "true" ]]; then ALL_READY=false; break; fi
+  done
+  $ALL_READY && break
+  (( SECONDS >= DEADLINE )) && {
+    for cnt in "${DEPOSIT_CNTS[@]}"; do
+      IFS='|' read -r DCNT BLK READY CLAIMED <<<"$(depo "$cnt")"
+      printf '    cnt=%s blk=%s ready=%s\n' "$DCNT" "$BLK" "$READY"
+    done
+    fail "deposits did not flip ready_for_claim=true within 30s"
+  }
+  sleep 1
+done
+
+for cnt in "${DEPOSIT_CNTS[@]}"; do
+  IFS='|' read -r DCNT BLK READY CLAIMED <<<"$(depo "$cnt")"
+  printf '    cnt=%s blk=%s ready=%s claimed=%s\n' "$DCNT" "$BLK" "$READY" "$CLAIMED"
+done
+pass "FIX VERIFIED end-to-end: all $N_DEPOSITS deposits now ready_for_claim"
+
+step "Done. Backlog cleared via updateExitRoot — same shape as bali recovery."
+say "NOTE: aggkit is still stopped — restart it with:"
+say "    docker compose -f docker-compose.e2e.yml --env-file fixtures/.env start aggkit"

--- a/scripts/one-shot-ger-inject.sh
+++ b/scripts/one-shot-ger-inject.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# One-shot GER injection — clears a stuck L1→L2 backlog.
+#
+# Reads the CURRENT (mainnetExitRoot, rollupExitRoot) pair from the L1
+# PolygonZkEVMGlobalExitRoot contract and submits one
+#   updateExitRoot(bytes32 newRollupExitRoot, bytes32 newMainnetExitRoot)
+# to the miden-agglayer JSON-RPC. The proxy stores BOTH roots from the call
+# parameters directly (no L1 refetch, so no race), computes
+# combined = keccak(M ‖ R), inserts one UpdateGerNote on Miden, emits one
+# UpdateHashChainValue synthetic log. bridge-service's L2 sync picks it up
+# on its next ~2s chunk and flips ready_for_claim=true for every pending
+# L1→L2 deposit whose L1InfoTreeIndex is at or below the new GER's index.
+#
+# WHY updateExitRoot AND NOT insertGlobalExitRoot
+# ───────────────────────────────────────────────
+# `insertGlobalExitRoot(bytes32 combined)` only carries the hashed pair.
+# The proxy MUST then re-read `lastMainnetExitRoot()` / `lastRollupExitRoot()`
+# from L1 itself to recover (M, R), and check keccak(M||R) == combined.
+# Between our cast call and the proxy's refetch, Sepolia almost always
+# advances under deposit load → mismatch → roots stored as (None, None)
+# → bridge-service can't resolve the GER → the combined hash gets
+# dedup-flagged and the very re-run we're trying does nothing.
+# This was measured at 92.9% orphan rate (see RD-862, commit 9e5b095).
+#
+# `updateExitRoot(R, M)` ships both roots in the calldata. The proxy
+# stores exactly what we sent — no refetch, no race.
+#
+# PARAMETER ORDER IS UNINTUITIVE: rollup FIRST, mainnet SECOND. See
+# `src/ger.rs:61` and the upstream Solidity at
+# GlobalExitRootManagerL2SovereignChain.sol#L131.
+#
+# Requires:
+#   - cast (foundry) on PATH
+#   - L1 RPC must expose lastMainnetExitRoot() / lastRollupExitRoot() view
+#   - signer key must be in proxy's ALLOWED_SIGNERS if that allow-list is set
+#     (typically aggoracle's key, the only one survives `--allowed-signers`)
+#
+# Env:
+#   L1_RPC_URL       Sepolia / anvil L1 RPC (required)
+#   L1_GER_ADDRESS   L1 PolygonZkEVMGlobalExitRoot contract (required)
+#   L2_RPC_URL       miden-agglayer JSON-RPC URL (required)
+#   SIGNER_KEY       hex private key (required)
+#   L2_GER_ADDRESS   target of the cast send (default: synthetic emitter
+#                    0xa40D...8fA — the proxy routes by selector, not addr)
+#   L2_CHAIN_ID      proxy chain id (default: queried via eth_chainId)
+#   GAS_PRICE_WEI    legacy tx gas price (default 1 gwei, matches proxy)
+set -euo pipefail
+
+: "${L1_RPC_URL:?L1 RPC URL (e.g. https://ethereum-sepolia-rpc.publicnode.com or http://localhost:8545)}"
+: "${L1_GER_ADDRESS:?L1 PolygonZkEVMGlobalExitRoot address}"
+: "${L2_RPC_URL:?miden-agglayer JSON-RPC URL}"
+: "${SIGNER_KEY:?hex private key for an ALLOWED_SIGNERS-permitted signer}"
+
+L2_GER_ADDRESS="${L2_GER_ADDRESS:-0xa40D5f56745a118D0906a34E69aeC8C0Db1cB8fA}"
+
+command -v cast >/dev/null || { echo "error: cast (foundry) not found" >&2; exit 1; }
+
+echo "→ Reading current (mainnet, rollup) pair from L1 GER at $L1_GER_ADDRESS..."
+MAIN=$(cast call "$L1_GER_ADDRESS" "lastMainnetExitRoot()(bytes32)" --rpc-url "$L1_RPC_URL")
+ROLL=$(cast call "$L1_GER_ADDRESS" "lastRollupExitRoot()(bytes32)"  --rpc-url "$L1_RPC_URL")
+COMB=$(cast keccak "$(cast concat-hex "$MAIN" "$ROLL")")
+printf "   mainnet     %s\n   rollup      %s\n   combined    %s  (informational; not sent)\n" \
+  "$MAIN" "$ROLL" "$COMB"
+
+SIGNER=$(cast wallet address --private-key "$SIGNER_KEY")
+NONCE_HEX=$(cast rpc eth_getTransactionCount "$SIGNER" "latest" --rpc-url "$L2_RPC_URL" | tr -d '"')
+CHAIN_HEX=$(cast rpc eth_chainId --rpc-url "$L2_RPC_URL" | tr -d '"')
+CHAIN_DEC=$((CHAIN_HEX))
+NONCE_DEC=$((NONCE_HEX))
+: "${L2_CHAIN_ID:=$CHAIN_DEC}"
+printf "→ Proxy state:\n   signer   %s\n   nonce    %s (= %s)\n   chainId  %s (= %s)\n" \
+  "$SIGNER" "$NONCE_HEX" "$NONCE_DEC" "$CHAIN_HEX" "$CHAIN_DEC"
+
+if [[ "$L2_CHAIN_ID" != "$CHAIN_DEC" ]]; then
+  echo "warning: L2_CHAIN_ID=$L2_CHAIN_ID overrides proxy-reported $CHAIN_DEC" >&2
+fi
+
+# Param order: rollup FIRST, mainnet SECOND.
+# Solidity signature: updateExitRoot(bytes32 newRollupExitRoot, bytes32 newMainnetExitRoot)
+echo "→ Submitting updateExitRoot(rollup=$ROLL, mainnet=$MAIN) to $L2_GER_ADDRESS via $L2_RPC_URL..."
+# Legacy (type-0) tx: the proxy implements eth_gasPrice but NOT eth_feeHistory,
+# so EIP-1559 fee discovery in `cast send` fails. --legacy + an explicit
+# gas price matches what the proxy's eth_gasPrice returns (1 gwei, see
+# src/service.rs:382). Adjust GAS_PRICE_WEI in env if your deployment differs.
+GAS_PRICE_WEI="${GAS_PRICE_WEI:-1000000000}"
+cast send "$L2_GER_ADDRESS" "updateExitRoot(bytes32,bytes32)" "$ROLL" "$MAIN" \
+  --rpc-url "$L2_RPC_URL" \
+  --chain "$L2_CHAIN_ID" \
+  --private-key "$SIGNER_KEY" \
+  --legacy \
+  --gas-price "$GAS_PRICE_WEI"
+
+echo "→ Done. bridge-service should flip ready_for_claim for all pending deposits within ~2-3s (its L2 SyncInterval)."
+echo "   If 'GER already seen, skipping duplicate' appears in proxy logs, this exact (M, R) pair was"
+echo "   previously injected (likely from a poisoned insertGlobalExitRoot run). Wait ~30s for Sepolia"
+echo "   to advance its exit roots, then re-run — the new pair will produce a fresh combined hash."


### PR DESCRIPTION
## What

Salvages three operator recovery / repro e2e scripts from the abandoned `feat/v0.3.0-self-heal` branch (PR #44, closed-not-merged) onto `main`.

## Why

During branch cleanup we confirmed the v0.3.0 **code** (self-heal retry, `account_recovery.rs`, `logging.rs`, in-process migrator, `publish_claim` unification, indexer cursor) all landed on `main` via the v0.4 → v0.5.1 line — `src/account_recovery.rs` and `src/logging.rs` are byte-identical to the branch, and every other source file on `main` is a strict superset.

The only things that never made it across were these scripts and some historical `docs/` evidence. The scripts are reusable operator tooling for the Bali **IAIC** (`IncorrectAccountInitialCommitment`) → **ADNF** (`AccountDataNotFound`) incident class, so they are worth keeping before the v0.3.0 branches are deleted.

## Scripts

| Script | Purpose |
|---|---|
| `e2e-account-reimport.sh` | Repro/heal for the "missing GER-manager account" failure (sqlite missing rows, toml + keystore intact). Modes: `expect_failure` / `expect_self_heal`. |
| `e2e-recover-l1-to-l2.sh` | End-to-end repro + fix verifier for the race-poisoned GER backlog (PART A reproduces the dedup-poisoned stuck backlog; PART B verifies the `updateExitRoot` cure). |
| `one-shot-ger-inject.sh` | Operator one-shot: clears a stuck L1→L2 backlog by submitting `updateExitRoot(rollupRoot, mainnetRoot)` (no L1 refetch, no race). |

## Notes

- Scripts only — no source changes. Nothing on `main` is modified.
- The historical `docs/` postmortem + evidence artifacts from the v0.3.0 effort are intentionally **not** included (one-time incident records, not reusable tooling). They can be added later if wanted.
