### PR TITLE
PRST-4044: repoint bridge monitor source from dropped rollup 76 to 78

### DIFF
--- a/tools/bali-bridge-monitor/index.html
+++ b/tools/bali-bridge-monitor/index.html
@@ -1486,7 +1486,7 @@
 
     // ---------- config ----------
     const CONFIG = {
-      l1RpcUrl: "https://ethereum-sepolia-rpc.publicnode.com",
+      l1RpcUrl: "https://sepolia.drpc.org",  // must serve historical getLogs w/ CORS; publicnode gates old ranges as "archive"
       bridgeServiceUrl: "https://miden-testnet-bridge.dev.eu-north-3.gateway.fm/api",
       bridgeContract: "0x1348947e282138d8f377b467f7d9c2eb0f335d1f",
       midenNetworkId: 78,           // rollup id on the Bali rollup manager (replaced dropped rollup 76)

--- a/tools/bali-bridge-monitor/index.html
+++ b/tools/bali-bridge-monitor/index.html
@@ -1397,7 +1397,7 @@
         <span class="hero-strip-sep"></span>
         <span class="hero-strip-pair"><span class="hero-strip-key">BRIDGE</span><span class="hero-strip-val">SEPOLIA ↔ MIDEN</span></span>
         <span class="hero-strip-sep"></span>
-        <span class="hero-strip-pair"><span class="hero-strip-key">LIVE SINCE</span><span class="hero-strip-val">20.05.2026</span></span>
+        <span class="hero-strip-pair"><span class="hero-strip-key">LIVE SINCE</span><span class="hero-strip-val">24.06.2026</span></span>
         <span class="hero-strip-sep"></span>
         <span class="hero-strip-pair"><span class="hero-strip-key">NEXT POLL</span><span class="hero-strip-val hero-strip-live"><span class="hero-strip-dot"></span><span id="pollCountdown">30S</span></span></span>
       </div>
@@ -1489,8 +1489,8 @@
       l1RpcUrl: "https://ethereum-sepolia-rpc.publicnode.com",
       bridgeServiceUrl: "https://miden-testnet-bridge.dev.eu-north-3.gateway.fm/api",
       bridgeContract: "0x1348947e282138d8f377b467f7d9c2eb0f335d1f",
-      midenNetworkId: 76,           // bali rollupId (per bali-l1-deposit.sh)
-      deploymentBlock: 10881795,    // bali rollup creation on Sepolia, 2026-05-20
+      midenNetworkId: 78,           // rollup id on the Bali rollup manager (replaced dropped rollup 76)
+      deploymentBlock: 11129934,    // rollup 78 creation on Sepolia, 2026-06-24
       windowDays: 10,               // rolling display window
       windowMs: 10 * 24 * 60 * 60 * 1000,
       pollIntervalMs: 30_000,
@@ -1501,10 +1501,9 @@
       // Without this we can only see CLAIMED outbounds via L1 logs. Add yours via
       // window.appendWatchedAddress("0x…"); persists in localStorage.
       watchedAddresses: [
-        "0xEFAD2016599b886A457Ffbf313dae2a7A4bfaa27",  // canonical bali test funder (per bridge-test-summary-r2-2026-05-20.md)
-        "0xC0fFCd2b7245D8B09E94f0526b92cDEDd292D19F",  // disposable bridge wallet from same summary
+        "0x9D865BC3034309095E4868f94b72b5F19919192e",  // rollup 78 L2->L1 withdrawal recipient (first relaunch exit)
       ],
-      storageKey: "bali-bridge:v5",
+      storageKey: "bali-bridge:v6-r78",
     };
 
     // Pre-baked watchedAddresses above + auto-discovery from L1 ClaimEvents
@@ -2394,9 +2393,9 @@
 
       const tag = (s) => s.done ? "DONE" : (s.active ? "IN FLIGHT" : "PENDING");
 
-      const direction = (Number(exit.network_id) === 76 && Number(exit.dest_net) === 0)
+      const direction = (Number(exit.network_id) === CONFIG.midenNetworkId && Number(exit.dest_net) === 0)
         ? { fromNet: "MIDEN · BALI · L2", fromAddr: "(L2 sender)", toNet: "SEPOLIA · L1", toAddr: exit.dest_addr, kind: "outbound" }
-        : (Number(exit.network_id) === 0 && Number(exit.dest_net) === 76)
+        : (Number(exit.network_id) === 0 && Number(exit.dest_net) === CONFIG.midenNetworkId)
           ? { fromNet: "SEPOLIA · L1", fromAddr: "(L1 sender)", toNet: "MIDEN · BALI · L2", toAddr: exit.dest_addr, kind: "inbound" }
           : { fromNet: "net " + exit.network_id, fromAddr: "·", toNet: "net " + exit.dest_net, toAddr: exit.dest_addr, kind: "other" };
 


### PR DESCRIPTION
## What
Syncs the bridge-monitor **source** (`tools/bali-bridge-monitor/index.html`) with the live fix already deployed to `github-pages` (commit `2d466f1`), so it doesn't regress on the next deploy.

Rollup **76 was dropped and replaced by rollup 78** on the Bali (Polygon devnet) rollup manager. The monitor was pinned to 76, so it showed all zeros for the relaunched agglayer install.

## Changes (parameters only; Bali branding kept — it names the rollup manager, not the rollup)
- `midenNetworkId` 76 → **78**
- `deploymentBlock` 10881795 → **11129934** (rollup 78 creation on Sepolia, 24.06.2026)
- `watchedAddresses` → `0x9D865BC3…` (first rollup-78 L2→L1 withdrawal recipient)
- `storageKey` → `bali-bridge:v6-r78` (drops cached rollup-76 state)
- hardcoded `76` row-direction checks → `CONFIG.midenNetworkId`
- LIVE SINCE → 24.06.2026

## Note
`feat/bridge-monitor-deeplinks` (WIP, ahead of main) still carries rollup 76 and should pick up these same params when it's reconciled/merged, or it will re-introduce the regression.

Closes PRST-4044.

🤖 Generated with [Claude Code](https://claude.com/claude-code)