### PR TITLE
chore(docker): bump base + Go builder images (Aikido #20321432, #18169693)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rustlang/rust:nightly-bookworm-slim AS builder
+FROM rustlang/rust:nightly-trixie-slim AS builder
 
 WORKDIR /usr/src/app
 
@@ -19,7 +19,7 @@ RUN \
     && cp target/release/miden-agglayer-service bin/miden-agglayer-service \
     && cp target/release/bridge-out-tool bin/bridge-out-tool
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/Dockerfile.miden-node
+++ b/Dockerfile.miden-node
@@ -26,7 +26,7 @@
 ARG MIDEN_NODE_GIT_URL
 ARG MIDEN_NODE_GIT_REF
 
-FROM rust:1.93-slim-bookworm AS builder
+FROM rust:1.93-slim-trixie AS builder
 
 RUN apt-get update && apt-get install -y \
     pkg-config \
@@ -63,7 +63,7 @@ RUN cargo build --release --bin miden-node
 RUN cp -r crates/store/src/genesis/config/samples /tmp/genesis-samples
 
 # Runtime
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 COPY --from=builder /tmp/miden-node-commit.txt /app/miden-node-commit.txt
 COPY --from=builder /tmp/genesis-samples /app/genesis-samples


### PR DESCRIPTION
## What

Bump stale Docker base/builder images from Debian **bookworm** (Debian 12) to **trixie** (Debian 13, current stable) to clear two Aikido findings driven by the stale base/builder layers.

## Aikido findings addressed

- **#18169693 — Debian Linux version no longer receiving security updates** (critical, EOL). `debian:bookworm-slim` runtime layers flagged as EOL. Fixed by moving to `debian:trixie-slim`.
- **#20321432 — openssl** (high, open_source). Stale openssl shipped by the bookworm base. Trixie ships openssl 3.5.x, clearing the finding.

## Changes (minimal)

- `Dockerfile`: `rustlang/rust:nightly-bookworm-slim` -> `nightly-trixie-slim`; runtime `debian:bookworm-slim` -> `debian:trixie-slim`.
- `Dockerfile.miden-node`: `rust:1.93-slim-bookworm` -> `rust:1.93-slim-trixie`; runtime `debian:bookworm-slim` -> `debian:trixie-slim`.

Note: this repo's builders are **Rust**, not Go; the Go-builder reference in the originating task does not apply here. The separate path-traversal SAST finding is intentionally out of scope and untouched.

## Verification

- All three trixie tags (`debian:trixie-slim`, `rustlang/rust:nightly-trixie-slim`, `rust:1.93-slim-trixie`) pull clean.
- **`docker build -f Dockerfile`** completed successfully (exit 0, image 265MB). Verified inside the built image:
  - `/etc/os-release` -> `Debian GNU/Linux 13 (trixie)`.
  - `openssl 3.5.6-1~deb13u2` (was bookworm's 3.0.x).
- `Dockerfile.miden-node` was **not** built locally: it clones + compiles an external miden-node repo and requires `MIDEN_NODE_GIT_URL` / `MIDEN_NODE_GIT_REF` build-args that are not available here, and exceeds the local time budget. The edit is identical in pattern and uses the same verified trixie tags. **CI must verify this image.**

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
