### PR TITLE
fix(restore): reconstruct GERs from metadata-less consumed UpdateGerNotes (MA#28 regression) [needs security sign-off]

### DIFF
--- a/src/restore.rs
+++ b/src/restore.rs
@@ -88,6 +88,23 @@ pub fn classify_ger_note(
     }
 }
 
+/// MA#28 restore policy: which `GerNoteVerdict`s mean "reconstruct this GER".
+///
+/// `Accept` (full metadata provenance verified) and `MissingMetadata`
+/// (consumed notes carry no metadata — see the call site) both reconstruct.
+/// `MissingMetadata` is safe at restore time because the note is recorded as
+/// *consumed*, i.e. the bridge network account already consumed it on-chain
+/// (only the targeted network account can consume a `NetworkAccountTarget`
+/// note) and the GER was already injected pre-crash. `SenderMismatch`,
+/// `TargetMismatch`, and `UndecodableTarget` only arise when metadata IS
+/// present and contradicts the expected provenance — those are refused.
+pub fn should_reconstruct_restored_ger(verdict: &GerNoteVerdict) -> bool {
+    matches!(
+        verdict,
+        GerNoteVerdict::Accept | GerNoteVerdict::MissingMetadata
+    )
+}
+
 /// Small wrapper so `classify_ger_note` doesn't have to import
 /// `miden_standards` into the public signature. Mirrors the decoder used
 /// by `bridge_out.rs::on_post_sync` for MINT notes.
@@ -591,15 +608,36 @@ async fn restore_gers(
                     // have restore silently replay it as a sanctioned GER
                     // injection. Pure-predicate classification is unit-tested
                     // via `classify_ger_note` — keep this match in sync.
-                    match classify_ger_note(note.metadata(), expected_sender, expected_target) {
+                    let verdict =
+                        classify_ger_note(note.metadata(), expected_sender, expected_target);
+                    match &verdict {
                         GerNoteVerdict::Accept => {}
                         GerNoteVerdict::MissingMetadata => {
+                            // MA#28 revisited (regression fix): consumed
+                            // UpdateGerNote records returned by
+                            // `get_input_notes(Consumed)` carry NO metadata —
+                            // the miden-client does not retain sender /
+                            // NetworkAccountTarget attachment on consumed
+                            // input-note records — so the sender/target
+                            // provenance signal is simply unavailable at
+                            // restore time. Absent metadata is therefore NOT a
+                            // spoof signal here: the note is recorded as
+                            // *consumed*, meaning the bridge network account
+                            // already consumed it on-chain (only the targeted
+                            // network account can consume a NetworkAccountTarget
+                            // note), and any GER it represents was already
+                            // injected into the pre-crash state. Restore
+                            // reconstructs prior reality; the anti-spoof control
+                            // lives at ingestion (`submit_update_ger_note`),
+                            // where metadata IS present. So we reconstruct and
+                            // record a metric for observability.
                             ::metrics::counter!("restore_ger_missing_metadata_total").increment(1);
                             tracing::warn!(
                                 note_id = %note.id(),
-                                "MA#28: UpdateGerNote-shaped consumed note has no metadata; skipping"
+                                "MA#28: consumed UpdateGerNote has no metadata (expected for \
+                                 consumed notes); reconstructing — on-chain consumption by the \
+                                 bridge is authoritative"
                             );
-                            continue;
                         }
                         GerNoteVerdict::SenderMismatch => {
                             ::metrics::counter!("restore_ger_sender_mismatch_total").increment(1);
@@ -610,7 +648,6 @@ async fn restore_gers(
                                 "MA#28: UpdateGerNote-shaped note has unexpected sender; \
                                  refusing to replay as restored GER"
                             );
-                            continue;
                         }
                         GerNoteVerdict::UndecodableTarget => {
                             ::metrics::counter!("restore_ger_no_target_total").increment(1);
@@ -619,7 +656,6 @@ async fn restore_gers(
                                 "MA#28: UpdateGerNote-shaped note has no decodable \
                                  NetworkAccountTarget attachment; refusing to replay"
                             );
-                            continue;
                         }
                         GerNoteVerdict::TargetMismatch => {
                             ::metrics::counter!("restore_ger_target_mismatch_total").increment(1);
@@ -629,8 +665,14 @@ async fn restore_gers(
                                 "MA#28: UpdateGerNote-shaped note targets a different \
                                  recipient than the configured bridge; refusing to replay"
                             );
-                            continue;
                         }
+                    }
+                    // Skip only the verdicts that indicate a note we must NOT
+                    // replay (provenance contradicted by metadata that IS
+                    // present). Accept + MissingMetadata both reconstruct — see
+                    // `should_reconstruct_restored_ger`.
+                    if !should_reconstruct_restored_ger(&verdict) {
+                        continue;
                     }
 
                     let storage = details.storage();
@@ -788,6 +830,28 @@ mod tests {
             classify_ger_note(None, sender, bridge),
             GerNoteVerdict::MissingMetadata,
         );
+    }
+
+    #[test]
+    fn ma28_restore_reconstructs_accept_and_missing_metadata_only() {
+        // Regression: consumed UpdateGerNotes have no metadata, so restore
+        // must reconstruct on MissingMetadata (on-chain consumption by the
+        // bridge is authoritative). It must still refuse the mismatch
+        // verdicts, which only occur when metadata IS present and contradicts
+        // the expected provenance.
+        assert!(should_reconstruct_restored_ger(&GerNoteVerdict::Accept));
+        assert!(should_reconstruct_restored_ger(
+            &GerNoteVerdict::MissingMetadata
+        ));
+        assert!(!should_reconstruct_restored_ger(
+            &GerNoteVerdict::SenderMismatch
+        ));
+        assert!(!should_reconstruct_restored_ger(
+            &GerNoteVerdict::TargetMismatch
+        ));
+        assert!(!should_reconstruct_restored_ger(
+            &GerNoteVerdict::UndecodableTarget
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## ⚠️ Touches Cantina **MA#28** — requesting the MA#28 author's / a security sign-off before merge.

## Problem (regression, gates a release tag)

`make e2e-restore` on `main` reconstructs **0 GERs** (`FAIL: No GERs restored`). MA#28 (PR #66 `0d64c9a`) added a metadata-based provenance gate to `restore_gers()`:

```rust
match classify_ger_note(note.metadata(), expected_sender, expected_target) {
    GerNoteVerdict::MissingMetadata => { /* skip */ }   // fires for EVERY consumed GER note
    ...
}
```

But consumed `UpdateGerNote` records returned by `get_input_notes(NoteFilter::Consumed)` have **`note.metadata() == None`** — the miden-client doesn't retain sender / `NetworkAccountTarget` attachment on consumed input-note records. So every legitimate GER note is skipped → disaster recovery rebuilds no GER state.

**Proof it's the gate, not missing data:** at `b883762` (pre-MA#28) restore rebuilt these same GERs from the same `get_input_notes(Consumed)` set with **zero `metadata()` references** (the GER value lives in the note's *data*). The 2026-05-29 regression report predates #66, which is why it wasn't caught then.

## Why `MissingMetadata` is safe to reconstruct at restore time

- The note is recorded as **consumed** — the bridge network account already consumed it on-chain. Only the targeted network account can consume a `NetworkAccountTarget` note, so **target provenance is implicit in the consumption record**.
- The GER it represents was **already injected into the pre-crash state**. Restore reconstructs prior reality; it does not authorize new state.
- The anti-spoof control belongs at **ingestion** (`submit_update_ger_note`), where metadata *is* present — not at restore.

## Change

- `classify_ger_note` still logs + metrics per verdict, but the skip/reconstruct decision moves to a small testable predicate `should_reconstruct_restored_ger()`:
  - `Accept` + `MissingMetadata` → **reconstruct**
  - `SenderMismatch` / `TargetMismatch` / `UndecodableTarget` → **refuse** (these only arise when metadata IS present and contradicts the expected provenance — defense-in-depth preserved).
- New unit test `ma28_restore_reconstructs_accept_and_missing_metadata_only`.

## Verification

- `cargo test --lib restore::` → 9/9 pass (incl. new test).
- **`make e2e-restore` → exit 0** with the fix (vs FAIL on `main`):
  ```
  WARN MA#28: consumed UpdateGerNote has no metadata (expected for consumed notes); reconstructing …
  Phase 3 complete: 1 GERs, 1 logs
  Restored: gers=1   # matches pre-wipe
  ```
  Full DR cycle passed end-to-end: restore → serve RPCs → L2→L1 bridge-out on restored state → certificate settled → L1 claim (+4.99e12 wei).

## Notes

- Found during the 2026-06-01 full regression run (`MIDEN-AGGLAYER-REGRESSION-REPORT-2026-06-01.md`); detailed finding in `RESTORE-MA28-REGRESSION-FINDING.md`.
- Depends on PR #72 (bridge-service pre-flight retry) only for running the suite cleanly; no code dependency.
- Suggested follow-up for the author: a finer-grained restore-level test that drives the real consumed-note path (the MA#28 unit tests only exercise the classifier with synthetic `Some`/`None`).
