### PR TITLE
PRST-4039: separate L1 and L2 bridge addresses in bridge-autoclaim

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,14 +164,21 @@ SPONSOR_PRIVATE_KEY=<from-secret-store> \
 bridge-autoclaim \
   --l2-rpc-url http://localhost:8546 \
   --l1-rpc-url http://localhost:8545 \
-  --bridge-address 0x<bridge> \
+  --l1-bridge-address 0x<l1-bridge> \
+  --l2-bridge-address 0x<l2-bridge> \
   --bridge-service-url http://localhost:18080 \
   --network-id 1
 ```
 
-All flags also read from env (`L2_RPC_URL`, `L1_RPC_URL`, `BRIDGE_ADDRESS`,
-`BRIDGE_SERVICE_URL`, `NETWORK_ID`, `POLL_INTERVAL_SECS`, `MAX_RANGE`,
-`START_BLOCK`, `CURSOR_DB`, `SPONSOR_KEY_ENV`).
+The L1 and L2 bridge addresses are separate: `--l1-bridge-address` is the
+`claimAsset`/`isClaimed` target on L1, `--l2-bridge-address` is the
+`eth_getLogs` BridgeEvent filter on the L2 proxy. They differ on
+non-deterministic deploys (e.g. the Miden outpost); set both the same on a
+canonical CDK shared-address deploy.
+
+All flags also read from env (`L2_RPC_URL`, `L1_RPC_URL`, `L1_BRIDGE_ADDRESS`,
+`L2_BRIDGE_ADDRESS`, `BRIDGE_SERVICE_URL`, `NETWORK_ID`, `POLL_INTERVAL_SECS`,
+`MAX_RANGE`, `START_BLOCK`, `CURSOR_DB`, `SPONSOR_KEY_ENV`).
 
 ## Prerequisites
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -340,7 +340,8 @@ services:
     command:
       - "--l2-rpc-url=http://miden-agglayer:8546"
       - "--l1-rpc-url=http://anvil:8545"
-      - "--bridge-address=${BRIDGE_ADDRESS}"
+      - "--l1-bridge-address=${BRIDGE_ADDRESS}"
+      - "--l2-bridge-address=${BRIDGE_ADDRESS}"
       - "--bridge-service-url=http://bridge-service:8080"
       - "--network-id=${NETWORK_ID:-1}"
       - "--poll-interval-secs=5"

--- a/src/bin/bridge_autoclaim.rs
+++ b/src/bin/bridge_autoclaim.rs
@@ -12,7 +12,8 @@
 //!   bridge-autoclaim \
 //!     --l2-rpc-url http://localhost:8546 \
 //!     --l1-rpc-url http://localhost:8545 \
-//!     --bridge-address 0x... \
+//!     --l1-bridge-address 0x... \
+//!     --l2-bridge-address 0x... \
 //!     --bridge-service-url http://localhost:18080 \
 //!     --network-id 1
 //!
@@ -36,10 +37,16 @@ struct Args {
     #[arg(long, env = "L1_RPC_URL")]
     l1_rpc_url: String,
 
-    /// Bridge contract address (L1 claim target + L2 BridgeEvent log filter;
-    /// assumes the canonical CDK shared bridge address).
-    #[arg(long, env = "BRIDGE_ADDRESS")]
-    bridge_address: String,
+    /// L1 bridge contract address — the `claimAsset` / `isClaimed` target on L1.
+    #[arg(long, env = "L1_BRIDGE_ADDRESS")]
+    l1_bridge_address: String,
+
+    /// L2 bridge contract address — the `eth_getLogs` BridgeEvent filter on the
+    /// L2 proxy. On non-deterministic deploys (e.g. the Miden outpost) this
+    /// differs from the L1 address; on a canonical CDK shared-address deploy,
+    /// set both to the same value.
+    #[arg(long, env = "L2_BRIDGE_ADDRESS")]
+    l2_bridge_address: String,
 
     /// Bridge-service base URL (for /merkle-proof).
     #[arg(long, env = "BRIDGE_SERVICE_URL")]
@@ -101,15 +108,24 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    let bridge_address = args
-        .bridge_address
-        .parse()
-        .map_err(|e| anyhow::anyhow!("invalid --bridge-address '{}': {e}", args.bridge_address))?;
+    let l1_bridge_address = args.l1_bridge_address.parse().map_err(|e| {
+        anyhow::anyhow!(
+            "invalid --l1-bridge-address '{}': {e}",
+            args.l1_bridge_address
+        )
+    })?;
+    let l2_bridge_address = args.l2_bridge_address.parse().map_err(|e| {
+        anyhow::anyhow!(
+            "invalid --l2-bridge-address '{}': {e}",
+            args.l2_bridge_address
+        )
+    })?;
 
     let cfg = ClaimerConfig {
         l2_rpc_url: args.l2_rpc_url,
         l1_rpc_url: args.l1_rpc_url,
-        bridge_address,
+        l1_bridge_address,
+        l2_bridge_address,
         bridge_service_url: args.bridge_service_url,
         network_id: args.network_id,
         sponsor_key,

--- a/src/l2_to_l1_claimer.rs
+++ b/src/l2_to_l1_claimer.rs
@@ -86,11 +86,13 @@ pub struct ClaimerConfig {
     pub l2_rpc_url: String,
     /// L1 JSON-RPC URL (isClaimed view-calls + claimAsset submission).
     pub l1_rpc_url: String,
-    /// Bridge contract address. Used both as the `eth_getLogs` address filter on
-    /// L2 (the proxy stamps synthetic BridgeEvent logs with this address) and as
-    /// the `claimAsset`/`isClaimed` target on L1. Assumes the canonical CDK
-    /// deterministic deploy where L1 and L2 share the bridge address.
-    pub bridge_address: Address,
+    /// L1 bridge contract address — the `claimAsset` / `isClaimed` target on L1.
+    pub l1_bridge_address: Address,
+    /// L2 bridge contract address — the `eth_getLogs` filter for the proxy's
+    /// synthetic `BridgeEvent` logs. On non-deterministic deploys (e.g. the Miden
+    /// outpost) this differs from the L1 address; on a canonical CDK
+    /// shared-address deploy the two are equal.
+    pub l2_bridge_address: Address,
     /// Bridge-service base URL (for `/merkle-proof`).
     pub bridge_service_url: String,
     /// Our rollup's agglayer network id (e.g. 1 in kurtosis, 76 on Bali).
@@ -390,7 +392,7 @@ fn scan_windows(from: u64, head: u64, max_range: u64) -> Vec<(u64, u64)> {
 /// is `< max_range`, which the caller keeps below the proxy cap.
 async fn discover<P: Provider>(
     l2: &P,
-    bridge_address: Address,
+    l2_bridge_address: Address,
     from: u64,
     max_range: u64,
 ) -> anyhow::Result<Vec<PendingExit>> {
@@ -400,7 +402,7 @@ async fn discover<P: Provider>(
     // Bulk catch-up: numeric windows up to the (possibly lagging) numeric head.
     for (w_from, w_to) in scan_windows(from, head, max_range) {
         let filter = Filter::new()
-            .address(bridge_address)
+            .address(l2_bridge_address)
             .from_block(w_from)
             .to_block(w_to)
             .event_signature(BridgeEvent::SIGNATURE_HASH);
@@ -419,12 +421,12 @@ async fn discover<P: Provider>(
     // the loop, or `from` when `from > head` (loop produced no windows).
     let tail_from = from.max(head.saturating_add(1));
     let filter = Filter::new()
-        .address(bridge_address)
+        .address(l2_bridge_address)
         .from_block(tail_from)
         .to_block(BlockNumberOrTag::Latest)
         .event_signature(BridgeEvent::SIGNATURE_HASH);
     let logs = l2.get_logs(&filter).await?;
-    tracing::debug!(from = tail_from, %bridge_address, raw_logs = logs.len(), "discover: latest tail");
+    tracing::debug!(from = tail_from, %l2_bridge_address, raw_logs = logs.len(), "discover: latest tail");
     collect_exits(logs, &mut out);
 
     Ok(out)
@@ -529,7 +531,7 @@ async fn process_exit<P1: Provider, P2: Provider>(
 ) -> anyhow::Result<bool> {
     let src_net = source_bridge_network(cfg.network_id);
 
-    if is_claimed(l1, cfg.bridge_address, exit.leaf_index, src_net).await? {
+    if is_claimed(l1, cfg.l1_bridge_address, exit.leaf_index, src_net).await? {
         tracing::debug!(leaf = exit.leaf_index, "already claimed on L1; skipping");
         return Ok(true);
     }
@@ -554,9 +556,9 @@ async fn process_exit<P1: Provider, P2: Provider>(
 
     let call = build_claim_call(exit, &proof, cfg.network_id);
 
-    let resolved = match simulate(l1, cfg.bridge_address, sponsor, &call).await {
+    let resolved = match simulate(l1, cfg.l1_bridge_address, sponsor, &call).await {
         Readiness::Ready => {
-            let tx = submit(l1, cfg.bridge_address, &call).await?;
+            let tx = submit(l1, cfg.l1_bridge_address, &call).await?;
             tracing::info!(
                 leaf = exit.leaf_index,
                 dest = %exit.destination_address,
@@ -612,7 +614,8 @@ pub async fn run(cfg: ClaimerConfig) -> anyhow::Result<()> {
     tracing::info!(
         l2_rpc = %cfg.l2_rpc_url,
         l1_rpc = %cfg.l1_rpc_url,
-        bridge = %cfg.bridge_address,
+        l1_bridge = %cfg.l1_bridge_address,
+        l2_bridge = %cfg.l2_bridge_address,
         network_id = cfg.network_id,
         sponsor = %sponsor,
         poll_interval_s = cfg.poll_interval.as_secs(),
@@ -663,7 +666,7 @@ async fn poll_once<P1: Provider, P2: Provider>(
     // Chunked scan (see `discover`): numeric windows up to the head + a final
     // `latest`-bounded window, each <= cfg.max_range to respect the proxy's
     // eth_getLogs cap (PRST-4030).
-    let exits = discover(l2, cfg.bridge_address, from, cfg.max_range).await?;
+    let exits = discover(l2, cfg.l2_bridge_address, from, cfg.max_range).await?;
     if !exits.is_empty() {
         tracing::info!(from, count = exits.len(), "discovered L2->L1 exits");
     }


### PR DESCRIPTION
Ports the PRST-4039 fix from #103 (merged to `release/0.15`, e2e-passed) onto `main`.

`bridge-autoclaim` used one `BRIDGE_ADDRESS` for both the L2 `eth_getLogs` discovery filter and the L1 `claimAsset`/`isClaimed` target — broken when they differ (Miden outpost: L2 `0xc8cbeb…` vs L1 `0x1348947e…`). Split into two required flags:
- `--l1-bridge-address` / `L1_BRIDGE_ADDRESS` — claimAsset / isClaimed on L1
- `--l2-bridge-address` / `L2_BRIDGE_ADDRESS` — BridgeEvent getLogs filter on L2

`discover()` uses the L2 address; `is_claimed`/`simulate`/`submit` use the L1 address; banner logs both; README + `docker-compose.e2e.yml` updated. Builds clean, 15 claimer tests pass.

**Merge-conflict resolution note:** `main` doesn't yet have PRST-4037 (`redact_rpc_url`), so the banner keeps `l1_rpc = %cfg.l1_rpc_url` here (release/0.15 redacts it).

**Heads-up:** `main` is behind `release/0.15` on the whole autoclaimer series — it still lacks PRST-4030 (chunked getLogs), PRST-4035 (node block-scan recovery), and PRST-4037 (apiKey redaction). This PR ports only 4039; the others should follow if `main` is to match the 0.15 line.

Same change validated end-to-end by the e2e suite on #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)