### PR TITLE
fix(bridge-out): thread real ERC20 metadata into synthetic BridgeEvent (Cantina #13)

### DIFF
--- a/migrations/008_faucet_metadata.sql
+++ b/migrations/008_faucet_metadata.sql
@@ -1,0 +1,12 @@
+-- Cantina #13 — thread real ERC-20 token metadata through bridge-outs.
+--
+-- The faucet registry now persists the raw ABI-encoded metadata preimage
+-- (`abi.encode(name, symbol, decimals)` for ERC-20s, empty for native ETH),
+-- whose keccak256 is the faucet's on-Miden MetadataHash. A bridge-out's
+-- synthetic BridgeEvent carries these exact bytes so the downstream exit leaf
+-- matches Miden's bridge state and a fresh-destination
+-- `_deployWrappedToken(abi.decode(...))` succeeds.
+--
+-- Legacy rows (written before this column existed) default to empty, matching
+-- the native-ETH / unknown-metadata case.
+ALTER TABLE faucet_registry ADD COLUMN IF NOT EXISTS metadata BYTEA NOT NULL DEFAULT ''::bytea;

--- a/scripts/e2e-dynamic-erc20.sh
+++ b/scripts/e2e-dynamic-erc20.sh
@@ -324,6 +324,30 @@ GLOBAL_INDEX=$(echo "$DEPOSIT_INFO" | python3 -c "import json,sys; print(json.lo
 
 log "Deposit #$DEPOSIT_CNT: amount=$AMOUNT_CLAIM, globalIndex=$GLOBAL_INDEX"
 
+# ── Cantina #13 — synthetic BridgeEvent must carry the real ERC20 metadata ────
+# When an ERC20 is bridged out, the proxy SYNTHESISES the BridgeEvent. Its
+# `metadata` must be the token's abi.encode(name, symbol, decimals) — the same
+# preimage that produced the faucet's MetadataHash on Miden. With empty metadata
+# (the bug) the certified exit leaf diverges from Miden's bridge state, and a
+# first claim of this ERC20 on a fresh NON-origin destination reverts inside
+# `_deployWrappedToken`'s `abi.decode`. The cross-L2 revert isn't reproducible on
+# this single-L2 stack, so we assert the metadata directly (the prerequisite the
+# PoC also targets). `METADATA_CLAIM` was read above from the bridge-service
+# deposit, i.e. exactly the bytes the proxy's synthetic event carried.
+TOKEN_NAME_CLEAN=$(printf '%s' "$TOKEN_NAME" | tr -d '"')
+TOKEN_SYMBOL_CLEAN=$(cast call --rpc-url "$L1_RPC" "$TOKEN_ADDR" "symbol()(string)" 2>/dev/null | tr -d '"')
+EXPECTED_METADATA=$(cast abi-encode 'f(string,string,uint8)' \
+    "$TOKEN_NAME_CLEAN" "$TOKEN_SYMBOL_CLEAN" "$TOKEN_DECIMALS")
+log "bridge-out metadata: got=$METADATA_CLAIM"
+log "  expected abi.encode($TOKEN_NAME_CLEAN, $TOKEN_SYMBOL_CLEAN, $TOKEN_DECIMALS) = $EXPECTED_METADATA"
+[[ "$METADATA_CLAIM" == "0x" ]] && fail \
+    "Cantina #13: ERC20 bridge-out BridgeEvent has EMPTY metadata (0x). It must carry \
+abi.encode(name,symbol,decimals); empty metadata diverges the exit leaf from Miden and \
+breaks first claims on fresh non-origin chains (_deployWrappedToken abi.decode revert)."
+[[ "$(printf '%s' "$METADATA_CLAIM" | tr 'A-F' 'a-f')" == "$(printf '%s' "$EXPECTED_METADATA" | tr 'A-F' 'a-f')" ]] || fail \
+    "Cantina #13: ERC20 bridge-out metadata mismatch — got '$METADATA_CLAIM', expected '$EXPECTED_METADATA'."
+pass "Cantina #13: bridge-out BridgeEvent carries correct ERC20 metadata"
+
 # If the bridge-autoclaim service already claimed this deposit on L1, it carries
 # a claim_tx_hash. Re-claiming would revert (AlreadyClaimed), so verify the
 # autoclaim receipt + the L1 token balance change instead and finish. Mirrors

--- a/src/bridge_out.rs
+++ b/src/bridge_out.rs
@@ -125,6 +125,11 @@ pub struct FaucetOriginInfo {
     pub origin_network: u32,
     pub origin_address: [u8; 20],
     pub scale: u8,
+    /// Raw ABI-encoded token metadata preimage (`abi.encode(name, symbol,
+    /// decimals)` for ERC-20s, empty for native ETH). Threaded into the
+    /// synthetic bridge-out `BridgeEvent` so the exit leaf carries the real
+    /// metadata (Cantina #13).
+    pub metadata: Vec<u8>,
 }
 
 /// Resolve faucet origin info from the dynamic faucet registry.
@@ -142,6 +147,7 @@ pub async fn resolve_faucet_origin(
         origin_network: entry.origin_network,
         origin_address: entry.origin_address,
         scale: entry.scale,
+        metadata: entry.metadata,
     })
 }
 
@@ -547,7 +553,7 @@ impl BridgeOutScanner {
                 destination_network,
                 &destination_address,
                 origin_amount,
-                &[],
+                &origin.metadata,
             )
             .await
         {

--- a/src/bridge_out.rs
+++ b/src/bridge_out.rs
@@ -539,6 +539,22 @@ impl BridgeOutScanner {
         // emitted log, causing aggsender to skip the BridgeEvent and
         // wedge that bridge-out forever. PgStore folds all five writes
         // into one transaction; InMemoryStore uses the default impl.
+        //
+        // Cantina #13 follow-up — DoS guard. `origin.metadata` ultimately derives
+        // from untrusted L1 calldata and the BridgeEvent encoder does not cap it,
+        // so an oversized blob would drive a huge allocation. Refuse to encode it;
+        // skip + alert rather than emit (the cap is far above any legit token's
+        // abi.encode(name,symbol,decimals)).
+        if origin.metadata.len() > MAX_BRIDGE_EVENT_METADATA_BYTES {
+            ::metrics::counter!("bridge_out_b2agg_metadata_too_large_total").increment(1);
+            tracing::warn!(
+                note_id = %note_id_str,
+                metadata_len = origin.metadata.len(),
+                cap = MAX_BRIDGE_EVENT_METADATA_BYTES,
+                "B2AGG faucet metadata exceeds cap; skipping synthetic BridgeEvent (DoS guard)"
+            );
+            return false;
+        }
         match self
             .store
             .commit_b2agg_event_atomic(

--- a/src/bridge_out.rs
+++ b/src/bridge_out.rs
@@ -553,6 +553,22 @@ impl BridgeOutScanner {
                 cap = MAX_BRIDGE_EVENT_METADATA_BYTES,
                 "B2AGG faucet metadata exceeds cap; skipping synthetic BridgeEvent (DoS guard)"
             );
+            // Cantina #13 follow-up — record the note as unbridgeable so this
+            // permanent skip is not re-attempted every sync tick (the gate would
+            // otherwise re-surface the same oversized-metadata note forever — a
+            // free DoS on the sync loop). Mirrors the other MA#18 skip gates.
+            self.quarantine_unbridgeable_b2agg(
+                &note_id_str,
+                note,
+                block_number,
+                crate::store::UnbridgeableBridgeOutReason::MetadataTooLarge,
+                format!(
+                    "origin.metadata.len()={} exceeds MAX_BRIDGE_EVENT_METADATA_BYTES={}",
+                    origin.metadata.len(),
+                    MAX_BRIDGE_EVENT_METADATA_BYTES
+                ),
+            )
+            .await;
             return false;
         }
         match self
@@ -631,64 +647,98 @@ impl BridgeOutScanner {
         reason: crate::store::UnbridgeableBridgeOutReason,
         detail: String,
     ) {
-        // Bound the detail field so a flood of malformed notes can't
-        // bloat individual rows. The Postgres column has no length cap;
-        // bound here so the bound is enforced regardless of backend.
-        const MAX_DETAIL: usize = 4096;
-        let detail = if detail.len() > MAX_DETAIL {
-            format!(
-                "{}…[truncated {} bytes]",
-                &detail[..MAX_DETAIL],
-                detail.len() - MAX_DETAIL
-            )
-        } else {
-            detail
-        };
-
-        let note_dump = dump_note_for_quarantine(note);
-        metrics::counter!(
-            "bridge_out_quarantined_erased_b2agg_total",
-            "reason" => reason.as_str()
-        )
-        .increment(1);
-
-        let entry = crate::store::UnbridgeableBridgeOut {
-            note_id: note_id_str.to_string(),
-            bridge_account: self.bridge_account_id,
+        // Delegate to the shared free helper so the live scanner and the offline
+        // restore path (`restore.rs`) record quarantine rows identically.
+        quarantine_unbridgeable_b2agg(
+            &*self.store,
+            self.bridge_account_id,
+            note_id_str,
+            note,
+            observed_block,
             reason,
             detail,
-            note_dump,
-            observed_block,
-        };
+        )
+        .await;
+    }
+}
 
-        match self.store.record_unbridgeable_bridge_out(entry).await {
-            Ok(true) => {
-                tracing::warn!(
-                    target: "bridge_out::quarantine",
-                    note_id = %note_id_str,
-                    reason = reason.as_str(),
-                    "Cantina MA#18: B2AGG quarantined — operator handle persisted"
-                );
-            }
-            Ok(false) => {
-                // Already quarantined; idempotent — no spam.
-                tracing::debug!(
-                    target: "bridge_out::quarantine",
-                    note_id = %note_id_str,
-                    reason = reason.as_str(),
-                    "Cantina MA#18: B2AGG already quarantined (idempotent skip)"
-                );
-            }
-            Err(e) => {
-                tracing::error!(
-                    target: "bridge_out::quarantine",
-                    note_id = %note_id_str,
-                    reason = reason.as_str(),
-                    error = %e,
-                    "Cantina MA#18: failed to record quarantine row — \
-                     metric still fired but recovery handle is lost"
-                );
-            }
+/// Record a quarantine (`unbridgeable_bridge_outs`) row for a B2AGG that was
+/// observed consumed by the bridge but skipped by the indexer (Cantina MA#18).
+///
+/// Shared by the live scanner ([`BridgeOutScanner::quarantine_unbridgeable_b2agg`])
+/// and the offline restore path so both record a note as a *permanent skip*
+/// (note_id + reason + diagnostic) and the same oversized / erased note is not
+/// re-attempted on every sync tick or restore run.
+///
+/// Best-effort: a quarantine-write failure must not propagate — the caller's
+/// contract is that a skip path's only side effect is the skip itself.
+/// Quarantine errors are logged and the metric still fires.
+pub(crate) async fn quarantine_unbridgeable_b2agg(
+    store: &dyn crate::store::Store,
+    bridge_account: AccountId,
+    note_id_str: &str,
+    note: &InputNoteRecord,
+    observed_block: u64,
+    reason: crate::store::UnbridgeableBridgeOutReason,
+    detail: String,
+) {
+    // Bound the detail field so a flood of malformed notes can't
+    // bloat individual rows. The Postgres column has no length cap;
+    // bound here so the bound is enforced regardless of backend.
+    const MAX_DETAIL: usize = 4096;
+    let detail = if detail.len() > MAX_DETAIL {
+        format!(
+            "{}…[truncated {} bytes]",
+            &detail[..MAX_DETAIL],
+            detail.len() - MAX_DETAIL
+        )
+    } else {
+        detail
+    };
+
+    let note_dump = dump_note_for_quarantine(note);
+    metrics::counter!(
+        "bridge_out_quarantined_erased_b2agg_total",
+        "reason" => reason.as_str()
+    )
+    .increment(1);
+
+    let entry = crate::store::UnbridgeableBridgeOut {
+        note_id: note_id_str.to_string(),
+        bridge_account,
+        reason,
+        detail,
+        note_dump,
+        observed_block,
+    };
+
+    match store.record_unbridgeable_bridge_out(entry).await {
+        Ok(true) => {
+            tracing::warn!(
+                target: "bridge_out::quarantine",
+                note_id = %note_id_str,
+                reason = reason.as_str(),
+                "Cantina MA#18: B2AGG quarantined — operator handle persisted"
+            );
+        }
+        Ok(false) => {
+            // Already quarantined; idempotent — no spam.
+            tracing::debug!(
+                target: "bridge_out::quarantine",
+                note_id = %note_id_str,
+                reason = reason.as_str(),
+                "Cantina MA#18: B2AGG already quarantined (idempotent skip)"
+            );
+        }
+        Err(e) => {
+            tracing::error!(
+                target: "bridge_out::quarantine",
+                note_id = %note_id_str,
+                reason = reason.as_str(),
+                error = %e,
+                "Cantina MA#18: failed to record quarantine row — \
+                 metric still fired but recovery handle is lost"
+            );
         }
     }
 }
@@ -702,7 +752,7 @@ impl BridgeOutScanner {
 /// Kept simple text rather than `serde_json::to_string` to avoid pulling
 /// serde into the bridge_out hot path and to keep the format human-readable
 /// in psql.
-fn dump_note_for_quarantine(note: &InputNoteRecord) -> String {
+pub(crate) fn dump_note_for_quarantine(note: &InputNoteRecord) -> String {
     use std::fmt::Write as _;
     let details = note.details();
     let script_root_hex = hex::encode(details.script().root().as_bytes());
@@ -1981,6 +2031,49 @@ mod tests {
         assert_eq!(R::UnknownFaucet.as_str(), "unknown_faucet");
         assert_eq!(R::AmountOverflow.as_str(), "amount_overflow");
         assert_eq!(R::AtomicCommitFailed.as_str(), "atomic_commit_failed");
+        assert_eq!(R::MetadataTooLarge.as_str(), "metadata_too_large");
+    }
+
+    /// Cantina #13 follow-up — the oversized-metadata DoS guard must RECORD the
+    /// note as unbridgeable (not silently skip), so the same note isn't
+    /// re-attempted on every sync tick / restore run. This exercises the shared
+    /// free helper both call sites use, pinning that a `MetadataTooLarge`
+    /// quarantine row is persisted with the expected reason + forensic dump.
+    #[tokio::test]
+    async fn cantina13_metadata_too_large_records_unbridgeable() {
+        use crate::store::UnbridgeableBridgeOutReason;
+        use crate::store::memory::InMemoryStore;
+        use std::sync::Arc as StdArc;
+
+        let store: StdArc<dyn crate::store::Store> = StdArc::new(InMemoryStore::new());
+        let bridge_id = AccountId::from_hex("0xac0000000000dd110000ee000000fc").unwrap();
+        let note = build_b2agg_note_with_consumer(Some(bridge_id));
+        let note_id_str = hex::encode(note.details_commitment().as_bytes());
+
+        quarantine_unbridgeable_b2agg(
+            &*store,
+            bridge_id,
+            &note_id_str,
+            &note,
+            99,
+            UnbridgeableBridgeOutReason::MetadataTooLarge,
+            "origin.metadata.len()=70000 exceeds MAX_BRIDGE_EVENT_METADATA_BYTES=65536".to_string(),
+        )
+        .await;
+
+        let row = store
+            .get_unbridgeable_bridge_out(&note_id_str)
+            .await
+            .unwrap()
+            .expect("metadata-too-large note must be quarantined, not silently skipped");
+        assert_eq!(row.note_id, note_id_str);
+        assert_eq!(row.bridge_account, bridge_id);
+        assert_eq!(row.reason, UnbridgeableBridgeOutReason::MetadataTooLarge);
+        assert_eq!(row.observed_block, 99);
+        assert!(
+            row.detail
+                .contains("exceeds MAX_BRIDGE_EVENT_METADATA_BYTES")
+        );
     }
 
     /// Cantina MA#4 — wiring repro for the unknown-wrapper detector. Pins

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -157,6 +157,14 @@ async fn find_or_create_faucet(
     .await?;
 
     // 4. Save to store
+    //
+    // Cantina #13 — the metadata is attacker-controlled L1 `claimAsset` calldata
+    // and is otherwise unbounded. Cap it at storage: if it exceeds the bridge-out
+    // emit cap, persist EMPTY rather than the oversized blob. Empty-for-oversized
+    // is safe — the bridge-out emit site already gates oversized metadata, and the
+    // (#91) Layer-2 recovery re-derives bounded metadata from L1 — so we never need
+    // to keep the giant preimage around.
+    let stored_metadata = cap_stored_faucet_metadata(metadata, &token_address);
     let entry = FaucetEntry {
         faucet_id: faucet_account.id(),
         origin_address: token_address.0.0,
@@ -167,8 +175,9 @@ async fn find_or_create_faucet(
         scale,
         // Cantina #13 — store the raw ABI metadata preimage (same bytes whose
         // keccak256 is the faucet's MetadataHash) so a future bridge-out emits
-        // the real metadata in its synthetic BridgeEvent. Empty for native ETH.
-        metadata: metadata.to_vec(),
+        // the real metadata in its synthetic BridgeEvent. Empty for native ETH
+        // and for oversized blobs (capped above).
+        metadata: stored_metadata,
     };
     store.register_faucet(entry).await?;
 
@@ -181,6 +190,33 @@ async fn find_or_create_faucet(
 
 fn bytes32_array_to_smt_nodes(values: [FixedBytes<32>; 32]) -> [SmtNode; 32] {
     values.map(|v| SmtNode::new(v.0))
+}
+
+/// Cantina #13 — cap attacker-controlled L1 `claimAsset` metadata before it is
+/// persisted in the faucet registry. The calldata is otherwise unbounded; an
+/// oversized blob would bloat storage and (without the bridge-out emit-site
+/// guard) drive a huge allocation when synthesizing a BridgeEvent.
+///
+/// If the metadata exceeds the bridge-out emit cap we persist EMPTY rather than
+/// the oversized blob. Empty-for-oversized is safe: the bridge-out emit site
+/// already gates oversized metadata, and the (#91) Layer-2 recovery re-derives
+/// bounded metadata from L1 — so we never need to keep the giant preimage.
+fn cap_stored_faucet_metadata(
+    metadata: &Bytes,
+    token_address: &alloy::primitives::Address,
+) -> Vec<u8> {
+    if metadata.len() > crate::bridge_out::MAX_BRIDGE_EVENT_METADATA_BYTES {
+        ::metrics::counter!("faucet_metadata_too_large_at_store_total").increment(1);
+        tracing::warn!(
+            token_address = %token_address,
+            metadata_len = metadata.len(),
+            cap = crate::bridge_out::MAX_BRIDGE_EVENT_METADATA_BYTES,
+            "claim: ERC-20 metadata exceeds cap; storing empty metadata for faucet (Cantina #13)"
+        );
+        Vec::new()
+    } else {
+        metadata.to_vec()
+    }
 }
 
 /// Decode the agglayer mainnet flag from a `globalIndex` U256.
@@ -849,6 +885,47 @@ mod tests {
             hex::decode("f1885eda54b7a053318cd41e2093220dab15d65381b1157a3633a83bfd5c9239")
                 .unwrap();
         assert_eq!(hash.as_bytes(), expected.as_slice());
+    }
+
+    /// Cantina #13 — bounded metadata is stored verbatim (preimage preserved so
+    /// a later bridge-out emits the real ABI metadata).
+    #[test]
+    fn cap_stored_faucet_metadata_keeps_bounded() {
+        let token = address!("00000000000000000000000000000000000000aa");
+        let small = Bytes::from(vec![0xABu8; 128]);
+        let stored = cap_stored_faucet_metadata(&small, &token);
+        assert_eq!(stored, small.to_vec(), "bounded metadata must be preserved");
+
+        // Exactly at the cap is still kept (boundary).
+        let at_cap = Bytes::from(vec![
+            0u8;
+            crate::bridge_out::MAX_BRIDGE_EVENT_METADATA_BYTES
+        ]);
+        assert_eq!(
+            cap_stored_faucet_metadata(&at_cap, &token).len(),
+            crate::bridge_out::MAX_BRIDGE_EVENT_METADATA_BYTES,
+            "metadata exactly at the cap must be stored, not dropped"
+        );
+
+        // Empty (native ETH) stays empty.
+        assert!(cap_stored_faucet_metadata(&Bytes::new(), &token).is_empty());
+    }
+
+    /// Cantina #13 — oversized attacker-controlled metadata is stored as EMPTY,
+    /// never the giant blob.
+    #[test]
+    fn cap_stored_faucet_metadata_drops_oversized() {
+        let token = address!("00000000000000000000000000000000000000aa");
+        let huge = Bytes::from(vec![
+            0x42u8;
+            crate::bridge_out::MAX_BRIDGE_EVENT_METADATA_BYTES + 1
+        ]);
+        let stored = cap_stored_faucet_metadata(&huge, &token);
+        assert!(
+            stored.is_empty(),
+            "oversized metadata must be replaced with empty, got {} bytes",
+            stored.len()
+        );
     }
 
     #[test]

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -165,6 +165,10 @@ async fn find_or_create_faucet(
         origin_decimals,
         miden_decimals,
         scale,
+        // Cantina #13 — store the raw ABI metadata preimage (same bytes whose
+        // keccak256 is the faucet's MetadataHash) so a future bridge-out emits
+        // the real metadata in its synthetic BridgeEvent. Empty for native ETH.
+        metadata: metadata.to_vec(),
     };
     store.register_faucet(entry).await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -489,6 +489,7 @@ async fn main() -> anyhow::Result<()> {
                     origin_decimals: 18,
                     miden_decimals: 8,
                     scale: 10,
+                    metadata: vec![],
                 })
                 .await?;
             tracing::info!("seeded faucet registry with default ETH faucet");

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -424,8 +424,13 @@ async fn restore_one_b2agg_note(
 
     // Cantina #13 follow-up — DoS guard. `origin.metadata` ultimately derives
     // from untrusted L1 calldata and the BridgeEvent encoder does not cap it, so
-    // an oversized blob would drive a huge allocation. Refuse to encode it; skip
-    // without marking the note processed (mirrors the live scanner's guard).
+    // an oversized blob would drive a huge allocation. Refuse to encode it.
+    //
+    // Record the note as unbridgeable (Cantina MA#18 quarantine) — exactly as the
+    // live scanner does — so this permanent skip is not re-attempted on every
+    // restore run. The restore path has a clean `store` handle and the same
+    // `note` / `bridge_id` / block context the live path uses, so we can record
+    // the quarantine row directly via the shared helper.
     if origin.metadata.len() > crate::bridge_out::MAX_BRIDGE_EVENT_METADATA_BYTES {
         ::metrics::counter!("bridge_out_b2agg_metadata_too_large_total").increment(1);
         tracing::warn!(
@@ -434,6 +439,20 @@ async fn restore_one_b2agg_note(
             cap = crate::bridge_out::MAX_BRIDGE_EVENT_METADATA_BYTES,
             "restore: B2AGG faucet metadata exceeds cap; skipping synthetic BridgeEvent (DoS guard)"
         );
+        crate::bridge_out::quarantine_unbridgeable_b2agg(
+            &**store,
+            bridge_id,
+            &note_id_str,
+            note,
+            restore_block,
+            crate::store::UnbridgeableBridgeOutReason::MetadataTooLarge,
+            format!(
+                "origin.metadata.len()={} exceeds MAX_BRIDGE_EVENT_METADATA_BYTES={}",
+                origin.metadata.len(),
+                crate::bridge_out::MAX_BRIDGE_EVENT_METADATA_BYTES
+            ),
+        )
+        .await;
         return Ok(B2AggRestoreOutcome::Skipped);
     }
 

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -441,7 +441,7 @@ async fn restore_one_b2agg_note(
             destination_network,
             &destination_address,
             origin_amount,
-            &[],
+            &origin.metadata,
             deposit_count,
         )
         .await
@@ -1132,6 +1132,7 @@ mod tests {
                 origin_decimals: 18,
                 miden_decimals: 8,
                 scale: 10,
+                metadata: vec![],
             })
             .await
             .unwrap();

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -422,6 +422,21 @@ async fn restore_one_b2agg_note(
         }
     };
 
+    // Cantina #13 follow-up — DoS guard. `origin.metadata` ultimately derives
+    // from untrusted L1 calldata and the BridgeEvent encoder does not cap it, so
+    // an oversized blob would drive a huge allocation. Refuse to encode it; skip
+    // without marking the note processed (mirrors the live scanner's guard).
+    if origin.metadata.len() > crate::bridge_out::MAX_BRIDGE_EVENT_METADATA_BYTES {
+        ::metrics::counter!("bridge_out_b2agg_metadata_too_large_total").increment(1);
+        tracing::warn!(
+            note_id = %note_id_str,
+            metadata_len = origin.metadata.len(),
+            cap = crate::bridge_out::MAX_BRIDGE_EVENT_METADATA_BYTES,
+            "restore: B2AGG faucet metadata exceeds cap; skipping synthetic BridgeEvent (DoS guard)"
+        );
+        return Ok(B2AggRestoreOutcome::Skipped);
+    }
+
     // B5 — share the versioned domain-separated helper with bridge_out so the
     // tx_hash is byte-identical across first-observation and restore paths
     // (dedup-stable).
@@ -1305,6 +1320,46 @@ mod tests {
             outcome,
             B2AggRestoreOutcome::Skipped,
             "a correctly-processed bridge-out note must be a benign skip, not flagged",
+        );
+    }
+
+    /// Cantina #13 DoS guard: a faucet whose metadata exceeds the encoder cap
+    /// must gate the bridge-out (skip) — never feed an oversized blob (from
+    /// untrusted L1 calldata) into the BridgeEvent encoder.
+    #[tokio::test]
+    async fn ma3_restore_skips_b2agg_with_oversized_metadata() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let (faucet_id, bridge_id, _sender_id) = ma3_accounts();
+        store
+            .register_faucet(crate::store::FaucetEntry {
+                faucet_id,
+                origin_address: [0x11u8; 20],
+                origin_network: 0,
+                symbol: "BIG".into(),
+                origin_decimals: 18,
+                miden_decimals: 8,
+                scale: 10,
+                metadata: vec![0u8; crate::bridge_out::MAX_BRIDGE_EVENT_METADATA_BYTES + 1],
+            })
+            .await
+            .unwrap();
+
+        let note = ma3_b2agg_input_note(faucet_id, Some(bridge_id));
+        let note_id = hex::encode(note.details_commitment().as_bytes());
+
+        let outcome =
+            restore_one_b2agg_note(&store, &note, bridge_id, 1, [7u8; 32], get_bridge_address())
+                .await
+                .unwrap();
+
+        assert_eq!(
+            outcome,
+            B2AggRestoreOutcome::Skipped,
+            "B2AGG with oversized faucet metadata must be gated (DoS guard), not emitted",
+        );
+        assert!(
+            !store.is_note_processed(&note_id).await.unwrap(),
+            "gated note must not be marked processed",
         );
     }
 }

--- a/src/service_admin.rs
+++ b/src/service_admin.rs
@@ -12,6 +12,21 @@ use miden_protocol::account::AccountId;
 use serde::Deserialize;
 use std::sync::{Arc, OnceLock};
 
+// Mirror of the upstream `miden-agglayer` `SolTokenMetadata` struct (its
+// `encode_token_metadata` is `pub(crate)` so we can't call it directly). Encoding
+// this with `abi_encode_params` reproduces Solidity's `abi.encode(string name,
+// string symbol, uint8 decimals)` byte-for-byte, so `keccak256(bytes)` equals the
+// faucet's `MetadataHash` (Cantina #13). A plain tuple `.abi_encode()` won't do —
+// `u8` doesn't implement `SolValue`, and a dynamic tuple's `abi_encode` would add an
+// extra offset word.
+alloy_core::sol! {
+    struct AdminTokenMetadata {
+        string name;
+        string symbol;
+        uint8 decimals;
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct RegisterFaucetParams {
     pub symbol: String,
@@ -60,12 +75,24 @@ pub async fn admin_register_faucet(
     let service_id = accounts.service.0;
     let bridge_id = accounts.bridge.0;
 
-    // Compute MetadataHash from (name, symbol, origin_decimals) — matches the L1 bridge
-    // contract's `keccak256(abi.encode(name, symbol, decimals))`. Callers that skip the
-    // `name` field get `name = symbol`.
+    // Compute the raw ABI metadata preimage `abi.encode(name, symbol, decimals)` ONCE and
+    // reuse it for both the on-Miden `MetadataHash` and the stored `FaucetEntry.metadata`
+    // (Cantina #13). Using `abi_encode_params` (not `abi_encode`) matches Solidity's
+    // `abi.encode(string, string, uint8)` exactly — a plain `abi_encode` of a dynamic tuple
+    // would prepend an extra 32-byte offset word and diverge from the L1 bridge's
+    // `getTokenMetadata` encoding. Deriving the hash via `from_abi_encoded(&metadata_bytes)`
+    // guarantees `keccak256(stored_metadata) == faucet MetadataHash`, so a later bridge-out
+    // emits metadata whose hash matches Miden's bridge state. Callers that skip the `name`
+    // field get `name = symbol`.
+    use alloy_core::sol_types::SolValue;
     let metadata_name = params.name.clone().unwrap_or_else(|| params.symbol.clone());
-    let metadata_hash =
-        MetadataHash::from_token_info(&metadata_name, &params.symbol, params.origin_decimals);
+    let metadata_bytes = AdminTokenMetadata {
+        name: metadata_name.clone(),
+        symbol: params.symbol.clone(),
+        decimals: params.origin_decimals,
+    }
+    .abi_encode_params();
+    let metadata_hash = MetadataHash::from_abi_encoded(&metadata_bytes);
 
     // Create, deploy, register in bridge (using OnceLock pattern like publish_claim)
     let result = Arc::new(OnceLock::<AccountId>::new());
@@ -111,6 +138,7 @@ pub async fn admin_register_faucet(
             origin_decimals: params.origin_decimals,
             miden_decimals: params.miden_decimals,
             scale,
+            metadata: metadata_bytes,
         })
         .await?;
 

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1107,7 +1107,7 @@ mod tests {
                 origin_decimals: 18,
                 miden_decimals: 8,
                 scale: 10,
-            metadata: vec![],
+                metadata: vec![],
             })
             .await
             .unwrap();
@@ -1138,7 +1138,7 @@ mod tests {
                 origin_decimals: 18,
                 miden_decimals: 8,
                 scale: 10,
-            metadata: vec![],
+                metadata: vec![],
             })
             .await
             .unwrap();
@@ -1164,7 +1164,7 @@ mod tests {
                 origin_decimals: 6,
                 miden_decimals: 6,
                 scale: 0,
-            metadata: vec![],
+                metadata: vec![],
             })
             .await
             .unwrap();
@@ -1218,7 +1218,7 @@ mod tests {
                 origin_decimals: 18,
                 miden_decimals: 8,
                 scale: 10,
-            metadata: vec![],
+                metadata: vec![],
             })
             .await
             .unwrap();
@@ -1231,7 +1231,7 @@ mod tests {
                 origin_decimals: 18,
                 miden_decimals: 8,
                 scale: 10,
-            metadata: vec![],
+                metadata: vec![],
             })
             .await
             .unwrap();

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1107,6 +1107,7 @@ mod tests {
                 origin_decimals: 18,
                 miden_decimals: 8,
                 scale: 10,
+            metadata: vec![],
             })
             .await
             .unwrap();
@@ -1137,6 +1138,7 @@ mod tests {
                 origin_decimals: 18,
                 miden_decimals: 8,
                 scale: 10,
+            metadata: vec![],
             })
             .await
             .unwrap();
@@ -1162,6 +1164,7 @@ mod tests {
                 origin_decimals: 6,
                 miden_decimals: 6,
                 scale: 0,
+            metadata: vec![],
             })
             .await
             .unwrap();
@@ -1215,6 +1218,7 @@ mod tests {
                 origin_decimals: 18,
                 miden_decimals: 8,
                 scale: 10,
+            metadata: vec![],
             })
             .await
             .unwrap();
@@ -1227,6 +1231,7 @@ mod tests {
                 origin_decimals: 18,
                 miden_decimals: 8,
                 scale: 10,
+            metadata: vec![],
             })
             .await
             .unwrap();

--- a/src/store/migrator.rs
+++ b/src/store/migrator.rs
@@ -74,6 +74,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "007_monitor_state_persistence.sql",
         include_str!("../../migrations/007_monitor_state_persistence.sql"),
     ),
+    (
+        "008_faucet_metadata.sql",
+        include_str!("../../migrations/008_faucet_metadata.sql"),
+    ),
 ];
 
 /// Postgres advisory-lock key. Arbitrary 64-bit int; just needs to be

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -41,6 +41,14 @@ pub struct FaucetEntry {
     pub miden_decimals: u8,
     /// Decimal scaling factor: `origin_decimals - miden_decimals`.
     pub scale: u8,
+    /// Raw ABI-encoded token metadata preimage — `abi.encode(name, symbol,
+    /// decimals)` for ERC-20s, empty for native ETH. This is the exact byte
+    /// string whose keccak256 is the faucet's on-Miden `MetadataHash`, and the
+    /// `metadata` a bridge-out's synthetic `BridgeEvent` must carry so the
+    /// downstream exit leaf matches Miden's bridge state and a fresh-destination
+    /// `_deployWrappedToken(abi.decode(...))` succeeds (Cantina #13). Empty for
+    /// legacy rows written before this field existed.
+    pub metadata: Vec<u8>,
 }
 
 /// Data for registering a new transaction.

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -158,6 +158,12 @@ pub enum UnbridgeableBridgeOutReason {
     /// nothing persisted). Quarantine so a retry path or operator can
     /// re-attempt without missing the leaf.
     AtomicCommitFailed,
+    /// The faucet's stored metadata exceeds `MAX_BRIDGE_EVENT_METADATA_BYTES`
+    /// (Cantina #13 DoS guard). Encoding the synthetic BridgeEvent would drive
+    /// an oversized allocation, so we refuse to emit. Quarantined (rather than
+    /// silently skipped) so the note is recorded as a permanent skip and is not
+    /// re-attempted every sync tick / restore run.
+    MetadataTooLarge,
 }
 
 impl UnbridgeableBridgeOutReason {
@@ -168,6 +174,7 @@ impl UnbridgeableBridgeOutReason {
             Self::UnknownFaucet => "unknown_faucet",
             Self::AmountOverflow => "amount_overflow",
             Self::AtomicCommitFailed => "atomic_commit_failed",
+            Self::MetadataTooLarge => "metadata_too_large",
         }
     }
 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1496,15 +1496,16 @@ impl Store for PgStore {
         let faucet_id = entry.faucet_id.to_hex();
         client
             .execute(
-                "INSERT INTO faucet_registry (faucet_id, origin_address, origin_network, symbol, origin_decimals, miden_decimals, scale)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7)
+                "INSERT INTO faucet_registry (faucet_id, origin_address, origin_network, symbol, origin_decimals, miden_decimals, scale, metadata)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
                  ON CONFLICT (faucet_id) DO UPDATE
                  SET origin_address = EXCLUDED.origin_address,
                      origin_network = EXCLUDED.origin_network,
                      symbol = EXCLUDED.symbol,
                      origin_decimals = EXCLUDED.origin_decimals,
                      miden_decimals = EXCLUDED.miden_decimals,
-                     scale = EXCLUDED.scale",
+                     scale = EXCLUDED.scale,
+                     metadata = EXCLUDED.metadata",
                 &[
                     &faucet_id,
                     &entry.origin_address.as_slice(),
@@ -1513,6 +1514,7 @@ impl Store for PgStore {
                     &(entry.origin_decimals as i16),
                     &(entry.miden_decimals as i16),
                     &(entry.scale as i16),
+                    &entry.metadata.as_slice(),
                 ],
             )
             .await?;
@@ -1528,7 +1530,7 @@ impl Store for PgStore {
         let client = self.pool.get().await?;
         let rows = client
             .query(
-                "SELECT faucet_id, origin_address, origin_network, symbol, origin_decimals, miden_decimals, scale
+                "SELECT faucet_id, origin_address, origin_network, symbol, origin_decimals, miden_decimals, scale, metadata
                  FROM faucet_registry
                  WHERE origin_address = $1 AND origin_network = $2",
                 &[&origin_address.as_slice(), &(origin_network as i32)],
@@ -1545,7 +1547,7 @@ impl Store for PgStore {
         let client = self.pool.get().await?;
         let rows = client
             .query(
-                "SELECT faucet_id, origin_address, origin_network, symbol, origin_decimals, miden_decimals, scale
+                "SELECT faucet_id, origin_address, origin_network, symbol, origin_decimals, miden_decimals, scale, metadata
                  FROM faucet_registry
                  WHERE origin_address = $1",
                 &[&origin_address.as_slice()],
@@ -1560,7 +1562,7 @@ impl Store for PgStore {
         let id_str = faucet_id.to_hex();
         let rows = client
             .query(
-                "SELECT faucet_id, origin_address, origin_network, symbol, origin_decimals, miden_decimals, scale
+                "SELECT faucet_id, origin_address, origin_network, symbol, origin_decimals, miden_decimals, scale, metadata
                  FROM faucet_registry
                  WHERE faucet_id = $1",
                 &[&id_str],
@@ -1574,7 +1576,7 @@ impl Store for PgStore {
         let client = self.pool.get().await?;
         let rows = client
             .query(
-                "SELECT faucet_id, origin_address, origin_network, symbol, origin_decimals, miden_decimals, scale
+                "SELECT faucet_id, origin_address, origin_network, symbol, origin_decimals, miden_decimals, scale, metadata
                  FROM faucet_registry
                  ORDER BY created_at",
                 &[],
@@ -1751,5 +1753,9 @@ fn pg_row_to_faucet_entry(row: &tokio_postgres::Row) -> Option<FaucetEntry> {
         origin_decimals: row.get::<_, i16>(4) as u8,
         miden_decimals: row.get::<_, i16>(5) as u8,
         scale: row.get::<_, i16>(6) as u8,
+        metadata: {
+            let m: &[u8] = row.get(7);
+            m.to_vec()
+        },
     })
 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1148,6 +1148,7 @@ impl Store for PgStore {
             "unknown_faucet" => UnbridgeableBridgeOutReason::UnknownFaucet,
             "amount_overflow" => UnbridgeableBridgeOutReason::AmountOverflow,
             "atomic_commit_failed" => UnbridgeableBridgeOutReason::AtomicCommitFailed,
+            "metadata_too_large" => UnbridgeableBridgeOutReason::MetadataTooLarge,
             other => anyhow::bail!("unknown unbridgeable_bridge_outs.reason value: {other}"),
         };
 
@@ -1505,7 +1506,15 @@ impl Store for PgStore {
                      origin_decimals = EXCLUDED.origin_decimals,
                      miden_decimals = EXCLUDED.miden_decimals,
                      scale = EXCLUDED.scale,
-                     metadata = EXCLUDED.metadata",
+                     -- Cantina #13 — never clobber stored metadata with empty. A
+                     -- blank re-register (metadata = vec![]) must not wipe good
+                     -- metadata persisted by an earlier non-empty registration or
+                     -- the Layer-2 backfill (which always writes non-empty, so it
+                     -- still updates here).
+                     metadata = CASE
+                         WHEN EXCLUDED.metadata = ''::bytea THEN faucet_registry.metadata
+                         ELSE EXCLUDED.metadata
+                     END",
                 &[
                     &faucet_id,
                     &entry.origin_address.as_slice(),

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -45,6 +45,7 @@ pub async fn seed_test_faucets(store: &dyn Store) {
             origin_decimals: 18,
             miden_decimals: 8,
             scale: 10,
+            metadata: vec![],
         })
         .await
         .unwrap();


### PR DESCRIPTION
## Finding #13 (High) — ERC20 bridge-out reconstruction drops metadata

The proxy synthesises a `BridgeEvent` for every B2AGG bridge-out but emitted **empty `metadata`** (callers passed `&[]`). Harmless for native ETH (`keccak256("")`), but for an ERC20 the synthetic exit leaf's metadata hash diverges from the faucet's real on-Miden `MetadataHash`, so the certified exit tree drifts from Miden's bridge state and a **first claim on a fresh non-origin destination reverts** in `_deployWrappedToken`'s `abi.decode`. (Confirmed valid; the two commits cited in the finding thread — `92b67bd` X8, `522a789` X3/X4 — are unrelated, as cergyk noted.)

## RED → GREEN (e2e-proven)
- **RED** (`db7c754`): `e2e-dynamic-erc20.sh` now asserts the bridge-out's `BridgeEvent.metadata` (read from the bridge-service deposit) equals `abi.encode(name, symbol, decimals)`. Failed today: `got=0x`.
- **GREEN** (`96d6feb`): after the fix, the same assertion passes byte-exactly: `got == abi.encode("TestToken","TT",18)`, full ERC20 L1→L2→L1 round-trip green.

## Layer 1 — persist + thread the metadata (this PR)
- `FaucetEntry` gains `metadata: Vec<u8>`; `faucet_registry` gets a BYTEA `metadata` column (**migration 008**, registered in the embedded migrator, auto-applied on startup).
- Persisted **once at faucet creation**: `find_or_create_faucet` stores the exact L1 `claimAsset` preimage; `admin_register_faucet` re-encodes `(name,symbol,decimals)` via a `sol!` struct + `abi_encode_params`, deriving the hash from those same bytes (keccak-stable).
- `resolve_faucet_origin` returns it; `process_consumed_note` (live) and `restore_one_b2agg_note` (restore) pass `&origin.metadata` to the encoder instead of `&[]` (the encoder already accepted a `metadata` param).
- 251/251 lib tests pass; compiles clean on default + `postgres` features.

## Layer 2 — recovery (separate, plan only)
Legacy rows written before this column default to empty `metadata`. The recovery path — re-derive from L1 (`name()/symbol()/decimals()`) + **validate against the Miden faucet's `MetadataHash`**, or fail-safe gate — is tracked separately (the preimage is not recoverable from Miden's one-way hash alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)