### PR TITLE
fix(restore): recover network-consumed bridge-outs via node block-scan (PRST-4035)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -562,9 +562,15 @@ async fn main() -> anyhow::Result<()> {
     // their initial `submit_new_transaction` deploys them on-chain.
     // Run restore if requested
     if command.restore {
-        let result =
-            miden_agglayer_service::restore::restore(&store, &client, &accounts.0, &block_state)
-                .await?;
+        let result = miden_agglayer_service::restore::restore(
+            &store,
+            &client,
+            &accounts.0,
+            &block_state,
+            command.miden_node.as_deref(),
+            command.miden_api_key.as_deref(),
+        )
+        .await?;
 
         tracing::info!(
             "Restore complete: block={}, bridge_outs={}, claims={}, gers={}, logs={}",

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -176,7 +176,9 @@ pub async fn restore(
         match recover_missed_bridge_outs(miden_client, url, api_key, accounts.bridge.0, from_block)
             .await
         {
-            Ok(n) => tracing::info!("Phase 1.5 complete: recovered {n} B2AGG note(s) from the node"),
+            Ok(n) => {
+                tracing::info!("Phase 1.5 complete: recovered {n} B2AGG note(s) from the node")
+            }
             Err(e) => tracing::warn!(
                 err = %e,
                 "Phase 1.5 recovery scan failed; continuing with local-only restore"
@@ -269,13 +271,17 @@ async fn sync_miden_block(
 /// aggsender never certifies it, and it can't be claimed on L1.
 ///
 /// The notes are still on the node (public, nullifier committed). This
-/// re-discovers them by tag-scanning the node from `from_block` to the chain tip
-/// via `sync_notes_with_details` — which fetches the full body of EVERY public
-/// note in the range matching the bridge's note tag, regardless of local
-/// tracking — filters to the B2AGG script root, and imports them by id
-/// (`NoteFile::NoteId`, which fetches from the node and stores). A follow-up
-/// `sync_state()` marks each consumed, so they appear in `NoteFilter::Consumed`
-/// for [`restore_bridge_outs`] to rebuild the BridgeEvent from.
+/// re-discovers them by **block-scanning** the node from `from_block` to the
+/// chain tip: for every block it enumerates the notes created in it
+/// (`ProvenBlock::body().output_notes()`), fetches their full bodies via
+/// `get_notes_by_id` (public notes resolve to `FetchedNote::Public` even after
+/// they've been consumed), filters to the B2AGG script root with
+/// [`is_b2agg_note`], and imports the matches by id (`NoteFile::NoteId`, which
+/// fetches from the node and stores). A follow-up `sync_state()` marks each
+/// consumed, so they appear in `NoteFilter::Consumed` for [`restore_bridge_outs`]
+/// to rebuild the BridgeEvent from. (A tag-sync on `with_account_target(bridge)`
+/// returns zero — the bridge's B2AGG notes don't carry that tag — so the tag
+/// path is not usable here.)
 ///
 /// Returns the number of B2AGG notes imported. Best-effort: a scan/RPC failure is
 /// surfaced to the caller, which logs and continues with the local-only restore.
@@ -286,10 +292,9 @@ async fn recover_missed_bridge_outs(
     bridge_id: AccountId,
     from_block: u32,
 ) -> anyhow::Result<usize> {
-    use miden_client::rpc::domain::note::SyncedNoteDetails;
+    use miden_client::rpc::domain::note::FetchedNote;
     use miden_protocol::block::BlockNumber;
-    use miden_protocol::note::{NoteDetails, NoteFile, NoteTag};
-    use std::collections::BTreeSet;
+    use miden_protocol::note::{NoteDetails, NoteFile, NoteId};
 
     let endpoint = crate::miden_client::parse_node_url(node_url)?;
     let rpc = crate::miden_client::build_rpc_client(&endpoint, 30_000, api_key);
@@ -298,36 +303,75 @@ async fn recover_missed_bridge_outs(
         .get_block_header_by_number(None, false)
         .await
         .map_err(|e| anyhow::anyhow!("recovery: get chain tip: {e}"))?;
-    let tip = tip_header.block_num();
+    let to_block = tip_header.block_num().as_u32();
+    if from_block > to_block {
+        tracing::warn!(
+            from_block,
+            to_block,
+            "recovery: from_block is past the chain tip; nothing to scan"
+        );
+        return Ok(0);
+    }
 
-    // Notes the bridge consumes are tagged with the bridge as the target account
-    // (so the network/ntx-builder picks them up). `sync_notes` paginates the full
-    // [from_block, tip] range internally.
-    let mut tags = BTreeSet::new();
-    tags.insert(NoteTag::with_account_target(bridge_id));
-
-    let (_blocks, synced) = rpc
-        .sync_notes_with_details(BlockNumber::from(from_block), tip, &tags)
-        .await
-        .map_err(|e| anyhow::anyhow!("recovery: sync_notes_with_details: {e}"))?;
-
-    let mut b2agg_ids = Vec::new();
-    for (note_id, detail) in &synced {
-        if let SyncedNoteDetails::Public(note) = detail {
-            let details: NoteDetails = note.clone().into();
-            if is_b2agg_note(&details) {
-                b2agg_ids.push(*note_id);
+    // Tag-independent block scan. The bridge's B2AGG notes are NOT tagged with the
+    // bridge as the target account (a tag-sync on `with_account_target(bridge)`
+    // returns zero), so walk every block in `[from_block, to_block]`, enumerate
+    // the notes it created (`body().output_notes()`), fetch their full bodies via
+    // `get_notes_by_id` (public notes come back as `FetchedNote::Public` even when
+    // already consumed), and keep the ones whose script root is the B2AGG script.
+    // This is the explorer-style "scan blocks, filter is-b2agg" path. The on-chain
+    // `consumer == bridge` gating is enforced downstream by `restore_bridge_outs`
+    // once the notes are imported and observed consumed.
+    let mut b2agg_ids: Vec<NoteId> = Vec::new();
+    let mut scanned = 0usize;
+    for b in from_block..=to_block {
+        let block = match rpc.get_block_by_number(BlockNumber::from(b), false).await {
+            Ok(block) => block,
+            Err(e) => {
+                tracing::warn!(block = b, err = %e, "recovery: get_block_by_number failed; skipping");
+                continue;
             }
+        };
+
+        // All notes created in this block (public + private), by id.
+        let ids: Vec<NoteId> = block.body().output_notes().map(|(_, n)| n.id()).collect();
+        if !ids.is_empty() {
+            match rpc.get_notes_by_id(&ids).await {
+                Ok(fetched) => {
+                    for f in fetched {
+                        if let FetchedNote::Public(note, _) = f {
+                            let details: NoteDetails = note.clone().into();
+                            if is_b2agg_note(&details) {
+                                b2agg_ids.push(note.id());
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(block = b, err = %e, "recovery: get_notes_by_id failed; skipping block");
+                }
+            }
+        }
+
+        scanned += 1;
+        if scanned.is_multiple_of(200) {
+            tracing::info!(
+                at_block = b,
+                to_block,
+                scanned,
+                b2agg = b2agg_ids.len(),
+                "recovery scan: progress"
+            );
         }
     }
 
     tracing::info!(
         bridge = %bridge_id,
         from_block,
-        to_block = tip.as_u32(),
-        public_notes = synced.len(),
+        to_block,
+        blocks_scanned = scanned,
         b2agg = b2agg_ids.len(),
-        "recovery scan: B2AGG notes targeting the bridge found on the node"
+        "recovery scan complete: B2AGG bridge-out notes found on the node"
     );
 
     if b2agg_ids.is_empty() {

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -116,6 +116,8 @@ pub async fn restore(
     miden_client: &MidenClient,
     accounts: &AccountsConfig,
     block_state: &Arc<BlockState>,
+    node_url: Option<&str>,
+    api_key: Option<&str>,
 ) -> anyhow::Result<RestoreResult> {
     tracing::info!("=== RESTORE: starting state reconstruction ===");
 
@@ -157,6 +159,32 @@ pub async fn restore(
     // We'll assign synthetic logs to blocks starting after current
     let mut next_block = block_num + 1;
     let mut total_logs = 0usize;
+
+    // Phase 1.5 (PRST-4035): recover bridge-out notes the local store never
+    // recorded (consumed by the bridge via network txs). Tag-scan the node and
+    // import them so the Phase 2 NoteFilter::Consumed scan below can see them.
+    // Best-effort: a failure must not abort restore.
+    if let Some(url) = node_url {
+        let from_block: u32 = std::env::var("RECOVER_FROM_BLOCK")
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
+            .unwrap_or(0);
+        tracing::info!(
+            from_block,
+            "Phase 1.5: recovering missed bridge-out notes from the node..."
+        );
+        match recover_missed_bridge_outs(miden_client, url, api_key, accounts.bridge.0, from_block)
+            .await
+        {
+            Ok(n) => tracing::info!("Phase 1.5 complete: recovered {n} B2AGG note(s) from the node"),
+            Err(e) => tracing::warn!(
+                err = %e,
+                "Phase 1.5 recovery scan failed; continuing with local-only restore"
+            ),
+        }
+    } else {
+        tracing::warn!("Phase 1.5 skipped: no --miden-node URL available to restore()");
+    }
 
     // Phase 2: Scan miden consumed B2AGG notes
     tracing::info!("Phase 2: scanning miden consumed B2AGG notes...");
@@ -231,6 +259,105 @@ async fn sync_miden_block(
 
 /// Phase 2: scan miden consumed B2AGG notes and rebuild bridge-out state.
 /// Returns (notes_processed, logs_created).
+/// PRST-4035 — recover bridge-out notes the local store never saw.
+///
+/// The bridge account consumes B2AGG bridge-out notes via NETWORK transactions
+/// (executed by the ntx-builder, not the proxy's client). Those consumptions are
+/// never recorded in the proxy's local miden-client store, so the
+/// `NoteFilter::Consumed` scan that both the live [`crate::bridge_out::BridgeOutScanner`]
+/// and [`restore_bridge_outs`] rely on cannot see them — the exit is invisible,
+/// aggsender never certifies it, and it can't be claimed on L1.
+///
+/// The notes are still on the node (public, nullifier committed). This
+/// re-discovers them by tag-scanning the node from `from_block` to the chain tip
+/// via `sync_notes_with_details` — which fetches the full body of EVERY public
+/// note in the range matching the bridge's note tag, regardless of local
+/// tracking — filters to the B2AGG script root, and imports them by id
+/// (`NoteFile::NoteId`, which fetches from the node and stores). A follow-up
+/// `sync_state()` marks each consumed, so they appear in `NoteFilter::Consumed`
+/// for [`restore_bridge_outs`] to rebuild the BridgeEvent from.
+///
+/// Returns the number of B2AGG notes imported. Best-effort: a scan/RPC failure is
+/// surfaced to the caller, which logs and continues with the local-only restore.
+async fn recover_missed_bridge_outs(
+    miden_client: &MidenClient,
+    node_url: &str,
+    api_key: Option<&str>,
+    bridge_id: AccountId,
+    from_block: u32,
+) -> anyhow::Result<usize> {
+    use miden_client::rpc::domain::note::SyncedNoteDetails;
+    use miden_protocol::block::BlockNumber;
+    use miden_protocol::note::{NoteDetails, NoteFile, NoteTag};
+    use std::collections::BTreeSet;
+
+    let endpoint = crate::miden_client::parse_node_url(node_url)?;
+    let rpc = crate::miden_client::build_rpc_client(&endpoint, 30_000, api_key);
+
+    let (tip_header, _) = rpc
+        .get_block_header_by_number(None, false)
+        .await
+        .map_err(|e| anyhow::anyhow!("recovery: get chain tip: {e}"))?;
+    let tip = tip_header.block_num();
+
+    // Notes the bridge consumes are tagged with the bridge as the target account
+    // (so the network/ntx-builder picks them up). `sync_notes` paginates the full
+    // [from_block, tip] range internally.
+    let mut tags = BTreeSet::new();
+    tags.insert(NoteTag::with_account_target(bridge_id));
+
+    let (_blocks, synced) = rpc
+        .sync_notes_with_details(BlockNumber::from(from_block), tip, &tags)
+        .await
+        .map_err(|e| anyhow::anyhow!("recovery: sync_notes_with_details: {e}"))?;
+
+    let mut b2agg_ids = Vec::new();
+    for (note_id, detail) in &synced {
+        if let SyncedNoteDetails::Public(note) = detail {
+            let details: NoteDetails = note.clone().into();
+            if is_b2agg_note(&details) {
+                b2agg_ids.push(*note_id);
+            }
+        }
+    }
+
+    tracing::info!(
+        bridge = %bridge_id,
+        from_block,
+        to_block = tip.as_u32(),
+        public_notes = synced.len(),
+        b2agg = b2agg_ids.len(),
+        "recovery scan: B2AGG notes targeting the bridge found on the node"
+    );
+
+    if b2agg_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let note_files: Vec<NoteFile> = b2agg_ids.iter().copied().map(NoteFile::NoteId).collect();
+    let imported = b2agg_ids.len();
+
+    miden_client
+        .with(move |client| {
+            Box::new(async move {
+                client
+                    .import_notes(&note_files)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("recovery: import_notes: {e}"))?;
+                // Mark the freshly-imported notes consumed (their nullifiers are
+                // committed) so they land in NoteFilter::Consumed for Phase 2.
+                client
+                    .sync_state()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("recovery: sync_state after import: {e}"))?;
+                Ok(())
+            })
+        })
+        .await?;
+
+    Ok(imported)
+}
+
 async fn restore_bridge_outs(
     store: &Arc<dyn Store>,
     miden_client: &MidenClient,


### PR DESCRIPTION
## Problem (PRST-4035)

A L2→L1 bridge-out is consumed by the bridge account via a **network transaction**. The proxy's local miden-client store never records that consumption, so `NoteFilter::Consumed` — which both `BridgeOutScanner` and restore Phase 2 rely on — never sees the note. The bridge-out is invisible to the proxy: aggsender never certifies it and it can't be claimed on L1. `--restore` couldn't fix it (same filter); after a store reset the note is gone locally even though the node still holds it (public, `NULLIFIER_COMMITTED`).

Prod symptom: on-chain bridge LET=1 but aggkit `deposit_count`=0 (gap=1).

## Fix

New restore **Phase 1.5** `recover_missed_bridge_outs` — before Phase 2 runs, **block-scan the node** to re-discover the bridge's B2AGG notes regardless of local tracking:

1. `get_block_header_by_number` → chain tip
2. for each block in `[RECOVER_FROM_BLOCK, tip]`: `get_block_by_number(b)` → enumerate created output notes → `get_notes_by_id` → keep `FetchedNote::Public` where `is_b2agg_note`
3. `import_notes(NoteFile::NoteId)` + `sync_state()` → notes land consumed in the local store

The existing Phase 2 `restore_bridge_outs` (`NoteFilter::Consumed` + is_b2agg + `consumer == bridge`) then rebuilds the `BridgeEvent` and bumps `deposit_counter`. Best-effort: scan errors warn-and-continue; failed/missing blocks are skipped.

(Tag-based discovery via `sync_notes_with_details` was tried first, but the bridge's B2AGG notes don't carry the `with_account_target` tag — it returned 0. The block-scan is tag-independent.)

## Verification — real prod dump

Ran `--restore` against the stuck prod store (miden + Postgres) pointed at `rpc.testnet.miden.io`:
- `recovery scan complete: ... b2agg=1` → `Phase 2 complete: 1 bridge-outs`
- **`deposit_counter` 0 → 1**, `bridge_out_processed` = 1 — gap closed vs on-chain bridge LET=1

Then ran the proxy in normal serving mode against the recovered state; the bridge-out is served via `eth_getLogs` (the `BridgeEvent` topic `0x501781…`), decoded:
- `leafType=0`, `destNetwork=0` (Sepolia), `destAddress=0x9d865bc3…192e`, `amount=100000000000000` (0.0001 ETH), `depositCount=0`

Proxy healthy: 0 `database is locked`, 0 panics. aggkit would now observe the deposit → certify → claimable on L1.

## Ops note

Block-scan is ~2 RPCs/block. Set `RECOVER_FROM_BLOCK` near the stuck bridge-out's commit block for a fast scan; a from-genesis run is heavy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
