### PR TITLE
feat(bridge-monitor): deep-link deposits/withdrawals and the agglayer modal

### DIFF
--- a/tools/bali-bridge-monitor/index.html
+++ b/tools/bali-bridge-monitor/index.html
@@ -1124,6 +1124,51 @@
       .pill.claimable .dot { animation: none; }
     }
 
+    /* ---------- deep-link affordance + target pulse ---------- */
+    /* Each row carries a small "#" anchor in its meta cluster. Clicking it
+       writes a #row=<id> hash, copies the absolute URL, and pulses the row.
+       Opening that URL (anywhere) scrolls the matching row into view and
+       pulses it — see the deep-link wiring in the script. */
+    .row-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: none;
+      border: none;
+      padding: 2px;
+      margin-left: 4px;
+      border-radius: 3px;
+      color: var(--c-ink);
+      opacity: 0.4;
+      cursor: pointer;
+      transition: color 120ms var(--ease-micro), opacity 120ms var(--ease-micro), background 120ms var(--ease-micro);
+    }
+    .row-link svg { display: block; width: 13px; height: 13px; }
+    .row-link:hover  { opacity: 1; color: var(--c-alert); background: rgba(255, 68, 0, 0.08); }
+    .row-link.copied { opacity: 1; color: #009a52; }
+
+    /* Deep-link target: a few alert-orange pulses, then settle. The class is
+       removed by JS after the animation so the row returns to normal. */
+    .row.pulse-target { animation: rowPulse 1s ease-in-out 3; }
+    @keyframes rowPulse {
+      0%, 100% {
+        background: rgba(255, 68, 0, 0);
+        box-shadow: 0 0 0 0 rgba(255, 68, 0, 0);
+      }
+      18% {
+        background: rgba(255, 68, 0, 0.26);
+        box-shadow: 0 0 0 2px rgba(255, 68, 0, 0.45);
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      /* No flashing — hold a static highlight; JS still clears it after a beat. */
+      .row.pulse-target {
+        animation: none;
+        background: rgba(255, 68, 0, 0.12);
+        box-shadow: inset 0 0 0 1px rgba(255, 68, 0, 0.4);
+      }
+    }
+
     /* empty state */
     .empty {
       padding: 48px 0;
@@ -1804,6 +1849,10 @@
     };
 
     // ---------- render ----------
+    // Per-row "copy link" affordance icons (feather-style: clipboard + check).
+    const COPY_ICON  = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+    const CHECK_ICON = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>';
+
     const setLed = (mode) => {
       ui.led.className = "status-led " + (mode === "live" ? "live" : mode === "error" ? "error" : "");
       ui.ledText.textContent = mode === "live" ? "LIVE" : mode === "error" ? "DEGRADED" : "CONNECTING";
@@ -1898,6 +1947,9 @@
         <div class="row-meta">
           <span class="row-time">${timeText}</span>
           <span class="pill ${state}"><span class="dot"></span>${statusLabel(state)}</span>
+          <button type="button" class="row-link" data-link-id="${ev.id}"
+            title="Copy a shareable link to this ${kind === "inbound" ? "deposit" : "withdrawal"}"
+            aria-label="Copy link to this ${kind === "inbound" ? "deposit" : "withdrawal"}">${COPY_ICON}</button>
         </div>
         <div class="row-party">
           <span class="party-arrow">${arrow(kind)}</span>
@@ -2011,6 +2063,47 @@
         ? CSS.escape(s)
         : String(s).replace(/[^a-zA-Z0-9_\-]/g, (c) => "\\" + c);
 
+    // ---------- deep linking ----------
+    // A row is addressable by #row=<encoded ev.id>. Opening such a URL (or
+    // clicking a row's "#") scrolls the row into view and pulses it. We hold
+    // the requested id "pending" until its row actually exists AND is visible
+    // (the columns are display:none behind the cold-load banner), then fire.
+    const prefersReducedMotion =
+      !!(window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+    let pendingDeepLinkId = null;
+
+    const readDeepLinkHash = () => {
+      const m = (window.location.hash || "").match(/^#row=(.+)$/);
+      if (!m) return null;
+      try { return decodeURIComponent(m[1]); } catch { return m[1]; }
+    };
+
+    const deepLinkUrl = (id) =>
+      window.location.origin + window.location.pathname + "#row=" + encodeURIComponent(id);
+
+    // Scroll to + pulse the row for `id`. Returns true once handled; if the row
+    // isn't on screen yet (still loading, or not in the visible window) it
+    // stays pending and is retried after the next render / once loaded.
+    const focusDeepLink = (id, opts) => {
+      if (!id) return false;
+      const scroll = !opts || opts.scroll !== false;
+      const grid = document.querySelector(".layout-grid");
+      if (grid && grid.classList.contains("is-loading")) { pendingDeepLinkId = id; return false; }
+      const node = document.querySelector('.row[data-id="' + cssEscape(id) + '"]');
+      if (!node) { pendingDeepLinkId = id; return false; }
+      pendingDeepLinkId = null;
+      if (scroll) {
+        node.scrollIntoView({ behavior: prefersReducedMotion ? "auto" : "smooth", block: "center" });
+      }
+      // Restart the animation cleanly if the row is already mid-pulse.
+      node.classList.remove("pulse-target");
+      void node.offsetWidth;
+      node.classList.add("pulse-target");
+      clearTimeout(node._pulseTimer);
+      node._pulseTimer = setTimeout(() => node.classList.remove("pulse-target"), 3400);
+      return true;
+    };
+
     // Mini-scope renderer: 10 bins (one per day of the window), height
      // normalised to the max bin. Renders directly into the existing <svg>.
     const renderScope = (svgId, events, now) => {
@@ -2073,6 +2166,8 @@
       ui.lastUpdate.textContent = formatClock(new Date(now));
       // After the first paint, subsequent inserts are "fresh" arrivals.
       firstRenderDone = true;
+      // Honour a deep-link target now that the rows for it may exist.
+      if (pendingDeepLinkId) focusDeepLink(pendingDeepLinkId);
     };
 
     // ---------- merge + dedupe ----------
@@ -2231,6 +2326,8 @@
         }
       };
       await tick();
+      // Cold-load banner is down now — honour any #row=… from the opening URL.
+      if (pendingDeepLinkId) focusDeepLink(pendingDeepLinkId);
       setInterval(tick, CONFIG.pollIntervalMs);
 
       // re-render relative times every 20s without polling
@@ -2256,10 +2353,18 @@
     const modalRaw     = document.getElementById("modalRaw");
     const modeButtons  = modal?.querySelectorAll(".readout-mode button") || [];
 
+    // Tracks which exit the modal is currently showing (destAddr:gi), so the
+    // hashchange handler can tell "open a different exit" from "already shown".
+    let currentModalKey = null;
     const closeModal = () => {
       if (!modal) return;
       modal.hidden = true;
       document.documentElement.style.overflow = "";
+      currentModalKey = null;
+      // Drop the #agg=… deep-link hash on close (leave any other hash alone).
+      if (/^#agg=/.test(window.location.hash)) {
+        try { history.replaceState(null, "", window.location.pathname); } catch {}
+      }
       // Restore focus to the element that opened the modal — table-stakes a11y.
       if (modalOpenerEl && typeof modalOpenerEl.focus === "function") {
         modalOpenerEl.focus();
@@ -2472,7 +2577,18 @@
 
     const openAgglayerEventModal = async ({ aggHash, destAddr, globalIndex }) => {
       const apiUrl = CONFIG.bridgeServiceUrl + "/bridges/" + destAddr;
-      modalGi.textContent = globalIndex ? "gi " + globalIndex : aggHash.slice(0, 10) + "…";
+      // Make the open modal addressable: #agg=<destAddr>:<globalIndex>. The
+      // modal fetches its own data by address, so this link works on a cold
+      // load without waiting for the poll. (replaceState doesn't fire
+      // hashchange, so this won't re-enter our handler.)
+      currentModalKey = String(destAddr).toLowerCase() + ":" + String(globalIndex || "");
+      if (globalIndex) {
+        try {
+          history.replaceState(null, "",
+            "#agg=" + encodeURIComponent(destAddr) + ":" + encodeURIComponent(String(globalIndex)));
+        } catch {}
+      }
+      modalGi.textContent = globalIndex ? "gi " + globalIndex : (aggHash || "").slice(0, 10) + "…";
       modalSrc.textContent = "GET /api/bridges/" + destAddr;
       modalRaw.href = apiUrl;
       modalReadout.innerHTML = '<span class="json-muted">loading…</span>';
@@ -2514,6 +2630,85 @@
         destAddr: btn.dataset.destAddr,
         globalIndex: btn.dataset.globalIndex,
       });
+    });
+
+    // ---------- deep-link wiring ----------
+    // Two deep-link shapes share the hash:
+    //   #row=<encoded ev.id>           → scroll to + pulse a row
+    //   #agg=<destAddr>:<globalIndex>  → open the agglayer-info modal for an exit
+    const readAggDeepLink = () => {
+      const m = (window.location.hash || "").match(/^#agg=([^:]+):(.+)$/);
+      if (!m) return null;
+      try { return { destAddr: decodeURIComponent(m[1]), globalIndex: decodeURIComponent(m[2]) }; }
+      catch { return { destAddr: m[1], globalIndex: m[2] }; }
+    };
+
+    // Reconcile the modal + row pulse against whatever is in the hash now.
+    const applyHashState = () => {
+      const agg = readAggDeepLink();
+      if (agg) {
+        const key = String(agg.destAddr).toLowerCase() + ":" + agg.globalIndex;
+        if (modal && (modal.hidden || currentModalKey !== key)) {
+          openAgglayerEventModal({ aggHash: "", destAddr: agg.destAddr, globalIndex: agg.globalIndex });
+        }
+        return;
+      }
+      // No #agg → close the modal if it's showing a deep-linked exit.
+      if (modal && !modal.hidden && currentModalKey) closeModal();
+      const id = readDeepLinkHash();
+      if (id) focusDeepLink(id);
+    };
+
+    // Honour a deep link already present in the URL on first load.
+    const initialAgg = readAggDeepLink();
+    if (initialAgg) {
+      // The modal fetches its own data by address — safe to open straight away.
+      openAgglayerEventModal({ aggHash: "", destAddr: initialAgg.destAddr, globalIndex: initialAgg.globalIndex });
+    } else {
+      // bootstrap()'s first render (cached) or post-tick hook (cold) acts on this.
+      pendingDeepLinkId = readDeepLinkHash();
+    }
+
+    // Back/forward, or a link pasted into the same tab.
+    window.addEventListener("hashchange", applyHashState);
+
+    // Clicking a row's copy button copies its deep link, updates the URL, and
+    // pulses the row.
+    document.addEventListener("click", (e) => {
+      const btn = e.target && e.target.closest ? e.target.closest(".row-link") : null;
+      if (!btn) return;
+      e.preventDefault();
+      const id = btn.dataset.linkId;
+      if (!id) return;
+      // replaceState updates the URL without firing our hashchange handler.
+      try { history.replaceState(null, "", "#row=" + encodeURIComponent(id)); }
+      catch { window.location.hash = "row=" + encodeURIComponent(id); }
+      // Swap clipboard icon → check on success; revert after a beat.
+      const flash = (ok) => {
+        if (!ok) return;
+        btn.innerHTML = CHECK_ICON;
+        btn.classList.add("copied");
+        setTimeout(() => { btn.innerHTML = COPY_ICON; btn.classList.remove("copied"); }, 1300);
+      };
+      // Legacy fallback for non-secure contexts where navigator.clipboard is absent.
+      const legacyCopy = (text) => {
+        try {
+          const ta = document.createElement("textarea");
+          ta.value = text; ta.style.position = "fixed"; ta.style.opacity = "0";
+          document.body.appendChild(ta); ta.select();
+          const ok = document.execCommand("copy");
+          document.body.removeChild(ta);
+          return ok;
+        } catch { return false; }
+      };
+      const url = deepLinkUrl(id);
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(url).then(() => flash(true)).catch(() => flash(legacyCopy(url)));
+      } else {
+        flash(legacyCopy(url));
+      }
+      // Immediate visual feedback; no scroll — the user is already on the row.
+      focusDeepLink(id, { scroll: false });
     });
 
     bootstrap();


### PR DESCRIPTION
## What

Adds shareable **deep links** to the bali bridge monitor (`tools/bali-bridge-monitor/index.html`):

- `#row=<id>` — scrolls to a specific deposit/withdrawal row and pulses it. Each row gains a small `#` affordance that copies the absolute link and pulses the row on click.
- `#agg=<destAddr>:<globalIndex>` — opens the **agglayer-info modal** for a specific exit, even on a cold load. The modal fetches its own data by address, so the link resolves without waiting for the 30s poll. Clicking an **AGGLAYER EVENT** hash also writes this hash so it's copyable; closing the modal clears it.

Respects `prefers-reduced-motion` (static highlight instead of a flashing pulse).

## Deploy

Already published to the live Pages site (`github-pages` branch, `/docs`) — this PR keeps the `main` source-of-truth copy in sync.

Live: https://gateway-fm.github.io/miden-agglayer/bridge-monitor/bali/

## Verification

Driven against live bridge-service data in headless Chromium:
- `#row=…` deep link scrolls the target row into view (centered) and pulses it ✓
- Row `#` button pulses the row and writes the shareable hash ✓
- `#agg=…` opens the modal on cold load with correct gi / amount / lifecycle ✓
- Clicking AGGLAYER EVENT opens the modal and sets the `#agg` hash ✓
- Closing the modal clears the hash ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
