### PR TITLE
ci(release): pin artifact actions to SHAs (unblocks v0.15.0 multi-arch build)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         run: echo "PAIR=${{ matrix.platform }}" | tr '/' '-' >> "$GITHUB_ENV"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: digests-${{ env.PAIR }}
           path: /tmp/digests/*
@@ -74,7 +74,7 @@ jobs:
     needs: build
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: /tmp/digests
           pattern: digests-*


### PR DESCRIPTION
The v0.15.0 release workflow failed at "Set up job" — `actions/{upload,download}-artifact@v4` violated the repo's pin-to-SHA policy. Pinned both to their v4 commit SHAs. After merge I'll recreate the v0.15.0 tag so the multi-arch build runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)