### PR TITLE
fix(e2e): harness robustness — bridge-service pre-flight retry + rd940 writer seed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,6 +339,15 @@ e2e-rd940-claim-guard-cancellation: e2e-rd940-up ## 32 concurrent disconnects, n
 
 .PHONY: e2e-rd940
 e2e-rd940: e2e-rd940-up ## Run all 6 RD-940 e2e scripts in sequence
+	@# Seed the writer: the rd940 scripts (e.g. async-submit) probe writer
+	@# metrics that the metrics-exporter only renders AFTER the first
+	@# dispatch. On a cold stack nothing has gone through the writer yet
+	@# (init.rs never enqueues — only the runtime eth_sendRawTransaction
+	@# path does), so an L1->L2 flow is run first to route a claim through
+	@# the worker. This is the "L1->L2 path seeded" pre-req the scripts
+	@# document.
+	@echo ""; echo "── RD-940 seed: L1→L2 (routes a claim through the writer) ──"
+	$(COMPOSE_ENV) ./scripts/e2e-l1-to-l2.sh
 	@set -e; \
 	for s in async-submit pending-receipt queue-backpressure restart-inflight \
 	         worker-panic claim-guard-cancellation; do \

--- a/scripts/e2e-rd862-repro.sh
+++ b/scripts/e2e-rd862-repro.sh
@@ -74,9 +74,17 @@ cast block-number --rpc-url "$L1_RPC" >/dev/null 2>&1 \
 curl -sf "$L2_RPC" -X POST -H "Content-Type: application/json" \
     -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' >/dev/null 2>&1 \
     || { fail "L2 proxy not reachable at $L2_RPC"; exit 2; }
-curl -sf "$BRIDGE_SERVICE_URL/" >/dev/null 2>&1 \
-    || curl -sf "$BRIDGE_SERVICE_URL/bridges/0x0000000000000000000000000000000000000000000000000000000000000000" >/dev/null 2>&1 \
-    || { fail "bridge-service not reachable at $BRIDGE_SERVICE_URL"; exit 2; }
+# Bridge-service reports compose-Healthy before its host-port endpoint is
+# reliably serving, so a single probe races and flakes. Retry up to 60s.
+bs_ok=false
+for _ in $(seq 1 30); do
+    if curl -sf "$BRIDGE_SERVICE_URL/" >/dev/null 2>&1 \
+        || curl -sf "$BRIDGE_SERVICE_URL/bridges/0x0000000000000000000000000000000000000000000000000000000000000000" >/dev/null 2>&1; then
+        bs_ok=true; break
+    fi
+    sleep 2
+done
+[[ "$bs_ok" == true ]] || { fail "bridge-service not reachable at $BRIDGE_SERVICE_URL (after 60s)"; exit 2; }
 docker inspect "$AGGLAYER_CONTAINER" >/dev/null 2>&1 \
     || { fail "agglayer container '$AGGLAYER_CONTAINER' not running"; exit 2; }
 


### PR DESCRIPTION
## What

e2e-harness robustness fixes found during the 2026-06-01 full regression run. **Scripts/Makefile only — no product code, no test-assertion changes.**

> **Rebased onto current `main`.** The original PR also retried the bridge-service pre-flight in `e2e-l1-to-l2.sh`; that retry has since landed on `main` independently, so this PR now carries only the two pieces still missing there.

### 1. Retry the bridge-service pre-flight (`e2e-rd862-repro.sh`)
The bridge-service container reports compose-`Healthy` before its **host-port endpoint** is reliably serving. The single-shot `curl -sf "$BRIDGE_SERVICE_URL/..."` probe races that window and false-fails. `e2e-l1-to-l2.sh` already got this retry on `main`; `e2e-rd862-repro.sh` still had the single-shot probe — wrapped in the same bounded **30×2s retry**.

### 2. Seed L1→L2 before the rd940 suite (`Makefile` `e2e-rd940`)
The RD-940 scripts (e.g. `e2e-rd940-async-submit.sh`) probe writer metrics (`agglayer_writer_queue_depth`, `job_duration`, …) that `metrics-exporter-prometheus` only renders **after the first observation**. On a cold `e2e-rd940-up` stack nothing has gone through the writer yet — the worker is fed **only** by the runtime `eth_sendRawTransaction` path; `src/init.rs` never enqueues. So `async-submit` false-failed with *"Prometheus series agglayer_writer_queue_depth not exposed"*. The scripts already document this pre-req ("L1→L2 path seeded") but the `e2e-rd940` umbrella never honoured it. Now runs `e2e-l1-to-l2.sh` first to route a claim through the worker.

## Verification

- **`make e2e-rd940` → all 6 scripts PASS (exit 0)** with the seed (was failing on script #1).
- `make e2e-rd862` green with the retry (was false-failing).
- CI green on the rebased branch.

## Scope notes

- Does **not** include the `e2e-clean-data` root-owned-keystore fix (hardening item #3); that's a follow-up.
- The real product regression found in the same run (`e2e-restore` / MA#28) was **PR #73**, since closed as fixed on `main` by the synthetic-indexer redesign (PR #94).
