### PR TITLE
Fix/miden store db lock

### DIFF
--- a/DB-LOCK-WIP.md
+++ b/DB-LOCK-WIP.md
@@ -1,0 +1,32 @@
+# DB-lock WIP — handoff (`fix/miden-store-db-lock`, off `v0.15.1`)
+
+**Status:** RED reproduced (unit); RED e2e in progress; GREEN (WAL fix) **not yet applied**.
+
+## The bug
+The proxy opens the miden-client sqlite store (`<store-dir>/store.sqlite3`) from **two of its own contexts** — the Miden **sync thread** (`MidenClient` loop, `sync_state()`) and the **RPC claim path** (`src/service_send_raw_txn.rs`). The store runs in default **rollback-journal** mode: `miden-client-sqlite-store`'s pool manager sets only `foreign_keys=ON`, and rusqlite's default 5s `busy_timeout` applies. In rollback-journal mode a reader's SHARED lock blocks a writer's COMMIT (which needs EXCLUSIVE), so under concurrent load the claim-path COMMIT is blocked by the sync reader and eventually returns `SQLITE_BUSY` → `database is locked`. No external process is involved.
+
+> NOTE: prod's `database is locked` was the **Postgres** store — a *separate* issue. This branch is the **sqlite** one. The PRST-4035 bridge-out recovery (now shipped as **v0.15.2**, PR #96; merge-back PR #97) is unrelated to this work.
+
+## RED (done)
+- **Unit** — `src/sqlite_pragmas.rs::writer_commit_not_blocked_by_concurrent_reader`: reader holds `BEGIN; SELECT`, writer does `BEGIN IMMEDIATE; INSERT; COMMIT` w/ 300ms busy_timeout. RED in rollback-journal, GREEN with WAL.
+  Run: `cargo test --lib sqlite_pragmas` (currently **fails = RED**, as intended).
+- **E2E** — `scripts/e2e-bridge-loadtest.sh` (N=250 PARALLEL=5) on a fresh stack drives concurrent bridge load (parallel-batched L1→L2 deposits + sequential L2→L1) to reproduce the runtime lock. Watch: `docker logs miden-agglayer-miden-agglayer-1 2>&1 | grep -c "database is locked"`.
+  (The plain `e2e-fuzz-bridge.sh` does NOT reproduce it — its concurrency is read-only.)
+
+## GREEN (TODO — the fix)
+Open the store once in **WAL mode** at startup, before the miden-client builder opens it (WAL is persistent → the pool's connections inherit it):
+1. `src/sqlite_pragmas.rs::open_store_connection` — add `conn.pragma_update(None, "journal_mode", "WAL")?;` next to `foreign_keys=ON`. → flips the unit test GREEN.
+2. `src/miden_client.rs` `MidenClient::new` — the store is opened via `ClientBuilder` + `ClientBuilderSqliteExt` (line ~9), path `<store_dir>/store.sqlite3`. Call `crate::sqlite_pragmas::open_store_connection(<store_dir>/store.sqlite3)` **before** the builder runs, to set WAL persistently (then drop the connection).
+3. Verify: `cargo test --lib sqlite_pragmas` (GREEN) **and** re-run the loadtest (0 `database is locked`).
+
+## Continue on another machine
+```bash
+git fetch && git checkout fix/miden-store-db-lock
+make e2e-up                                          # fresh 0.15.1 stack (node v0.15.0, ~10-20 min build)
+N=250 PARALLEL=5 ./scripts/e2e-bridge-loadtest.sh    # RED: should produce "database is locked" in proxy logs
+# --- apply the GREEN fix above, then:
+make e2e-up                                          # rebuild proxy image with the fix
+N=250 PARALLEL=5 ./scripts/e2e-bridge-loadtest.sh    # GREEN: 0 lock lines
+cargo test --lib sqlite_pragmas                      # unit RED -> GREEN
+```
+Then commit the WAL fix, open a PR to `release/0.15` (same base as PR #96).

--- a/scripts/e2e-bridge-loadtest.sh
+++ b/scripts/e2e-bridge-loadtest.sh
@@ -1,0 +1,543 @@
+#!/usr/bin/env bash
+# ══════════════════════════════════════════════════════════════════════════════
+# Bridge RELIABILITY Load Test  (standalone — NOT part of the e2e suite)
+#
+# Sends N bridge round-trips across 10 tokens (1 native ETH + 9 ERC-20) and
+# measures how RELIABLE the bridge is = what fraction of SUBMITTED bridges
+# actually get DELIVERED (claimed) by the time the stack settles.
+#
+#   • L1→L2 deposits (bridgeAsset)  : submitted in PARALLEL batches of PARALLEL
+#       (default 5) using EXPLICIT sequential nonces so they pack a block
+#       without racing each other.
+#   • L2→L1 bridge-outs (bridge-out-tool) : STRICTLY SEQUENTIAL, one at a time —
+#       the Miden prover + account state cannot take concurrency.
+#
+# Reliability is read back from the bridge-service deposit index:
+#   GET /bridges/<addr> → {deposits:[{ready_for_claim, claim_tx_hash, amount,
+#   orig_addr, network_id, ...}]}.  L1→L2 deposits land at DEST_ADDR (the L2
+#   wallet), L2→L1 deposits land at FUNDED_ADDR (the L1 EOA).
+#
+# Output: a clean RESULTS log (progress lines + final reliability matrix — tail
+# this) and a VERBOSE log (all cast / bridge-out-tool output).
+#
+# Usage:
+#   ./scripts/e2e-bridge-loadtest.sh                 # default N=250
+#   N=6 PARALLEL=3 ./scripts/e2e-bridge-loadtest.sh  # small validation run
+#
+# Requires: a fresh stack already up (make e2e-up).  Run this against an
+# otherwise-idle stack — it snapshots the bridge-service baseline after funding
+# and reports DELTAS, so prior deposits don't pollute the matrix, but a quiet
+# stack keeps the numbers easiest to read.
+#
+# set -uo pipefail (NOT -e): a single failed bridge must NOT abort the run —
+# that failure IS the signal we are measuring. Failures are logged and counted.
+# ══════════════════════════════════════════════════════════════════════════════
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURES_DIR="$PROJECT_DIR/fixtures"
+
+source "$FIXTURES_DIR/.env"
+
+L1_RPC="${L1_RPC:-http://localhost:8545}"
+L2_RPC="${L2_RPC:-http://localhost:8546}"
+BRIDGE_SERVICE_URL="${BRIDGE_SERVICE_URL:-http://localhost:18080}"
+
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-miden-agglayer}"
+AGGLAYER_CONTAINER="${AGGLAYER_CONTAINER:-${COMPOSE_PROJECT_NAME}-miden-agglayer-1}"
+AGGKIT_CONTAINER="${AGGKIT_CONTAINER:-${COMPOSE_PROJECT_NAME}-aggkit-1}"
+
+FUNDED_KEY="${FUNDED_KEY:-0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625}"
+FUNDED_ADDR=$(cast wallet address --private-key "$FUNDED_KEY")
+DEST_NETWORK=1  # Miden network id — local topology patch pins MIDEN_NETWORK_ID=1
+
+# ── Tunables (env-overridable) ────────────────────────────────────────────────
+N="${N:-250}"                     # total bridge ops (both directions)
+PARALLEL="${PARALLEL:-5}"         # L1→L2 batch size (max concurrent same-block)
+NUM_ERC20="${NUM_ERC20:-9}"       # ERC-20 token count (total tokens = 1 + this)
+SEED="${SEED:-$$}"                # RNG seed for op selection (reproducible)
+
+# Per-op bridge amounts.
+WEI_PER_UNIT=10000000000          # 10^10 wei per Miden unit (18 ETH - 8 Miden dec)
+AMT_L1_NATIVE_WEI="${AMT_L1_NATIVE_WEI:-10000000000000}"   # 1e13 wei  -> 1000 units
+AMT_L1_ERC20_BASE="${AMT_L1_ERC20_BASE:-1000000000000000}" # 1e15 base -> 1e5  units
+AMT_L2_UNITS="${AMT_L2_UNITS:-10}"                          # 10 Miden units per bridge-out
+
+# Funding (large L1→L2 once per token so the L2 wallet has balance for bridge-outs).
+FUND_NATIVE_WEI="${FUND_NATIVE_WEI:-10000000000000000}"     # 1e16 wei -> 1e6 units
+FUND_ERC20_BASE="${FUND_ERC20_BASE:-1000000000000000000}"   # 1e18 base-> 1e8 units
+TOKEN_DECIMALS=18
+TOKEN_SUPPLY="1000000000000000000000000000"  # 1e27 — plenty for funding + load
+APPROVE_HUGE="115792089237316195423570985008687907853269984665640564039457584007913129639935" # 2^256-1
+
+# Settle polling.
+SETTLE_STALL="${SETTLE_STALL:-180}"   # stop polling after this many s with no new claims
+SETTLE_CAP="${SETTLE_CAP:-1800}"      # absolute backstop (30 min)
+SETTLE_INTERVAL="${SETTLE_INTERVAL:-10}"
+
+# ── Logs ──────────────────────────────────────────────────────────────────────
+OUT_DIR="${OUT_DIR:-$PROJECT_DIR/.loadtest-results}"
+mkdir -p "$OUT_DIR"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+RESULTS_LOG="${RESULTS_LOG:-$OUT_DIR/loadtest-$STAMP.results.log}"
+VERBOSE_LOG="${VERBOSE_LOG:-$OUT_DIR/loadtest-$STAMP.verbose.log}"
+: > "$RESULTS_LOG"
+: > "$VERBOSE_LOG"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# r() → results log + stdout ; v() → verbose log only.
+r()    { echo -e "[$(date +%H:%M:%S)] $*" | tee -a "$RESULTS_LOG"; }
+rraw() { echo -e "$*" | tee -a "$RESULTS_LOG"; }
+v()    { echo "[$(date +%H:%M:%S)] $*" >> "$VERBOSE_LOG"; }
+die()  { echo -e "[$(date +%H:%M:%S)] FATAL: $*" | tee -a "$RESULTS_LOG" >&2; exit 1; }
+
+# ── Python helpers (written once into $TMP) ───────────────────────────────────
+# count_deposits.py: read bridge-service JSON on stdin, group by orig_addr,
+# emit "orig_addr_lower<TAB>total<TAB>ready<TAB>claimed" per group, filtered to
+# the requested network_id (0 = L1-origin L1→L2 ; 1 = Miden-origin L2→L1).
+cat > "$TMP/count_deposits.py" <<'PY'
+import json, sys
+want_net = int(sys.argv[1])
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+groups = {}
+for dep in d.get("deposits", []):
+    if dep.get("network_id") != want_net:
+        continue
+    oa = (dep.get("orig_addr") or "").lower()
+    g = groups.setdefault(oa, [0, 0, 0])
+    g[0] += 1
+    if dep.get("ready_for_claim"):
+        g[1] += 1
+    if (dep.get("claim_tx_hash") or "") not in ("", None, "0x"):
+        g[2] += 1
+for oa, (t, rdy, cl) in groups.items():
+    print(f"{oa}\t{t}\t{rdy}\t{cl}")
+PY
+
+NATIVE_ADDR="0x0000000000000000000000000000000000000000"
+
+# count_for <endpoint_addr> <want_net> <orig_addr_lower>  → "total ready claimed"
+count_for() {
+    local endpoint="$1" net="$2" oa="$3"
+    curl -sf "$BRIDGE_SERVICE_URL/bridges/$endpoint" 2>/dev/null \
+        | python3 "$TMP/count_deposits.py" "$net" 2>/dev/null \
+        | awk -v k="$oa" -F'\t' '$1==k{print $2, $3, $4; found=1} END{if(!found) print "0 0 0"}'
+}
+
+# count_all <endpoint_addr> <want_net>  → "total ready claimed" summed over all tokens
+count_all() {
+    curl -sf "$BRIDGE_SERVICE_URL/bridges/$1" 2>/dev/null \
+        | python3 "$TMP/count_deposits.py" "$2" 2>/dev/null \
+        | awk -F'\t' '{t+=$2; r+=$3; c+=$4} END{print (t+0), (r+0), (c+0)}'
+}
+
+wait_for() {
+    local desc="$1" cmd="$2" timeout="$3" interval="${4:-5}" elapsed=0
+    v "WAIT: $desc (timeout ${timeout}s)"
+    while ! ( set +o pipefail; eval "$cmd" ) 2>/dev/null; do
+        elapsed=$((elapsed + interval))
+        [[ $elapsed -ge $timeout ]] && { v "WAIT TIMEOUT: $desc"; return 1; }
+        sleep "$interval"
+    done
+    return 0
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Pre-flight
+# ══════════════════════════════════════════════════════════════════════════════
+command -v cast  >/dev/null || die "cast (foundry) not found"
+command -v forge >/dev/null || die "forge (foundry) not found"
+command -v python3 >/dev/null || die "python3 not found"
+cast block-number --rpc-url "$L1_RPC" >/dev/null 2>&1 || die "L1 (Anvil) not reachable at $L1_RPC"
+: "${ADMIN_API_KEY:?fixtures/.env must define ADMIN_API_KEY}"
+ADMIN_BEARER="Authorization: Bearer ${ADMIN_API_KEY}"
+
+# bridge-service binds its HTTP API a little after the container is healthy.
+BRIDGE_UP=false
+for _ in $(seq 1 30); do
+    if curl -sf "$BRIDGE_SERVICE_URL/bridges/$NATIVE_ADDR" >/dev/null 2>&1; then BRIDGE_UP=true; break; fi
+    sleep 2
+done
+[[ "$BRIDGE_UP" == "true" ]] || die "Bridge service not reachable at $BRIDGE_SERVICE_URL"
+
+# ── Account IDs + DEST_ADDR (zero-padded L2 wallet) ───────────────────────────
+ACCOUNTS=$(docker exec "$AGGLAYER_CONTAINER" \
+    cat /var/lib/miden-agglayer-service/bridge_accounts.toml 2>/dev/null) \
+    || die "miden-agglayer not initialized"
+WALLET_ID=$(echo "$ACCOUNTS" | grep wallet_hardhat | sed 's/.*= "//;s/"//')
+BRIDGE_ID=$(echo "$ACCOUNTS" | grep 'bridge = ' | sed 's/.*= "//;s/"//')
+FAUCET_ETH=$(echo "$ACCOUNTS" | grep faucet_eth | sed 's/.*= "//;s/"//')
+[[ -n "$WALLET_ID" && -n "$BRIDGE_ID" && -n "$FAUCET_ETH" ]] || die "could not parse bridge_accounts.toml"
+
+WALLET_HEX=$(docker exec "$AGGLAYER_CONTAINER" bridge-out-tool \
+    --store-dir /var/lib/miden-agglayer-service --node-url http://miden-node:57291 \
+    --wallet-id "$WALLET_ID" --bridge-id "$BRIDGE_ID" --faucet-id "$FAUCET_ETH" \
+    --amount 1 --dest-address 0xdead --dest-network 0 2>&1 | grep "wallet:" | awk '{print $NF}' || true)
+[[ -n "$WALLET_HEX" ]] || die "could not resolve wallet hex"
+INNER="${WALLET_HEX#0x}"
+DEST_ADDR="0x00000000${INNER:0:16}${INNER:16:14}00"
+
+# ── Token tables (index 0 = native ETH) ───────────────────────────────────────
+declare -a T_ADDR T_LABEL T_FAUCET T_NATIVE
+T_ADDR[0]="$NATIVE_ADDR"; T_LABEL[0]="ETH"; T_FAUCET[0]="$FAUCET_ETH"; T_NATIVE[0]=1
+NUM_TOKENS=$((NUM_ERC20 + 1))
+
+r "======================================================================"
+r "  Bridge RELIABILITY Load Test"
+r "======================================================================"
+r "  N=$N  PARALLEL=$PARALLEL  tokens=$NUM_TOKENS (1 ETH + $NUM_ERC20 ERC20)  seed=$SEED"
+r "  Wallet:  $WALLET_HEX"
+r "  Dest:    $DEST_ADDR"
+r "  Results: $RESULTS_LOG"
+r "  Verbose: $VERBOSE_LOG"
+r "======================================================================"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Setup: deploy + approve ERC-20s
+# ══════════════════════════════════════════════════════════════════════════════
+r "Setup 1/4: deploying $NUM_ERC20 ERC-20 tokens (distinct symbols TT0..TT$((NUM_ERC20-1)))..."
+for k in $(seq 0 $((NUM_ERC20 - 1))); do
+    idx=$((k + 1))
+    sym="TT$k"
+    out=$(forge create "$FIXTURES_DIR/TestToken.sol:TestToken" \
+        --rpc-url "$L1_RPC" --private-key "$FUNDED_KEY" --broadcast \
+        --constructor-args "LoadToken$k" "$sym" "$TOKEN_DECIMALS" "$TOKEN_SUPPLY" 2>&1)
+    echo "$out" >> "$VERBOSE_LOG"
+    addr=$(echo "$out" | grep "Deployed to:" | awk '{print $NF}')
+    [[ -n "$addr" ]] || die "deploy failed for $sym: $(echo "$out" | tail -3)"
+    T_ADDR[$idx]="$addr"; T_LABEL[$idx]="$sym"; T_NATIVE[$idx]=0; T_FAUCET[$idx]=""
+    # Pre-approve the bridge once, huge, so per-bridge sends skip approve.
+    cast send --rpc-url "$L1_RPC" --private-key "$FUNDED_KEY" \
+        "$addr" "approve(address,uint256)" "$BRIDGE_ADDRESS" "$APPROVE_HUGE" \
+        >> "$VERBOSE_LOG" 2>&1 || die "approve failed for $sym ($addr)"
+    r "  $sym -> $addr (approved)"
+done
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Setup 2/4: fund the L2 wallet — one LARGE L1→L2 per token (parallel batches).
+# ══════════════════════════════════════════════════════════════════════════════
+# submit_l1 <nonce> <token_idx> <amount> <result_file>  (backgroundable)
+submit_l1() {
+    local nonce="$1" ti="$2" amt="$3" rf="$4"
+    # --gas-limit: parallel same-block deposits each grow the bridge exit-tree, so a
+    # deposit mined later in the block costs more gas than cast's pre-block estimate
+    # -> out-of-gas revert (status 0). A generous fixed limit sidesteps the
+    # under-estimate (Anvil gas is effectively free, so over-provisioning is harmless).
+    if [[ "${T_NATIVE[$ti]}" == "1" ]]; then
+        cast send --rpc-url "$L1_RPC" --private-key "$FUNDED_KEY" --nonce "$nonce" --gas-limit 2000000 \
+            "$BRIDGE_ADDRESS" 'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+            "$DEST_NETWORK" "$DEST_ADDR" "$amt" \
+            "$NATIVE_ADDR" true 0x --value "$amt" > "$rf" 2>&1
+    else
+        cast send --rpc-url "$L1_RPC" --private-key "$FUNDED_KEY" --nonce "$nonce" --gas-limit 2000000 \
+            "$BRIDGE_ADDRESS" 'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+            "$DEST_NETWORK" "$DEST_ADDR" "$amt" \
+            "${T_ADDR[$ti]}" true 0x > "$rf" 2>&1
+    fi
+}
+l1_status() { awk '$1=="status"{print $2; exit}' "$1"; }
+
+r "Setup 2/4: funding L2 wallet (1 large L1→L2 per token, batches of $PARALLEL)..."
+fund_idx=0
+while [[ $fund_idx -lt $NUM_TOKENS ]]; do
+    base_nonce=$(cast nonce --rpc-url "$L1_RPC" "$FUNDED_ADDR")
+    pids=(); slots=()
+    for j in $(seq 0 $((PARALLEL - 1))); do
+        ti=$((fund_idx + j))
+        [[ $ti -ge $NUM_TOKENS ]] && break
+        amt="$FUND_ERC20_BASE"; [[ "${T_NATIVE[$ti]}" == "1" ]] && amt="$FUND_NATIVE_WEI"
+        submit_l1 $((base_nonce + j)) "$ti" "$amt" "$TMP/fund_$ti" &
+        pids+=($!); slots+=("$ti")
+    done
+    for p in "${pids[@]}"; do wait "$p"; done
+    for ti in "${slots[@]}"; do
+        st=$(l1_status "$TMP/fund_$ti")
+        [[ "$st" == "1" ]] || die "funding L1 tx failed for ${T_LABEL[$ti]} (status=$st)"
+    done
+    fund_idx=$((fund_idx + PARALLEL))
+done
+r "  all $NUM_TOKENS funding deposits submitted on L1"
+
+# Wait until all funding deposits are ready_for_claim on L2 (count >= NUM_TOKENS).
+r "Setup 3/4: waiting for funding deposits to be ready_for_claim + auto-claimed..."
+wait_for "all funding deposits ready_for_claim" \
+    "[ \$(curl -sf '$BRIDGE_SERVICE_URL/bridges/$DEST_ADDR' 2>/dev/null | python3 -c \"import json,sys; d=json.load(sys.stdin); print(len([x for x in d.get('deposits',[]) if x.get('ready_for_claim') and x.get('amount')!='0']))\" 2>/dev/null || echo 0) -ge $NUM_TOKENS ]" \
+    600 5 || r "  WARN: not all funding deposits ready within 600s (continuing)"
+
+# Build token -> faucet_id map from admin_listFaucets (key on origin token addr).
+r "Setup 4/4: mapping tokens -> faucet ids + confirming L2 balances..."
+map_faucets() {
+    local fj
+    fj=$(curl -sf "$L2_RPC" -H "Content-Type: application/json" -H "$ADMIN_BEARER" \
+        -d '{"jsonrpc":"2.0","method":"admin_listFaucets","params":[],"id":1}' 2>/dev/null)
+    echo "$fj" >> "$VERBOSE_LOG"
+    for k in $(seq 1 $NUM_ERC20); do
+        [[ -n "${T_FAUCET[$k]}" ]] && continue
+        local fid
+        fid=$(echo "$fj" | python3 -c "
+import json,sys
+want='${T_ADDR[$k]}'.lower(); sym='${T_LABEL[$k]}'
+try: r=json.load(sys.stdin)
+except Exception: r={}
+for f in r.get('result',[]):
+    oa=(f.get('origin_address') or f.get('orig_addr') or '').lower()
+    if oa==want or f.get('symbol')==sym:
+        print(f.get('faucet_id') or ''); break
+" 2>/dev/null)
+        [[ -n "$fid" ]] && T_FAUCET[$k]="$fid"
+    done
+}
+# Faucets auto-create on the first claim; retry the mapping while claims land.
+# The Miden prover processes claims ~1-2/min, so 10 funding claims can take
+# ~15min to all land — wait generously (FAUCET_WAIT_ATTEMPTS x 10s).
+for attempt in $(seq 1 "${FAUCET_WAIT_ATTEMPTS:-180}"); do
+    map_faucets
+    missing=0
+    for k in $(seq 1 $NUM_ERC20); do [[ -z "${T_FAUCET[$k]}" ]] && missing=$((missing+1)); done
+    [[ $missing -eq 0 ]] && break
+    v "faucet map: $missing tokens still unmapped (attempt $attempt)"
+    sleep 10
+done
+for k in $(seq 0 $((NUM_TOKENS - 1))); do
+    [[ -z "${T_FAUCET[$k]}" ]] && die "no faucet id for ${T_LABEL[$k]} (${T_ADDR[$k]}) — funding claim may not have landed"
+    r "  ${T_LABEL[$k]}: faucet=${T_FAUCET[$k]}"
+done
+
+# Confirm each faucet shows a positive L2 wallet balance (funding delivered).
+for k in $(seq 0 $((NUM_TOKENS - 1))); do
+    bal=0
+    for attempt in $(seq 1 18); do
+        out=$(docker exec "$AGGLAYER_CONTAINER" bridge-out-tool \
+            --store-dir /var/lib/miden-agglayer-service --node-url http://miden-node:57291 \
+            --wallet-id "$WALLET_ID" --bridge-id "$BRIDGE_ID" --faucet-id "${T_FAUCET[$k]}" \
+            --amount 999999999 --dest-address 0xdead --dest-network 0 2>&1 || true)
+        echo "$out" >> "$VERBOSE_LOG"
+        bal=$(echo "$out" | grep "wallet balance:" | head -1 | awk '{print $NF}')
+        [[ -n "$bal" && "$bal" != "0" ]] && break
+        sleep 10
+    done
+    [[ -n "$bal" && "$bal" != "0" ]] || die "${T_LABEL[$k]} L2 balance still 0 — cannot fund bridge-outs"
+    r "  ${T_LABEL[$k]}: L2 balance=$bal"
+done
+
+# ── Baseline snapshot (so the matrix reports only load-loop deltas) ───────────
+declare -a BASE_L1_T BASE_L1_R BASE_L1_C BASE_L2_T BASE_L2_R BASE_L2_C
+for k in $(seq 0 $((NUM_TOKENS - 1))); do
+    read -r t rdy cl < <(count_for "$DEST_ADDR" 0 "$(echo "${T_ADDR[$k]}" | tr 'A-F' 'a-f')")
+    BASE_L1_T[$k]=$t; BASE_L1_R[$k]=$rdy; BASE_L1_C[$k]=$cl
+    read -r t rdy cl < <(count_for "$FUNDED_ADDR" 1 "$(echo "${T_ADDR[$k]}" | tr 'A-F' 'a-f')")
+    BASE_L2_T[$k]=$t; BASE_L2_R[$k]=$rdy; BASE_L2_C[$k]=$cl
+done
+# aggregate baseline totals (subtracted in the live status line so it shows load-only)
+BASE_L1_R_TOT=0; BASE_L1_C_TOT=0; BASE_L2_R_TOT=0; BASE_L2_C_TOT=0
+for k in $(seq 0 $((NUM_TOKENS - 1))); do
+    BASE_L1_R_TOT=$((BASE_L1_R_TOT + BASE_L1_R[$k])); BASE_L1_C_TOT=$((BASE_L1_C_TOT + BASE_L1_C[$k]))
+    BASE_L2_R_TOT=$((BASE_L2_R_TOT + BASE_L2_R[$k])); BASE_L2_C_TOT=$((BASE_L2_C_TOT + BASE_L2_C[$k]))
+done
+v "baseline captured"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Load loop
+# ══════════════════════════════════════════════════════════════════════════════
+# Build the randomized op plan: N ops, each (token_idx, dir). dir: 0=L1→L2, 1=L2→L1.
+RANDOM=$SEED
+declare -a OP_TOKEN OP_DIR
+declare -a SUB_L1 SUB_L2 FAIL_L1 FAIL_L2
+for k in $(seq 0 $((NUM_TOKENS - 1))); do SUB_L1[$k]=0; SUB_L2[$k]=0; FAIL_L1[$k]=0; FAIL_L2[$k]=0; done
+PLAN_L1=0; PLAN_L2=0
+for i in $(seq 1 "$N"); do
+    OP_TOKEN[$i]=$((RANDOM % NUM_TOKENS))
+    d=$((RANDOM % 2)); OP_DIR[$i]=$d
+    [[ $d -eq 0 ]] && PLAN_L1=$((PLAN_L1+1)) || PLAN_L2=$((PLAN_L2+1))
+done
+r "----------------------------------------------------------------------"
+r "Load: $N ops planned — L1→L2=$PLAN_L1  L2→L1=$PLAN_L2"
+r "----------------------------------------------------------------------"
+
+DONE_L1=0; DONE_L2=0
+declare -a L1BUF_OP L1BUF_TI
+L1BUF_OP=(); L1BUF_TI=()
+
+progress() {  # <op#> <label> <dir-str> <verb>
+    r "#$1 ${2} ${3} ${4}"
+}
+
+# status_line: the live picture both ways — submitted (our counters) / ready / claimed
+# (bridge-service, load-only via baseline subtraction) / failed. Printed each step.
+status_line() {
+    local s1=0 f1=0 s2=0 f2=0 k
+    for k in $(seq 0 $((NUM_TOKENS - 1))); do
+        s1=$((s1 + SUB_L1[$k])); f1=$((f1 + FAIL_L1[$k]))
+        s2=$((s2 + SUB_L2[$k])); f2=$((f2 + FAIL_L2[$k]))
+    done
+    local t1 r1 c1 t2 r2 c2
+    read -r t1 r1 c1 < <(count_all "$DEST_ADDR" 0)
+    read -r t2 r2 c2 < <(count_all "$FUNDED_ADDR" 1)
+    r "   ┊ L1→L2  submitted=$s1/$PLAN_L1  ready=$((r1 - BASE_L1_R_TOT))  claimed=$((c1 - BASE_L1_C_TOT))  failed=$f1"
+    r "   ┊ L2→L1  submitted=$s2/$PLAN_L2  ready=$((r2 - BASE_L2_R_TOT))  claimed=$((c2 - BASE_L2_C_TOT))  failed=$f2"
+}
+
+flush_l1_buf() {
+    [[ ${#L1BUF_OP[@]} -eq 0 ]] && return
+    local base_nonce; base_nonce=$(cast nonce --rpc-url "$L1_RPC" "$FUNDED_ADDR")
+    local pids=() j=0
+    for n in "${!L1BUF_OP[@]}"; do
+        local ti="${L1BUF_TI[$n]}"
+        local amt="$AMT_L1_ERC20_BASE"; [[ "${T_NATIVE[$ti]}" == "1" ]] && amt="$AMT_L1_NATIVE_WEI"
+        submit_l1 $((base_nonce + j)) "$ti" "$amt" "$TMP/op_${L1BUF_OP[$n]}" &
+        pids+=($!); j=$((j+1))
+    done
+    for p in "${pids[@]}"; do wait "$p"; done
+    for n in "${!L1BUF_OP[@]}"; do
+        local op="${L1BUF_OP[$n]}" ti="${L1BUF_TI[$n]}"
+        local st; st=$(l1_status "$TMP/op_$op")
+        DONE_L1=$((DONE_L1+1))
+        if [[ "$st" == "1" ]]; then
+            SUB_L1[$ti]=$(( ${SUB_L1[$ti]} + 1 ))
+            progress "$op" "${T_LABEL[$ti]}" "L1→L2" "submitted"
+        else
+            FAIL_L1[$ti]=$(( ${FAIL_L1[$ti]} + 1 ))
+            v "OP $op L1→L2 ${T_LABEL[$ti]} SUBMIT FAILED (status=$st): $(tail -2 "$TMP/op_$op" | tr '\n' ' ')"
+            progress "$op" "${T_LABEL[$ti]}" "L1→L2" "SUBMIT-FAILED"
+        fi
+    done
+    L1BUF_OP=(); L1BUF_TI=()
+    status_line
+}
+
+run_l2_out() {  # <op#> <token_idx>
+    local op="$1" ti="$2"
+    DONE_L2=$((DONE_L2+1))
+    local out rc
+    out=$(docker exec "$AGGLAYER_CONTAINER" bridge-out-tool \
+        --store-dir /var/lib/miden-agglayer-service --node-url http://miden-node:57291 \
+        --wallet-id "$WALLET_ID" --bridge-id "$BRIDGE_ID" --faucet-id "${T_FAUCET[$ti]}" \
+        --amount "$AMT_L2_UNITS" --dest-address "$FUNDED_ADDR" --dest-network 0 2>&1)
+    rc=$?
+    echo "$out" >> "$VERBOSE_LOG"
+    if [[ $rc -eq 0 ]]; then
+        SUB_L2[$ti]=$(( ${SUB_L2[$ti]} + 1 ))
+        progress "$op" "${T_LABEL[$ti]}" "L2→L1" "submitted"
+    else
+        FAIL_L2[$ti]=$(( ${FAIL_L2[$ti]} + 1 ))
+        v "OP $op L2→L1 ${T_LABEL[$ti]} BRIDGE-OUT FAILED (rc=$rc): $(echo "$out" | tail -2 | tr '\n' ' ')"
+        progress "$op" "${T_LABEL[$ti]}" "L2→L1" "BRIDGE-OUT-FAILED"
+    fi
+    status_line
+}
+
+LOAD_START=$(date +%s)
+for i in $(seq 1 "$N"); do
+    ti="${OP_TOKEN[$i]}"; d="${OP_DIR[$i]}"
+    if [[ "$d" -eq 0 ]]; then
+        L1BUF_OP+=("$i"); L1BUF_TI+=("$ti")
+        [[ ${#L1BUF_OP[@]} -ge $PARALLEL ]] && flush_l1_buf
+    else
+        flush_l1_buf          # keep ordering: drain pending L1 batch before a sequential L2 op
+        run_l2_out "$i" "$ti"
+    fi
+done
+flush_l1_buf
+LOAD_SECS=$(( $(date +%s) - LOAD_START ))
+
+TOT_SUB_L1=0; TOT_SUB_L2=0; TOT_FAIL_L1=0; TOT_FAIL_L2=0
+for k in $(seq 0 $((NUM_TOKENS - 1))); do
+    TOT_SUB_L1=$((TOT_SUB_L1 + SUB_L1[$k])); TOT_SUB_L2=$((TOT_SUB_L2 + SUB_L2[$k]))
+    TOT_FAIL_L1=$((TOT_FAIL_L1 + FAIL_L1[$k])); TOT_FAIL_L2=$((TOT_FAIL_L2 + FAIL_L2[$k]))
+done
+r "----------------------------------------------------------------------"
+r "Load complete in ${LOAD_SECS}s — submitted L1→L2=$TOT_SUB_L1 (fail $TOT_FAIL_L1), L2→L1=$TOT_SUB_L2 (fail $TOT_FAIL_L2)"
+r "----------------------------------------------------------------------"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Settle: poll until claimed counts stop rising
+# ══════════════════════════════════════════════════════════════════════════════
+# total claimed (delta over baseline) across all tokens, both directions
+total_claimed_delta() {
+    local sum=0 k oa t rdy cl
+    for k in $(seq 0 $((NUM_TOKENS - 1))); do
+        oa=$(echo "${T_ADDR[$k]}" | tr 'A-F' 'a-f')
+        read -r t rdy cl < <(count_for "$DEST_ADDR" 0 "$oa")
+        sum=$((sum + cl - BASE_L1_C[$k]))
+        read -r t rdy cl < <(count_for "$FUNDED_ADDR" 1 "$oa")
+        sum=$((sum + cl - BASE_L2_C[$k]))
+    done
+    echo "$sum"
+}
+
+r "Settle: polling bridge-service until claims stall (${SETTLE_STALL}s) or cap ${SETTLE_CAP}s..."
+last=-1; stalled=0; elapsed=0
+while :; do
+    cur=$(total_claimed_delta)
+    if [[ "$cur" != "$last" ]]; then
+        r "  settle: claimed(delta)=$cur  (elapsed ${elapsed}s)"
+        last="$cur"; stalled=0
+    else
+        stalled=$((stalled + SETTLE_INTERVAL))
+    fi
+    [[ $stalled -ge $SETTLE_STALL ]] && { r "  settle: no new claims for ${SETTLE_STALL}s — done"; break; }
+    [[ $elapsed -ge $SETTLE_CAP ]]   && { r "  settle: hit ${SETTLE_CAP}s cap — done"; break; }
+    sleep "$SETTLE_INTERVAL"; elapsed=$((elapsed + SETTLE_INTERVAL))
+done
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Reliability matrix
+# ══════════════════════════════════════════════════════════════════════════════
+pct() { [[ "$2" -eq 0 ]] && { echo "  n/a"; return; }; LC_NUMERIC=C awk -v a="$1" -v b="$2" 'BEGIN{printf "%5.1f%%", 100*a/b}'; }
+
+rraw ""
+r "======================================================================"
+r "  RELIABILITY MATRIX  (delivered = claim_tx_hash present)"
+r "======================================================================"
+printf "%-7s %-7s %9s %9s %9s %9s %8s\n" "TOKEN" "DIR" "submit" "ready" "claimed" "fail" "deliv%" | tee -a "$RESULTS_LOG"
+r "----------------------------------------------------------------------"
+
+declare -i G_SUB=0 G_RDY=0 G_CLM=0 G_FAIL=0
+FAILURES_DETAIL=""
+emit_row() {  # <k> <dir 0|1>
+    local k="$1" dir="$2" endpoint net sub fail t rdy cl oa
+    oa=$(echo "${T_ADDR[$k]}" | tr 'A-F' 'a-f')
+    if [[ "$dir" -eq 0 ]]; then
+        endpoint="$DEST_ADDR"; net=0; sub=${SUB_L1[$k]}; fail=${FAIL_L1[$k]}
+        read -r t rdy cl < <(count_for "$endpoint" "$net" "$oa")
+        rdy=$((rdy - BASE_L1_R[$k])); cl=$((cl - BASE_L1_C[$k]))
+        dirs="L1→L2"
+    else
+        endpoint="$FUNDED_ADDR"; net=1; sub=${SUB_L2[$k]}; fail=${FAIL_L2[$k]}
+        read -r t rdy cl < <(count_for "$endpoint" "$net" "$oa")
+        rdy=$((rdy - BASE_L2_R[$k])); cl=$((cl - BASE_L2_C[$k]))
+        dirs="L2→L1"
+    fi
+    [[ $rdy -lt 0 ]] && rdy=0; [[ $cl -lt 0 ]] && cl=0
+    printf "%-7s %-7s %9s %9s %9s %9s %8s\n" \
+        "${T_LABEL[$k]}" "$dirs" "$sub" "$rdy" "$cl" "$fail" "$(pct "$cl" "$sub")" | tee -a "$RESULTS_LOG"
+    G_SUB+=$sub; G_RDY+=$rdy; G_CLM+=$cl; G_FAIL+=$fail
+    local undeliv=$((sub - cl))
+    [[ $undeliv -gt 0 ]] && FAILURES_DETAIL+="  ${T_LABEL[$k]} ${dirs}: ${undeliv} submitted-but-unclaimed (amount ${3})\n"
+}
+
+for k in $(seq 0 $((NUM_TOKENS - 1))); do
+    amt="$AMT_L1_ERC20_BASE"; [[ "${T_NATIVE[$k]}" == "1" ]] && amt="$AMT_L1_NATIVE_WEI"
+    emit_row "$k" 0 "$amt"
+done
+for k in $(seq 0 $((NUM_TOKENS - 1))); do emit_row "$k" 1 "$AMT_L2_UNITS units"; done
+
+r "----------------------------------------------------------------------"
+printf "%-7s %-7s %9s %9s %9s %9s %8s\n" "TOTAL" "both" "$G_SUB" "$G_RDY" "$G_CLM" "$G_FAIL" "$(pct "$G_CLM" "$G_SUB")" | tee -a "$RESULTS_LOG"
+r "======================================================================"
+r "  OVERALL RELIABILITY: $(pct "$G_CLM" "$G_SUB")  ($G_CLM claimed / $G_SUB submitted)"
+r "  ready_for_claim but not yet claimed: $((G_RDY > G_CLM ? G_RDY - G_CLM : 0))"
+r "======================================================================"
+if [[ -n "$FAILURES_DETAIL" ]]; then
+    r "Submitted-but-undelivered (the failures):"
+    rraw "$FAILURES_DETAIL"
+else
+    r "No undelivered bridges — 100% of submitted bridges were claimed."
+fi
+r "Results log: $RESULTS_LOG"
+r "Verbose log: $VERBOSE_LOG"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub(crate) mod service_helpers;
 pub mod service_send_raw_txn;
 pub mod service_state;
 pub(crate) mod service_zkevm;
+pub mod sqlite_pragmas;
 pub mod store;
 #[cfg(test)]
 pub mod test_helpers;

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -428,6 +428,14 @@ impl MidenClient {
                         Err(other_err) => {
                             metrics::counter!("miden_sync_errors_total", "kind" => "other")
                                 .increment(1);
+                            // RD-1112 — tag the sqlite "database is locked"
+                            // contention with a stable prod-grep token (no-op
+                            // for any other error); the existing line below is
+                            // kept for the per-tick backoff context.
+                            crate::sqlite_pragmas::trace_store_locked(
+                                "miden_client::sync",
+                                &other_err,
+                            );
                             tracing::error!(
                                 "MidenClient::sync non-connection error: {other_err:#}, retrying in {backoff:?}..."
                             );
@@ -645,7 +653,16 @@ pub async fn wait_for_transaction_commit(
                         );
                         tokio::time::sleep(Duration::from_secs(2)).await;
                     }
-                    Err(other_err) => return Err(other_err),
+                    Err(other_err) => {
+                        // RD-1112 — post-submit sync contention surfaces here;
+                        // previously propagated silently with no log, hiding
+                        // the write-side lock from prod telemetry.
+                        crate::sqlite_pragmas::trace_store_locked(
+                            "wait_for_transaction_commit",
+                            &other_err,
+                        );
+                        return Err(other_err);
+                    }
                 },
             }
         }

--- a/src/sqlite_pragmas.rs
+++ b/src/sqlite_pragmas.rs
@@ -25,6 +25,51 @@ pub fn open_store_connection(path: &Path) -> rusqlite::Result<Connection> {
     Ok(conn)
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// RD-1112 — prod tripwire for the sqlite "database is locked" contention.
+//
+// Every catch site that handles a miden-client store error is routed through
+// `trace_store_locked`, which emits one log line prefixed with the stable token
+// below and bumps `miden_store_locked_total{path}`. That gives ops a single
+// prod query (Grafana/Loki: search `RD-1112`, or alert on the counter rate) for
+// a regression that otherwise hides inside a generic
+// "MidenClient::sync non-connection error" line. The WAL remediation in
+// `open_store_connection` (once `journal_mode=WAL` is set) makes this path
+// unreachable; the tag + counter stay as the canary.
+
+/// Stable log prefix / search token for the sqlite "database is locked"
+/// contention. Branch `fix/miden-store-db-lock`.
+pub const STORE_LOCK_TAG: &str = "RD-1112";
+
+/// True iff `err` renders like sqlite's "database is locked" condition
+/// (SQLITE_BUSY / SQLITE_LOCKED). `miden-client-sqlite-store` surfaces it as
+/// `StoreError::DatabaseError(..)`, which through `ClientError` / `anyhow`
+/// renders as `"... database-related non-query error: database is locked"`.
+/// Matched on the rendered chain (not a typed enum) because the store crate's
+/// error is wrapped opaquely — by the time it reaches our catch sites it's an
+/// `anyhow::Error` (which deliberately does not impl `std::error::Error`), so we
+/// key off `Display` (`{:#}` prints anyhow's full cause chain).
+pub fn is_store_locked<E: std::fmt::Display + ?Sized>(err: &E) -> bool {
+    let rendered = format!("{err:#}");
+    rendered.contains("database is locked")
+        || rendered.contains("database-related non-query error")
+        || rendered.contains("SQLITE_BUSY")
+        || rendered.contains("SQLITE_LOCKED")
+}
+
+/// Log + meter a miden-client sqlite "database is locked" hit at `origin`
+/// (e.g. `"miden_client::sync"`, `"wait_for_transaction_commit"`). No-op for
+/// any other error, so callers can route every store error through it cheaply.
+/// Returns whether the lock signature fired.
+pub fn trace_store_locked<E: std::fmt::Display + ?Sized>(origin: &'static str, err: &E) -> bool {
+    if !is_store_locked(err) {
+        return false;
+    }
+    tracing::error!("{STORE_LOCK_TAG}: miden-client sqlite store locked at {origin}: {err:#}",);
+    metrics::counter!("miden_store_locked_total", "path" => origin).increment(1);
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -45,14 +90,15 @@ mod tests {
 
         // The sync thread holds a SHARED lock via an open read transaction.
         let reader = open_store_connection(&db).unwrap();
-        reader.execute_batch("BEGIN; SELECT COUNT(*) FROM t;").unwrap();
+        reader
+            .execute_batch("BEGIN; SELECT COUNT(*) FROM t;")
+            .unwrap();
 
         // The RPC claim path commits a write concurrently. Short busy_timeout so
         // the RED case fails in ~300ms instead of after the 5s default.
         let writer = open_store_connection(&db).unwrap();
         writer.busy_timeout(Duration::from_millis(300)).unwrap();
-        let res =
-            writer.execute_batch("BEGIN IMMEDIATE; INSERT INTO t (v) VALUES (1); COMMIT;");
+        let res = writer.execute_batch("BEGIN IMMEDIATE; INSERT INTO t (v) VALUES (1); COMMIT;");
 
         res.expect(
             "writer COMMIT must not be blocked by a concurrent reader \

--- a/src/sqlite_pragmas.rs
+++ b/src/sqlite_pragmas.rs
@@ -1,0 +1,62 @@
+//! Canonical opener for miden-client store connections, and the regression test
+//! for the proxy's `database is locked`.
+//!
+//! Root cause: `miden-client-sqlite-store`'s pool manager opens each pooled
+//! connection with only `PRAGMA foreign_keys=ON` (its `new_connection`) and
+//! leaves the database in the default **rollback-journal** mode. rusqlite
+//! already applies a 5s `busy_timeout`, so the issue is NOT transient
+//! write/write contention — it's that in rollback-journal mode a reader's
+//! SHARED lock blocks a writer's COMMIT (which must take EXCLUSIVE). The proxy
+//! reads the store from its Miden sync thread while the RPC claim path commits a
+//! write on another pooled connection → the commit is blocked and eventually
+//! returns SQLITE_BUSY ("database is locked"). `journal_mode=WAL` lets readers
+//! and a single writer coexist, so the commit is never blocked by a reader.
+
+use rusqlite::Connection;
+use std::path::Path;
+
+/// Open a miden-client store connection with the PRAGMAs required for safe
+/// concurrent access from the proxy's multiple contexts. Mirrors what the store
+/// crate's pool manager applies to every pooled connection.
+pub fn open_store_connection(path: &Path) -> rusqlite::Result<Connection> {
+    let conn = Connection::open(path)?;
+    // Matches miden-client-sqlite-store `pool_manager::new_connection`.
+    conn.pragma_update(None, "foreign_keys", "ON")?;
+    Ok(conn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// RED: a writer committing while another connection holds an open read
+    /// transaction must not be blocked into SQLITE_BUSY. Fails in
+    /// rollback-journal mode; passes once `open_store_connection` sets
+    /// `journal_mode=WAL`.
+    #[test]
+    fn writer_commit_not_blocked_by_concurrent_reader() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("store.sqlite3");
+        open_store_connection(&db)
+            .unwrap()
+            .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)", [])
+            .unwrap();
+
+        // The sync thread holds a SHARED lock via an open read transaction.
+        let reader = open_store_connection(&db).unwrap();
+        reader.execute_batch("BEGIN; SELECT COUNT(*) FROM t;").unwrap();
+
+        // The RPC claim path commits a write concurrently. Short busy_timeout so
+        // the RED case fails in ~300ms instead of after the 5s default.
+        let writer = open_store_connection(&db).unwrap();
+        writer.busy_timeout(Duration::from_millis(300)).unwrap();
+        let res =
+            writer.execute_batch("BEGIN IMMEDIATE; INSERT INTO t (v) VALUES (1); COMMIT;");
+
+        res.expect(
+            "writer COMMIT must not be blocked by a concurrent reader \
+             (needs journal_mode=WAL)",
+        );
+    }
+}


### PR DESCRIPTION
## What / why

`RD-1112` — the miden-client sqlite store wedges on `database is locked` under the proxy's concurrent access. Confirmed **root cause of PRST-4035**: prod telemetry (outpost-testnet, 2026-06-30) showed `MidenClient::sync` stalled ~15 min on `SQLITE_BUSY` (19 hits, backoff pinned at the 60s cap), so sync never reached the bridge-out block → the exit went unobserved.

Root cause is upstream: `miden-client-sqlite-store`'s `pool_manager::new_connection` opens every pooled connection with only `PRAGMA foreign_keys=ON` — no `journal_mode` (→ rollback-journal, where a reader's SHARED lock blocks a writer's COMMIT), no `busy_timeout` override, and no config knob. The proxy reads the store from its Miden sync thread while the RPC claim path commits a write → the commit is blocked into `SQLITE_BUSY`.

## What's in this PR

- **RED reproduction** (`src/sqlite_pragmas.rs`): `writer_commit_not_blocked_by_concurrent_reader` (raw rusqlite) and `real_miden_store_write_locked_by_concurrent_reader` (drives the **actual** `miden-client-sqlite-store::SqliteStore` into the prod `database is locked` in ~5s). Both go GREEN once the store is opened in WAL.
- **RD-1112 observability** (`fe08a04`): `trace_store_locked()` emits a stable `RD-1112:` log prefix + bumps `miden_store_locked_total{path}`; no-op for non-lock errors. Wired into both catch sites — `MidenClient::sync` (the path seen in prod) and `wait_for_transaction_commit` (the claim-path post-submit sync, which previously propagated the lock with **no** log). Makes it a single Grafana/Loki query + rate-alertable metric, and stays as a regression tripwire after the fix.
- **Vendored loadtest + handoff** (`DB-LOCK-WIP.md`, `scripts/e2e-bridge-loadtest.sh`): N=250 concurrent-bridge loadtest and the continue-anywhere runbook.

## Pending (not in this PR yet)

- **GREEN — the WAL stopgap**: open the store once in `journal_mode=WAL` at `MidenClient::new` startup (persists in the DB header → the whole pool inherits it). Flips both tests RED→GREEN.
- **Upstream PR** to `0xMiden/miden-client-sqlite-store` adding `journal_mode=WAL` (+ real `busy_timeout`) to `new_connection`.

No behavior change from the observability commit. Base: `release/0.15`.
