### PR TITLE
PRST-4037: redact L1 RPC apiKey in bridge-autoclaim startup log

### DIFF
--- a/src/l2_to_l1_claimer.rs
+++ b/src/l2_to_l1_claimer.rs
@@ -139,6 +139,21 @@ pub fn source_bridge_network(network_id: u32) -> u32 {
     network_id
 }
 
+/// Redact secrets from an RPC URL before logging it.
+///
+/// Our L1 endpoint carries the credential in the query string
+/// (`...sepolia?apiKey=<secret>`). Logging the raw URL leaks it to the SIEM —
+/// and the startup banner does so at INFO, so it leaks by default. Strip the
+/// entire query string (catches `apiKey` and any future secret param), keeping
+/// the scheme/host/path visible for operators. Mirrors the redaction the proxy
+/// applies to `l1_rpc_url` in `Command`'s `Debug` impl (`main.rs`).
+pub fn redact_rpc_url(url: &str) -> String {
+    match url.split_once('?') {
+        Some((base, _)) => format!("{base}?<redacted>"),
+        None => url.to_string(),
+    }
+}
+
 /// Outcome of simulating (or attempting) a claim, used to decide retry vs skip.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Readiness {
@@ -556,7 +571,7 @@ pub async fn run(cfg: ClaimerConfig) -> anyhow::Result<()> {
 
     tracing::info!(
         l2_rpc = %cfg.l2_rpc_url,
-        l1_rpc = %cfg.l1_rpc_url,
+        l1_rpc = %redact_rpc_url(&cfg.l1_rpc_url),
         bridge = %cfg.bridge_address,
         network_id = cfg.network_id,
         sponsor = %sponsor,
@@ -654,6 +669,35 @@ async fn poll_once<P1: Provider, P2: Provider>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn redact_rpc_url_strips_apikey_query() {
+        // The exact shape of our leaking L1 endpoint.
+        assert_eq!(
+            redact_rpc_url(
+                "https://rpc.eu-central-1.gateway.fm/v4/ethereum/archival/sepolia?apiKey=SECRET123"
+            ),
+            "https://rpc.eu-central-1.gateway.fm/v4/ethereum/archival/sepolia?<redacted>"
+        );
+    }
+
+    #[test]
+    fn redact_rpc_url_strips_all_query_params() {
+        // Robust against any secret param, not just `apiKey`, and multi-param queries.
+        let r = redact_rpc_url("https://h/p?foo=1&apiKey=abc&token=xyz");
+        assert_eq!(r, "https://h/p?<redacted>");
+        assert!(!r.contains("abc"));
+        assert!(!r.contains("xyz"));
+    }
+
+    #[test]
+    fn redact_rpc_url_noop_without_query() {
+        // No query string (e.g. the in-cluster L2 RPC) is left untouched.
+        assert_eq!(
+            redact_rpc_url("http://miden-agglayer:8546"),
+            "http://miden-agglayer:8546"
+        );
+    }
 
     #[test]
     fn global_index_layout_rollup() {


### PR DESCRIPTION
## Problem
`bridge-autoclaim` logged the full L1 RPC URL — including the `?apiKey=<secret>` query string — at **INFO** level in its startup banner (`src/l2_to_l1_claimer.rs`), leaking the Sepolia archival apiKey to the SIEM by default (no `RUST_LOG=debug` needed). Observed live on the dev outpost.

The proxy's existing guards don't cover it: `logging.rs` only clamps the `alloy_transport_http`/`reqwest` library logs, and `Command`'s `Debug` redaction (`l1_rpc_url -> [REDACTED]`) is bypassed because the claimer logs `cfg.l1_rpc_url` directly.

## Fix
Add a pure `redact_rpc_url` helper that strips the query string (catches `apiKey` and any future secret param, keeps scheme/host/path for operators) and use it in the startup banner. Mirrors the proxy's secret-redaction intent. Unit-tested (3 cases: apiKey stripped, multi-param stripped, no-query no-op).

Closes PRST-4037. (The leaked dev apiKey should be rotated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)