### PR TITLE
fix(address_mapper): remove Hardhat default-account special case (Cantina MA#8)

### DIFF
--- a/src/address_mapper.rs
+++ b/src/address_mapper.rs
@@ -3,11 +3,6 @@ use alloy::primitives::Address;
 use miden_base_agglayer::{EthAddress, EthEmbeddedAccountId};
 use miden_protocol::account::AccountId;
 
-const HARDHAT_ADDRESS: Address = Address::new([
-    0xf3, 0x9f, 0xd6, 0xe5, 0x1a, 0xad, 0x88, 0xf6, 0xf4, 0xce, 0x6a, 0xb8, 0x82, 0x72, 0x79, 0xcf,
-    0xff, 0xb9, 0x22, 0x66,
-]);
-
 pub fn is_miden_compatible_address(address: Address) -> bool {
     // The canonical EthEmbeddedAccountId encoding embeds AccountId as:
     //   [4 zero bytes] [prefix(8 bytes)] [suffix(8 bytes)]
@@ -30,7 +25,15 @@ pub fn account_id_from_address(address: Address) -> Option<AccountId> {
 }
 
 /// Resolve an Ethereum address to a Miden AccountId.
-/// Resolution order: hardhat special case → known mapping → zero-padding.
+/// Resolution order: known store mapping → zero-padding.
+///
+/// Cantina MA#8 — there is no special case for the well-known Hardhat
+/// default-account address (`0xf39f...2266`). It flows through the normal
+/// mapping path like any other address: a deposit targeting it resolves
+/// only if an operator has explicitly mapped it (or it happens to be a
+/// zero-padded Miden id, which the Hardhat EOA is not). No dev-only remap
+/// to `wallet_hardhat`, no gate, no bail — the address is treated like any
+/// other EVM address.
 ///
 /// Self-review C5 — the zero-padding fallback maps any 4-leading-zero EVM
 /// address to a Miden AccountId WITHOUT verifying the account exists on
@@ -49,47 +52,24 @@ pub async fn resolve_address(
     address: Address,
     config: &AccountsConfig,
 ) -> anyhow::Result<AccountId> {
-    resolve_address_with_policy(store, address, config, false, false).await
+    resolve_address_with_policy(store, address, config, false).await
 }
 
 /// Same as `resolve_address` but allows the caller to disable the
 /// zero-padding fallback (production posture). When `reject_zero_padding`
 /// is `true`, addresses that aren't in the store mapping fail with a
 /// clear error rather than falling through to the structural reconstruction.
-///
-/// Cantina MA#8 — `reject_hardhat_alias`: when `true`, the special-case
-/// remap of the well-known Hardhat default-account address
-/// (`0xf39f...2266`) to `config.wallet_hardhat` is disabled. The alias is
-/// useful for local dev (the Hardhat default signer becomes a valid
-/// Miden bridge destination without an explicit mapping) but is
-/// dangerous in production: any deposit on L1 with that destination
-/// would be silently rerouted into the operator-owned `wallet_hardhat`
-/// account. Gated by `--require-hardening` at the caller layer.
 pub async fn resolve_address_with_policy(
     store: &dyn crate::store::Store,
     address: Address,
-    config: &AccountsConfig,
+    _config: &AccountsConfig,
     reject_zero_padding: bool,
-    reject_hardhat_alias: bool,
 ) -> anyhow::Result<AccountId> {
-    // 1. Hardhat special case (dev convenience) — gated by policy in production.
-    if address == HARDHAT_ADDRESS {
-        if reject_hardhat_alias {
-            ::metrics::counter!("address_mapper_hardhat_alias_rejected_total").increment(1);
-            anyhow::bail!(
-                "Hardhat default-account alias is disabled in this deployment \
-                 (MA#8). The Hardhat address {address} would have been rerouted \
-                 to wallet_hardhat — set --disable-hardhat-alias=false or add \
-                 an explicit store mapping for legitimate use."
-            );
-        }
-        return Ok(config.wallet_hardhat.0);
-    }
-    // 2. Check existing mapping from store
+    // 1. Check existing mapping from store
     if let Some(id) = store.get_address_mapping(&address).await? {
         return Ok(id);
     }
-    // 3. Try zero-padding (native Miden address) unless disabled.
+    // 2. Try zero-padding (native Miden address) unless disabled.
     if reject_zero_padding {
         anyhow::bail!(
             "no known Miden AccountId for Ethereum address {address}; \
@@ -163,11 +143,11 @@ mod tests {
         let zero_padded = address!("0x00000000ac0000000000dd110000ee000000fc00");
 
         // Default policy (reject = false): fallback succeeds.
-        let r = resolve_address_with_policy(&store, zero_padded, &cfg, false, false).await;
+        let r = resolve_address_with_policy(&store, zero_padded, &cfg, false).await;
         assert!(r.is_ok());
 
         // Strict policy (reject = true): fallback refused with clear error.
-        let r = resolve_address_with_policy(&store, zero_padded, &cfg, true, false).await;
+        let r = resolve_address_with_policy(&store, zero_padded, &cfg, true).await;
         let err = r.unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("fallback disabled"));
@@ -190,82 +170,73 @@ mod tests {
             .unwrap();
 
         // With strict policy, the mapping still resolves.
-        let r = resolve_address_with_policy(&store, mapped_addr, &cfg, true, false).await;
+        let r = resolve_address_with_policy(&store, mapped_addr, &cfg, true).await;
         assert_eq!(r.unwrap(), target);
     }
 
-    /// Cantina MA#8 — the Hardhat default-account alias must be
-    /// rejectable in production. Pre-fix the remap fired
-    /// unconditionally on every claim, so a deposit on L1 with the
-    /// well-known Hardhat address as destination would always land in
-    /// `wallet_hardhat`. With `reject_hardhat_alias = true` the
-    /// resolver refuses the remap and the caller gets a clear error.
+    /// Cantina MA#8 — the well-known Hardhat default-account address
+    /// (`0xf39f...2266`) must NOT be special-cased in `resolve_address`.
+    /// Pre-fix there was an `if address == HARDHAT_ADDRESS` branch that
+    /// remapped it to `config.wallet_hardhat` on every claim (later
+    /// merely gated behind a flag). cergyk required the branch be
+    /// removed entirely so the address flows through the normal mapping
+    /// path with no special behavior. This test pins that: with no
+    /// explicit store mapping, the Hardhat EOA (which is not a
+    /// zero-padded Miden id) resolves to nothing — it does NOT silently
+    /// land in `wallet_hardhat`, and resolution behaves exactly as it
+    /// would for any other un-mapped, non-zero-padded EVM address.
     #[tokio::test]
-    async fn ma8_reject_hardhat_alias_when_policy_set() {
+    async fn ma8_hardhat_address_not_special_cased() {
         use crate::store::memory::InMemoryStore;
         let store = InMemoryStore::new();
         let cfg = test_accounts_config();
-        let hardhat = Address::new([
-            0xf3, 0x9f, 0xd6, 0xe5, 0x1a, 0xad, 0x88, 0xf6, 0xf4, 0xce, 0x6a, 0xb8, 0x82, 0x72,
-            0x79, 0xcf, 0xff, 0xb9, 0x22, 0x66,
-        ]);
+        // `wallet_hardhat` in the config is a real, valid AccountId. If the
+        // old special case were still present, resolving the Hardhat EOA
+        // below would return `cfg.wallet_hardhat.0` (an `Ok`). With the
+        // branch removed it must error like any other un-mapped address.
+        let wallet_hardhat = cfg.wallet_hardhat.0;
+        let hardhat = address!("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266");
 
-        // Dev posture: alias still works.
-        let r = resolve_address_with_policy(&store, hardhat, &cfg, false, false).await;
-        assert_eq!(r.unwrap(), cfg.wallet_hardhat.0);
-
-        // Hardened posture: alias refused with a Cantina MA#8 error.
-        let r = resolve_address_with_policy(&store, hardhat, &cfg, false, true).await;
-        let err = r.unwrap_err();
-        let msg = format!("{err}");
+        // Default policy: the Hardhat EOA is NOT zero-padded (high bytes
+        // are 0xf39f...), there is no store mapping, so resolution errors
+        // exactly like any other un-mapped non-zero-padded address —
+        // never resolves to wallet_hardhat.
+        let r = resolve_address_with_policy(&store, hardhat, &cfg, false).await;
         assert!(
-            msg.contains("Hardhat default-account alias is disabled"),
-            "expected MA#8 error message, got: {msg}"
+            r.is_err(),
+            "Hardhat EOA must not be special-cased; expected the normal \
+             'no known Miden AccountId' error, but it resolved to {:?} \
+             (== wallet_hardhat? {})",
+            r.as_ref().ok(),
+            r.as_ref().ok() == Some(&wallet_hardhat)
         );
+
+        // And a generic un-mapped non-zero-padded address gives the same
+        // outcome — proving the Hardhat address gets no distinct treatment.
+        let other = address!("0xabcdef1234567890abcdef1234567890abcdef12");
+        let r_other = resolve_address_with_policy(&store, other, &cfg, false).await;
+        assert!(r_other.is_err());
     }
 
-    /// Cantina MA#8 — with the alias disabled and no explicit mapping,
-    /// the Hardhat address (which is not zero-padded) cannot be
-    /// resolved by any other branch, so resolution must error. This
-    /// pins the "no silent rerouting" guarantee: a production deposit
-    /// targeting `0xf39f...2266` is refused outright instead of
-    /// landing in `wallet_hardhat`.
+    /// Cantina MA#8 — once an operator explicitly maps the Hardhat EOA,
+    /// it resolves to exactly the mapped target via the normal store
+    /// path (no special case interferes).
     #[tokio::test]
-    async fn ma8_disabled_alias_no_silent_fallback() {
-        use crate::store::memory::InMemoryStore;
-        let store = InMemoryStore::new();
-        let cfg = test_accounts_config();
-        let hardhat = Address::new([
-            0xf3, 0x9f, 0xd6, 0xe5, 0x1a, 0xad, 0x88, 0xf6, 0xf4, 0xce, 0x6a, 0xb8, 0x82, 0x72,
-            0x79, 0xcf, 0xff, 0xb9, 0x22, 0x66,
-        ]);
-
-        // Alias disabled, no store mapping, address is not zero-padded →
-        // resolution must error.
-        let r = resolve_address_with_policy(&store, hardhat, &cfg, false, true).await;
-        assert!(r.is_err());
-    }
-
-    /// Cantina MA#8 — non-Hardhat addresses must be unaffected by the
-    /// alias-rejection flag. Only the single special-case remap is gated.
-    #[tokio::test]
-    async fn ma8_non_hardhat_address_unaffected_by_alias_policy() {
+    async fn ma8_hardhat_address_resolves_via_explicit_mapping() {
         use crate::Store;
         use crate::store::memory::InMemoryStore;
         let store = InMemoryStore::new();
         let cfg = test_accounts_config();
-        let mapped_addr = address!("0xabcdef1234567890abcdef1234567890abcdef12");
+        let hardhat = address!("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266");
         let target = AccountId::from_hex("0xac0000000000dd110000ee000000fc").unwrap();
-        store
-            .set_address_mapping(mapped_addr, target)
-            .await
-            .unwrap();
+        store.set_address_mapping(hardhat, target).await.unwrap();
 
-        // With alias rejected (and zero-padding allowed), the explicit
-        // mapping still resolves cleanly — the MA#8 policy doesn't
-        // touch the store-mapping path.
-        let r = resolve_address_with_policy(&store, mapped_addr, &cfg, false, true).await;
-        assert_eq!(r.unwrap(), target);
+        let r = resolve_address_with_policy(&store, hardhat, &cfg, false).await;
+        assert_eq!(
+            r.unwrap(),
+            target,
+            "Hardhat EOA must resolve through the normal store mapping"
+        );
     }
 
     fn test_accounts_config() -> AccountsConfig {

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -365,7 +365,6 @@ async fn create_claim(
     store: &dyn Store,
     rng: &mut impl FeltRng,
     reject_zero_padding: bool,
-    reject_hardhat_alias: bool,
 ) -> anyhow::Result<Note> {
     let sender = accounts.service.0;
 
@@ -374,7 +373,6 @@ async fn create_claim(
         params.destinationAddress,
         accounts,
         reject_zero_padding,
-        reject_hardhat_alias,
     )
     .await?;
 
@@ -456,7 +454,6 @@ async fn publish_claim_internal(
     store: &dyn Store,
     latest_block_num: BlockNumber,
     reject_zero_padding: bool,
-    reject_hardhat_alias: bool,
     expected_mints: Option<&Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
     // Opt-in local prover used as a fallback when the remote prover
     // configured on the surrounding `MidenClient` fails. `None` when
@@ -495,7 +492,6 @@ async fn publish_claim_internal(
         store,
         client.rng(),
         reject_zero_padding,
-        reject_hardhat_alias,
     )
     .await?;
     let claim_note_id = claim_note.id().to_string();
@@ -771,7 +767,6 @@ pub async fn publish_claim(
     txn_envelope: alloy::consensus::TxEnvelope,
     signer: alloy::primitives::Address,
     reject_zero_padding: bool,
-    reject_hardhat_alias: bool,
     expected_mints: Option<Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
 ) -> anyhow::Result<PublishClaimTxn> {
     // Submit with runtime self-heal, mirroring the pattern in
@@ -799,7 +794,6 @@ pub async fn publish_claim(
         txn_envelope.clone(),
         signer,
         reject_zero_padding,
-        reject_hardhat_alias,
         expected_mints.clone(),
     )
     .await
@@ -822,7 +816,6 @@ pub async fn publish_claim(
                 txn_envelope,
                 signer,
                 reject_zero_padding,
-                reject_hardhat_alias,
                 expected_mints,
             )
             .await
@@ -842,7 +835,6 @@ async fn attempt_publish_claim(
     txn_envelope: alloy::consensus::TxEnvelope,
     signer: alloy::primitives::Address,
     reject_zero_padding: bool,
-    reject_hardhat_alias: bool,
     expected_mints: Option<Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
 ) -> anyhow::Result<PublishClaimTxn> {
     // Snapshot the opt-in local-prover fallback BEFORE entering the
@@ -865,7 +857,6 @@ async fn attempt_publish_claim(
                     &*store,
                     latest_block_num,
                     reject_zero_padding,
-                    reject_hardhat_alias,
                     expected_mints.as_ref(),
                     local_prover_fallback,
                 )

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,16 +145,6 @@ struct Command {
     #[arg(long, env = "REJECT_ZERO_PADDING_ADDRESSES", default_value_t = false)]
     reject_zero_padding_addresses: bool,
 
-    /// Disable the built-in Hardhat default-account alias (Cantina MA#8).
-    /// When set, the special-case remap of the well-known Hardhat address
-    /// (`0xf39f...2266`) to `wallet_hardhat` is refused. Production
-    /// deployments MUST set this flag — otherwise an L1 deposit targeting
-    /// the Hardhat default-account address would be silently routed into
-    /// the operator's `wallet_hardhat` account. Enforced as a
-    /// `--require-hardening` invariant.
-    #[arg(long, env = "DISABLE_HARDHAT_ALIAS", default_value_t = false)]
-    disable_hardhat_alias: bool,
-
     /// Production hardening invariant. When set, refuse to start if any of
     /// the following hardening flags are at their fail-open defaults:
     /// - `--admin-api-key` unset (admin endpoints accept any caller)
@@ -259,18 +249,6 @@ fn check_hardening_invariants(command: &Command) -> Result<(), Vec<String>> {
                 .to_string(),
         );
     }
-    // Cantina MA#8 — the Hardhat default-account alias is unsafe in
-    // production. With `--require-hardening` set, the operator MUST
-    // also pass `--disable-hardhat-alias` (env `DISABLE_HARDHAT_ALIAS`).
-    if !command.disable_hardhat_alias {
-        reasons.push(
-            "  - --disable-hardhat-alias is unset (Cantina MA#8: the well-known \
-             Hardhat default-account address `0xf39f...2266` would be silently \
-             remapped to `wallet_hardhat` on every claim). Set \
-             DISABLE_HARDHAT_ALIAS=true to refuse the remap in production."
-                .to_string(),
-        );
-    }
     if reasons.is_empty() {
         Ok(())
     } else {
@@ -309,7 +287,6 @@ impl std::fmt::Debug for Command {
             .field("cors_allowed_origins", &self.cors_allowed_origins)
             .field("allowed_signers", &self.allowed_signers)
             .field("require_hardening", &self.require_hardening)
-            .field("disable_hardhat_alias", &self.disable_hardhat_alias)
             .field(
                 "miden_api_key",
                 &self.miden_api_key.as_ref().map(|_| "[REDACTED]"),
@@ -692,7 +669,6 @@ async fn main() -> anyhow::Result<()> {
     state.rate_limit_per_second = command.rate_limit_per_second;
     state.rate_limit_burst = command.rate_limit_burst;
     state.reject_zero_padding_addresses = command.reject_zero_padding_addresses;
-    state.reject_hardhat_alias = command.disable_hardhat_alias;
     // Cantina #7: share the BridgeOutScanner's expected-MINT tracker so
     // `publish_claim_internal` can record the CLAIM NoteId and the scanner
     // can mark it Landed once it sees the bridge consume it.
@@ -1000,11 +976,6 @@ mod hardening_tests {
             rate_limit_burst: miden_agglayer_service::service::DEFAULT_RATE_LIMIT_BURST,
             reject_zero_padding_addresses: false,
             require_hardening: require,
-            // Cantina MA#8 — tests default the alias to disabled so the
-            // pre-existing hardening tests below only flex the flag they
-            // care about. The dedicated `hardening_flags_hardhat_alias`
-            // test below pins the new invariant in isolation.
-            disable_hardhat_alias: true,
             miden_api_key: None,
             miden_prover_url: prover_url,
             miden_prover_timeout_secs: 120,
@@ -1017,8 +988,7 @@ mod hardening_tests {
     /// When --require-hardening is false, no invariant is enforced.
     #[test]
     fn hardening_disabled_passes_with_open_defaults() {
-        let mut c = cmd(false, None, None, None);
-        c.disable_hardhat_alias = false;
+        let c = cmd(false, None, None, None);
         assert!(check_hardening_invariants(&c).is_ok());
     }
 
@@ -1072,38 +1042,5 @@ mod hardening_tests {
         let reasons = check_hardening_invariants(&c).unwrap_err();
         assert_eq!(reasons.len(), 1);
         assert!(reasons[0].contains("--miden-prover-url"));
-    }
-
-    /// Cantina MA#8 — `--require-hardening` MUST require
-    /// `--disable-hardhat-alias` to be set. Otherwise an operator
-    /// thinks they're running a hardened build but the Hardhat default
-    /// address is still being remapped to `wallet_hardhat` on every
-    /// claim.
-    #[test]
-    fn hardening_flags_hardhat_alias_when_unset() {
-        let mut c = cmd(
-            true,
-            Some("strong-admin-key".into()),
-            Some(vec![alloy::primitives::Address::ZERO]),
-            Some(vec!["https://app.example.com".into()]),
-        );
-        c.disable_hardhat_alias = false;
-        let reasons = check_hardening_invariants(&c).unwrap_err();
-        assert_eq!(reasons.len(), 1);
-        assert!(
-            reasons[0].contains("--disable-hardhat-alias"),
-            "expected MA#8 invariant, got: {}",
-            reasons[0]
-        );
-    }
-
-    /// Cantina MA#8 — when `--require-hardening` is OFF, the hardhat
-    /// invariant is not enforced. Operators can run dev-mode with the
-    /// alias on (current default) or off.
-    #[test]
-    fn hardening_disabled_does_not_enforce_hardhat_alias() {
-        let mut c = cmd(false, None, None, None);
-        c.disable_hardhat_alias = false;
-        assert!(check_hardening_invariants(&c).is_ok());
     }
 }

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -403,7 +403,6 @@ async fn publish_and_record_claim(
         txn_envelope,
         signer,
         service.reject_zero_padding_addresses,
-        service.reject_hardhat_alias,
         Some(service.expected_mints.clone()),
     )
     .await?;

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -108,14 +108,6 @@ pub struct ServiceState {
     /// reconstruction. Production posture; default false for backward
     /// compatibility with aggsender / aggoracle / hardhat dev flows.
     pub reject_zero_padding_addresses: bool,
-    /// Reject the Hardhat default-account alias remap (Cantina MA#8).
-    /// When `true`, the special-case remap of the well-known Hardhat
-    /// address (`0xf39f...2266`) to `wallet_hardhat` is disabled. Required
-    /// for production deployments — otherwise any L1 deposit targeting
-    /// the Hardhat address is silently routed into the operator-owned
-    /// wallet account. Enforced as a `--require-hardening` invariant in
-    /// `main.rs::check_hardening_invariants`.
-    pub reject_hardhat_alias: bool,
     /// Cantina #7 expected-MINT tracker, shared with the `BridgeOutScanner`.
     /// `publish_claim_internal` records each submitted CLAIM's NoteId here;
     /// the scanner ticks it each sync, marking entries Landed once it
@@ -183,7 +175,6 @@ impl ServiceState {
             rate_limit_per_second: crate::service::DEFAULT_RATE_LIMIT_PER_SECOND,
             rate_limit_burst: crate::service::DEFAULT_RATE_LIMIT_BURST,
             reject_zero_padding_addresses: false,
-            reject_hardhat_alias: false,
             expected_mints,
             miden_api_key: None,
             enable_writer_worker: false,


### PR DESCRIPTION
## Cantina MA#8 — Remove the Hardhat default-account special case

Finding: [#8](https://cantina.xyz/code/c338caaf-fb92-403b-b3e8-2294541f29f4/findings/8) — *Hardhat test destination alias remains enabled by default and yields successful-looking claim publications* (LOW). Auditor: cergyk. Re-audit verdict on the prior fix: **Not fixed.**

### cergyk's objection (2026-06-08)
> "The production path should not have any special behavior when `address == HARDHAT_ADDRESS`, not even return an error (`anyhow::bail`). Would be better to just remove the if clause altogether to simplify the flow."

Our prior fix (5e8765d / PR #64) merely **gated** the `HARDHAT_ADDRESS` branch behind `--require-hardening` and `anyhow::bail`-ed when hardened — the exact gate/bail approach cergyk rejected. The branch was still present on `origin/main`:

```rust
// 1. Hardhat special case (dev convenience) — gated by policy in production.
if address == HARDHAT_ADDRESS {
    if reject_hardhat_alias {
        ::metrics::counter!("address_mapper_hardhat_alias_rejected_total").increment(1);
        anyhow::bail!("Hardhat default-account alias is disabled ...");
    }
    return Ok(config.wallet_hardhat.0);
}
```

> **Rebased onto current `main`** (was `77ba880`, now `1e28ebe`); CI green. The rebase also fixed a stale test constant — the target `AccountId` `0x3d7c…` no longer validates under the current miden-client (`UnknownAccountIdVersion(0)`), swapped to the valid `0xac00…`.

### The diff
Deletes the special case entirely — no gate, no bail, no branch:

- `address_mapper.rs`: dropped the `HARDHAT_ADDRESS` const and the entire `if address == HARDHAT_ADDRESS { ... }` block (both the `bail` and the `return Ok(config.wallet_hardhat.0)`), plus the `reject_hardhat_alias` parameter. `resolve_address_with_policy` now goes straight from store-mapping → zero-padding fallback. The Hardhat EOA (`0xf39f...2266`) resolves only via an explicit store mapping or the zero-padding scheme, identical to any other EVM address.
- Unwound `reject_hardhat_alias` through `claim.rs` (`create_claim`, `publish_claim_internal`, `publish_claim`, `attempt_publish_claim`), `service_send_raw_txn.rs`, and `service_state.rs` (field + init).
- `main.rs`: removed the `--disable-hardhat-alias` CLI flag, its Debug field + state assignment, the MA#8 hardening invariant in `check_hardening_invariants`, and its two tests + the test-fixture field.

The `wallet_hardhat` account is retained as a normal deployed wallet in `AccountsConfig` — `e2e-l1-to-l2.sh` derives a zero-padded `DEST_ADDR` from its Miden `AccountId` and never targets the raw Hardhat EOA, so e2e is unaffected. It is simply no longer a special case inside `resolve_address`.

### Tests (in-memory, execute without DATABASE_URL)
- `ma8_hardhat_address_not_special_cased` — the Hardhat EOA with no store mapping errors like any other un-mapped, non-zero-padded address; it never resolves to `wallet_hardhat`. `test_accounts_config` sets `wallet_hardhat` to a valid `AccountId`, so a reintroduced branch would return `Ok(wallet_hardhat)` and the `assert!(r.is_err())` would fail — genuine regression catcher.
- `ma8_hardhat_address_resolves_via_explicit_mapping` — with an explicit operator mapping it resolves through the normal store path.

### Status
- Build: **green** (`cargo build`, Finished dev profile).
- Tests: **pass** — `ma8_hardhat_address_not_special_cased` ok, `ma8_hardhat_address_resolves_via_explicit_mapping` ok (2 passed / 0 failed). MA#8 hardening tests removed (the invariant they enforced no longer exists).

### Verifier verdict
**addresses** / `makesObjectionFalse: true`. Verified on disk that `resolve_address_with_policy` goes straight store-mapping → zero-padding with no special case; grep confirms zero live `HARDHAT_ADDRESS` / `reject_hardhat_alias` references (one comment-only mention). The objection sentence is now literally false: no special behavior, no gate, no bail. No `mustFix` items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

