### PR TITLE
Merge release/0.15 into main (v0.15.2)

### DIFF
--- a/src/l2_to_l1_claimer.rs
+++ b/src/l2_to_l1_claimer.rs
@@ -332,30 +332,8 @@ impl CursorStore {
 
 // ─── I/O ──────────────────────────────────────────────────────────────────
 
-/// Discover our rollup's L2→L1 asset exits from block `from` onward, from the
-/// proxy's synthetic `BridgeEvent` logs.
-///
-/// The upper bound is the `latest` tag, NOT `eth_blockNumber`: the proxy's
-/// `eth_blockNumber` mirror can lag the synthetic-log tip (it is advanced by
-/// some write paths but not the bridge-out synthetic-log path), while
-/// `eth_getLogs` with the `latest` tag is resolved against the true tip. Bounding
-/// by `eth_blockNumber` made `discover` miss every bridge-out whose
-/// (Miden-derived) block number exceeded the lagging head — so no exit was ever
-/// claimed.
-async fn discover<P: Provider>(
-    l2: &P,
-    bridge_address: Address,
-    from: u64,
-) -> anyhow::Result<Vec<PendingExit>> {
-    let filter = Filter::new()
-        .address(bridge_address)
-        .from_block(from)
-        .to_block(BlockNumberOrTag::Latest)
-        .event_signature(BridgeEvent::SIGNATURE_HASH);
-
-    let logs = l2.get_logs(&filter).await?;
-    tracing::debug!(from, %bridge_address, raw_logs = logs.len(), "discover: get_logs returned");
-    let mut out = Vec::new();
+/// Decode raw `BridgeEvent` logs into our L2→L1 (destination network 0) exits.
+fn collect_exits(logs: Vec<alloy::rpc::types::Log>, out: &mut Vec<PendingExit>) {
     for log in logs {
         let block = log.block_number.unwrap_or(0);
         match BridgeEvent::decode_log_data(log.data()) {
@@ -372,6 +350,83 @@ async fn discover<P: Provider>(
             }
         }
     }
+}
+
+/// Inclusive numeric `[from, to]` windows covering `[from, head]`, each spanning
+/// at most `max_range` blocks. The trailing `(head, latest]` window is handled
+/// separately by `discover` (it must use the `latest` tag, see below). Returns
+/// empty when `from > head` (cursor already at/after the numeric head).
+///
+/// Pure (no I/O) so the windowing — the part that has to respect the proxy's
+/// getLogs cap — is unit-tested.
+fn scan_windows(from: u64, head: u64, max_range: u64) -> Vec<(u64, u64)> {
+    let step = max_range.max(1);
+    let mut windows = Vec::new();
+    let mut cur = from;
+    while cur <= head {
+        // span (to - from) == step - 1, strictly below `max_range`.
+        let to = cur.saturating_add(step - 1).min(head);
+        windows.push((cur, to));
+        cur = to + 1;
+    }
+    windows
+}
+
+/// Discover our rollup's L2→L1 asset exits from block `from` onward, from the
+/// proxy's synthetic `BridgeEvent` logs.
+///
+/// The miden-agglayer proxy caps `eth_getLogs` at `MAX_GETLOGS_BLOCK_RANGE`
+/// (10_000 blocks) and rejects wider spans. A single `from -> latest` query (the
+/// previous behaviour) therefore failed whenever `(tip - from)` exceeded the cap
+/// — on a fresh cursor (`from = 0`) that was *every* poll (PRST-4030). We chunk
+/// the scan into `<= max_range` windows instead.
+///
+/// The upper bound is still the `latest` tag for the final window, NOT
+/// `eth_blockNumber`: the proxy's `eth_blockNumber` mirror can lag the
+/// synthetic-log tip (it is advanced by some write paths but not the bridge-out
+/// synthetic-log path). So we scan the bulk `[from, head]` in numeric windows,
+/// then finish with one `latest`-bounded window to capture logs beyond the
+/// numeric head. That trailing span is just the (small) lag; each numeric window
+/// is `< max_range`, which the caller keeps below the proxy cap.
+async fn discover<P: Provider>(
+    l2: &P,
+    bridge_address: Address,
+    from: u64,
+    max_range: u64,
+) -> anyhow::Result<Vec<PendingExit>> {
+    let head = l2.get_block_number().await?;
+    let mut out = Vec::new();
+
+    // Bulk catch-up: numeric windows up to the (possibly lagging) numeric head.
+    for (w_from, w_to) in scan_windows(from, head, max_range) {
+        let filter = Filter::new()
+            .address(bridge_address)
+            .from_block(w_from)
+            .to_block(w_to)
+            .event_signature(BridgeEvent::SIGNATURE_HASH);
+        let logs = l2.get_logs(&filter).await?;
+        tracing::debug!(
+            from = w_from,
+            to = w_to,
+            raw_logs = logs.len(),
+            "discover: numeric window"
+        );
+        collect_exits(logs, &mut out);
+    }
+
+    // Trailing window to the true tip via the `latest` tag, to catch synthetic
+    // logs the numeric head doesn't yet reflect. `tail_from` is `head + 1` after
+    // the loop, or `from` when `from > head` (loop produced no windows).
+    let tail_from = from.max(head.saturating_add(1));
+    let filter = Filter::new()
+        .address(bridge_address)
+        .from_block(tail_from)
+        .to_block(BlockNumberOrTag::Latest)
+        .event_signature(BridgeEvent::SIGNATURE_HASH);
+    let logs = l2.get_logs(&filter).await?;
+    tracing::debug!(from = tail_from, %bridge_address, raw_logs = logs.len(), "discover: latest tail");
+    collect_exits(logs, &mut out);
+
     Ok(out)
 }
 
@@ -605,9 +660,10 @@ async fn poll_once<P1: Provider, P2: Provider>(
     last_processed: &mut u64,
 ) -> anyhow::Result<()> {
     let from = *last_processed + 1;
-    // Scan to the `latest` tag (see `discover`): the proxy's `eth_blockNumber`
-    // can lag the synthetic-log tip, so a numeric head bound would skip exits.
-    let exits = discover(l2, cfg.bridge_address, from).await?;
+    // Chunked scan (see `discover`): numeric windows up to the head + a final
+    // `latest`-bounded window, each <= cfg.max_range to respect the proxy's
+    // eth_getLogs cap (PRST-4030).
+    let exits = discover(l2, cfg.bridge_address, from, cfg.max_range).await?;
     if !exits.is_empty() {
         tracing::info!(from, count = exits.len(), "discovered L2->L1 exits");
     }
@@ -654,6 +710,54 @@ async fn poll_once<P1: Provider, P2: Provider>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── scan_windows: the chunking that must respect the proxy getLogs cap ──
+
+    /// Every numeric window spans strictly less than `max_range` blocks, so each
+    /// `eth_getLogs` stays under the proxy's MAX_GETLOGS_BLOCK_RANGE cap. This is
+    /// the regression guard for PRST-4030 (a single `0 -> latest` query, span
+    /// ~196k, was rejected on every poll).
+    #[test]
+    fn scan_windows_each_under_max_range_and_contiguous() {
+        let from = 0;
+        let head = 196_476; // ~the L2 synthetic head that triggered the bug
+        let max_range = 10_000;
+        let ws = scan_windows(from, head, max_range);
+        assert_eq!(ws.first().unwrap().0, from);
+        assert_eq!(ws.last().unwrap().1, head, "windows must cover up to head");
+        let mut expected_next = from;
+        for (f, t) in &ws {
+            assert_eq!(*f, expected_next, "windows must be contiguous, no gaps");
+            assert!(t >= f);
+            assert!(
+                t - f < max_range,
+                "span {} must be < cap {max_range}",
+                t - f
+            );
+            expected_next = t + 1;
+        }
+    }
+
+    /// `from > head` (cursor at/after the numeric head) yields no numeric
+    /// windows — `discover` then does only the trailing `latest` query.
+    #[test]
+    fn scan_windows_empty_when_from_past_head() {
+        assert!(scan_windows(500, 499, 10_000).is_empty());
+        assert!(scan_windows(1, 0, 10_000).is_empty());
+    }
+
+    /// A span that fits in one window produces exactly one `[from, head]` window.
+    #[test]
+    fn scan_windows_single_small_span() {
+        assert_eq!(scan_windows(100, 600, 10_000), vec![(100, 600)]);
+    }
+
+    /// `max_range = 0` must not divide-by-zero / loop forever; clamps to 1.
+    #[test]
+    fn scan_windows_zero_max_range_is_safe() {
+        let ws = scan_windows(0, 3, 0);
+        assert_eq!(ws, vec![(0, 0), (1, 1), (2, 2), (3, 3)]);
+    }
 
     #[test]
     fn global_index_layout_rollup() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -562,9 +562,15 @@ async fn main() -> anyhow::Result<()> {
     // their initial `submit_new_transaction` deploys them on-chain.
     // Run restore if requested
     if command.restore {
-        let result =
-            miden_agglayer_service::restore::restore(&store, &client, &accounts.0, &block_state)
-                .await?;
+        let result = miden_agglayer_service::restore::restore(
+            &store,
+            &client,
+            &accounts.0,
+            &block_state,
+            command.miden_node.as_deref(),
+            command.miden_api_key.as_deref(),
+        )
+        .await?;
 
         tracing::info!(
             "Restore complete: block={}, bridge_outs={}, claims={}, gers={}, logs={}",

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -176,7 +176,9 @@ pub async fn restore(
         match recover_missed_bridge_outs(miden_client, url, api_key, accounts.bridge.0, from_block)
             .await
         {
-            Ok(n) => tracing::info!("Phase 1.5 complete: recovered {n} B2AGG note(s) from the node"),
+            Ok(n) => {
+                tracing::info!("Phase 1.5 complete: recovered {n} B2AGG note(s) from the node")
+            }
             Err(e) => tracing::warn!(
                 err = %e,
                 "Phase 1.5 recovery scan failed; continuing with local-only restore"
@@ -269,13 +271,17 @@ async fn sync_miden_block(
 /// aggsender never certifies it, and it can't be claimed on L1.
 ///
 /// The notes are still on the node (public, nullifier committed). This
-/// re-discovers them by tag-scanning the node from `from_block` to the chain tip
-/// via `sync_notes_with_details` — which fetches the full body of EVERY public
-/// note in the range matching the bridge's note tag, regardless of local
-/// tracking — filters to the B2AGG script root, and imports them by id
-/// (`NoteFile::NoteId`, which fetches from the node and stores). A follow-up
-/// `sync_state()` marks each consumed, so they appear in `NoteFilter::Consumed`
-/// for [`restore_bridge_outs`] to rebuild the BridgeEvent from.
+/// re-discovers them by **block-scanning** the node from `from_block` to the
+/// chain tip: for every block it enumerates the notes created in it
+/// (`ProvenBlock::body().output_notes()`), fetches their full bodies via
+/// `get_notes_by_id` (public notes resolve to `FetchedNote::Public` even after
+/// they've been consumed), filters to the B2AGG script root with
+/// [`is_b2agg_note`], and imports the matches by id (`NoteFile::NoteId`, which
+/// fetches from the node and stores). A follow-up `sync_state()` marks each
+/// consumed, so they appear in `NoteFilter::Consumed` for [`restore_bridge_outs`]
+/// to rebuild the BridgeEvent from. (A tag-sync on `with_account_target(bridge)`
+/// returns zero — the bridge's B2AGG notes don't carry that tag — so the tag
+/// path is not usable here.)
 ///
 /// Returns the number of B2AGG notes imported. Best-effort: a scan/RPC failure is
 /// surfaced to the caller, which logs and continues with the local-only restore.
@@ -286,10 +292,9 @@ async fn recover_missed_bridge_outs(
     bridge_id: AccountId,
     from_block: u32,
 ) -> anyhow::Result<usize> {
-    use miden_client::rpc::domain::note::SyncedNoteDetails;
+    use miden_client::rpc::domain::note::FetchedNote;
     use miden_protocol::block::BlockNumber;
-    use miden_protocol::note::{NoteDetails, NoteFile, NoteTag};
-    use std::collections::BTreeSet;
+    use miden_protocol::note::{NoteDetails, NoteFile, NoteId};
 
     let endpoint = crate::miden_client::parse_node_url(node_url)?;
     let rpc = crate::miden_client::build_rpc_client(&endpoint, 30_000, api_key);
@@ -298,36 +303,75 @@ async fn recover_missed_bridge_outs(
         .get_block_header_by_number(None, false)
         .await
         .map_err(|e| anyhow::anyhow!("recovery: get chain tip: {e}"))?;
-    let tip = tip_header.block_num();
+    let to_block = tip_header.block_num().as_u32();
+    if from_block > to_block {
+        tracing::warn!(
+            from_block,
+            to_block,
+            "recovery: from_block is past the chain tip; nothing to scan"
+        );
+        return Ok(0);
+    }
 
-    // Notes the bridge consumes are tagged with the bridge as the target account
-    // (so the network/ntx-builder picks them up). `sync_notes` paginates the full
-    // [from_block, tip] range internally.
-    let mut tags = BTreeSet::new();
-    tags.insert(NoteTag::with_account_target(bridge_id));
-
-    let (_blocks, synced) = rpc
-        .sync_notes_with_details(BlockNumber::from(from_block), tip, &tags)
-        .await
-        .map_err(|e| anyhow::anyhow!("recovery: sync_notes_with_details: {e}"))?;
-
-    let mut b2agg_ids = Vec::new();
-    for (note_id, detail) in &synced {
-        if let SyncedNoteDetails::Public(note) = detail {
-            let details: NoteDetails = note.clone().into();
-            if is_b2agg_note(&details) {
-                b2agg_ids.push(*note_id);
+    // Tag-independent block scan. The bridge's B2AGG notes are NOT tagged with the
+    // bridge as the target account (a tag-sync on `with_account_target(bridge)`
+    // returns zero), so walk every block in `[from_block, to_block]`, enumerate
+    // the notes it created (`body().output_notes()`), fetch their full bodies via
+    // `get_notes_by_id` (public notes come back as `FetchedNote::Public` even when
+    // already consumed), and keep the ones whose script root is the B2AGG script.
+    // This is the explorer-style "scan blocks, filter is-b2agg" path. The on-chain
+    // `consumer == bridge` gating is enforced downstream by `restore_bridge_outs`
+    // once the notes are imported and observed consumed.
+    let mut b2agg_ids: Vec<NoteId> = Vec::new();
+    let mut scanned = 0usize;
+    for b in from_block..=to_block {
+        let block = match rpc.get_block_by_number(BlockNumber::from(b), false).await {
+            Ok(block) => block,
+            Err(e) => {
+                tracing::warn!(block = b, err = %e, "recovery: get_block_by_number failed; skipping");
+                continue;
             }
+        };
+
+        // All notes created in this block (public + private), by id.
+        let ids: Vec<NoteId> = block.body().output_notes().map(|(_, n)| n.id()).collect();
+        if !ids.is_empty() {
+            match rpc.get_notes_by_id(&ids).await {
+                Ok(fetched) => {
+                    for f in fetched {
+                        if let FetchedNote::Public(note, _) = f {
+                            let details: NoteDetails = note.clone().into();
+                            if is_b2agg_note(&details) {
+                                b2agg_ids.push(note.id());
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(block = b, err = %e, "recovery: get_notes_by_id failed; skipping block");
+                }
+            }
+        }
+
+        scanned += 1;
+        if scanned.is_multiple_of(200) {
+            tracing::info!(
+                at_block = b,
+                to_block,
+                scanned,
+                b2agg = b2agg_ids.len(),
+                "recovery scan: progress"
+            );
         }
     }
 
     tracing::info!(
         bridge = %bridge_id,
         from_block,
-        to_block = tip.as_u32(),
-        public_notes = synced.len(),
+        to_block,
+        blocks_scanned = scanned,
         b2agg = b2agg_ids.len(),
-        "recovery scan: B2AGG notes targeting the bridge found on the node"
+        "recovery scan complete: B2AGG bridge-out notes found on the node"
     );
 
     if b2agg_ids.is_empty() {

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -116,6 +116,8 @@ pub async fn restore(
     miden_client: &MidenClient,
     accounts: &AccountsConfig,
     block_state: &Arc<BlockState>,
+    node_url: Option<&str>,
+    api_key: Option<&str>,
 ) -> anyhow::Result<RestoreResult> {
     tracing::info!("=== RESTORE: starting state reconstruction ===");
 
@@ -157,6 +159,32 @@ pub async fn restore(
     // We'll assign synthetic logs to blocks starting after current
     let mut next_block = block_num + 1;
     let mut total_logs = 0usize;
+
+    // Phase 1.5 (PRST-4035): recover bridge-out notes the local store never
+    // recorded (consumed by the bridge via network txs). Tag-scan the node and
+    // import them so the Phase 2 NoteFilter::Consumed scan below can see them.
+    // Best-effort: a failure must not abort restore.
+    if let Some(url) = node_url {
+        let from_block: u32 = std::env::var("RECOVER_FROM_BLOCK")
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
+            .unwrap_or(0);
+        tracing::info!(
+            from_block,
+            "Phase 1.5: recovering missed bridge-out notes from the node..."
+        );
+        match recover_missed_bridge_outs(miden_client, url, api_key, accounts.bridge.0, from_block)
+            .await
+        {
+            Ok(n) => tracing::info!("Phase 1.5 complete: recovered {n} B2AGG note(s) from the node"),
+            Err(e) => tracing::warn!(
+                err = %e,
+                "Phase 1.5 recovery scan failed; continuing with local-only restore"
+            ),
+        }
+    } else {
+        tracing::warn!("Phase 1.5 skipped: no --miden-node URL available to restore()");
+    }
 
     // Phase 2: Scan miden consumed B2AGG notes
     tracing::info!("Phase 2: scanning miden consumed B2AGG notes...");
@@ -231,6 +259,105 @@ async fn sync_miden_block(
 
 /// Phase 2: scan miden consumed B2AGG notes and rebuild bridge-out state.
 /// Returns (notes_processed, logs_created).
+/// PRST-4035 — recover bridge-out notes the local store never saw.
+///
+/// The bridge account consumes B2AGG bridge-out notes via NETWORK transactions
+/// (executed by the ntx-builder, not the proxy's client). Those consumptions are
+/// never recorded in the proxy's local miden-client store, so the
+/// `NoteFilter::Consumed` scan that both the live [`crate::bridge_out::BridgeOutScanner`]
+/// and [`restore_bridge_outs`] rely on cannot see them — the exit is invisible,
+/// aggsender never certifies it, and it can't be claimed on L1.
+///
+/// The notes are still on the node (public, nullifier committed). This
+/// re-discovers them by tag-scanning the node from `from_block` to the chain tip
+/// via `sync_notes_with_details` — which fetches the full body of EVERY public
+/// note in the range matching the bridge's note tag, regardless of local
+/// tracking — filters to the B2AGG script root, and imports them by id
+/// (`NoteFile::NoteId`, which fetches from the node and stores). A follow-up
+/// `sync_state()` marks each consumed, so they appear in `NoteFilter::Consumed`
+/// for [`restore_bridge_outs`] to rebuild the BridgeEvent from.
+///
+/// Returns the number of B2AGG notes imported. Best-effort: a scan/RPC failure is
+/// surfaced to the caller, which logs and continues with the local-only restore.
+async fn recover_missed_bridge_outs(
+    miden_client: &MidenClient,
+    node_url: &str,
+    api_key: Option<&str>,
+    bridge_id: AccountId,
+    from_block: u32,
+) -> anyhow::Result<usize> {
+    use miden_client::rpc::domain::note::SyncedNoteDetails;
+    use miden_protocol::block::BlockNumber;
+    use miden_protocol::note::{NoteDetails, NoteFile, NoteTag};
+    use std::collections::BTreeSet;
+
+    let endpoint = crate::miden_client::parse_node_url(node_url)?;
+    let rpc = crate::miden_client::build_rpc_client(&endpoint, 30_000, api_key);
+
+    let (tip_header, _) = rpc
+        .get_block_header_by_number(None, false)
+        .await
+        .map_err(|e| anyhow::anyhow!("recovery: get chain tip: {e}"))?;
+    let tip = tip_header.block_num();
+
+    // Notes the bridge consumes are tagged with the bridge as the target account
+    // (so the network/ntx-builder picks them up). `sync_notes` paginates the full
+    // [from_block, tip] range internally.
+    let mut tags = BTreeSet::new();
+    tags.insert(NoteTag::with_account_target(bridge_id));
+
+    let (_blocks, synced) = rpc
+        .sync_notes_with_details(BlockNumber::from(from_block), tip, &tags)
+        .await
+        .map_err(|e| anyhow::anyhow!("recovery: sync_notes_with_details: {e}"))?;
+
+    let mut b2agg_ids = Vec::new();
+    for (note_id, detail) in &synced {
+        if let SyncedNoteDetails::Public(note) = detail {
+            let details: NoteDetails = note.clone().into();
+            if is_b2agg_note(&details) {
+                b2agg_ids.push(*note_id);
+            }
+        }
+    }
+
+    tracing::info!(
+        bridge = %bridge_id,
+        from_block,
+        to_block = tip.as_u32(),
+        public_notes = synced.len(),
+        b2agg = b2agg_ids.len(),
+        "recovery scan: B2AGG notes targeting the bridge found on the node"
+    );
+
+    if b2agg_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let note_files: Vec<NoteFile> = b2agg_ids.iter().copied().map(NoteFile::NoteId).collect();
+    let imported = b2agg_ids.len();
+
+    miden_client
+        .with(move |client| {
+            Box::new(async move {
+                client
+                    .import_notes(&note_files)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("recovery: import_notes: {e}"))?;
+                // Mark the freshly-imported notes consumed (their nullifiers are
+                // committed) so they land in NoteFilter::Consumed for Phase 2.
+                client
+                    .sync_state()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("recovery: sync_state after import: {e}"))?;
+                Ok(())
+            })
+        })
+        .await?;
+
+    Ok(imported)
+}
+
 async fn restore_bridge_outs(
     store: &Arc<dyn Store>,
     miden_client: &MidenClient,


### PR DESCRIPTION
Merge `release/0.15` back into `main` following the **v0.15.2** release.

Brings the two L2→L1 reliability fixes shipped in v0.15.2 into `main`:
- **PRST-4035** — recover network-consumed bridge-outs via the `--restore` node block-scan (#96)
- **PRST-4030** — chunk bridge-autoclaim `eth_getLogs` to respect the proxy's block-range cap (#95)

`release/0.15` was 5 commits ahead of `main`; `main` is 8 ahead with independent work — this reconciles the two lines.
