### PR TITLE
perf/fix(reconciler): persist sweep cursor + concurrent budgeted catch-up (restart hardening) + #110 e2e lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3324,9 +3324,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,11 @@ clap = { features = ["derive", "env"], version = "4.5" }
 # read path that touches it on every aggkit poll).
 dashmap = { version = "6" }
 hex = { version = "0.4" }
-metrics = { version = "0.24" }
+# 0.24.6 minimum: 0.24.5 (since yanked) shipped a broken KeyHasher — registry
+# lookups missed on (almost) every emission, so /metrics rendered frozen gauges
+# and non-cumulative counters (live-observed; see
+# metrics::tests::metrics_from_second_runtime_render_cumulatively).
+metrics = { version = "0.24.6" }
 metrics-exporter-prometheus = { version = "0.16", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = [
   "json",

--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,10 @@ e2e-fuzz: e2e-up ## Spin up stack + run bridge fuzz/stress tests
 e2e-rd913-restart-burn-collision: e2e-up ## Spin up stack + verify monitor state survives proxy restart (RD-913)
 	$(COMPOSE_ENV) ./scripts/e2e-rd913-restart-burn-collision.sh
 
+.PHONY: e2e-reconciler-cursor-persistence
+e2e-reconciler-cursor-persistence: e2e-up ## Spin up stack + verify the reconciler sweep cursor survives proxy restart (no genesis re-sweep)
+	$(COMPOSE_ENV) ./scripts/e2e-reconciler-cursor-persistence.sh
+
 # --- RD-940 e2e -----------------------------------------------------------
 # All RD-940 e2e scripts require the writer worker active. The `e2e-rd940-up`
 # helper sets AGGLAYER_ENABLE_WRITER_WORKER=true before bringing up the stack.

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,10 @@ e2e-claim-watcher: e2e-l1-to-l2 ## After L1→L2, assert the chain-tail CLAIM wa
 e2e-claim-watcher-synthesis: e2e-claim-watcher ## After watcher happy path, simulate desync and assert synthesis fires (RD-860/EFAD repro)
 	$(COMPOSE_ENV) ./scripts/e2e-claim-watcher-synthesis.sh
 
+.PHONY: e2e-claim-provenance
+e2e-claim-provenance: ## Deploy a FOREIGN bridge on the same chain, drive a claim through it, assert zero ClaimEvent leakage (stack must be up)
+	$(COMPOSE_ENV) ./scripts/e2e-claim-provenance.sh
+
 .PHONY: e2e-l2-to-l1
 e2e-l2-to-l1: e2e-l1-to-l2 ## Spin up stack + L1→L2 to fund wallet + run L2→L1 bridge-out test (strict)
 	$(COMPOSE_ENV) ./scripts/e2e-l2-to-l1.sh

--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,10 @@ e2e-l2-to-l1-autoclaim: ensure-sponsor-key e2e-l1-to-l2 ## Spin up stack + L1→
 e2e-restore: e2e-up ## Spin up stack + run disaster recovery restore test
 	$(COMPOSE_ENV) ./scripts/e2e-restore.sh
 
+.PHONY: e2e-reconciler-private-note
+e2e-reconciler-private-note: e2e-up ## Spin up stack + reconciler private-note wedge regression (0.15.5 hotfix, PR #110)
+	$(COMPOSE_ENV) ./scripts/e2e-reconciler-private-note.sh
+
 .PHONY: e2e-ger-decomposition
 e2e-ger-decomposition: e2e-up ## Spin up stack + run GER decomposition bug regression test
 	$(COMPOSE_ENV) ./scripts/e2e-ger-decomposition.sh

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -142,6 +142,7 @@ Treat each one as a hard-page criterion at any non-zero rate.
 |---|---|
 | `claim_watcher_synthesised_total` | Watcher synthesised a ClaimEvent for a consumed CLAIM the normal path didn't record. Normal during crash recovery; sustained in steady state = `eth_sendRawTransaction` path broken. |
 | `claim_watcher_already_recorded_total` | Dedup-rate monitor. |
+| `claim_event_foreign_skipped_total` | CLAIM-shaped consumed note NOT provably ours (consumer ≠ our bridge, not minted by our service targeting our bridge) — skipped fail-closed. Expected when the chain hosts a foreign miden-agglayer deployment; on a single-deployment chain any non-zero rate = unverifiable claim consumption, investigate. |
 | `claim_watcher_storage_decode_total` / `claim_watcher_unrecoverable_total` | On-chain CLAIM storage that won't decode → quarantined. Should be zero; page on spikes. |
 | `store_envelope_decode_errors_total` | Corrupt / schema-drifted `transactions` row. Investigate immediately. |
 | `rpc_claim_ger_not_seen_total` | Claim rejected because its GER isn't injected yet. Cheap, retry-friendly; sustained spike = aggoracle behind. |

--- a/migrations/010_reconcile_cursor.sql
+++ b/migrations/010_reconcile_cursor.sql
@@ -1,0 +1,24 @@
+-- ============================================================================
+-- Note-reconciler sweep cursor — persist across restarts
+-- ============================================================================
+--
+-- The note-visibility reconciler (`SyntheticProjector::reconcile_notes`,
+-- src/synthetic_projector.rs) walks the Miden chain in RECONCILE_CHUNK-block
+-- windows via `sync_notes` and imports externally-created network notes that
+-- tag/interest-based `sync_state` never delivers. Its sweep cursor was
+-- memory-only (an AtomicU64 hardcoded to 0 at boot), so EVERY container
+-- restart — image update, crash, plain restart — re-walked the sweep from
+-- genesis. On prod history that was ~3h of resync and node load per restart.
+--
+-- This migration gives the sweep cursor the same durable substrate the
+-- projection cursor already has (migration 009 `projector_cursor`): a column
+-- on the existing single-row `service_state` table. Defaults to 0 — a fresh
+-- deployment (and the existing row, backfilled by the column DEFAULT) sweeps
+-- from genesis exactly once, which is the designed first-boot heal.
+--
+-- The reconciler persists the cursor write-behind AFTER each window completes,
+-- so the durable value never runs ahead of work actually done. Recovery flows
+-- (`--restore`, `--reset-miden-store`) and the `--resweep-from-genesis`
+-- escape hatch reset it to 0 to deliberately re-run the full-history sweep.
+ALTER TABLE service_state
+    ADD COLUMN IF NOT EXISTS reconcile_cursor BIGINT NOT NULL DEFAULT 0;

--- a/scripts/e2e-claim-provenance.sh
+++ b/scripts/e2e-claim-provenance.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# E2E: foreign-bridge claim provenance — a SECOND miden-agglayer deployment on
+# the SAME Miden chain must not leak ClaimEvents into our synthetic_logs.
+#
+# Reproduces the live incident (read-only reindex of the real testnet, which
+# hosts a foreign miden-agglayer deployment): the foreign deployment's consumed
+# CLAIM notes share our ClaimNote script root, and pre-fix `project_claim_note`
+# gated ONLY on that root — 3 foreign ClaimEvents were projected into our
+# synthetic_logs. The fix (restore.rs::classify_claim_note) requires a claim to
+# be provably OURS: consumed by OUR bridge, or minted by OUR service targeting
+# OUR bridge. Foreign claims are skipped fail-closed with
+# `claim_event_foreign_skipped_total`.
+#
+# Topology driven here (all LIVE on-chain, no store surgery):
+#   1. Deploy a fully independent FOREIGN deployment on the same Miden chain:
+#      foreign service + ger_manager wallets, foreign bridge account
+#      (network id 2 — an id our stack does NOT serve), foreign ETH faucet
+#      registered in the FOREIGN bridge (bridge-out-tool --create-foreign-bridge,
+#      isolated store — the proxy's store is never touched).
+#   2. FABRICATE the foreign deposit's world locally — no L1 deposit, no
+#      bridge-service. The foreign deployment is fully ours, so its exit
+#      roots are whatever its ger_manager injects: build the LxLy leaf hash
+#      (keccak256 of the 113-byte packed leaf, exactly what the bridge MASM's
+#      leaf_utils::compute_leaf_value hashes), fold it up a depth-32 tree at
+#      index=cnt with all-zero siblings (bridge_in.masm::calculate_root fold:
+#      bit 0 → keccak(node||sib), bit 1 → keccak(sib||node)) to get a
+#      mainnet_exit_root that covers exactly our leaf; rollup_exit_root = 0.
+#      Our L1 never saw this leaf and our aggkit can never claim it — the
+#      foreign claim is the ONLY claimant of its global index, exactly like
+#      the real incident's foreign deposits.
+#   3. Build the claimAsset calldata from the fabricated proof (32 zero
+#      siblings verify by construction) and drive the claim through the
+#      FOREIGN bridge (--submit-foreign-claim: inject keccak(mainnet||rollup)
+#      — the fabricated GER — via the foreign ger_manager, mint the CLAIM
+#      from the foreign service targeting the foreign bridge, wait for LIVE
+#      consumption by the foreign bridge network account; the MASM validates
+#      the merkle proof against the injected GER and accepts).
+#   4. Our proxy's note-visibility reconciler imports the foreign tag-0 notes
+#      and the projector evaluates the consumed CLAIM — the provenance gate
+#      must skip it.
+#
+# Assertions:
+#   (a) claim_event_foreign_skipped_total >= baseline+1 on /metrics — the gate
+#       fired. (Also exercises the /metrics second-runtime fix on this branch:
+#       the counter is emitted from the MidenClient runtime thread.)
+#   (b) ZERO synthetic_logs ClaimEvent rows carry the foreign claim's global
+#       index (PG, topic 0x1df3f2a9...).
+#   (c) Our OWN claim still emits: >= 1 ClaimEvent row exists for a non-foreign
+#       global index (bootstrapped via e2e-l1-to-l2.sh when missing).
+#   (d) Proxy healthy: synthetic tip still advancing, /metrics serving.
+#
+# Usage:  ./scripts/e2e-claim-provenance.sh    (stack must be up: make e2e-up)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURES_DIR="$PROJECT_DIR/fixtures"
+
+# kept for parity with sibling scripts (e2e-l1-to-l2.sh bootstrap re-sources it)
+source "$FIXTURES_DIR/.env"
+
+L2_RPC="${L2_RPC:-http://localhost:8546}"
+PG_HOST="${PG_HOST:-localhost}"
+PG_PORT="${PG_PORT:-5434}"
+PG_USER="${PG_USER:-agglayer}"
+PG_PASS="${PG_PASS:-agglayer}"
+PG_DB="${PG_DB:-agglayer_store}"
+
+CLAIM_EVENT_TOPIC="0x1df3f2a973a00d6635911755c260704e95e8a5876997546798770f76396fda4d"
+# The foreign deployment's AggLayer network id. MUST differ from our stack's
+# (NETWORK_ID, default 1): our aggkit then never auto-claims the deposit, so
+# the foreign claim is the only claimant of its global index.
+FOREIGN_NETWORK_ID="${FOREIGN_NETWORK_ID:-2}"
+DEPOSIT_AMOUNT="10000000000000" # 10^13 wei → 1000 Miden units at scale 10^10
+# How long we give the proxy's reconciler+projector to observe the consumed
+# foreign CLAIM and fire the gate (sweep tick is 5s; import must precede the
+# projector's consumption discovery).
+GATE_TIMEOUT_SECS="${GATE_TIMEOUT_SECS:-600}"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[$(date +%H:%M:%S)]${NC} $*"; }
+step() { echo -e "${CYAN}[$(date +%H:%M:%S)] STEP:${NC} $*"; }
+warn() { echo -e "${YELLOW}[$(date +%H:%M:%S)] WARN:${NC} $*"; }
+fail() { echo -e "${RED}[$(date +%H:%M:%S)] FAIL:${NC} $*" >&2; exit 1; }
+pass() { echo -e "${GREEN}[$(date +%H:%M:%S)] PASS:${NC} $*"; }
+
+command -v cast    >/dev/null || fail "cast (foundry) not found"
+command -v psql    >/dev/null || fail "psql not found (apt-get install postgresql-client)"
+command -v curl    >/dev/null || fail "curl not found"
+command -v python3 >/dev/null || fail "python3 not found"
+
+export PGPASSWORD="$PG_PASS"
+PSQL=(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAX)
+# stderr dropped: locale-warning noise corrupts captures (see sibling scripts).
+pgq() { "${PSQL[@]}" -c "$1" 2>/dev/null; }
+
+# Prometheus counter from the proxy's /metrics (0 when absent). State/metric
+# assertions over log greps throughout — docker-log field regexes are fragile
+# (ANSI escapes / format drift; see e2e log-assertion history).
+counter() {
+    local name="$1" value
+    value=$(curl -s "${L2_RPC}/metrics" | awk -v n="$name" '
+        $0 ~ ("^" n " ") { print $2; found=1; exit }
+        END { if (!found) print 0 }
+    ')
+    echo "${value%.*}"
+}
+
+l2_tip() {
+    curl -sf -X POST "$L2_RPC" -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+        | python3 -c 'import json,sys; print(int(json.load(sys.stdin)["result"],16))'
+}
+
+# ── Isolated store for the FOREIGN deployment ────────────────────────────────
+# Own subdir (not the shared e2e-suite wallet store): the foreign deployment
+# is a separate trust domain with its own keys, exactly like production.
+B2AGG_STORE_DIR="${B2AGG_STORE_DIR:-$PROJECT_DIR/.b2agg-store/e2e-claim-provenance}"
+source "$SCRIPT_DIR/lib-isolated-wallet.sh"
+mkdir -p "$B2AGG_STORE_DIR/tmp"
+
+log "======================================================================"
+log "  Foreign-Bridge Claim Provenance E2E"
+log "======================================================================"
+
+# ── Step 0: Positive-control precondition — OUR ClaimEvent exists ───────────
+# Assertion (c) needs at least one legitimate ClaimEvent from our own
+# deployment; bootstrap the standard L1→L2 flow when the stack is fresh.
+step "Ensuring a legitimate OWN ClaimEvent exists (positive control)"
+OWN_ROWS=$(pgq "SELECT COUNT(*) FROM synthetic_logs WHERE topics[1] = '${CLAIM_EVENT_TOPIC}';")
+if [[ "${OWN_ROWS:-0}" -lt 1 ]]; then
+    log "no ClaimEvent yet — bootstrapping via e2e-l1-to-l2.sh"
+    "$SCRIPT_DIR/e2e-l1-to-l2.sh"
+    OWN_ROWS=$(pgq "SELECT COUNT(*) FROM synthetic_logs WHERE topics[1] = '${CLAIM_EVENT_TOPIC}';")
+fi
+[[ "${OWN_ROWS:-0}" -ge 1 ]] || fail "no own ClaimEvent even after bootstrap"
+log "own ClaimEvent rows: $OWN_ROWS"
+
+# ── Step 1: Baselines ────────────────────────────────────────────────────────
+step "Snapshotting baselines (/metrics + PG + tip)"
+BASE_FOREIGN_SKIPPED=$(counter claim_event_foreign_skipped_total)
+BASE_TIP=$(l2_tip) || fail "proxy eth_blockNumber unreachable"
+log "  claim_event_foreign_skipped_total = $BASE_FOREIGN_SKIPPED"
+log "  synthetic tip                     = $BASE_TIP"
+
+# ── Step 2: Deploy the FOREIGN deployment on the same chain ─────────────────
+step "Deploying foreign deployment (service, ger_manager, bridge net=$FOREIGN_NETWORK_ID, ETH faucet)"
+FB_OUT=$(iso_tool --create-foreign-bridge --foreign-network-id "$FOREIGN_NETWORK_ID" 2>&1) \
+    || { echo "$FB_OUT" | tail -30 >&2; fail "--create-foreign-bridge failed"; }
+FOREIGN_SERVICE_ID=$(echo "$FB_OUT" | grep "service-id:" | awk '{print $NF}')
+FOREIGN_GER_MANAGER_ID=$(echo "$FB_OUT" | grep "ger-manager-id:" | awk '{print $NF}')
+FOREIGN_BRIDGE_ID=$(echo "$FB_OUT" | grep -w "bridge-id:" | awk '{print $NF}')
+FOREIGN_FAUCET_ID=$(echo "$FB_OUT" | grep "faucet-id:" | awk '{print $NF}')
+[[ -n "$FOREIGN_SERVICE_ID" && -n "$FOREIGN_GER_MANAGER_ID" && -n "$FOREIGN_BRIDGE_ID" && -n "$FOREIGN_FAUCET_ID" ]] \
+    || { echo "$FB_OUT" | tail -30 >&2; fail "could not parse foreign deployment ids"; }
+log "  foreign service:     $FOREIGN_SERVICE_ID"
+log "  foreign ger_manager: $FOREIGN_GER_MANAGER_ID"
+log "  foreign bridge:      $FOREIGN_BRIDGE_ID"
+log "  foreign faucet:      $FOREIGN_FAUCET_ID"
+
+# Deposit destination: zero-padded eth-address form of the foreign service id
+# (same decodable mapping the suite's DEST_ADDR uses — the MASM claim path
+# must be able to decode it into a Miden account id).
+FS_INNER="${FOREIGN_SERVICE_ID#0x}"
+FOREIGN_DEST="0x00000000${FS_INNER:0:16}${FS_INNER:16:14}00"
+log "  foreign deposit dest: $FOREIGN_DEST"
+
+# ── Step 3: FABRICATE the foreign deposit's leaf, proof and exit roots ──────
+# No L1 deposit, no bridge-service (its sync model only covers network-1
+# destinations — a net-2 leaf never becomes "synchronized", observed live).
+# The foreign deployment trusts whatever GER its own ger_manager injects, so
+# we fabricate a self-consistent world:
+#
+#   leaf  = keccak256(abi.encodePacked(leafType u8, origNet u32, origAddr,
+#           destNet u32, destAddr, amount u256, keccak256(metadata)))
+#           — 113 bytes, the exact preimage bridge MASM leaf_utils.masm
+#           (compute_leaf_value, LEAF_DATA_BYTES=113) hashes on consumption.
+#   root  = fold(leaf, index=cnt, 32 all-zero siblings) — the calculate_root
+#           fold in bridge_in.masm: index bit 0 → keccak(node||sibling),
+#           bit 1 → keccak(sibling||node), index >>= 1 per level.
+#   GER   = keccak256(mainnet_exit_root || rollup_exit_root), rollup = 0 —
+#           computed by bridge-out-tool from the calldata roots and injected
+#           into the FOREIGN bridge (src/ger.rs::combined_ger).
+step "Fabricating foreign leaf + depth-32 proof (index unique per run)"
+# Leaf index / deposit count: unique per run (u32; also keeps the PG global-
+# index assertion collision-free across runs). Global index = 2^64 + cnt:
+# mainnet flag 1, rollup index 0, leaf index cnt — the exact shape
+# process_global_index_mainnet accepts.
+DEPOSIT_CNT=$(date +%s)
+GLOBAL_INDEX=$(python3 -c "print(2**64 + $DEPOSIT_CNT)")
+
+ZERO_WORD="$(printf '0%.0s' {1..64})" # 32 zero bytes (one merkle sibling)
+EMPTY_METADATA_HASH=$(cast keccak 0x) # keccak256("") — native ETH, no metadata
+AMOUNT_HEX=$(printf '%064x' "$DEPOSIT_AMOUNT")
+LEAF_PACKED="0x00$(printf '%08x' 0)$(printf '0%.0s' {1..40})$(printf '%08x' "$FOREIGN_NETWORK_ID")${FOREIGN_DEST#0x}${AMOUNT_HEX}${EMPTY_METADATA_HASH#0x}"
+[[ ${#LEAF_PACKED} -eq 228 ]] || fail "packed leaf is $(( (${#LEAF_PACKED}-2)/2 )) bytes, want 113"
+LEAF=$(cast keccak "$LEAF_PACKED")
+log "  leaf index (deposit_cnt): $DEPOSIT_CNT"
+log "  leaf value:               $LEAF"
+
+# Mainnet exit root: fold the leaf up 32 levels against all-zero siblings.
+NODE="${LEAF#0x}"
+IDX="$DEPOSIT_CNT"
+for _ in $(seq 1 32); do
+    if (( IDX & 1 )); then
+        NODE=$(cast keccak "0x${ZERO_WORD}${NODE}")
+    else
+        NODE=$(cast keccak "0x${NODE}${ZERO_WORD}")
+    fi
+    NODE="${NODE#0x}"
+    IDX=$(( IDX >> 1 ))
+done
+MAINNET_EXIT_ROOT="0x${NODE}"
+ROLLUP_EXIT_ROOT="0x${ZERO_WORD}"
+SMT_LOCAL=$(python3 -c "print('[' + ','.join(['0x' + '00'*32]*32) + ']')")
+SMT_ROLLUP="$SMT_LOCAL"
+log "  mainnet_exit_root = $MAINNET_EXIT_ROOT"
+log "  rollup_exit_root  = $ROLLUP_EXIT_ROOT"
+pass "fabricated world ready: globalIndex=$GLOBAL_INDEX (mainnet flag + leaf $DEPOSIT_CNT)"
+
+# ── Step 4: Build claimAsset calldata (identical shape to the L1 siblings) ──
+step "Building claimAsset calldata for the FOREIGN claim"
+CALLDATA=$(cast calldata \
+    'claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)' \
+    "$SMT_LOCAL" "$SMT_ROLLUP" "$GLOBAL_INDEX" \
+    "$MAINNET_EXIT_ROOT" "$ROLLUP_EXIT_ROOT" \
+    0 0x0000000000000000000000000000000000000000 \
+    "$FOREIGN_NETWORK_ID" "$FOREIGN_DEST" \
+    "$DEPOSIT_AMOUNT" 0x)
+echo "$CALLDATA" > "$B2AGG_STORE_DIR/foreign-claim-calldata.hex"
+log "  calldata: ${#CALLDATA} hex chars → $B2AGG_STORE_DIR/foreign-claim-calldata.hex"
+
+# ── Step 5: Drive the claim through the FOREIGN bridge (live consumption) ───
+step "Submitting foreign GER inject + CLAIM (waiting for the foreign bridge to consume)"
+FC_OUT=$(iso_tool --submit-foreign-claim \
+    --claim-calldata-file /store/foreign-claim-calldata.hex \
+    --foreign-bridge-id "$FOREIGN_BRIDGE_ID" \
+    --foreign-service-id "$FOREIGN_SERVICE_ID" \
+    --foreign-ger-manager-id "$FOREIGN_GER_MANAGER_ID" \
+    --scale-exp 10 2>&1) \
+    || { echo "$FC_OUT" | tail -40 >&2; fail "--submit-foreign-claim failed (foreign bridge did not consume)"; }
+echo "$FC_OUT" | tail -8
+FOREIGN_GI=$(echo "$FC_OUT" | grep "global-index:" | awk '{print $NF}')
+FOREIGN_NOTE_COMMITMENT=$(echo "$FC_OUT" | grep "note-commitment:" | awk '{print $NF}')
+[[ -n "$FOREIGN_GI" && -n "$FOREIGN_NOTE_COMMITMENT" ]] \
+    || fail "could not parse foreign claim identifiers from tool output"
+FOREIGN_GI_HEX="${FOREIGN_GI#0x}"
+pass "foreign bridge CONSUMED the claim (note commitment $FOREIGN_NOTE_COMMITMENT, gi $FOREIGN_GI)"
+
+# ── Step 6: Wait for our proxy's provenance gate to evaluate it ──────────────
+# The note-visibility reconciler imports the foreign tag-0 notes; once the
+# consumption is discovered the projector runs the CLAIM derivation and the
+# gate must skip it, incrementing the counter. Metric-first (fixed on this
+# branch — emitted from the MidenClient runtime and now rendered reliably).
+step "Waiting for claim_event_foreign_skipped_total to advance (≤${GATE_TIMEOUT_SECS}s)"
+ELAPSED=0
+NEW_FOREIGN_SKIPPED="$BASE_FOREIGN_SKIPPED"
+while [[ "$ELAPSED" -lt "$GATE_TIMEOUT_SECS" ]]; do
+    NEW_FOREIGN_SKIPPED=$(counter claim_event_foreign_skipped_total)
+    [[ "$NEW_FOREIGN_SKIPPED" -gt "$BASE_FOREIGN_SKIPPED" ]] && break
+    sleep 5; ELAPSED=$((ELAPSED + 5)); echo -n "."
+done
+echo ""
+if [[ "$NEW_FOREIGN_SKIPPED" -le "$BASE_FOREIGN_SKIPPED" ]]; then
+    warn "diagnostics: tip=$(l2_tip 2>/dev/null || echo '?') foreign_skipped=$NEW_FOREIGN_SKIPPED (base $BASE_FOREIGN_SKIPPED)"
+    warn "if the foreign CLAIM was consumed before the reconciler imported it, miden-client"
+    warn "drops the import (spent-before-import applies to B2AGG recovery only) — the gate"
+    warn "then never evaluates the note. Re-run against a quieter stack before treating as regression."
+    fail "provenance gate did not fire within ${GATE_TIMEOUT_SECS}s (claim_event_foreign_skipped_total stuck at $NEW_FOREIGN_SKIPPED)"
+fi
+pass "gate fired: claim_event_foreign_skipped_total $BASE_FOREIGN_SKIPPED → $NEW_FOREIGN_SKIPPED"
+
+# ── Step 7: PG assertions — the load-bearing state checks ────────────────────
+step "Asserting synthetic_logs state"
+# (b) ZERO ClaimEvent rows for the foreign global index. ABI data layout of
+# ClaimEvent: word 0 = globalIndex — prefix-match on the data column.
+FOREIGN_ROWS=$(pgq "SELECT COUNT(*) FROM synthetic_logs WHERE topics[1] = '${CLAIM_EVENT_TOPIC}' AND lower(data) LIKE '0x${FOREIGN_GI_HEX}%';")
+[[ "$FOREIGN_ROWS" == "0" ]] \
+    || fail "FOREIGN CLAIM LEAKED: $FOREIGN_ROWS ClaimEvent row(s) carry the foreign global index 0x${FOREIGN_GI_HEX}"
+pass "zero ClaimEvent rows for the foreign global index"
+
+# (c) our own claim's row still present (and not somehow gated away).
+OWN_ROWS_AFTER=$(pgq "SELECT COUNT(*) FROM synthetic_logs WHERE topics[1] = '${CLAIM_EVENT_TOPIC}' AND lower(data) NOT LIKE '0x${FOREIGN_GI_HEX}%';")
+[[ "${OWN_ROWS_AFTER:-0}" -ge 1 ]] \
+    || fail "positive control broken: no OWN ClaimEvent rows remain (gate over-eager?)"
+pass "own ClaimEvent rows intact: $OWN_ROWS_AFTER"
+
+# ── Step 8: Proxy health ─────────────────────────────────────────────────────
+step "Proxy health: tip advancing + /metrics serving"
+TIP_A=$(l2_tip) || fail "eth_blockNumber unreachable after test"
+sleep 12
+TIP_B=$(l2_tip) || fail "eth_blockNumber unreachable after test"
+[[ "$TIP_B" -gt "$TIP_A" ]] || fail "synthetic tip frozen at $TIP_A — proxy unhealthy after foreign-claim exposure"
+pass "tip advancing: $TIP_A → $TIP_B"
+
+log "======================================================================"
+log "  FOREIGN-BRIDGE CLAIM PROVENANCE PASS"
+log "    foreign bridge:                    $FOREIGN_BRIDGE_ID (network $FOREIGN_NETWORK_ID)"
+log "    foreign claim gi:                  $FOREIGN_GI"
+log "    claim_event_foreign_skipped_total: $BASE_FOREIGN_SKIPPED → $NEW_FOREIGN_SKIPPED"
+log "    foreign ClaimEvent rows:           $FOREIGN_ROWS (must be 0)"
+log "    own ClaimEvent rows:               $OWN_ROWS_AFTER"
+log "======================================================================"

--- a/scripts/e2e-reconciler-cursor-persistence.sh
+++ b/scripts/e2e-reconciler-cursor-persistence.sh
@@ -13,7 +13,8 @@
 # Flow:
 #   1. Preflight: stack up, PG reachable, migration 010 applied.
 #   2. Wait for the reconciler to catch up near the Miden tip (the sweep
-#      advances RECONCILE_CHUNK=200 blocks per ~5s tick).
+#      processes multiple RECONCILE_CHUNK-block windows per ~5s tick, under
+#      the RECONCILE_TICK_BUDGET_MS budget).
 #   3. Snapshot the persisted cursor, restart the proxy container
 #      (same pattern as e2e-rd913-restart-burn-collision.sh: docker restart,
 #      PostgreSQL untouched).
@@ -54,8 +55,9 @@ PG_DB="agglayer_store"
 COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-miden-agglayer}"
 AGGLAYER_CONTAINER="${AGGLAYER_CONTAINER:-${COMPOSE_PROJECT_NAME}-miden-agglayer-1}"
 
-# Must match RECONCILE_CHUNK in src/synthetic_projector.rs.
-RECONCILE_CHUNK=200
+# Must match RECONCILE_CHUNK in src/synthetic_projector.rs (default; the
+# service may override via the RECONCILE_CHUNK env var).
+RECONCILE_CHUNK=1000
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'; NC='\033[0m'
 log()  { echo -e "${GREEN}[$(date +%H:%M:%S)]${NC} $*"; }
@@ -114,8 +116,9 @@ log "  Reconciler sweep-cursor persistence — restart-survival regression"
 log "======================================================================"
 
 # ── Step 1: let the sweep catch up near the tip. ─────────────────────────
-# The reconciler advances one RECONCILE_CHUNK window per ~5s projector tick,
-# so on a fresh e2e stack catch-up is quick; the timeout is generous for CI.
+# The reconciler processes multiple RECONCILE_CHUNK windows per ~5s projector
+# tick (budgeted concurrent catch-up), so on a fresh e2e stack catch-up is
+# near-instant; the timeout is generous for CI.
 step "Waiting for the reconciler sweep to catch up near the Miden tip..."
 wait_for "reconcile_cursor within one chunk of the tip" \
     '[[ "$(reconcile_cursor)" -ge $(( $(chain_tip) - RECONCILE_CHUNK )) ]]' \

--- a/scripts/e2e-reconciler-cursor-persistence.sh
+++ b/scripts/e2e-reconciler-cursor-persistence.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Reconciler sweep-cursor persistence — restart must NOT re-sweep from genesis.
+#
+# PROD INCIDENT this regression-protects: the note-visibility reconciler's
+# sweep cursor (`SyntheticProjector::reconcile_cursor`,
+# src/synthetic_projector.rs) was a memory-only AtomicU64 hardcoded to 0 at
+# boot. EVERY container restart — image update, crash, plain `docker restart` —
+# re-walked the sweep from genesis: ~3h of resync and node load per restart on
+# prod history. The cursor is now persisted in
+# `service_state.reconcile_cursor` (migration 010) and loaded at boot, exactly
+# like the projection cursor (migration 009 `projector_cursor`).
+#
+# Flow:
+#   1. Preflight: stack up, PG reachable, migration 010 applied.
+#   2. Wait for the reconciler to catch up near the Miden tip (the sweep
+#      advances RECONCILE_CHUNK=200 blocks per ~5s tick).
+#   3. Snapshot the persisted cursor, restart the proxy container
+#      (same pattern as e2e-rd913-restart-burn-collision.sh: docker restart,
+#      PostgreSQL untouched).
+#   4. Assert, state-first (DB) with a log cross-check:
+#        a. the boot-loaded cursor is the persisted one (near the tip:
+#           first window `from > tip - 3*RECONCILE_CHUNK`), NOT 0;
+#        b. the persisted cursor never regresses across the restart;
+#        c. no genesis window (`from=1`) appears in the reconciler's
+#           post-restart logs.
+#
+# Prerequisites:
+#   - Full E2E stack running (`make e2e-up`); see Makefile for setup.
+#   - miden-agglayer running with PgStore (DATABASE_URL set in compose).
+#   - psql, curl, jq available on the host.
+#
+# Usage:
+#   source fixtures/.env && ./scripts/e2e-reconciler-cursor-persistence.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURES_DIR="$PROJECT_DIR/fixtures"
+
+source "$FIXTURES_DIR/.env"
+
+# Required by docker-compose.e2e.yml's miden-node build args, even for
+# `docker compose run` invocations the file is fully interpolated. Same
+# defaults as the Makefile (source-of-truth — bump both together).
+export MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-https://github.com/0xMiden/node.git}"
+export MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-v0.15.0}"
+
+L2_RPC="http://localhost:8546"
+PG_HOST="localhost"
+PG_PORT="5434"
+PG_USER="agglayer"
+PG_PASS="agglayer"
+PG_DB="agglayer_store"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-miden-agglayer}"
+AGGLAYER_CONTAINER="${AGGLAYER_CONTAINER:-${COMPOSE_PROJECT_NAME}-miden-agglayer-1}"
+
+# Must match RECONCILE_CHUNK in src/synthetic_projector.rs.
+RECONCILE_CHUNK=200
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[$(date +%H:%M:%S)]${NC} $*"; }
+warn() { echo -e "${YELLOW}[$(date +%H:%M:%S)] WARN:${NC} $*"; }
+fail() { echo -e "${RED}[$(date +%H:%M:%S)] FAIL:${NC} $*" >&2; exit 1; }
+pass() { echo -e "${GREEN}[$(date +%H:%M:%S)] PASS:${NC} $*"; }
+step() { echo -e "${CYAN}[$(date +%H:%M:%S)] ▶${NC} $*"; }
+
+pgquery() {
+    PGPASSWORD="$PG_PASS" psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -t -A -c "$1" 2>/dev/null
+}
+
+wait_for() {
+    local desc="$1" cmd="$2" timeout="$3" interval="${4:-5}"
+    local elapsed=0
+    log "Waiting: $desc (timeout: ${timeout}s)..."
+    while ! ( set +o pipefail; eval "$cmd" ) 2>/dev/null; do
+        elapsed=$((elapsed + interval))
+        [[ $elapsed -ge $timeout ]] && fail "Timed out: $desc"
+        echo -n "."
+        sleep "$interval"
+    done
+    echo ""
+}
+
+reconcile_cursor() {
+    pgquery "SELECT reconcile_cursor FROM service_state WHERE id = 1"
+}
+
+# Synthetic tip == Miden tip under Miden-1:1, so eth_blockNumber is the tip
+# the reconciler sweeps toward.
+chain_tip() {
+    curl -sf "$L2_RPC" -X POST -H "Content-Type: application/json" \
+        -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+        | jq -r '.result' | xargs printf '%d\n'
+}
+
+# ── Pre-flight ───────────────────────────────────────────────────────────
+command -v psql >/dev/null || fail "psql not found"
+command -v curl >/dev/null || fail "curl not found"
+command -v jq   >/dev/null || fail "jq not found"
+curl -sf "$L2_RPC" -X POST -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' >/dev/null 2>&1 \
+    || fail "L2 (miden-agglayer) not reachable at $L2_RPC"
+pgquery "SELECT 1" >/dev/null || fail "PostgreSQL not reachable on $PG_HOST:$PG_PORT"
+
+# Confirm the migration is present. If the operator forgot to rerun
+# migrations after upgrading, fail loudly here rather than producing a
+# confusing empty-value comparison later.
+if [[ "$(reconcile_cursor)" == "" ]]; then
+    fail "service_state.reconcile_cursor is missing — has 010_reconcile_cursor.sql been applied?"
+fi
+
+log "======================================================================"
+log "  Reconciler sweep-cursor persistence — restart-survival regression"
+log "======================================================================"
+
+# ── Step 1: let the sweep catch up near the tip. ─────────────────────────
+# The reconciler advances one RECONCILE_CHUNK window per ~5s projector tick,
+# so on a fresh e2e stack catch-up is quick; the timeout is generous for CI.
+step "Waiting for the reconciler sweep to catch up near the Miden tip..."
+wait_for "reconcile_cursor within one chunk of the tip" \
+    '[[ "$(reconcile_cursor)" -ge $(( $(chain_tip) - RECONCILE_CHUNK )) ]]' \
+    300 5
+TIP_PRE="$(chain_tip)"
+PRE_CURSOR="$(reconcile_cursor)"
+log "Pre-restart: tip=$TIP_PRE persisted reconcile_cursor=$PRE_CURSOR"
+[[ "$PRE_CURSOR" -ge 1 ]] || fail "pre-restart cursor is 0 — sweep never advanced; cannot test restart resume"
+
+# ── Step 2: restart the proxy (PostgreSQL untouched). ────────────────────
+step "Restarting $AGGLAYER_CONTAINER (PG is untouched)..."
+# Timestamp for `docker logs --since` — everything we grep below must come
+# from AFTER the restart, or we'd read the previous boot's genesis sweep.
+RESTART_TS="$(date -u '+%Y-%m-%dT%H:%M:%S')"
+docker restart "$AGGLAYER_CONTAINER" >/dev/null
+wait_for "miden-agglayer back up" \
+    "curl -sf '$L2_RPC' -X POST -H 'Content-Type: application/json' \
+     -d '{\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":[],\"id\":1}' >/dev/null" \
+    90 3
+pass "miden-agglayer restarted and responsive"
+
+# ── Step 3: the first post-restart sweep window starts NEAR THE TIP. ─────
+# State-based primary assertion: the cursor the projector loaded at boot is
+# the persisted one, so the first window is `from = PRE_CURSOR + 1`. "Near
+# the tip" = within 3 chunks (the tip keeps moving while we restart).
+FIRST_FROM=$(( PRE_CURSOR + 1 ))
+TIP_POST="$(chain_tip)"
+NEAR_TIP_FLOOR=$(( TIP_POST - 3 * RECONCILE_CHUNK ))
+log "Post-restart: tip=$TIP_POST first sweep window from=$FIRST_FROM (floor: $NEAR_TIP_FLOOR)"
+if [[ "$FIRST_FROM" -le "$NEAR_TIP_FLOOR" ]]; then
+    fail "first post-restart sweep window starts at $FIRST_FROM ≤ tip - 3*$RECONCILE_CHUNK = $NEAR_TIP_FLOOR — restart re-swept history"
+fi
+pass "first post-restart sweep window ($FIRST_FROM) is near the tip ($TIP_POST)"
+
+# Cross-check against the boot log. Pinned format — src/synthetic_projector.rs
+# `SyntheticProjector::new`:
+#   tracing::info!(reconcile_cursor = start_reconcile,
+#       "note reconciler: sweep cursor loaded — next sweep window starts at block {}", ...)
+# which the compact fmt layer renders as:
+#   ... note reconciler: sweep cursor loaded — next sweep window starts at block 4201 reconcile_cursor=4200
+# Strip ANSI escapes FIRST: tracing's colored fmt injects resets between the
+# field name and value (`reconcile_cursor\x1b[0m: 181`), which silently breaks
+# any field-value regex on the raw stream.
+BOOT_LINE="$(docker logs --since "$RESTART_TS" "$AGGLAYER_CONTAINER" 2>&1 \
+    | sed 's/\x1b\[[0-9;]*m//g' \
+    | grep -F 'note reconciler: sweep cursor loaded' | head -1 || true)"
+if [[ -z "$BOOT_LINE" ]]; then
+    fail "post-restart boot log line 'note reconciler: sweep cursor loaded' not found"
+fi
+# tracing renders structured fields as `reconcile_cursor: N` (colon-space),
+# not `reconcile_cursor=N` — accept both so a formatter change doesn't
+# silently blank the capture (pinned format: synthetic_projector.rs boot line).
+LOADED="$(sed -n 's/.*reconcile_cursor[:=] *\([0-9]\+\).*/\1/p' <<<"$BOOT_LINE")"
+log "Boot log reports loaded reconcile_cursor=$LOADED"
+# >= not ==: the sweep keeps advancing between our PG snapshot and the actual
+# process stop (all the more with the concurrent catch-up), so the persisted
+# value at boot may legitimately exceed the snapshot. The property under test
+# is "boot loaded a persisted, non-genesis cursor" — never that the chain
+# stood still for the restart.
+if [[ -z "$LOADED" || "$LOADED" -lt "$PRE_CURSOR" || "$LOADED" -eq 0 ]]; then
+    fail "boot loaded reconcile_cursor=$LOADED (PG snapshot pre-restart: $PRE_CURSOR) — cursor not loaded from store"
+fi
+pass "boot loaded a persisted cursor ($LOADED >= snapshot $PRE_CURSOR), not genesis"
+
+# ── Step 4: the persisted cursor keeps advancing and never regresses. ────
+step "Waiting for the first post-restart sweep window to complete..."
+wait_for "reconcile_cursor advanced past pre-restart value" \
+    '[[ "$(reconcile_cursor)" -gt '"$PRE_CURSOR"' ]]' \
+    120 5
+POST_CURSOR="$(reconcile_cursor)"
+log "Post-restart persisted reconcile_cursor=$POST_CURSOR"
+if [[ "$POST_CURSOR" -lt "$PRE_CURSOR" ]]; then
+    fail "reconcile cursor regressed across restart: $PRE_CURSOR → $POST_CURSOR"
+fi
+pass "reconcile cursor resumed and advanced: $PRE_CURSOR → $POST_CURSOR"
+
+# ── Step 5: NO genesis window in the post-restart reconciler logs. ───────
+# Pinned format — src/synthetic_projector.rs `reconcile_notes`:
+#   tracing::info!(imported, skipped_private, from, to,
+#       "note reconciler: imported network notes missed by sync")
+# renders as `... missed by sync imported=N skipped_private=N from=N to=N`.
+# The line only fires when a window imports notes, so its ABSENCE alone
+# proves nothing (steps 3–4 are the primary assertions) — but its PRESENCE
+# with `from=1 ` post-restart is the genesis-re-sweep signature and must
+# never appear (the very first boot of the stack swept genesis long before
+# RESTART_TS).
+GENESIS_LINE="$(docker logs --since "$RESTART_TS" "$AGGLAYER_CONTAINER" 2>&1 \
+    | grep -F 'note reconciler: imported network notes missed by sync' \
+    | grep -E ' from=1( |$)' | head -1 || true)"
+if [[ -n "$GENESIS_LINE" ]]; then
+    fail "genesis sweep window appeared after restart: $GENESIS_LINE"
+fi
+pass "no genesis window (from=1) in post-restart reconciler logs"
+
+log "======================================================================"
+log "  RECONCILER CURSOR PERSISTENCE TEST COMPLETE"
+log "======================================================================"

--- a/scripts/e2e-reconciler-private-note.sh
+++ b/scripts/e2e-reconciler-private-note.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# ══════════════════════════════════════════════════════════════════════════════
+# e2e-reconciler-private-note.sh — reconciler private-note wedge repro
+#                                   (0.15.5 hotfix 9712945, PR #110)
+#
+# The note-visibility reconciler sweeps blocks via `sync_notes(tags={0})` and
+# imports every unknown tag-0 note by id (`import_notes(NoteFile::NoteId)`).
+# A PRIVATE note's id lands on-chain in that same tag-0 family (the default
+# NoteTag), but its details are never published, so the import fails with
+# miden-client's "Incomplete imported note is private" — and a private
+# HISTORICAL note never becomes importable. Pre-hotfix the whole batch import
+# failed on every tick and the sweep froze on that block window FOREVER: the
+# retroactive-heal path (restart → re-sweep from genesis) could never walk
+# PAST the private-note block to re-discover later bridge-out notes.
+#
+# Post-hotfix (9712945): a per-note fallback skips just the private notes
+# (metric `synthetic_reconciler_private_skipped_total`, WARN "skipping
+# un-importable private network note"); other errors stay fatal.
+#
+# Phases:
+#   0. Fund an ISOLATED wallet via L1→L2 deposit + auto-claim.
+#   A. Live skip: inject a PRIVATE tag-0 P2ID note from the isolated wallet
+#      (bridge-out-tool --send-private-note). Assert the reconciler skips it
+#      (metric increments + WARN with the note id) and does NOT enter the
+#      wedge loop ("note reconciler failed ... is private" repeating).
+#   B. The prod wedge scenario: AFTER the private note, do a normal bridge-out
+#      and record its BridgeEvent. Then stop the proxy, wipe ONLY the miden
+#      sqlite store (--reset-miden-store --restore, the supported operator
+#      flow) and restart — the reconciler's genesis re-sweep must now re-walk
+#      history THROUGH the private-note block. Assert the sweep skips the
+#      private note again (fresh metric ≥ 1 + WARN post-restart), never enters
+#      the wedge loop, and the bridge-out's BridgeEvent is still served by
+#      eth_getLogs — i.e. the private note did not block healing.
+#
+# Pre-hotfix both phases fail loud: the metric never appears and the proxy
+# logs "note reconciler failed (transient — will retry next tick)" with
+# "Incomplete imported note is private" every tick, frozen on one window.
+#
+# Prerequisites: full e2e stack running (make e2e-up).
+# ══════════════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURES_DIR="$PROJECT_DIR/fixtures"
+
+source "$FIXTURES_DIR/.env"
+
+# Required by docker-compose.e2e.yml's miden-node build args (`${VAR:?...}`) —
+# even one-shot `docker compose run/stop/start` interpolates the whole file.
+export MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-https://github.com/0xMiden/node.git}"
+export MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-v0.15.0}"
+
+L1_RPC="${L1_RPC:-http://localhost:8545}"
+L2_RPC="${L2_RPC:-http://localhost:8546}"
+BRIDGE_SERVICE_URL="${BRIDGE_SERVICE_URL:-http://localhost:18080}"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-miden-agglayer}"
+AGGLAYER_CONTAINER="${AGGLAYER_CONTAINER:-${COMPOSE_PROJECT_NAME}-miden-agglayer-1}"
+COMPOSE_FILE="$PROJECT_DIR/docker-compose.e2e.yml"
+ENV_FILE="$FIXTURES_DIR/.env"
+
+FUNDED_KEY="0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"
+L1_DEST=$(cast wallet address --private-key "$FUNDED_KEY")
+DEST_NETWORK=1                   # Miden network id (fixtures pin MIDEN_NETWORK_ID=1)
+DEPOSIT_AMOUNT="10000000000000"  # 10^13 wei → 1000 Miden units
+
+# Synthetic BridgeEvent topic (same as e2e-l2-to-l1.sh).
+BRIDGE_EVENT_TOPIC="0x501781209a1f8899323b96b4ef08b168df93e0a90c673d1e4cce39366cb62f9b"
+
+METRIC="synthetic_reconciler_private_skipped_total"
+SKIP_LINE="skipping un-importable private network note"
+WEDGE_LINE="note reconciler failed"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[$(date +%H:%M:%S)]${NC} $*"; }
+warn() { echo -e "${YELLOW}[$(date +%H:%M:%S)] WARN:${NC} $*"; }
+fail() { echo -e "${RED}[$(date +%H:%M:%S)] FAIL:${NC} $*" >&2; exit 1; }
+pass() { echo -e "${GREEN}[$(date +%H:%M:%S)] PASS:${NC} $*"; }
+step() { echo -e "${CYAN}[$(date +%H:%M:%S)] STEP:${NC} $*"; }
+
+wait_for() {
+    local desc="$1" cmd="$2" timeout="$3" interval="${4:-5}"
+    local elapsed=0
+    log "Waiting: $desc (timeout: ${timeout}s)..."
+    # Subshell with pipefail off — see e2e-dynamic-erc20.sh for the SIGPIPE
+    # rationale.
+    while ! ( set +o pipefail; eval "$cmd" ) 2>/dev/null; do
+        elapsed=$((elapsed + interval))
+        [[ $elapsed -ge $timeout ]] && fail "Timed out: $desc"
+        echo -n "."
+        sleep "$interval"
+    done
+    echo ""
+}
+
+# Current value of the private-skip counter (0 when the series hasn't been
+# rendered yet — metrics-exporter-prometheus only emits a counter after its
+# first increment).
+metric_value() {
+    curl -s "$L2_RPC/metrics" 2>/dev/null \
+        | awk -v m="$METRIC" '$1==m{v=$2} END{print v+0}'
+}
+
+# Proxy log lines AFTER the given line-count mark.
+logs_since() {
+    docker logs "$AGGLAYER_CONTAINER" 2>&1 | tail -n +"$(( $1 + 1 ))"
+}
+
+log_mark() {
+    docker logs "$AGGLAYER_CONTAINER" 2>&1 | wc -l
+}
+
+# Wedge-loop lines since a mark: the per-tick reconciler failure caused by the
+# un-importable private note. Post-hotfix this must be ZERO.
+wedge_count_since() {
+    logs_since "$1" | grep "$WEDGE_LINE" | grep -ci "is private" || true
+}
+
+bridge_event_count() {
+    curl -s "$L2_RPC" -X POST -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_getLogs\",\"params\":[{\"fromBlock\":\"0x0\",\"toBlock\":\"latest\",\"topics\":[\"$BRIDGE_EVENT_TOPIC\"]}]}" \
+        | python3 -c 'import sys,json; r=json.load(sys.stdin).get("result"); print(len(r) if isinstance(r,list) else 0)' 2>/dev/null \
+        || echo 0
+}
+
+# Wait for the reconciler to SKIP the given note (the per-note WARN naming its
+# id), failing FAST (with wedge evidence) if the pre-hotfix wedge loop shows up
+# instead: >=3 per-tick reconciler failures on the private note is the
+# frozen-sweep signature — waiting longer cannot help, the window is stuck.
+#
+# The wait is log-driven (note-id-specific, so reruns against a chain that
+# already carries older private notes stay deterministic); the metric is
+# asserted separately as >= 1 — note the proxy's prometheus exporter renders
+# counters saturated at 1 (pre-existing quirk on main, every *_total series
+# reads 1 no matter how often it increments), so a delta assertion on the
+# counter VALUE would be meaningless.
+wait_for_skip_or_wedge() {
+    local note_id="$1" mark="$2" timeout="$3" what="$4"
+    local elapsed=0 w
+    log "Waiting: $what (skip WARN for $note_id, timeout ${timeout}s)..."
+    while :; do
+        if logs_since "$mark" | grep "$SKIP_LINE" | grep -q "$note_id"; then
+            echo ""
+            return 0
+        fi
+        w=$(wedge_count_since "$mark")
+        if [[ "$w" -ge 3 ]]; then
+            echo ""
+            warn "reconciler WEDGE detected: $w per-tick import failures on the private note"
+            warn "wedge evidence (proxy log):"
+            logs_since "$mark" | grep "$WEDGE_LINE" | grep -i "is private" | head -5 >&2
+            fail "$what: reconciler wedged on the private note instead of skipping it (pre-hotfix behaviour — sweep frozen, retroactive healing dead)"
+        fi
+        elapsed=$((elapsed + 5))
+        [[ $elapsed -ge $timeout ]] && {
+            echo ""
+            warn "last proxy reconciler lines:"
+            logs_since "$mark" | grep -i "reconciler" | tail -10 >&2
+            fail "Timed out: $what (no skip WARN for $note_id)"
+        }
+        echo -n "."
+        sleep 5
+    done
+}
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+command -v cast >/dev/null || fail "cast (foundry) not found"
+command -v python3 >/dev/null || fail "python3 not found"
+cast block-number --rpc-url "$L1_RPC" >/dev/null 2>&1 || fail "L1 (Anvil) not reachable"
+curl -sf "$L2_RPC" -X POST -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' >/dev/null 2>&1 \
+    || fail "L2 (miden-agglayer) not reachable"
+
+ACCOUNTS=$(docker exec "$AGGLAYER_CONTAINER" \
+    cat /var/lib/miden-agglayer-service/bridge_accounts.toml 2>/dev/null) \
+    || fail "miden-agglayer not initialized yet"
+BRIDGE_ID=$(echo "$ACCOUNTS" | grep 'bridge = ' | sed 's/.*= "//;s/"//')
+FAUCET_ID=$(echo "$ACCOUNTS" | grep faucet_eth | sed 's/.*= "//;s/"//')
+
+# ── Isolated wallet (single-owner store policy — NEVER the proxy's store) ────
+B2AGG_STORE_DIR="${B2AGG_STORE_DIR:-$PROJECT_DIR/.b2agg-store/e2e-private-note}"
+B2AGG_FRESH="${B2AGG_FRESH:-1}"
+source "$SCRIPT_DIR/lib-isolated-wallet.sh"
+provision_isolated_wallet "$BRIDGE_ID" "$FAUCET_ID" \
+    || fail "could not provision isolated wallet"
+
+log "======================================================================"
+log "  Reconciler Private-Note Wedge E2E (0.15.5 hotfix, PR #110)"
+log "======================================================================"
+log "Wallet:  $WALLET_ID (isolated store: $B2AGG_STORE_DIR)"
+log "Bridge:  $BRIDGE_ID"
+log "Faucet:  $FAUCET_ID"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Phase 0 — fund the isolated wallet (L1→L2 deposit + auto-claim)
+# ══════════════════════════════════════════════════════════════════════════════
+step "Phase 0: funding the isolated wallet via L1→L2 deposit..."
+BAL=$(iso_wallet_balance "$BRIDGE_ID" "$FAUCET_ID")
+BAL="${BAL:-0}"
+if [[ "$BAL" -gt 0 ]]; then
+    log "wallet already funded (balance $BAL) — skipping deposit"
+else
+    TX=$(cast send --rpc-url "$L1_RPC" --private-key "$FUNDED_KEY" "$BRIDGE_ADDRESS" \
+        'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+        "$DEST_NETWORK" "$DEST_ADDR" "$DEPOSIT_AMOUNT" \
+        0x0000000000000000000000000000000000000000 true 0x \
+        --value "$DEPOSIT_AMOUNT" 2>&1)
+    STATUS=$(printf '%s\n' "$TX" | awk '$1=="status"{print $2; exit}')
+    [[ "$STATUS" == "1" ]] || fail "L1 deposit tx failed (status=$STATUS)"
+    log "L1 deposit sent; waiting for auto-claim + P2ID delivery..."
+    for attempt in $(seq 1 24); do
+        sleep 10
+        BAL=$(iso_wallet_balance "$BRIDGE_ID" "$FAUCET_ID")
+        BAL="${BAL:-0}"
+        log "  attempt $attempt/24: balance = $BAL"
+        [[ "$BAL" -gt 0 ]] && break
+    done
+    [[ "$BAL" -gt 0 ]] || fail "wallet not funded after 240s"
+fi
+pass "isolated wallet funded (balance $BAL)"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Phase A — live skip: inject the private note, reconciler must skip (not wedge)
+# ══════════════════════════════════════════════════════════════════════════════
+step "Phase A: injecting a PRIVATE tag-0 note (bridge-out-tool --send-private-note)..."
+MARK_A=$(log_mark)
+
+PRIV_OUT=$(iso_tool --send-private-note --wallet-id "$WALLET_ID" 2>&1) \
+    || { echo "$PRIV_OUT" | tail -20 >&2; fail "--send-private-note failed"; }
+NOTE_ID=$(echo "$PRIV_OUT" | grep '\[private-note\] note-id:' | awk '{print $NF}')
+COMMIT_BLOCK=$(echo "$PRIV_OUT" | grep '\[private-note\] commit-block:' | awk '{print $NF}')
+[[ -n "$NOTE_ID" && -n "$COMMIT_BLOCK" ]] \
+    || { echo "$PRIV_OUT" | tail -20 >&2; fail "could not parse private note id / commit block"; }
+log "  private note $NOTE_ID committed at Miden block $COMMIT_BLOCK"
+
+wait_for_skip_or_wedge "$NOTE_ID" "$MARK_A" 300 "live reconciler skip of the private note"
+pass "reconciler skipped the private note (WARN names our note id)"
+
+SKIP_METRIC=$(metric_value)
+[[ "$SKIP_METRIC" -ge 1 ]] \
+    || fail "$METRIC not >= 1 on /metrics after the skip (got $SKIP_METRIC)"
+pass "$METRIC >= 1 on /metrics ($SKIP_METRIC)"
+
+# Post-skip quiescence: several ticks with ZERO wedge-loop lines. Pre-hotfix
+# the same window fails every tick forever.
+log "verifying no wedge loop after the skip (15s / ~3 ticks)..."
+sleep 15
+WEDGES=$(wedge_count_since "$MARK_A")
+[[ "$WEDGES" -eq 0 ]] \
+    || { logs_since "$MARK_A" | grep "$WEDGE_LINE" | grep -i "is private" | head -5 >&2; \
+         fail "reconciler entered the wedge loop ($WEDGES per-tick failures) despite skipping"; }
+HEALTH=$(docker inspect -f '{{.State.Health.Status}}' "$AGGLAYER_CONTAINER" 2>/dev/null || echo none)
+[[ "$HEALTH" == "healthy" ]] || fail "proxy not healthy after private-note skip (status: $HEALTH)"
+pass "Phase A: live skip clean — no repeated import_notes failures, proxy healthy"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Phase B — the prod wedge scenario: genesis re-sweep through the private block
+# ══════════════════════════════════════════════════════════════════════════════
+step "Phase B: bridge-out AFTER the private note, then reset-miden-store + restore..."
+
+EVENTS_BEFORE=$(bridge_event_count)
+BRIDGE_AMOUNT=$((BAL / 2))
+[[ "$BRIDGE_AMOUNT" -gt 0 ]] || fail "wallet balance too small to bridge out ($BAL)"
+log "  bridge-out $BRIDGE_AMOUNT units → $L1_DEST (BridgeEvents before: $EVENTS_BEFORE)"
+iso_tool \
+    --wallet-id "$WALLET_ID" --bridge-id "$BRIDGE_ID" --faucet-id "$FAUCET_ID" \
+    --amount "$BRIDGE_AMOUNT" --dest-address "$L1_DEST" --dest-network 0 2>&1 \
+    | tail -5 || fail "bridge-out failed"
+
+wait_for "post-private-note BridgeEvent in eth_getLogs" \
+    "[[ \$(bridge_event_count) -gt $EVENTS_BEFORE ]]" 240 5
+EVENTS_WITH_EXIT=$(bridge_event_count)
+pass "bridge-out BridgeEvent recorded (count $EVENTS_BEFORE → $EVENTS_WITH_EXIT)"
+
+# ── Operator flow: wipe ONLY the miden sqlite store, restore, restart ────────
+# (--reset-miden-store deletes store.sqlite3; postgres is untouched. The
+# reconcile cursor is in-memory, so the restarted proxy re-sweeps from genesis
+# and must re-walk THROUGH the private-note block. Pre-hotfix it froze there.)
+log "stopping proxy..."
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" stop miden-agglayer >/dev/null 2>&1
+
+RESTORE_LOG=$(mktemp /tmp/e2e-private-note-restore.XXXXXX.log)
+log "running one-shot: --reset-miden-store --restore (log: $RESTORE_LOG)"
+set +e
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" \
+    run --rm --no-deps miden-agglayer \
+    --port=8546 \
+    --miden-node=http://miden-node:57291 \
+    --miden-store-dir=/var/lib/miden-agglayer-service \
+    --l1-rpc-url=http://anvil:8545 \
+    --ger-l1-address=0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674 \
+    --reset-miden-store \
+    --restore \
+    >"$RESTORE_LOG" 2>&1
+RESTORE_EXIT=$?
+set -e
+[[ "$RESTORE_EXIT" -eq 0 ]] \
+    || { tail -20 "$RESTORE_LOG" >&2; fail "reset+restore one-shot exited $RESTORE_EXIT"; }
+grep -q 'reset_miden_store: deleted' "$RESTORE_LOG" \
+    || fail "reset marker missing — --reset-miden-store did not wipe the sqlite"
+grep -q 'RESTORE: complete' "$RESTORE_LOG" || fail "restore did not complete"
+pass "miden sqlite wiped + restore completed (postgres untouched)"
+
+log "restarting proxy..."
+# Mark BEFORE the restart: the reconciler can reach (and skip) the private
+# block before the container's healthcheck flips to healthy, and `docker logs`
+# accumulates across restarts of the same container.
+MARK_B=$(log_mark)
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" start miden-agglayer >/dev/null 2>&1
+wait_for "proxy healthy after restart" \
+    "[[ \$(docker inspect -f '{{.State.Health.Status}}' $AGGLAYER_CONTAINER 2>/dev/null) == healthy ]]" \
+    180 3
+
+# The genesis re-sweep (the reconcile cursor is in-memory, so a restart always
+# re-walks from block 1) must re-encounter — and re-skip — the private note at
+# block $COMMIT_BLOCK to reach anything after it. Pre-hotfix: it wedges there
+# instead and the sweep never passes the block — retroactive healing dead.
+wait_for_skip_or_wedge "$NOTE_ID" "$MARK_B" 420 "genesis re-sweep skipping the private note again"
+pass "re-sweep advanced past the private-note block (post-restart WARN names our note id)"
+
+# Restarted process → fresh metrics registry → the counter re-appears only
+# because the re-sweep re-skipped.
+SKIP_METRIC_B=$(metric_value)
+[[ "$SKIP_METRIC_B" -ge 1 ]] \
+    || fail "$METRIC not >= 1 on /metrics after the re-sweep skip (got $SKIP_METRIC_B)"
+pass "$METRIC >= 1 on /metrics post-restart ($SKIP_METRIC_B)"
+
+log "verifying no wedge loop after the re-sweep skip (15s / ~3 ticks)..."
+sleep 15
+WEDGES_B=$(wedge_count_since "$MARK_B")
+[[ "$WEDGES_B" -eq 0 ]] \
+    || { logs_since "$MARK_B" | grep "$WEDGE_LINE" | grep -i "is private" | head -5 >&2; \
+         fail "reconciler wedge loop after restart ($WEDGES_B per-tick failures)"; }
+pass "no wedge loop post-restart"
+
+# The post-private-note exit survived the heal: eth_getLogs still serves its
+# BridgeEvent (and the count did not regress).
+EVENTS_AFTER=$(bridge_event_count)
+log "BridgeEvents after heal: $EVENTS_AFTER (had $EVENTS_WITH_EXIT before the reset)"
+[[ "$EVENTS_AFTER" -ge "$EVENTS_WITH_EXIT" ]] \
+    || fail "BridgeEvent lost after reset+restore heal ($EVENTS_WITH_EXIT → $EVENTS_AFTER)"
+pass "post-private-note bridge-out's BridgeEvent present after the heal"
+
+# Leave the stack coherent for any subsequent suite scripts (same as
+# e2e-restore.sh): dependents reconnect to the restarted proxy.
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" \
+    restart bridge-service aggkit >/dev/null 2>&1 || true
+
+log "======================================================================"
+log "  RECONCILER PRIVATE-NOTE TEST COMPLETE"
+log "  private note: $NOTE_ID @ block $COMMIT_BLOCK (tag 0, type Private)"
+log "  Phase A: live skip (metric + WARN), zero wedge-loop lines"
+log "  Phase B: reset-miden-store + restore + restart → re-sweep skipped the"
+log "           private note again and the post-private-note BridgeEvent"
+log "           survived ($EVENTS_AFTER events served)"
+log "======================================================================"

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -35,6 +35,10 @@ case "$test_filter" in
         "$SCRIPT_DIR/e2e-security.sh"
         echo ""
         "$SCRIPT_DIR/e2e-dynamic-erc20.sh"
+        echo ""
+        # Last: it stops/restarts the proxy (reset-miden-store + restore), so
+        # it must not race the other scripts' steady-state assumptions.
+        "$SCRIPT_DIR/e2e-reconciler-private-note.sh"
         ;;
     tip-consistency)
         "$SCRIPT_DIR/e2e-rpc-tip-consistency.sh"
@@ -57,9 +61,12 @@ case "$test_filter" in
     fuzz)
         "$SCRIPT_DIR/e2e-fuzz-bridge.sh"
         ;;
+    reconciler-private-note)
+        "$SCRIPT_DIR/e2e-reconciler-private-note.sh"
+        ;;
     *)
         echo -e "${RED}Unknown test: $test_filter${NC}" >&2
-        echo "Usage: $0 [all|tip-consistency|l1-to-l2|l2-to-l1|dynamic-erc20|ger-decomposition|security|fuzz]" >&2
+        echo "Usage: $0 [all|tip-consistency|l1-to-l2|l2-to-l1|dynamic-erc20|ger-decomposition|security|fuzz|reconciler-private-note]" >&2
         exit 1
         ;;
 esac

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -36,6 +36,12 @@ case "$test_filter" in
         echo ""
         "$SCRIPT_DIR/e2e-dynamic-erc20.sh"
         echo ""
+        # Foreign-bridge claim provenance: deploys a SECOND agglayer deployment
+        # on the same chain and drives a claim through it — must not leak a
+        # ClaimEvent into our synthetic_logs. Runs before the proxy-restarting
+        # tests (it needs the steady-state reconciler/projector, no restarts).
+        "$SCRIPT_DIR/e2e-claim-provenance.sh"
+        echo ""
         # Proxy-restarting tests run LAST (they must not race the other
         # scripts' steady-state assumptions), in this order: the cursor test
         # does a plain restart and asserts the sweep RESUMES from the
@@ -74,9 +80,12 @@ case "$test_filter" in
     reconciler-cursor)
         "$SCRIPT_DIR/e2e-reconciler-cursor-persistence.sh"
         ;;
+    claim-provenance)
+        "$SCRIPT_DIR/e2e-claim-provenance.sh"
+        ;;
     *)
         echo -e "${RED}Unknown test: $test_filter${NC}" >&2
-        echo "Usage: $0 [all|tip-consistency|l1-to-l2|l2-to-l1|dynamic-erc20|ger-decomposition|security|fuzz|reconciler-private-note|reconciler-cursor]" >&2
+        echo "Usage: $0 [all|tip-consistency|l1-to-l2|l2-to-l1|dynamic-erc20|ger-decomposition|security|fuzz|reconciler-private-note|reconciler-cursor|claim-provenance]" >&2
         exit 1
         ;;
 esac

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -36,8 +36,15 @@ case "$test_filter" in
         echo ""
         "$SCRIPT_DIR/e2e-dynamic-erc20.sh"
         echo ""
-        # Last: it stops/restarts the proxy (reset-miden-store + restore), so
-        # it must not race the other scripts' steady-state assumptions.
+        # Proxy-restarting tests run LAST (they must not race the other
+        # scripts' steady-state assumptions), in this order: the cursor test
+        # does a plain restart and asserts the sweep RESUMES from the
+        # persisted cursor; the private-note test then ends with
+        # reset-miden-store + restore, which deliberately RESETS that cursor
+        # for a full re-sweep — so it must come after, or the cursor
+        # assertion races the restore's intentional genesis walk.
+        "$SCRIPT_DIR/e2e-reconciler-cursor-persistence.sh"
+        echo ""
         "$SCRIPT_DIR/e2e-reconciler-private-note.sh"
         ;;
     tip-consistency)
@@ -64,9 +71,12 @@ case "$test_filter" in
     reconciler-private-note)
         "$SCRIPT_DIR/e2e-reconciler-private-note.sh"
         ;;
+    reconciler-cursor)
+        "$SCRIPT_DIR/e2e-reconciler-cursor-persistence.sh"
+        ;;
     *)
         echo -e "${RED}Unknown test: $test_filter${NC}" >&2
-        echo "Usage: $0 [all|tip-consistency|l1-to-l2|l2-to-l1|dynamic-erc20|ger-decomposition|security|fuzz|reconciler-private-note]" >&2
+        echo "Usage: $0 [all|tip-consistency|l1-to-l2|l2-to-l1|dynamic-erc20|ger-decomposition|security|fuzz|reconciler-private-note|reconciler-cursor]" >&2
         exit 1
         ;;
 esac

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -113,6 +113,60 @@ struct Args {
     /// tx acceptance alone floods the bridge with in-flight consumptions.
     #[arg(long, env = "B2AGG_WAIT_CONSUMED_SECS", default_value_t = 180)]
     wait_consumed_secs: u64,
+
+    /// Foreign-deployment provision mode (claim-provenance e2e): stand up a
+    /// SECOND, fully independent miden-agglayer deployment on the SAME chain —
+    /// foreign service + ger_manager wallets, a foreign bridge account
+    /// (`create_bridge_account`, deployed via dummy txn like init.rs), and a
+    /// foreign ETH faucet registered in the FOREIGN bridge's token registry
+    /// (required for its MASM claim path). Keys live in THIS isolated store.
+    /// Prints the four account ids and exits. Mirrors the real-testnet
+    /// topology where a foreign deployment's claims leaked into our reindex.
+    #[arg(long)]
+    create_foreign_bridge: bool,
+
+    /// AggLayer network id the foreign bridge is created with (its MASM
+    /// rejects claims whose leaf destinationNetwork differs). Use an id our
+    /// own stack does NOT serve (default 2; ours is 1) so the foreign-destined
+    /// deposit is never auto-claimed by our aggkit.
+    #[arg(long, default_value_t = 2)]
+    foreign_network_id: u32,
+
+    /// Foreign-claim mode (claim-provenance e2e): read `claimAsset` calldata
+    /// from --claim-calldata-file, inject its GER (keccak(mainnetExitRoot ||
+    /// rollupExitRoot)) into the FOREIGN bridge via an UpdateGerNote from the
+    /// foreign ger_manager, then build the CLAIM note exactly like
+    /// `claim.rs::create_claim` (shared `claim_storage_from_call`) targeting
+    /// the FOREIGN bridge, submit it from the foreign service account, and
+    /// wait for the foreign bridge to consume it. Prints the note id,
+    /// details-commitment and canonical global index.
+    #[arg(long)]
+    submit_foreign_claim: bool,
+
+    /// Hex file (with or without 0x) containing full `claimAsset` calldata
+    /// (selector + ABI args). Required with --submit-foreign-claim.
+    #[arg(long)]
+    claim_calldata_file: Option<PathBuf>,
+
+    /// Foreign bridge account id. Required with --submit-foreign-claim.
+    #[arg(long)]
+    foreign_bridge_id: Option<String>,
+
+    /// Foreign service account id (mints the CLAIM — the foreign deployment's
+    /// `accounts.service` analogue). Required with --submit-foreign-claim.
+    #[arg(long)]
+    foreign_service_id: Option<String>,
+
+    /// Foreign ger_manager account id (mints the UpdateGerNote). Required
+    /// with --submit-foreign-claim.
+    #[arg(long)]
+    foreign_ger_manager_id: Option<String>,
+
+    /// `origin_token_decimals - miden_decimals` of the faucet the foreign
+    /// bridge has registered for the claimed token (10 for the standard
+    /// 18→8 ETH faucet created by --create-foreign-bridge).
+    #[arg(long, default_value_t = 10)]
+    scale_exp: u32,
 }
 
 impl std::fmt::Debug for Args {
@@ -177,8 +231,8 @@ async fn main() -> anyhow::Result<()> {
     let store_path = args.store_dir.join("store.sqlite3");
     let keystore_path = args.store_dir.join("keystore");
 
-    if args.create_wallet {
-        // Provision mode: the store/keystore may not exist yet — create them.
+    if args.create_wallet || args.create_foreign_bridge {
+        // Provision modes: the store/keystore may not exist yet — create them.
         std::fs::create_dir_all(&keystore_path)
             .with_context(|| format!("creating keystore dir {}", keystore_path.display()))?;
     } else {
@@ -267,6 +321,244 @@ async fn main() -> anyhow::Result<()> {
         }
         println!("[create-wallet] wallet-id: {}", wallet.id().to_hex());
         println!("[create-wallet] done");
+        return Ok(());
+    }
+
+    // ── Foreign-deployment provision mode (claim-provenance e2e) ─────────────
+    // Stand up a SECOND independent miden-agglayer deployment on the same
+    // chain, mirroring init.rs::add_accounts: service + ger_manager wallets,
+    // bridge account, ETH faucet registered in the FOREIGN bridge. All keys
+    // live in this isolated store — the proxy's store is never touched.
+    if args.create_foreign_bridge {
+        use miden_agglayer_service::miden_client::{
+            submit_new_transaction, wait_for_transaction_commit,
+        };
+        use miden_base_agglayer::{MetadataHash, create_bridge_account};
+        use miden_client::crypto::FeltRng;
+
+        println!(
+            "[foreign-bridge] provisioning independent deployment in {} (network id {})",
+            store_path.display(),
+            args.foreign_network_id
+        );
+        client
+            .sync_state()
+            .await
+            .map_err(|e| anyhow!("initial sync failed: {e}"))?;
+
+        let service =
+            miden_agglayer_service::init::create_standalone_wallet(&mut client, keystore.clone())
+                .await
+                .map_err(|e| anyhow!("foreign service wallet creation failed: {e}"))?;
+        let ger_manager =
+            miden_agglayer_service::init::create_standalone_wallet(&mut client, keystore.clone())
+                .await
+                .map_err(|e| anyhow!("foreign ger_manager wallet creation failed: {e}"))?;
+
+        // Deploy ger_manager via dummy txn (mirrors init.rs::deploy_account).
+        let dummy = TransactionRequestBuilder::new().build()?;
+        let txn_id = submit_new_transaction(&mut client, ger_manager.id(), dummy)
+            .await
+            .map_err(|e| anyhow!("foreign ger_manager deploy failed: {e}"))?;
+        wait_for_transaction_commit(&mut client, txn_id, 30, std::time::Duration::from_secs(2))
+            .await
+            .map_err(|e| anyhow!("foreign ger_manager deploy commit wait failed: {e}"))?;
+
+        // Foreign bridge (mirrors init.rs::add_bridge).
+        let bridge = create_bridge_account(
+            client.rng().draw_word(),
+            service.id(),
+            ger_manager.id(),
+            args.foreign_network_id,
+        );
+        client
+            .add_account(&bridge, false)
+            .await
+            .map_err(|e| anyhow!("adding foreign bridge account failed: {e}"))?;
+        let dummy = TransactionRequestBuilder::new().build()?;
+        let txn_id = submit_new_transaction(&mut client, bridge.id(), dummy)
+            .await
+            .map_err(|e| anyhow!("foreign bridge deploy failed: {e}"))?;
+        wait_for_transaction_commit(&mut client, txn_id, 30, std::time::Duration::from_secs(2))
+            .await
+            .map_err(|e| anyhow!("foreign bridge deploy commit wait failed: {e}"))?;
+
+        // Settle accounts before the faucet registration note targets the bridge
+        // (mirrors init.rs's NTX-builder settlement wait).
+        for _ in 0..10 {
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+            client.sync_state().await.ok();
+        }
+
+        // Foreign ETH faucet, registered in the FOREIGN bridge's on-chain
+        // token registry — without it the foreign bridge's MASM claim path
+        // panics on the (origin_token, origin_network) registry lookup and the
+        // CLAIM is never consumed. Same parameters as init.rs (18→8, scale 10).
+        let faucet = miden_agglayer_service::faucet_ops::create_and_register_faucet(
+            &mut client,
+            "ETH",
+            8,
+            &[0u8; 20],
+            0,
+            10,
+            service.id(),
+            bridge.id(),
+            MetadataHash::from_abi_encoded(&[]),
+        )
+        .await
+        .map_err(|e| anyhow!("foreign faucet creation/registration failed: {e}"))?;
+        for _ in 0..10 {
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+            client.sync_state().await.ok();
+        }
+
+        // Stable, machine-parseable output — e2e-claim-provenance.sh greps these.
+        println!("[foreign-bridge] service-id: {}", service.id().to_hex());
+        println!(
+            "[foreign-bridge] ger-manager-id: {}",
+            ger_manager.id().to_hex()
+        );
+        println!("[foreign-bridge] bridge-id: {}", bridge.id().to_hex());
+        println!("[foreign-bridge] faucet-id: {}", faucet.id().to_hex());
+        println!("[foreign-bridge] network-id: {}", args.foreign_network_id);
+        println!("[foreign-bridge] done");
+        return Ok(());
+    }
+
+    // ── Foreign-claim mode (claim-provenance e2e) ─────────────────────────────
+    // Drive ONE claim through the FOREIGN bridge: inject its GER, then submit a
+    // CLAIM note (built by the same `claim_storage_from_call` the proxy's claim
+    // path uses) targeting the foreign bridge, and wait for consumption.
+    if args.submit_foreign_claim {
+        use alloy_core::sol_types::SolCall;
+        use miden_agglayer_service::claim::{claim_storage_from_call, claimAssetCall};
+        use miden_agglayer_service::miden_client::submit_new_transaction;
+        use miden_base_agglayer::{ClaimNote, ExitRoot, UpdateGerNote};
+        use miden_client::store::NoteFilter;
+
+        let bridge_id = parse_account_id(
+            args.foreign_bridge_id
+                .as_deref()
+                .context("--foreign-bridge-id is required with --submit-foreign-claim")?,
+        )
+        .context("foreign-bridge-id")?;
+        let service_id = parse_account_id(
+            args.foreign_service_id
+                .as_deref()
+                .context("--foreign-service-id is required with --submit-foreign-claim")?,
+        )
+        .context("foreign-service-id")?;
+        let ger_manager_id = parse_account_id(
+            args.foreign_ger_manager_id
+                .as_deref()
+                .context("--foreign-ger-manager-id is required with --submit-foreign-claim")?,
+        )
+        .context("foreign-ger-manager-id")?;
+        let calldata_path = args
+            .claim_calldata_file
+            .as_ref()
+            .context("--claim-calldata-file is required with --submit-foreign-claim")?;
+
+        let calldata_hex = std::fs::read_to_string(calldata_path)
+            .with_context(|| format!("reading {}", calldata_path.display()))?;
+        let calldata = hex::decode(calldata_hex.trim().trim_start_matches("0x"))
+            .context("claim calldata is not valid hex")?;
+        let call = claimAssetCall::abi_decode(&calldata).context("decoding claimAsset calldata")?;
+        println!(
+            "[foreign-claim] decoded claimAsset: origin_network={} dest_network={} amount={}",
+            call.originNetwork, call.destinationNetwork, call.amount
+        );
+
+        client
+            .sync_state()
+            .await
+            .map_err(|e| anyhow!("initial sync failed: {e}"))?;
+
+        // Wait for an OUTPUT note (by id) to be consumed on-chain, mirroring
+        // the B2AGG wait_consumed loop below.
+        async fn wait_output_consumed(
+            client: &mut miden_agglayer_service::miden_client::MidenClientLib,
+            note_id: miden_protocol::note::NoteId,
+            what: &str,
+            secs: u64,
+        ) -> anyhow::Result<()> {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+            while std::time::Instant::now() < deadline {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                client.sync_state().await.ok();
+                let recs = client
+                    .get_output_notes(NoteFilter::Consumed)
+                    .await
+                    .unwrap_or_default();
+                if recs.iter().any(|r| r.id() == note_id) {
+                    return Ok(());
+                }
+            }
+            Err(anyhow!("{what} note {note_id} not consumed within {secs}s"))
+        }
+
+        // 1. Inject the claim's GER into the FOREIGN bridge (the foreign
+        //    ger_manager is its authorized GER sender). The bridge's MASM
+        //    claim path recomputes keccak(mainnetExitRoot || rollupExitRoot)
+        //    and requires it in the bridge's GER map.
+        let ger_bytes = miden_agglayer_service::ger::combined_ger(
+            &call.mainnetExitRoot.0,
+            &call.rollupExitRoot.0,
+        );
+        let ger_note = UpdateGerNote::create(
+            ExitRoot::new(ger_bytes),
+            ger_manager_id,
+            bridge_id,
+            client.rng(),
+        )?;
+        let ger_note_id = ger_note.id();
+        println!(
+            "[foreign-claim] injecting GER 0x{} into foreign bridge (note {ger_note_id})",
+            hex::encode(ger_bytes)
+        );
+        let tx_request = TransactionRequestBuilder::new()
+            .own_output_notes(vec![ger_note])
+            .build()?;
+        let txn_id = submit_new_transaction(&mut client, ger_manager_id, tx_request)
+            .await
+            .map_err(|e| anyhow!("foreign GER inject submit failed: {e}"))?;
+        println!("[foreign-claim] GER inject transaction submitted: {txn_id}");
+        wait_output_consumed(&mut client, ger_note_id, "foreign UpdateGer", 240).await?;
+        println!("[foreign-claim] GER injected (UpdateGerNote consumed by foreign bridge)");
+
+        // 2. Build + submit the CLAIM note against the FOREIGN bridge — the
+        //    same storage the proxy's create_claim would build, minted by the
+        //    FOREIGN service and targeting the FOREIGN bridge.
+        let storage = claim_storage_from_call(&call, args.scale_exp)?;
+        let note = ClaimNote::create(storage, bridge_id, service_id, client.rng())?;
+        let note_id = note.id();
+        let note_commitment = hex::encode(
+            miden_protocol::note::NoteDetails::from(&note)
+                .commitment()
+                .as_bytes(),
+        );
+        // Canonical global index — what a projector would record in a
+        // ClaimEvent for this note (mirrors build_canonical_proof_data:
+        // mainnet rollup-index bytes zeroed).
+        let mut gi = call.globalIndex.to_be_bytes::<32>();
+        let mainnet_flag = u32::from_be_bytes([gi[20], gi[21], gi[22], gi[23]]);
+        if mainnet_flag == 1 {
+            gi[24..28].fill(0);
+        }
+        let tx_request = TransactionRequestBuilder::new()
+            .own_output_notes(vec![note])
+            .build()?;
+        let txn_id = submit_new_transaction(&mut client, service_id, tx_request)
+            .await
+            .map_err(|e| anyhow!("foreign CLAIM submit failed: {e}"))?;
+        println!("[foreign-claim] CLAIM transaction submitted: {txn_id}");
+        wait_output_consumed(&mut client, note_id, "foreign CLAIM", 300).await?;
+
+        // Stable, machine-parseable output — e2e-claim-provenance.sh greps these.
+        println!("[foreign-claim] note-id: {note_id}");
+        println!("[foreign-claim] note-commitment: {note_commitment}");
+        println!("[foreign-claim] global-index: 0x{}", hex::encode(gi));
+        println!("[foreign-claim] done");
         return Ok(());
     }
 

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -95,6 +95,18 @@ struct Args {
     #[arg(long)]
     print_script_roots: bool,
 
+    /// Injection mode for the reconciler private-note e2e (0.15.5 hotfix):
+    /// create + submit a PRIVATE P2ID note from the isolated wallet to itself
+    /// (zero assets) with the DEFAULT note tag (0) — the same tag-0 family the
+    /// proxy's note-visibility reconciler sweeps via `sync_notes(tags={0})`.
+    /// Only the note id + metadata land on-chain (the details stay private),
+    /// so the reconciler's `import_notes(NoteFile::NoteId)` fails with
+    /// "Incomplete imported note is private" — pre-hotfix that wedged the whole
+    /// sweep window forever. Prints the note id + commit block and exits.
+    /// Requires --wallet-id.
+    #[arg(long)]
+    send_private_note: bool,
+
     /// After submitting the B2AGG, wait until the note is actually CONSUMED
     /// on-chain (polling sync), up to this many seconds. 0 disables the wait
     /// (legacy behaviour: 5 blind sync cycles). Load tests MUST wait: pacing on
@@ -124,6 +136,7 @@ impl std::fmt::Debug for Args {
                 &self.miden_prover_url.as_ref().map(|_| "[REDACTED]"),
             )
             .field("miden_prover_timeout_secs", &self.miden_prover_timeout_secs)
+            .field("send_private_note", &self.send_private_note)
             .finish()
     }
 }
@@ -254,6 +267,107 @@ async fn main() -> anyhow::Result<()> {
         }
         println!("[create-wallet] wallet-id: {}", wallet.id().to_hex());
         println!("[create-wallet] done");
+        return Ok(());
+    }
+
+    // ── Private-note injection mode ───────────────────────────────────────────
+    // Reconciler private-note e2e (0.15.5 hotfix): submit a PRIVATE, tag-0,
+    // zero-asset P2ID note to the wallet itself. Its id lands on-chain in the
+    // tag-0 family the reconciler sweeps, but the details are never published,
+    // so the reconciler's import-by-id can never succeed — the exact prod shape
+    // that wedged the retroactive-heal sweep pre-hotfix.
+    if args.send_private_note {
+        use miden_client::crypto::FeltRng;
+        use miden_client::note::Note;
+        use miden_protocol::note::{NoteType, PartialNoteMetadata};
+        use miden_standards::note::P2idNoteStorage;
+
+        let wallet_id = parse_account_id(
+            args.wallet_id
+                .as_deref()
+                .context("--wallet-id is required with --send-private-note")?,
+        )
+        .context("wallet-id")?;
+        println!("[private-note] wallet: {wallet_id}");
+
+        println!("[private-note] syncing state...");
+        client
+            .sync_state()
+            .await
+            .map_err(|e| anyhow!("sync failed: {e}"))?;
+
+        // P2ID recipient targeting the wallet itself; PRIVATE note type; note
+        // tag left at the default (0) so `sync_notes(tags={0})` lists it — the
+        // same default tag B2AGG bridge-out notes carry (PartialNoteMetadata
+        // defaults the tag; B2AggNote::create never overrides it).
+        let serial_num = client.rng().draw_word();
+        let recipient = P2idNoteStorage::new(wallet_id).into_recipient(serial_num);
+        let metadata = PartialNoteMetadata::new(wallet_id, NoteType::Private);
+        let note = Note::new(
+            NoteAssets::new(vec![]).map_err(|e| anyhow!("note assets: {e}"))?,
+            metadata,
+            recipient,
+        );
+        let note_id = note.id();
+        let tag: u32 = note.metadata().tag().into();
+        println!("[private-note] note created: {note_id} (tag {tag}, type Private)");
+
+        let tx_request = TransactionRequestBuilder::new()
+            .own_output_notes(vec![note])
+            .build()
+            .map_err(|e| anyhow!("tx request build failed: {e}"))?;
+
+        // Bounded submit retry — same prover-backpressure rationale as the
+        // bridge-out path below.
+        const ATTEMPTS: u32 = 4;
+        let mut tx_id = None;
+        for attempt in 1..=ATTEMPTS {
+            println!("[private-note] submitting transaction (attempt {attempt}/{ATTEMPTS})...");
+            match client
+                .submit_new_transaction(wallet_id, tx_request.clone())
+                .await
+            {
+                Ok(id) => {
+                    tx_id = Some(id);
+                    break;
+                }
+                Err(e) if attempt < ATTEMPTS => {
+                    eprintln!(
+                        "[private-note] submit attempt {attempt} failed: {e}; retrying in 10s"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                }
+                Err(e) => return Err(anyhow!("submit failed after {ATTEMPTS} attempts: {e}")),
+            }
+        }
+        let tx_id = tx_id.expect("loop either sets tx_id or returns");
+        println!("[private-note] transaction submitted: {tx_id}");
+
+        // Wait until the note is COMMITTED on-chain and report its block.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(180);
+        let mut commit_block: Option<u32> = None;
+        while std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            client.sync_state().await.ok();
+            let recs = client
+                .get_output_notes(miden_client::store::NoteFilter::Committed)
+                .await
+                .unwrap_or_default();
+            if let Some(rec) = recs.iter().find(|r| r.id() == note_id) {
+                commit_block = rec
+                    .inclusion_proof()
+                    .map(|p| p.location().block_num().as_u32());
+                break;
+            }
+        }
+        let commit_block =
+            commit_block.ok_or_else(|| anyhow!("private note {note_id} not committed in 180s"))?;
+
+        // Stable, machine-parseable output — the e2e script greps these.
+        println!("[private-note] note-id: {note_id}");
+        println!("[private-note] tag: {tag}");
+        println!("[private-note] commit-block: {commit_block}");
+        println!("[private-note] done");
         return Ok(());
     }
 

--- a/src/bin/note_probe.rs
+++ b/src/bin/note_probe.rs
@@ -1,10 +1,236 @@
-//! Empirical probe: do SyncNotes / GetNotesById return already-CONSUMED notes?
+//! Empirical probes against a Miden node.
+//!
+//! Mode 1 (legacy, positional args): do SyncNotes / GetNotesById return
+//! already-CONSUMED notes?
+//!
+//! ```text
+//! note_probe <url> <note_id_hex> <from> <to>
+//! ```
+//!
+//! Mode 2 (`--bench-sweep`): measure the reconciler's window-fetch pipeline
+//! (`sync_notes` + candidate-id extraction, NO imports) over a block range —
+//! sequential (the historical one-window-at-a-time sweep) vs concurrent
+//! (`RECONCILE_CONCURRENCY`-style in-flight windows), plus a chunk-size probe.
+//! This is the evidence harness for the budgeted concurrent catch-up in
+//! `synthetic_projector::reconcile_notes`.
+//!
+//! ```text
+//! note_probe --bench-sweep --node https://rpc.testnet.miden.io \
+//!     [--from 1] [--blocks 10000] [--cap-secs 300] \
+//!     [--chunk 200] [--concurrency 8] [--probe-chunks 200,1000,2000]
+//! ```
+use miden_client::rpc::NodeRpcClient;
 use miden_protocol::note::{NoteId, NoteTag};
 use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == name)
+        .and_then(|i| args.get(i + 1).cloned())
+}
+
+/// One reconciler window fetch: `sync_notes` over `[from, to]` + candidate-id
+/// extraction (the exact pre-import per-window work). Returns the note count.
+async fn fetch_window(rpc: &Arc<dyn NodeRpcClient>, from: u64, to: u64) -> anyhow::Result<usize> {
+    let tags: BTreeSet<NoteTag> = BTreeSet::from([NoteTag::from(0u32)]);
+    let blocks = rpc
+        .sync_notes((from as u32).into(), (to as u32).into(), &tags)
+        .await
+        .map_err(|e| anyhow::anyhow!("sync_notes({from}..{to}): {e}"))?;
+    let candidates: Vec<NoteId> = blocks
+        .iter()
+        .flat_map(|b| b.notes.keys().copied())
+        .collect();
+    Ok(candidates.len())
+}
+
+fn windows(from: u64, to: u64, chunk: u64) -> Vec<(u64, u64)> {
+    let mut out = Vec::new();
+    let mut f = from;
+    while f <= to {
+        let t = (f + chunk - 1).min(to);
+        out.push((f, t));
+        f = t + 1;
+    }
+    out
+}
+
+struct RunReport {
+    blocks: u64,
+    elapsed: Duration,
+    notes: usize,
+}
+
+impl RunReport {
+    fn rate(&self) -> f64 {
+        self.blocks as f64 / self.elapsed.as_secs_f64().max(1e-9)
+    }
+}
+
+/// Sequential pipeline: one window in flight at a time — the OLD sweep's fetch
+/// pattern, minus its 5s-per-window tick cap (raw RPC-bound throughput).
+async fn run_sequential(
+    rpc: &Arc<dyn NodeRpcClient>,
+    wins: &[(u64, u64)],
+    cap: Duration,
+) -> anyhow::Result<RunReport> {
+    let start = Instant::now();
+    let (mut blocks, mut notes) = (0u64, 0usize);
+    for &(f, t) in wins {
+        if start.elapsed() >= cap {
+            break;
+        }
+        notes += fetch_window(rpc, f, t).await?;
+        blocks += t - f + 1;
+    }
+    Ok(RunReport {
+        blocks,
+        elapsed: start.elapsed(),
+        notes,
+    })
+}
+
+/// Concurrent pipeline: up to `concurrency` windows in flight (sliding refill,
+/// buffer_unordered-style) — the NEW reconciler fetch stage.
+async fn run_concurrent(
+    rpc: &Arc<dyn NodeRpcClient>,
+    wins: &[(u64, u64)],
+    concurrency: usize,
+    cap: Duration,
+) -> anyhow::Result<RunReport> {
+    let start = Instant::now();
+    let (mut blocks, mut notes) = (0u64, 0usize);
+    let mut next = 0usize;
+    let mut set = tokio::task::JoinSet::new();
+    let spawn = |set: &mut tokio::task::JoinSet<anyhow::Result<(usize, u64)>>, i: usize| {
+        let (f, t) = wins[i];
+        let rpc = Arc::clone(rpc);
+        set.spawn(async move { fetch_window(&rpc, f, t).await.map(|n| (n, t - f + 1)) });
+    };
+    while next < wins.len() && set.len() < concurrency {
+        spawn(&mut set, next);
+        next += 1;
+    }
+    while let Some(joined) = set.join_next().await {
+        let (n, b) = joined??;
+        notes += n;
+        blocks += b;
+        if next < wins.len() && start.elapsed() < cap {
+            spawn(&mut set, next);
+            next += 1;
+        }
+    }
+    Ok(RunReport {
+        blocks,
+        elapsed: start.elapsed(),
+        notes,
+    })
+}
+
+async fn bench_sweep(args: Vec<String>) -> anyhow::Result<()> {
+    let node = arg_value(&args, "--node")
+        .ok_or_else(|| anyhow::anyhow!("--bench-sweep requires --node <url>"))?;
+    let from: u64 = arg_value(&args, "--from").map_or(Ok(1), |v| v.parse())?;
+    let blocks: u64 = arg_value(&args, "--blocks").map_or(Ok(10_000), |v| v.parse())?;
+    let cap = Duration::from_secs(arg_value(&args, "--cap-secs").map_or(Ok(300), |v| v.parse())?);
+    let chunk: u64 = arg_value(&args, "--chunk").map_or(Ok(200), |v| v.parse())?;
+    let concurrency: usize = arg_value(&args, "--concurrency").map_or(Ok(8), |v| v.parse())?;
+    let probe_chunks: Vec<u64> = arg_value(&args, "--probe-chunks")
+        .unwrap_or_else(|| "200,1000,2000".into())
+        .split(',')
+        .filter_map(|s| s.trim().parse().ok())
+        .collect();
+
+    let ep = miden_agglayer_service::miden_client::parse_node_url(&node)?;
+    let rpc = miden_agglayer_service::miden_client::build_rpc_client(&ep, 30_000, None);
+
+    let (tip_header, _) = rpc
+        .get_block_header_by_number(None, false)
+        .await
+        .map_err(|e| anyhow::anyhow!("get_block_header_by_number(tip): {e}"))?;
+    let tip = tip_header.block_num().as_u64();
+    let to = (from + blocks - 1).min(tip);
+    println!(
+        "node tip: {tip}; benchmarking blocks {from}..{to} (cap {}s per pipeline)",
+        cap.as_secs()
+    );
+
+    // Chunk-size probe: does the node accept larger sync_notes spans, and are
+    // they faster per block? One call per size.
+    println!("\n== chunk-size probe (single window per size) ==");
+    for &c in &probe_chunks {
+        let t = (from + c - 1).min(tip);
+        let started = Instant::now();
+        match fetch_window(&rpc, from, t).await {
+            Ok(n) => println!(
+                "  span {c:>5}: OK  {:>8.1} ms  ({n} notes)  {:>8.1} blocks/s single-stream",
+                started.elapsed().as_secs_f64() * 1e3,
+                (t - from + 1) as f64 / started.elapsed().as_secs_f64()
+            ),
+            Err(e) => println!(
+                "  span {c:>5}: REJECTED/ERR after {:?}: {e}",
+                started.elapsed()
+            ),
+        }
+    }
+
+    let wins = windows(from, to, chunk);
+    println!(
+        "\n== sequential pipeline (chunk {chunk}, 1 in flight) — OLD sweep minus its 5s tick cap =="
+    );
+    let seq = run_sequential(&rpc, &wins, cap).await?;
+    println!(
+        "  blocks {:>6}  wall {:>7.1}s  {:>8.1} blocks/s  ({} notes seen)",
+        seq.blocks,
+        seq.elapsed.as_secs_f64(),
+        seq.rate(),
+        seq.notes
+    );
+
+    println!(
+        "\n== concurrent pipeline (chunk {chunk}, {concurrency} in flight) — NEW fetch stage =="
+    );
+    let conc = run_concurrent(&rpc, &wins, concurrency, cap).await?;
+    println!(
+        "  blocks {:>6}  wall {:>7.1}s  {:>8.1} blocks/s  ({} notes seen)",
+        conc.blocks,
+        conc.elapsed.as_secs_f64(),
+        conc.rate(),
+        conc.notes
+    );
+
+    println!("\n== summary ==");
+    println!("  raw pipeline speedup: {:.1}x", conc.rate() / seq.rate());
+    // Old effective prod rate: exactly ONE chunk-block window per ~5s sync
+    // tick, regardless of RPC speed.
+    let old_effective = (200.0 / 5.0f64).min(seq.rate());
+    // New effective prod rate: the catch-up loop runs for RECONCILE_TICK_BUDGET_MS
+    // (default 2000ms) of every ~5s tick at the concurrent pipeline rate.
+    let new_effective = conc.rate() * (2.0 / 5.0);
+    println!(
+        "  old effective prod rate (1x200 window / 5s tick):     {old_effective:>8.1} blocks/s"
+    );
+    println!(
+        "  new effective prod rate (2s budget of every 5s tick): {new_effective:>8.1} blocks/s  ({:.1}x end-to-end)",
+        new_effective / old_effective
+    );
+    println!(
+        "  full-history sweep of {tip} blocks: old {:>6.2} h -> new {:>6.2} h",
+        tip as f64 / old_effective / 3600.0,
+        tip as f64 / new_effective / 3600.0
+    );
+    Ok(())
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let mut a = std::env::args().skip(1);
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.iter().any(|a| a == "--bench-sweep") {
+        return bench_sweep(args).await;
+    }
+    let mut a = args.into_iter();
     let (url, id_hex, from, to) = (
         a.next().unwrap(),
         a.next().unwrap(),

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -403,6 +403,41 @@ async fn create_claim(
     Ok(note)
 }
 
+/// Build the on-chain [`ClaimNoteStorage`] for a decoded `claimAsset` call —
+/// the exact storage `create_claim` puts on a CLAIM note (same
+/// [`build_canonical_proof_data`] canonicalisation, same [`LeafData`] mapping,
+/// same amount scaling), factored so `bridge-out-tool`'s foreign-bridge e2e
+/// mode (`--submit-foreign-claim`) can construct a byte-identical CLAIM
+/// against a SECOND agglayer deployment on the same chain.
+///
+/// `scale_exp` is `origin_token_decimals - miden_decimals` for the faucet the
+/// consuming bridge has registered for `(originTokenAddress, originNetwork)`
+/// (10 for the standard 18→8 ETH faucet). Errors if the amount does not scale
+/// to a representable Miden token amount.
+pub fn claim_storage_from_call(
+    params: &claimAssetCall,
+    scale_exp: u32,
+) -> anyhow::Result<ClaimNoteStorage> {
+    let proof_data = build_canonical_proof_data(params);
+    let leaf_data = LeafData {
+        origin_network: params.originNetwork,
+        origin_token_address: EthAddress::new(params.originTokenAddress.0.0),
+        destination_network: params.destinationNetwork,
+        destination_address: EthAddress::new(params.destinationAddress.0.0),
+        amount: EthAmount::new(params.amount.to_be_bytes::<32>()),
+        metadata_hash: MetadataHash::from_abi_encoded(params.metadata.as_ref()),
+    };
+    let miden_claim_amount = leaf_data
+        .amount
+        .scale_to_token_amount(scale_exp)
+        .map_err(|e| anyhow::anyhow!("claim amount is not representable on Miden: {e}"))?;
+    Ok(ClaimNoteStorage {
+        proof_data,
+        leaf_data,
+        miden_claim_amount,
+    })
+}
+
 #[derive(Debug, Clone)]
 pub struct PublishClaimTxn {
     pub txn_id: TransactionId,
@@ -1074,6 +1109,54 @@ mod tests {
         assert_eq!(event.globalIndex, U256::from(42u64));
         assert_eq!(event.originNetwork, 1);
         assert_eq!(event.amount, U256::from(1000u64));
+    }
+
+    /// `claim_storage_from_call` (the foreign-bridge e2e's storage builder)
+    /// must produce storage that round-trips through the SAME decoders the
+    /// projector uses on consumed CLAIM notes — pinning it byte-compatible
+    /// with what `create_claim` puts on-chain.
+    #[test]
+    fn claim_storage_from_call_roundtrips_through_watcher_decoder() {
+        use alloy::primitives::{Address, U256};
+        use miden_protocol::note::NoteStorage;
+
+        // Mainnet deposit: globalIndex = 2^64 (mainnet flag) + leaf 7, with
+        // garbage in the rollup-index bytes that canonicalisation must zero.
+        let mut gi = U256::from(7u64) + (U256::from(1u64) << 64);
+        gi += U256::from(0xDEADu64) << 32; // rollup-index garbage (bytes 24..28)
+        let call = claimAssetCall {
+            smtProofLocalExitRoot: [FixedBytes::ZERO; 32],
+            smtProofRollupExitRoot: [FixedBytes::from([0x11; 32]); 32],
+            globalIndex: gi,
+            mainnetExitRoot: FixedBytes::from([0xAA; 32]),
+            rollupExitRoot: FixedBytes::from([0xBB; 32]),
+            originNetwork: 0,
+            originTokenAddress: Address::ZERO,
+            destinationNetwork: 2,
+            destinationAddress: address!("1234567890abcdef1234567890abcdef12345678"),
+            amount: U256::from(10_000_000_000_000u64), // 10^13 wei
+            metadata: Default::default(),
+        };
+
+        let storage = claim_storage_from_call(&call, 10).expect("storage builds");
+        // 18→8 scaling: 10^13 / 10^10 = 1000 Miden units.
+        assert_eq!(storage.miden_claim_amount.as_canonical_u64(), 1_000);
+
+        let note_storage = NoteStorage::try_from(storage).expect("valid CLAIM storage layout");
+        let decoded = crate::claim_watcher::parse_claim_event_from_storage(&note_storage)
+            .expect("projector decoder accepts the storage");
+
+        // Canonical global index: mainnet flag kept, rollup-index bytes zeroed.
+        let mut expected_gi = [0u8; 32];
+        expected_gi[23] = 1; // mainnet flag (limb 5)
+        expected_gi[31] = 7; // leaf index
+        assert_eq!(decoded.global_index, expected_gi);
+        assert_eq!(decoded.origin_network, 0);
+        assert_eq!(
+            decoded.destination_address, call.destinationAddress.0.0,
+            "leaf destination must round-trip"
+        );
+        assert_eq!(decoded.amount, 10_000_000_000_000u64);
     }
 
     #[test]

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -589,6 +589,12 @@ async fn publish_claim_internal(
     }
 
     let txn_id = tx_result.executed_transaction().id();
+    // `--read-only` guard: the CLAIM hot path is the one site that submits
+    // via `submit_proven_transaction` instead of the guarded
+    // `miden_client::submit_new_transaction` wrapper (it needs the explicit
+    // prove step for the remote→local prover fallback above), so it must
+    // call the chokepoint check itself before touching the node.
+    crate::miden_client::ensure_writable(accounts.service.0)?;
     let _submission_height = client
         .submit_proven_transaction(proven_tx, &tx_result)
         .await?;

--- a/src/faucet_ops.rs
+++ b/src/faucet_ops.rs
@@ -59,7 +59,7 @@ pub async fn create_and_register_faucet(
     let dummy_txn = TransactionRequestBuilder::new().build()?;
     let txn_id = crate::metrics::meter_proof(
         crate::metrics::ProofKind::Faucet,
-        client.submit_new_transaction(account.id(), dummy_txn),
+        crate::miden_client::submit_new_transaction(client, account.id(), dummy_txn),
     )
     .await?;
     tracing::info!("deployed {symbol} faucet with txn_id {txn_id}");
@@ -143,7 +143,7 @@ pub async fn register_faucet_in_bridge(
 
     let txn_id = crate::metrics::meter_proof(
         crate::metrics::ProofKind::Faucet,
-        client.submit_new_transaction(service_id, txn),
+        crate::miden_client::submit_new_transaction(client, service_id, txn),
     )
     .await?;
     tracing::info!(

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -86,7 +86,7 @@ async fn submit_update_ger_note(
                     .build()?;
                 let tx_id = crate::metrics::meter_proof(
                     crate::metrics::ProofKind::Ger,
-                    client.submit_new_transaction(ger_manager_id, tx_request),
+                    crate::miden_client::submit_new_transaction(client, ger_manager_id, tx_request),
                 )
                 .await?;
                 tracing::info!(

--- a/src/init.rs
+++ b/src/init.rs
@@ -67,7 +67,7 @@ async fn deploy_account(
     let dummy_txn = TransactionRequestBuilder::new().build()?;
     let txn_id = crate::metrics::meter_proof(
         crate::metrics::ProofKind::Init,
-        client.submit_new_transaction(account_id, dummy_txn),
+        crate::miden_client::submit_new_transaction(client, account_id, dummy_txn),
     )
     .await?;
     tracing::info!("deployed {name} account with txn_id {txn_id}");
@@ -270,7 +270,7 @@ async fn register_p2id_script(
 
     let txn_id = crate::metrics::meter_proof(
         crate::metrics::ProofKind::Init,
-        client.submit_new_transaction(sender, txn),
+        crate::miden_client::submit_new_transaction(client, sender, txn),
     )
     .await?;
     tracing::info!("registered P2ID script with txn_id {txn_id}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,19 @@ struct Command {
     #[arg(long)]
     unlock_miden_accounts: bool,
 
+    /// Escape hatch: reset the persisted note-reconciler sweep cursor to 0 at
+    /// boot so the reconciler re-walks the ENTIRE Miden history looking for
+    /// externally-created network notes that sync missed. Use for deliberate
+    /// full-history audits (e.g. after a proxy/node upgrade that may have
+    /// changed note visibility). Idempotent per boot but expensive: on a long
+    /// chain the sweep takes hours and loads the node — remove the flag after
+    /// the audit boot. Normal restarts resume from the persisted cursor and
+    /// do NOT need this. (`--restore` / `--reset-miden-store` already reset
+    /// the cursor themselves — the wiped miden store makes the genesis
+    /// re-sweep the healing pass.)
+    #[arg(long, env = "RESWEEP_FROM_GENESIS")]
+    resweep_from_genesis: bool,
+
     /// L1 bridge contract address used for synthetic log emission
     #[arg(
         long,
@@ -271,6 +284,7 @@ impl std::fmt::Debug for Command {
             .field("restore", &self.restore)
             .field("reset_miden_store", &self.reset_miden_store)
             .field("unlock_miden_accounts", &self.unlock_miden_accounts)
+            .field("resweep_from_genesis", &self.resweep_from_genesis)
             .field("bridge_address", &self.bridge_address)
             .field(
                 "l1_rpc_url",
@@ -467,6 +481,28 @@ async fn main() -> anyhow::Result<()> {
     } else {
         Arc::new(InMemoryStore::new())
     };
+
+    // Reset the persisted note-reconciler sweep cursor BEFORE the
+    // SyntheticProjector is constructed (it loads the cursor in `new()`):
+    //   * `--reset-miden-store` wiped the miden-client sqlite above — the
+    //     client has forgotten every imported note, so the genesis re-sweep
+    //     IS the healing pass and must not be skipped by a stale cursor.
+    //     (`--restore` resets it too, inside `restore()` Phase 4, and then
+    //     exits — the next boot picks up the 0.)
+    //   * `--resweep-from-genesis` is the operator escape hatch for
+    //     deliberate full-history audits (e.g. after upgrades).
+    if command.reset_miden_store || command.resweep_from_genesis {
+        let reason = if command.reset_miden_store {
+            "--reset-miden-store (miden store wiped; genesis sweep is the healing pass)"
+        } else {
+            "--resweep-from-genesis (operator-requested full-history audit)"
+        };
+        store.set_reconcile_cursor(0).await?;
+        tracing::warn!(
+            reason,
+            "reconcile cursor reset — full-history re-sweep will run"
+        );
+    }
 
     // Phase 3: Load config and create full client
     let block_state = Arc::new(BlockState::new());
@@ -950,6 +986,7 @@ mod hardening_tests {
             restore: false,
             reset_miden_store: false,
             unlock_miden_accounts: false,
+            resweep_from_genesis: false,
             bridge_address: miden_agglayer_service::bridge_address::DEFAULT_BRIDGE_ADDRESS
                 .to_string(),
             l1_rpc_url: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,6 +333,15 @@ impl std::fmt::Debug for Command {
 async fn main() -> anyhow::Result<()> {
     let command = Command::parse();
     logging::setup_tracing()?;
+    // Install the process-wide Prometheus recorder FIRST — before any thread
+    // or runtime that can emit a metric exists. `metrics` resolves the global
+    // recorder per macro call, so this single install covers the MidenClient's
+    // dedicated second runtime/thread, the writer worker, and the L1 indexer;
+    // but anything emitted BEFORE this line would go to the no-op recorder and
+    // silently vanish from /metrics (which is exactly what happened when the
+    // install lived after client construction — init/restore/early-sync
+    // emissions never reached the served registry).
+    let metrics_handle = miden_agglayer_service::metrics::install_prometheus_recorder()?;
     miden_agglayer_service::bridge_address::init_bridge_address(command.bridge_address.clone());
     // Install the read-only switch BEFORE any client / submit path exists so
     // the guarantee holds from the very first instruction that could mutate
@@ -780,39 +789,9 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    // Initialize metrics.
-    //
-    // Histograms registered with `metrics-exporter-prometheus` default to the
-    // Prometheus *summary* representation (a fixed set of quantiles), which
-    // loses p95/p99 fidelity for low-volume metrics and — more importantly —
-    // can't be aggregated across replicas in PromQL. For the two latency
-    // metrics we actually care about (proof generation, JSON-RPC requests)
-    // we install explicit bucket sets so they're emitted as real
-    // `*_bucket{le="…"}` series. The proof buckets span 100ms (local prover
-    // warm) → 5min (remote prover under load) because bali has empirically
-    // seen 60–120s p99 proves; the RPC buckets are typical hot-path latencies
-    // (1ms → 5s). Both metric names match the `histogram!()` call-site
-    // strings in `metrics.rs` / `service.rs` exactly — using `Matcher::Full`
-    // means a typo here silently falls back to summary, so add a test if
-    // either name changes.
-    let metrics_handle = metrics_exporter_prometheus::PrometheusBuilder::new()
-        .set_buckets_for_metric(
-            metrics_exporter_prometheus::Matcher::Full("miden_proof_duration_seconds".to_string()),
-            &[
-                0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0, 300.0,
-            ],
-        )
-        .context("set_buckets_for_metric (miden_proof_duration_seconds) failed")?
-        .set_buckets_for_metric(
-            metrics_exporter_prometheus::Matcher::Full("rpc_request_duration_seconds".to_string()),
-            &[
-                0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
-            ],
-        )
-        .context("set_buckets_for_metric (rpc_request_duration_seconds) failed")?
-        .install_recorder()
-        .context("failed to install metrics recorder")?;
-    miden_agglayer_service::metrics::init_metrics();
+    // (Metrics recorder + `init_metrics` are installed at the very top of
+    // main, before any metric-emitting thread exists — see
+    // `metrics::install_prometheus_recorder`.)
 
     // RD-940 Phase 5 — read the previous process's graceful-shutdown
     // snapshot. A non-zero value means in-flight WriteJobs whose hashes

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,16 @@ struct Command {
     /// it lands in Phase 1.
     #[arg(long, env = "AGGLAYER_ENABLE_WRITER_WORKER", default_value_t = false)]
     enable_writer_worker: bool,
+
+    /// Hard read-only guarantee for recovery drills / cold reindexes against
+    /// production networks. When set, EVERY transaction submission is refused
+    /// at the single chokepoint all chain mutations funnel through
+    /// (`miden_client::submit_new_transaction` + the CLAIM hot path's
+    /// pre-submit check): the call returns an error, ERROR-logs, and
+    /// increments `readonly_submissions_refused_total`. The proxy reads
+    /// history (sync, sweep, reconcile) but can never send a transaction.
+    #[arg(long, env = "AGGLAYER_READ_ONLY", default_value_t = false)]
+    read_only: bool,
 }
 
 /// Validate the `--require-hardening` invariants. Returns a list of
@@ -314,6 +324,7 @@ impl std::fmt::Debug for Command {
                 &self.miden_prover_fallback_to_local,
             )
             .field("enable_writer_worker", &self.enable_writer_worker)
+            .field("read_only", &self.read_only)
             .finish()
     }
 }
@@ -323,6 +334,16 @@ async fn main() -> anyhow::Result<()> {
     let command = Command::parse();
     logging::setup_tracing()?;
     miden_agglayer_service::bridge_address::init_bridge_address(command.bridge_address.clone());
+    // Install the read-only switch BEFORE any client / submit path exists so
+    // the guarantee holds from the very first instruction that could mutate
+    // chain state (including the init phase's deploy transactions).
+    miden_agglayer_service::miden_client::init_read_only(command.read_only);
+    if command.read_only {
+        tracing::warn!(
+            "READ-ONLY mode active (--read-only / AGGLAYER_READ_ONLY): every transaction \
+             submission will be refused at the submit chokepoint"
+        );
+    }
     tracing::info!("{command:?}");
 
     // Hardening startup invariants — fail loud on fail-open production
@@ -1010,6 +1031,7 @@ mod hardening_tests {
             miden_prover_timeout_secs: 120,
             miden_prover_fallback_to_local: false,
             enable_writer_worker: false,
+            read_only: false,
         }
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,4 +1,63 @@
+use anyhow::Context;
 use metrics::{describe_counter, describe_gauge, describe_histogram};
+
+/// Build and install the process-wide Prometheus recorder, returning the
+/// handle the `/metrics` endpoint renders.
+///
+/// MUST be called before ANY thread/runtime that can emit a metric is
+/// spawned — in particular before `MidenClient::new` (which spawns a
+/// dedicated thread + second Tokio runtime that starts syncing, running
+/// SyncListeners, and emitting immediately), the RD-940 writer worker, and
+/// the L1InfoTreeIndexer. `metrics` resolves the global recorder on every
+/// macro call (there is no per-thread caching), so a single global install
+/// covers every thread and runtime in the process — but every emission that
+/// happens BEFORE the install goes to the no-op recorder and is silently
+/// lost. Historically main.rs installed this recorder AFTER creating the
+/// MidenClient and spawning the writer worker / L1 indexer, so their early
+/// emissions (init deploys, first sync ticks, first reconciler windows,
+/// restore phases) never reached the registry served by `/metrics`.
+///
+/// NOTE the /metrics freeze observed on the live reindex had a second,
+/// independent cause: `metrics` 0.24.5's broken `KeyHasher` (yanked
+/// upstream, fixed in 0.24.6 — see
+/// `metrics_from_second_runtime_render_cumulatively` for the full
+/// mechanism and reproduction).
+///
+/// Histograms registered with `metrics-exporter-prometheus` default to the
+/// Prometheus *summary* representation (a fixed set of quantiles), which
+/// loses p95/p99 fidelity for low-volume metrics and — more importantly —
+/// can't be aggregated across replicas in PromQL. For the two latency
+/// metrics we actually care about (proof generation, JSON-RPC requests)
+/// we install explicit bucket sets so they're emitted as real
+/// `*_bucket{le="…"}` series. The proof buckets span 100ms (local prover
+/// warm) → 5min (remote prover under load) because bali has empirically
+/// seen 60–120s p99 proves; the RPC buckets are typical hot-path latencies
+/// (1ms → 5s). Both metric names match the `histogram!()` call-site
+/// strings in `metrics.rs` / `service.rs` exactly — using `Matcher::Full`
+/// means a typo here silently falls back to summary, so add a test if
+/// either name changes.
+pub fn install_prometheus_recorder() -> anyhow::Result<metrics_exporter_prometheus::PrometheusHandle>
+{
+    let handle = metrics_exporter_prometheus::PrometheusBuilder::new()
+        .set_buckets_for_metric(
+            metrics_exporter_prometheus::Matcher::Full("miden_proof_duration_seconds".to_string()),
+            &[
+                0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0, 300.0,
+            ],
+        )
+        .context("set_buckets_for_metric (miden_proof_duration_seconds) failed")?
+        .set_buckets_for_metric(
+            metrics_exporter_prometheus::Matcher::Full("rpc_request_duration_seconds".to_string()),
+            &[
+                0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
+            ],
+        )
+        .context("set_buckets_for_metric (rpc_request_duration_seconds) failed")?
+        .install_recorder()
+        .context("failed to install metrics recorder")?;
+    init_metrics();
+    Ok(handle)
+}
 
 pub fn init_metrics() {
     describe_counter!("rpc_requests_total", "Total JSON-RPC requests by method");
@@ -513,6 +572,67 @@ pub fn record_fallback_attempt<T, E>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// RED→GREEN regression for the live /metrics unreliability (reindex run:
+    /// gauge frozen at 2000 while the true value was 156000; counters
+    /// rendering per-window values instead of cumulative ones — all from code
+    /// on the MidenClient's dedicated second Tokio runtime).
+    ///
+    /// Root cause (reproduced deterministically, then fixed): `metrics`
+    /// 0.24.5 — since YANKED upstream — shipped a broken `KeyHasher` whose
+    /// hash of a `Key` was inconsistent between the registry's insert and
+    /// lookup paths, so (almost) every emission MISSED the existing registry
+    /// entry and created a fresh phantom entry holding only that emission's
+    /// delta. The Prometheus exporter's render dedups by (name, labels) via
+    /// overwrite, surfacing an arbitrary phantom per scrape: counters showed
+    /// small non-cumulative "windows", gauges showed stale early sets.
+    /// Fixed in `metrics` 0.24.6 (rewritten `KeyHasher`, Cargo.lock updated);
+    /// this test FAILED on 0.24.5 (rendered `..._events_total 1` and
+    /// `..._cursor 2000`) and passes on 0.24.6.
+    ///
+    /// Contract pinned: with the process-wide recorder installed via
+    /// `install_prometheus_recorder`, metrics emitted from a *separate thread
+    /// running its own Tokio runtime* — the exact construction
+    /// `MidenClient::new` uses — land in the ONE global registry the endpoint
+    /// handle renders: counters cumulative (increment twice → 2), gauges at
+    /// their LATEST set value.
+    #[test]
+    fn metrics_from_second_runtime_render_cumulatively() {
+        // Sole global-recorder install in the test binary (installing twice
+        // errors, so this test owns it; unique metric names keep concurrent
+        // tests' emissions from mattering).
+        let handle = install_prometheus_recorder().expect("install must succeed once");
+
+        // Mirror MidenClient::new: a dedicated OS thread driving its OWN
+        // multi-thread Tokio runtime, emitting both from the block_on future
+        // (the run loop) and from a spawned task (runtime worker thread).
+        let t = std::thread::spawn(|| {
+            let runtime = tokio::runtime::Runtime::new().expect("second runtime");
+            runtime.block_on(async {
+                ::metrics::counter!("test_second_runtime_events_total").increment(1);
+                ::metrics::gauge!("test_second_runtime_cursor").set(2_000.0);
+                tokio::spawn(async {
+                    ::metrics::counter!("test_second_runtime_events_total").increment(1);
+                    ::metrics::gauge!("test_second_runtime_cursor").set(156_000.0);
+                })
+                .await
+                .expect("spawned emitter");
+            });
+        });
+        t.join().expect("second-runtime thread");
+
+        let rendered = handle.render();
+        assert!(
+            rendered.contains("test_second_runtime_events_total 2"),
+            "counter emitted from the second runtime must render CUMULATIVELY \
+             (2 after two increments) on the endpoint handle; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("test_second_runtime_cursor 156000"),
+            "gauge emitted from the second runtime must render its LATEST value \
+             (156000), not a stale early one; got:\n{rendered}"
+        );
+    }
 
     #[test]
     fn proof_kind_label_stable() {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -17,6 +17,12 @@ pub fn init_metrics() {
     );
     describe_counter!("miden_sync_errors_total", "Sync errors by kind");
     describe_counter!(
+        "readonly_submissions_refused_total",
+        "Transaction submissions refused by --read-only mode at the submit \
+         chokepoint. Non-zero during a read-only drill means some code path \
+         ATTEMPTED a chain mutation (and was stopped)."
+    );
+    describe_counter!(
         "bridge_out_self_targeted_total",
         "B2AGG bridge-outs whose destination_network equals our local network_id; \
          each one is a poison leaf that wedges the bridge (Cantina #13)"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -131,6 +131,16 @@ pub fn init_metrics() {
          (crash recovery or foreign-CLAIM observation)."
     );
     describe_counter!(
+        "claim_event_foreign_skipped_total",
+        "A consumed CLAIM-shaped note was NOT provably ours (consumer is not \
+         our bridge, and it was not minted by our service targeting our \
+         bridge) and was skipped instead of projected as a ClaimEvent. \
+         Expected on chains shared with a foreign miden-agglayer deployment \
+         (its claims share our ClaimNote script root); on a single-deployment \
+         chain any non-zero rate means unverifiable claim consumptions — \
+         investigate."
+    );
+    describe_counter!(
         "claim_watcher_already_recorded_total",
         "ClaimWatcher observed a consumed CLAIM whose ClaimEvent was \
          already in the store (either prior watcher emission or \

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -37,6 +37,69 @@ const BACKOFF_MAX: Duration = Duration::from_secs(60);
 /// (`new_test*`) deliberately bypass this guard.
 static LIVE_CLIENT: std::sync::Mutex<bool> = std::sync::Mutex::new(false);
 
+/// Process-wide read-only switch (`--read-only` / `AGGLAYER_READ_ONLY`).
+///
+/// When set, EVERY chain mutation is refused at the single chokepoint all
+/// submit sites funnel through — [`submit_new_transaction`] (and the CLAIM
+/// hot path's explicit [`ensure_writable`] call before
+/// `submit_proven_transaction`). This is a hard operational guarantee for
+/// recovery drills / cold reindexes against production networks: the proxy
+/// may read history but must never send a transaction.
+///
+/// Set once at startup via [`init_read_only`] (same pattern as
+/// `bridge_address::init_bridge_address`), before any submit path can run.
+static READ_ONLY: AtomicBool = AtomicBool::new(false);
+
+/// Enable/disable read-only mode. Called once from `main` at startup,
+/// before the runtime `MidenClient` (and therefore any submit path) exists.
+pub fn init_read_only(enabled: bool) {
+    READ_ONLY.store(enabled, Ordering::Release);
+}
+
+/// True when the proxy is running in read-only mode.
+pub fn is_read_only() -> bool {
+    READ_ONLY.load(Ordering::Acquire)
+}
+
+/// Refuse the mutation when read-only mode is active.
+///
+/// Increments `readonly_submissions_refused_total` and ERROR-logs so a
+/// refusal during a supposedly read-only drill is loud in both metrics and
+/// logs. Returns `Ok(())` when writable.
+pub fn ensure_writable(account_id: miden_protocol::account::AccountId) -> anyhow::Result<()> {
+    if !is_read_only() {
+        return Ok(());
+    }
+    metrics::counter!("readonly_submissions_refused_total").increment(1);
+    tracing::error!(
+        account_id = %account_id.to_hex(),
+        "read-only mode: transaction submission refused"
+    );
+    Err(anyhow!(
+        "read-only mode: transaction submission refused (account {})",
+        account_id.to_hex()
+    ))
+}
+
+/// Read-only-guarded wrapper around `MidenClientLib::submit_new_transaction`.
+///
+/// This is the single chokepoint every chain mutation in the service funnels
+/// through (init deploys, faucet ops, GER injection). Call sites MUST use
+/// this instead of the raw library method so `--read-only` is enforced
+/// uniformly. The guard fires BEFORE any node interaction: in read-only mode
+/// the transaction is neither executed, proven, nor submitted.
+pub async fn submit_new_transaction(
+    client: &mut MidenClientLib,
+    account_id: miden_protocol::account::AccountId,
+    tx_request: miden_client::transaction::TransactionRequest,
+) -> anyhow::Result<miden_protocol::transaction::TransactionId> {
+    ensure_writable(account_id)?;
+    client
+        .submit_new_transaction(account_id, tx_request)
+        .await
+        .map_err(anyhow::Error::from)
+}
+
 fn next_backoff(current: Duration) -> Duration {
     (current * 2).min(BACKOFF_MAX)
 }
@@ -750,6 +813,38 @@ mod tests {
         assert!(res.is_err());
         assert!(res.unwrap_err().to_string().contains("simulated failure"));
         assert_eq!(client.test_call_count(), 1);
+    }
+
+    /// `--read-only` mode — the submit chokepoint must refuse the mutation
+    /// BEFORE any node interaction. Uses the offline `MidenClientLib` (no
+    /// node behind it): if the guard failed to fire first, the call would
+    /// surface an execution/connection error instead of the read-only
+    /// refusal, so asserting on the error text proves ordering.
+    #[tokio::test]
+    async fn read_only_mode_refuses_submission() {
+        use miden_client::transaction::TransactionRequestBuilder;
+
+        // Valid protocol-0.15 (version-1) account id (same as the
+        // accounts_config tests).
+        let account_id =
+            miden_protocol::account::AccountId::from_hex("0xcc0000000000dd010000ee000000ff")
+                .unwrap();
+        let mut client = crate::test_helpers::offline_miden_client_lib().await;
+        let tx_request = TransactionRequestBuilder::new().build().unwrap();
+
+        init_read_only(true);
+        let res = submit_new_transaction(&mut client, account_id, tx_request).await;
+        // Restore the process-global default before asserting so a failed
+        // assert can't leave other tests in read-only mode.
+        init_read_only(false);
+
+        let err = res.expect_err("read-only mode must refuse submission");
+        assert!(
+            err.to_string().contains("read-only mode"),
+            "expected the read-only refusal (fired before any node \
+             interaction), got: {err:#}"
+        );
+        assert!(err.to_string().contains(&account_id.to_hex()));
     }
 
     /// Cantina MA#23 — the listener pause flag flips on while a guard is

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -102,6 +102,62 @@ fn decode_network_target(attachments: &NoteAttachments) -> Option<AccountId> {
         .map(|nat| nat.target_id())
 }
 
+/// Provenance verdict for a `ClaimNote`-shaped consumed note — the ClaimEvent
+/// analogue of MA#28's [`GerNoteVerdict`] (GER path) and MA#3's
+/// [`crate::bridge_out::B2AggConsumerClass`] (B2AGG path).
+///
+/// Live-proven gap: a read-only reindex of a chain shared with a FOREIGN
+/// miden-agglayer deployment projected the foreign deployment's claims into
+/// our synthetic_logs, because `project_claim_note` gated only on the
+/// ClaimNote script root. The script root is deployment-independent — every
+/// agglayer instance on the chain mints notes with the identical script.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ClaimNoteVerdict {
+    /// Provably OURS — safe to project a synthetic ClaimEvent.
+    Ours,
+    /// Not provably ours: consumed by some other account (a foreign
+    /// deployment's bridge) and not minted by our service targeting our
+    /// bridge. Fail-closed skip.
+    Foreign,
+}
+
+/// Pure provenance predicate for a `ClaimNote`-shaped consumed note. A claim
+/// is OURS iff at least one of two independent proofs holds:
+///
+/// 1. **Consumer proof (MA#3 trust root):** `consumer == our bridge`. Our
+///    bridge network account only consumes notes targeted at it, and its MASM
+///    validates the claim proof on consumption — so a bridge-consumed CLAIM is
+///    a sanctioned claim through OUR deployment regardless of who minted it.
+///    This is the same attribution the projector's spent-before-import
+///    recovery derives from the bridge's `sync_transactions` feed.
+/// 2. **Mint proof (MA#28 trust root):** the note's (own-output-record
+///    recovered) metadata shows `sender == our service` — `create_claim` mints
+///    every CLAIM from `accounts.service` — AND its `NetworkAccountTarget`
+///    attachment targets OUR bridge.
+///
+/// A foreign deployment's claim satisfies neither: it targets and is consumed
+/// by the FOREIGN bridge account, and its sender is the foreign service.
+/// Pure (no I/O, no metrics) so it is unit-testable directly; metric emission
+/// and tracing live at the call site in `project_claim_note`.
+pub fn classify_claim_note(
+    consumer: Option<AccountId>,
+    metadata: Option<&NoteMetadata>,
+    attachments: &NoteAttachments,
+    expected_sender: AccountId,
+    bridge_id: AccountId,
+) -> ClaimNoteVerdict {
+    if consumer == Some(bridge_id) {
+        return ClaimNoteVerdict::Ours;
+    }
+    if let Some(meta) = metadata
+        && meta.sender() == expected_sender
+        && decode_network_target(attachments) == Some(bridge_id)
+    {
+        return ClaimNoteVerdict::Ours;
+    }
+    ClaimNoteVerdict::Foreign
+}
+
 /// Decode the 32-byte GER from an `UpdateGerNote`'s storage felts.
 ///
 /// `UpdateGerNote` storage is `ExitRoot::to_elements()` — each 4-byte GER limb
@@ -286,7 +342,8 @@ pub async fn restore(
     // watcher uses so the synthetic logs are byte-identical (same tx-hash
     // derivation, same `commit_manual_claim_event_atomic` store path).
     tracing::info!("Phase 2.5: scanning miden consumed CLAIM notes (MA#27)...");
-    let (claims, claim_logs) = restore_claims(store, miden_client, block_state, miden_tip).await?;
+    let (claims, claim_logs) =
+        restore_claims(store, miden_client, accounts, block_state, miden_tip).await?;
     total_logs += claim_logs;
     tracing::info!("Phase 2.5 complete: {claims} claims, {claim_logs} logs");
 
@@ -939,9 +996,20 @@ pub(crate) enum ClaimProjectOutcome {
 /// filter, same storage decoder, same dedup predicates, same atomic commit
 /// primitive — so the synthetic logs are byte-identical regardless of which
 /// path observes the CLAIM note.
+///
+/// Provenance gate (live-proven): the note must be provably OURS — see
+/// [`classify_claim_note`]. `output_metadata` maps a note's details-commitment
+/// to the metadata of our own output-note record, the same MA#28 fallback the
+/// GER path uses for the metadata-less `ConsumedExternal` state.
+/// `expected_sender` is the account `create_claim` mints from
+/// (`accounts.service`); `bridge_id` is our bridge account.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn project_claim_note(
     store: &Arc<dyn Store>,
     note: &InputNoteRecord,
+    output_metadata: &std::collections::HashMap<[u8; 32], NoteMetadata>,
+    expected_sender: AccountId,
+    bridge_id: AccountId,
     block_number: u64,
     block_hash: [u8; 32],
     bridge_address: &str,
@@ -953,6 +1021,36 @@ pub(crate) async fn project_claim_note(
     }
 
     let note_id_str = hex::encode(note.details_commitment().as_bytes());
+
+    // Provenance gate — BEFORE any storage read, dedup mark, or emission
+    // (the MA#28 posture). On a chain shared with a foreign miden-agglayer
+    // deployment, foreign claims share our ClaimNote script root; projecting
+    // them poisons synthetic_logs with ClaimEvents our L1 never saw.
+    let effective_metadata = note
+        .metadata()
+        .or_else(|| output_metadata.get(&note.details_commitment().as_bytes()));
+    if classify_claim_note(
+        note.consumer_account(),
+        effective_metadata,
+        note.attachments(),
+        expected_sender,
+        bridge_id,
+    ) == ClaimNoteVerdict::Foreign
+    {
+        ::metrics::counter!("claim_event_foreign_skipped_total").increment(1);
+        tracing::warn!(
+            target: "restore::claims",
+            note_id = %note_id_str,
+            consumer = ?note.consumer_account(),
+            sender = ?effective_metadata.map(|m| m.sender()),
+            expected_sender = %expected_sender,
+            bridge = %bridge_id,
+            "CLAIM-shaped note is not provably ours (consumer != our bridge, and \
+             sender/target don't verify against our service/bridge) — foreign \
+             deployment's claim on a shared chain; skipping ClaimEvent (fail-closed)"
+        );
+        return Ok(ClaimProjectOutcome::Skipped);
+    }
 
     // Dedup 1: was this CLAIM already replayed by an earlier restore (or by the
     // live watcher)?
@@ -1078,11 +1176,17 @@ pub(crate) async fn project_claim_note(
 async fn restore_claims(
     store: &Arc<dyn Store>,
     miden_client: &MidenClient,
+    accounts: &AccountsConfig,
     block_state: &Arc<BlockState>,
     restore_block: u64,
 ) -> anyhow::Result<(usize, usize)> {
     let store_clone = store.clone();
     let block_state_clone = block_state.clone();
+    // Claim provenance gate: `create_claim` mints every CLAIM from the
+    // service account, targeting the bridge; the bridge is also the sole
+    // legitimate consumer. See `classify_claim_note`.
+    let expected_sender = accounts.service.0;
+    let bridge_id = accounts.bridge.0;
 
     let result = Arc::new(std::sync::Mutex::new((0usize, 0usize)));
     let result_inner = result.clone();
@@ -1094,6 +1198,20 @@ async fn restore_claims(
                     .get_input_notes(NoteFilter::Consumed)
                     .await
                     .map_err(|e| anyhow::anyhow!("failed to get consumed notes: {e}"))?;
+
+                // MA#28-style provenance fallback (same as `restore_gers`):
+                // protocol 0.15's `ConsumedExternal` state carries no metadata,
+                // but we MINTED our own CLAIM notes, so our output-note records
+                // retain the full metadata permanently. A claim-shaped note we
+                // did not mint has no output record and no bridge-consumer
+                // attribution → skipped as Foreign (fail-closed).
+                let own_output_metadata: std::collections::HashMap<[u8; 32], NoteMetadata> = client
+                    .get_output_notes(NoteFilter::All)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("failed to get output notes: {e}"))?
+                    .into_iter()
+                    .map(|rec| (rec.details_commitment().as_bytes(), *rec.metadata()))
+                    .collect();
 
                 let bridge_address = get_bridge_address();
                 let mut claim_count = 0usize;
@@ -1111,8 +1229,17 @@ async fn restore_claims(
                     // Per-note CLAIM derivation lives in `project_claim_note` so
                     // the live cursor-driven projector and this recovery phase
                     // share one implementation.
-                    if project_claim_note(&store_clone, note, blk, block_hash, bridge_address)
-                        .await?
+                    if project_claim_note(
+                        &store_clone,
+                        note,
+                        &own_output_metadata,
+                        expected_sender,
+                        bridge_id,
+                        blk,
+                        block_hash,
+                        bridge_address,
+                    )
+                    .await?
                         == ClaimProjectOutcome::Emitted
                     {
                         claim_count += 1;
@@ -2371,6 +2498,273 @@ mod tests {
         assert!(
             logs.is_empty(),
             "fail-closed skip must emit NO synthetic log"
+        );
+    }
+
+    // ── ClaimEvent provenance gate — foreign-deployment claims (live-proven) ─
+    //
+    // A read-only reindex of the real testnet (which hosts a FOREIGN
+    // miden-agglayer deployment on the SAME Miden chain) projected 3
+    // ClaimEvents from the foreign deployment's claims into our
+    // synthetic_logs: `project_claim_note` gated only on the ClaimNote
+    // script root, unlike the GER path's MA#28 sender/target gate and the
+    // B2AGG path's MA#3 consumer gate. These tests pin the fix: a
+    // CLAIM-shaped consumed note must be provably OURS (consumed by OUR
+    // bridge, or minted by OUR service targeting OUR bridge) before a
+    // synthetic ClaimEvent is projected.
+
+    /// Build a consumed CLAIM note with a valid `ClaimNoteStorage` (so the
+    /// pre-fix pipeline would decode + emit — the test then fails on the
+    /// missing provenance gate, not an unrelated decode skip), consumed by
+    /// `consumer`, with a per-test `gi_byte` to keep global indexes distinct
+    /// across tests (Dedup 2 keys on global_index).
+    fn claim_input_note(consumer: Option<AccountId>, gi_byte: u8) -> InputNoteRecord {
+        use miden_base_agglayer::{
+            ClaimNote, ClaimNoteStorage, EthAddress, EthAmount, ExitRoot, GlobalIndex, LeafData,
+            MetadataHash, ProofData, SmtNode,
+        };
+        use miden_client::store::InputNoteState;
+        use miden_client::store::input_note_states::ConsumedExternalNoteState;
+        use miden_protocol::block::BlockNumber;
+        use miden_protocol::note::{NoteAssets, NoteDetails, NoteRecipient, NoteStorage};
+        use miden_protocol::{Felt, Word};
+
+        let mut gi_bytes = [0u8; 32];
+        gi_bytes[31] = gi_byte;
+        let mut amount_bytes = [0u8; 32];
+        amount_bytes[28..32].copy_from_slice(&1_000_000u32.to_be_bytes());
+
+        let claim_storage = ClaimNoteStorage {
+            proof_data: ProofData {
+                smt_proof_local_exit_root: [SmtNode::new([0u8; 32]); 32],
+                smt_proof_rollup_exit_root: [SmtNode::new([0u8; 32]); 32],
+                global_index: GlobalIndex::new(gi_bytes),
+                mainnet_exit_root: ExitRoot::new([0u8; 32]),
+                rollup_exit_root: ExitRoot::new([0u8; 32]),
+            },
+            leaf_data: LeafData {
+                origin_network: 7,
+                origin_token_address: EthAddress::new([0xAB; 20]),
+                destination_network: 1,
+                destination_address: EthAddress::new([0xCD; 20]),
+                amount: EthAmount::new(amount_bytes),
+                metadata_hash: MetadataHash::from_abi_encoded(&[]),
+            },
+            miden_claim_amount: Felt::ZERO,
+        };
+        let storage = NoteStorage::try_from(claim_storage).expect("claim storage round-trips");
+        let recipient = NoteRecipient::new(Word::default(), ClaimNote::script(), storage);
+        let details = NoteDetails::new(NoteAssets::new(vec![]).unwrap(), recipient);
+
+        let state = InputNoteState::ConsumedExternal(ConsumedExternalNoteState {
+            nullifier_block_height: BlockNumber::from(0u32),
+            consumer_account: consumer,
+            consumed_tx_order: None,
+        });
+        InputNoteRecord::new(details, NoteAttachments::default(), None, state)
+    }
+
+    /// RED→GREEN PoC for the live finding: a consumed claim-shaped note whose
+    /// consumer is NOT our bridge (a foreign deployment's bridge on the same
+    /// chain) and which we did not mint must NOT project a ClaimEvent.
+    /// Pre-fix this test fails: the note projects (`Emitted`) because
+    /// `project_claim_note` gated only on the ClaimNote script root.
+    #[tokio::test]
+    async fn finding_claim_provenance_foreign_claim_not_projected() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        // Foreign bridge consumed it; we never minted it (no output record).
+        let foreign_bridge = id(TEST_SENDER_ATTACKER);
+        let note = claim_input_note(Some(foreign_bridge), 0x71);
+        let note_id = hex::encode(note.details_commitment().as_bytes());
+
+        let outcome = project_claim_note(
+            &store,
+            &note,
+            &std::collections::HashMap::new(), // we did not mint it → no output record
+            id(TEST_SENDER_MANAGER),           // our service
+            id(TEST_TARGET_BRIDGE),            // our bridge
+            5,
+            [5u8; 32],
+            get_bridge_address(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            ClaimProjectOutcome::Skipped,
+            "a claim-shaped note consumed by a FOREIGN bridge must not project a ClaimEvent",
+        );
+        assert!(
+            !store.is_claim_note_processed(&note_id).await.unwrap(),
+            "foreign claim must not be marked processed",
+        );
+        let mut gi = [0u8; 32];
+        gi[31] = 0x71;
+        assert!(
+            !store.has_claim_event_for_global_index(&gi).await.unwrap(),
+            "no ClaimEvent row may exist for the foreign claim's global index",
+        );
+    }
+
+    /// Positive counterpart — the SAME claim shape consumed by OUR bridge must
+    /// still project (consumer proof, MA#3 trust root). Proves the foreign
+    /// skip above is the provenance gate, not an over-eager claim kill-switch.
+    #[tokio::test]
+    async fn finding_claim_provenance_bridge_consumed_claim_projects() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let note = claim_input_note(Some(id(TEST_TARGET_BRIDGE)), 0x72);
+        let note_id = hex::encode(note.details_commitment().as_bytes());
+
+        let outcome = project_claim_note(
+            &store,
+            &note,
+            &std::collections::HashMap::new(),
+            id(TEST_SENDER_MANAGER),
+            id(TEST_TARGET_BRIDGE),
+            5,
+            [5u8; 32],
+            get_bridge_address(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            ClaimProjectOutcome::Emitted,
+            "a claim consumed by OUR bridge must still project a ClaimEvent",
+        );
+        assert!(store.is_claim_note_processed(&note_id).await.unwrap());
+        let mut gi = [0u8; 32];
+        gi[31] = 0x72;
+        assert!(store.has_claim_event_for_global_index(&gi).await.unwrap());
+    }
+
+    /// Mint-proof fallback — a claim with NO consumer attribution but whose
+    /// own-output-record metadata shows OUR service minted it targeting OUR
+    /// bridge must project (MA#28 trust root: we created it). This is the
+    /// `ConsumedExternal` posture for our own claims when the consumer is
+    /// untracked.
+    #[tokio::test]
+    async fn finding_claim_provenance_minted_by_us_projects_via_output_record() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let note = claim_input_note(None, 0x73);
+
+        // Our own output-note record: sender = service, target = our bridge.
+        // The record's attachments must also carry the target — mirror what
+        // `ClaimNote::create` produces.
+        let (metadata, attachments) =
+            make_metadata(id(TEST_SENDER_MANAGER), Some(id(TEST_TARGET_BRIDGE)));
+        let note = InputNoteRecord::new(
+            note.details().clone(),
+            attachments,
+            None,
+            note.state().clone(),
+        );
+        let output_metadata =
+            std::collections::HashMap::from([(note.details_commitment().as_bytes(), metadata)]);
+
+        let outcome = project_claim_note(
+            &store,
+            &note,
+            &output_metadata,
+            id(TEST_SENDER_MANAGER),
+            id(TEST_TARGET_BRIDGE),
+            5,
+            [5u8; 32],
+            get_bridge_address(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            ClaimProjectOutcome::Emitted,
+            "our own minted claim (output-record metadata proof) must project",
+        );
+    }
+
+    /// Fail-closed floor — no consumer attribution AND no mint proof (we have
+    /// no output record for it) must skip, even though the storage decodes.
+    #[tokio::test]
+    async fn finding_claim_provenance_unattributed_claim_is_fail_closed_skip() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let note = claim_input_note(None, 0x74);
+
+        let outcome = project_claim_note(
+            &store,
+            &note,
+            &std::collections::HashMap::new(),
+            id(TEST_SENDER_MANAGER),
+            id(TEST_TARGET_BRIDGE),
+            5,
+            [5u8; 32],
+            get_bridge_address(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, ClaimProjectOutcome::Skipped);
+    }
+
+    /// Pure-classifier pins for `classify_claim_note` — both proofs and the
+    /// reject branches (mirrors the `ma28_classify_*` pin style).
+    #[test]
+    fn claim_provenance_classifier_branches() {
+        let service = id(TEST_SENDER_MANAGER);
+        let bridge = id(TEST_TARGET_BRIDGE);
+        let foreign = id(TEST_SENDER_ATTACKER);
+
+        // Consumer proof: consumed by our bridge → Ours (metadata irrelevant).
+        assert_eq!(
+            classify_claim_note(
+                Some(bridge),
+                None,
+                &NoteAttachments::default(),
+                service,
+                bridge
+            ),
+            ClaimNoteVerdict::Ours,
+        );
+        // Mint proof: sender == service AND target == bridge → Ours.
+        let (meta, attachments) = make_metadata(service, Some(bridge));
+        assert_eq!(
+            classify_claim_note(None, Some(&meta), &attachments, service, bridge),
+            ClaimNoteVerdict::Ours,
+        );
+        // Foreign consumer, no metadata → Foreign.
+        assert_eq!(
+            classify_claim_note(
+                Some(foreign),
+                None,
+                &NoteAttachments::default(),
+                service,
+                bridge
+            ),
+            ClaimNoteVerdict::Foreign,
+        );
+        // Foreign sender (their service minted it) → Foreign.
+        let (foreign_meta, foreign_attachments) = make_metadata(foreign, Some(bridge));
+        assert_eq!(
+            classify_claim_note(
+                None,
+                Some(&foreign_meta),
+                &foreign_attachments,
+                service,
+                bridge
+            ),
+            ClaimNoteVerdict::Foreign,
+        );
+        // Our sender but a DIFFERENT target (their bridge) → Foreign.
+        let (meta2, attachments2) = make_metadata(service, Some(id(TEST_TARGET_OTHER)));
+        assert_eq!(
+            classify_claim_note(None, Some(&meta2), &attachments2, service, bridge),
+            ClaimNoteVerdict::Foreign,
+        );
+        // No attribution at all → Foreign (fail-closed floor).
+        assert_eq!(
+            classify_claim_note(None, None, &NoteAttachments::default(), service, bridge),
+            ClaimNoteVerdict::Foreign,
         );
     }
 

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -297,14 +297,9 @@ pub async fn restore(
     total_logs += ger_logs;
     tracing::info!("Phase 3 complete: {gers} GERs, {ger_logs} logs");
 
-    // Phase 4: Miden-1:1 — the synthetic tip == the Miden tip, and the projector
-    // cursor is set to the Miden tip so the live projector resumes from there
-    // rather than re-scanning the blocks restore just replayed (idempotent dedup
-    // would skip them anyway). The restored events already sit at their own
-    // Miden blocks.
-    store.set_latest_block_number(miden_tip).await?;
-    store.set_projector_cursor(miden_tip).await?;
-    tracing::info!("Phase 4: synthetic tip + projector cursor set to Miden tip {miden_tip}");
+    // Phase 4: cursor finalization (factored into a helper so the reconcile-
+    // cursor reset is unit-testable — see `finalize_restore_cursors`).
+    finalize_restore_cursors(store, miden_tip).await?;
 
     // Phase 5: Verify
     tracing::info!("Phase 5: verification");
@@ -318,6 +313,34 @@ pub async fn restore(
         gers_restored: gers,
         logs_created: total_logs,
     })
+}
+
+/// Phase 4 of [`restore`]: finalize the persisted cursors.
+///
+/// Miden-1:1 — the synthetic tip == the Miden tip, and the projector cursor is
+/// set to the Miden tip so the live projector resumes from there rather than
+/// re-scanning the blocks restore just replayed (idempotent dedup would skip
+/// them anyway). The restored events already sit at their own Miden blocks.
+///
+/// The note-reconciler sweep cursor is the OPPOSITE: it is reset to 0. Restore
+/// runs against a wiped/rebuilt miden store (`--reset-miden-store --restore` is
+/// the canonical recovery invocation), so the client has forgotten every
+/// imported note — the genesis re-sweep IS the healing pass that re-discovers
+/// externally-created network notes, and it must not be skipped by a stale
+/// persisted cursor.
+pub(crate) async fn finalize_restore_cursors(
+    store: &Arc<dyn Store>,
+    miden_tip: u64,
+) -> anyhow::Result<()> {
+    store.set_latest_block_number(miden_tip).await?;
+    store.set_projector_cursor(miden_tip).await?;
+    tracing::info!("Phase 4: synthetic tip + projector cursor set to Miden tip {miden_tip}");
+    store.set_reconcile_cursor(0).await?;
+    tracing::info!(
+        "reconcile cursor reset — full-history re-sweep will run (restore rebuilds the miden \
+         store; the genesis sweep is the healing pass that re-discovers external notes)"
+    );
+    Ok(())
 }
 
 /// Phase 1: sync miden and return the current MIDEN tip (sync height) — the
@@ -1657,6 +1680,37 @@ mod tests {
     // a reclaim branch (consumer == sender, asset stays on Miden) and a bridge
     // branch (consumer == bridge, asset leaves). Rebuilding a BridgeEvent for a
     // reclaim hands the user a claimable withdrawal for value that never left.
+
+    /// Regression lock for the prod restart-resync incident: a restore run
+    /// rebuilds the miden store, so the client has forgotten every imported
+    /// note — the genesis re-sweep IS the healing pass. `restore`'s Phase 4
+    /// (`finalize_restore_cursors`) must therefore reset the persisted
+    /// note-reconciler sweep cursor to 0, even when a previous deployment
+    /// left it deep in history — while the projector cursor jumps to the tip.
+    #[tokio::test]
+    async fn restore_resets_reconcile_cursor_to_genesis() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+
+        // Simulate a long-running pre-restore deployment: both cursors deep
+        // into history.
+        store.set_reconcile_cursor(123_456).await.unwrap();
+        store.set_projector_cursor(100_000).await.unwrap();
+
+        // Phase 4 of restore() — the exact code path the real restore runs.
+        finalize_restore_cursors(&store, 130_000).await.unwrap();
+
+        assert_eq!(
+            store.get_reconcile_cursor().await.unwrap(),
+            0,
+            "restore must reset the reconcile cursor to genesis (full-history heal sweep)"
+        );
+        assert_eq!(
+            store.get_projector_cursor().await.unwrap(),
+            130_000,
+            "projector cursor resumes at the Miden tip (restore already replayed history)"
+        );
+        assert_eq!(store.get_latest_block_number().await.unwrap(), 130_000);
+    }
 
     /// `(faucet_id, bridge_id, sender_id)` — valid protocol-0.15 ids. The faucet
     /// is a real fungible-faucet id (reused from the store tests) so

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -82,6 +82,12 @@ pub struct InMemoryStore {
     // Store::get_projector_cursor / docs/SYNTHETIC-INDEXER-REDESIGN.md.
     projector_cursor: RwLock<u64>,
 
+    // Note-reconciler sweep cursor — last Miden block fully swept by the
+    // note-visibility reconciler. Field-backed mirror of the PgStore
+    // `service_state.reconcile_cursor` column (migration 010). See
+    // Store::get_reconcile_cursor.
+    reconcile_cursor: RwLock<u64>,
+
     // Receipts map (synthetic-indexer redesign, Phase 2b substrate) —
     // first-write-wins evm_tx_hash -> note_commitment, with the reverse index
     // mirrored alongside it. UNUSED in Phase 2a. See Store::record_tx_note_link.
@@ -125,6 +131,7 @@ impl InMemoryStore {
             monitor_twin_notes: RwLock::new(HashMap::new()),
             monitor_expected_mints: RwLock::new(HashMap::new()),
             projector_cursor: RwLock::new(0),
+            reconcile_cursor: RwLock::new(0),
             tx_note_links: RwLock::new(HashMap::new()),
             note_tx_links: RwLock::new(HashMap::new()),
         }
@@ -164,6 +171,17 @@ impl Store for InMemoryStore {
 
     async fn set_projector_cursor(&self, block: u64) -> anyhow::Result<()> {
         *self.projector_cursor.write() = block;
+        Ok(())
+    }
+
+    // ── Note-reconciler sweep cursor ─────────────────────────────
+
+    async fn get_reconcile_cursor(&self) -> anyhow::Result<u64> {
+        Ok(*self.reconcile_cursor.read())
+    }
+
+    async fn set_reconcile_cursor(&self, block: u64) -> anyhow::Result<()> {
+        *self.reconcile_cursor.write() = block;
         Ok(())
     }
 
@@ -900,6 +918,28 @@ mod tests {
         // not enforce it — it just persists whatever the single owner writes).
         store.set_projector_cursor(42).await.unwrap();
         assert_eq!(store.get_projector_cursor().await.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_cursor_round_trip() {
+        // Note-reconciler sweep cursor persistence (prod incident: the cursor
+        // was memory-only, so every container restart re-swept from genesis —
+        // ~3h of resync on prod history). Defaults to 0 on a fresh store (the
+        // designed first-boot heal sweep) and round-trips through set/get,
+        // including the reset-to-0 the recovery flows perform.
+        let store = InMemoryStore::new();
+        assert_eq!(
+            store.get_reconcile_cursor().await.unwrap(),
+            0,
+            "fresh store reconcile cursor must default to 0 (first-boot heal)"
+        );
+        store.set_reconcile_cursor(200).await.unwrap();
+        assert_eq!(store.get_reconcile_cursor().await.unwrap(), 200);
+        store.set_reconcile_cursor(400).await.unwrap();
+        assert_eq!(store.get_reconcile_cursor().await.unwrap(), 400);
+        // Reset-to-genesis (restore / --reset-miden-store / --resweep-from-genesis).
+        store.set_reconcile_cursor(0).await.unwrap();
+        assert_eq!(store.get_reconcile_cursor().await.unwrap(), 0);
     }
 
     #[tokio::test]

--- a/src/store/migrator.rs
+++ b/src/store/migrator.rs
@@ -82,6 +82,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "009_synthetic_projector.sql",
         include_str!("../../migrations/009_synthetic_projector.sql"),
     ),
+    (
+        "010_reconcile_cursor.sql",
+        include_str!("../../migrations/010_reconcile_cursor.sql"),
+    ),
 ];
 
 /// Postgres advisory-lock key. Arbitrary 64-bit int; just needs to be

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -257,6 +257,27 @@ pub trait Store: Send + Sync + 'static {
         Ok(())
     }
 
+    // === Note-reconciler sweep cursor (restart must not re-sweep from genesis) ===
+    /// Last Miden block fully swept by the note-visibility reconciler
+    /// (`SyntheticProjector::reconcile_notes`). Returns 0 if the reconciler has
+    /// never persisted a cursor on this deployment — the very first boot then
+    /// sweeps from genesis, which is the designed first-boot heal. Before this
+    /// cursor was persisted it was memory-only, so EVERY container restart
+    /// re-walked the sweep from genesis (~3h of resync + node load on prod
+    /// history per restart).
+    async fn get_reconcile_cursor(&self) -> anyhow::Result<u64> {
+        Ok(0)
+    }
+    /// Persist the last reconciler-swept Miden block. Written write-behind
+    /// AFTER a sweep window completes, so the durable cursor never runs ahead
+    /// of work actually done (a crash mid-window redoes that window — safe,
+    /// the sweep is idempotent). Recovery flows (`--restore`,
+    /// `--reset-miden-store`) and the `--resweep-from-genesis` escape hatch
+    /// reset this to 0 so the full-history heal sweep runs again.
+    async fn set_reconcile_cursor(&self, _block: u64) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     // === Receipts map (synthetic-indexer redesign, Phase 2b substrate) ===
     //
     // See the "Receipts — the submit ⟂ project handoff" section of

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -151,6 +151,36 @@ impl Store for PgStore {
         Ok(())
     }
 
+    // ── Note-reconciler sweep cursor ─────────────────────────────
+    //
+    // Persisted as a column on the single-row service_state table, mirroring
+    // projector_cursor (migration 010). Written write-behind AFTER a sweep
+    // window completes; reset to 0 by the recovery flows so the full-history
+    // heal sweep re-runs.
+
+    async fn get_reconcile_cursor(&self) -> anyhow::Result<u64> {
+        let client = self.pool.get().await?;
+        let row = client
+            .query_one(
+                "SELECT reconcile_cursor FROM service_state WHERE id = 1",
+                &[],
+            )
+            .await?;
+        let val: i64 = row.get(0);
+        Ok(val as u64)
+    }
+
+    async fn set_reconcile_cursor(&self, block: u64) -> anyhow::Result<()> {
+        let client = self.pool.get().await?;
+        client
+            .execute(
+                "UPDATE service_state SET reconcile_cursor = $1, updated_at = now() WHERE id = 1",
+                &[&(block as i64)],
+            )
+            .await?;
+        Ok(())
+    }
+
     // ── Receipts map (Phase 2b substrate; unused in 2a) ──────────
     //
     // First-write-wins evm_tx_hash -> note_commitment (migration 009). The

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -83,6 +83,33 @@ async fn test_pgstore_block_number() {
     assert_eq!(store.get_latest_block_number().await.unwrap(), 43);
 }
 
+// ── Note-reconciler sweep cursor (migration 010) ─────────────
+
+#[tokio::test]
+async fn test_pgstore_reconcile_cursor_round_trip() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+
+    // Round-trip through the service_state.reconcile_cursor column, including
+    // the reset-to-0 the recovery flows (--restore / --reset-miden-store /
+    // --resweep-from-genesis) perform. Prod incident: the cursor was
+    // memory-only, so every container restart re-swept from genesis (~3h of
+    // resync on prod history).
+    store.set_reconcile_cursor(0).await.unwrap();
+    assert_eq!(store.get_reconcile_cursor().await.unwrap(), 0);
+
+    store.set_reconcile_cursor(200).await.unwrap();
+    assert_eq!(store.get_reconcile_cursor().await.unwrap(), 200);
+
+    store.set_reconcile_cursor(123_456).await.unwrap();
+    assert_eq!(store.get_reconcile_cursor().await.unwrap(), 123_456);
+
+    // Reset-to-genesis must persist too (recovery flows depend on it).
+    store.set_reconcile_cursor(0).await.unwrap();
+    assert_eq!(store.get_reconcile_cursor().await.unwrap(), 0);
+}
+
 // ── Logs ─────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/src/synthetic_projector.rs
+++ b/src/synthetic_projector.rs
@@ -170,6 +170,12 @@ pub struct SyntheticProjector {
     local_network_id: u32,
     /// Expected GER sender (ger_manager, or service for legacy deployments).
     expected_ger_sender: AccountId,
+    /// Expected CLAIM minter (`accounts.service` — the account `create_claim`
+    /// mints every ClaimNote from). Together with `bridge_id` this backs the
+    /// claim provenance gate: on a chain shared with a FOREIGN miden-agglayer
+    /// deployment, foreign claims share our ClaimNote script root and must
+    /// not be projected (see `restore::classify_claim_note`).
+    expected_claim_sender: AccountId,
     /// L1 JSON-RPC endpoint for the Cantina #13 Layer-2 ERC-20 metadata
     /// recovery path (mirrors `BridgeOutScanner::l1_rpc_url`). Threaded into
     /// `project_b2agg_note` so legacy/DB-loss faucet rows with empty ERC-20
@@ -303,6 +309,7 @@ impl SyntheticProjector {
             bridge_id: accounts.bridge.0,
             local_network_id,
             expected_ger_sender,
+            expected_claim_sender: accounts.service.0,
             l1_rpc_url,
             cursor: AtomicU64::new(start_cursor),
             node_rpc,
@@ -941,8 +948,17 @@ impl SyntheticProjector {
                 continue;
             }
 
-            if project_claim_note(&self.store, note, miden_block, block_hash, bridge_address)
-                .await?
+            if project_claim_note(
+                &self.store,
+                note,
+                output_metadata,
+                self.expected_claim_sender,
+                self.bridge_id,
+                miden_block,
+                block_hash,
+                bridge_address,
+            )
+            .await?
                 == ClaimProjectOutcome::Emitted
             {
                 logs += 1;

--- a/src/synthetic_projector.rs
+++ b/src/synthetic_projector.rs
@@ -68,10 +68,77 @@ use miden_protocol::note::{
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
-/// Blocks swept per tick by the note-visibility reconciler. Bounds the
-/// per-tick RPC work; catch-up from genesis proceeds at CHUNK blocks/tick.
-const RECONCILE_CHUNK: u64 = 200;
+/// Blocks per `sync_notes` window walked by the note-visibility reconciler.
+/// Env-tunable via `RECONCILE_CHUNK`. Raised from the historical 200 with
+/// testnet evidence (see `note_probe --bench-sweep`): the node happily serves
+/// 1000- and 2000-block spans in near-constant time (~240ms for 200 blocks vs
+/// ~310ms for 1000 — the call is latency-dominated), so a 1000-block window is
+/// ~5x the blocks/s per request AND 5x fewer requests for the same sweep rate,
+/// which is what keeps the concurrent catch-up under the public node's rate
+/// limiter (sustained ~45 req/s of 200-block windows tripped it; 1000-block
+/// windows finish the same span in a fifth of the requests).
+const RECONCILE_CHUNK: u64 = 1_000;
+
+/// Concurrent in-flight `sync_notes` window fetches during catch-up.
+/// Env-tunable via `RECONCILE_CONCURRENCY`, hard-capped at
+/// [`RECONCILE_CONCURRENCY_MAX`] to stay a polite RPC citizen.
+const RECONCILE_CONCURRENCY_DEFAULT: usize = 8;
+const RECONCILE_CONCURRENCY_MAX: usize = 16;
+
+/// Per-tick time budget for the reconciler's catch-up loop, in milliseconds.
+/// Env-tunable via `RECONCILE_TICK_BUDGET_MS`. Projection runs AFTER the
+/// reconciler inside `tick`, so the budget bounds how long a deep catch-up can
+/// starve projection (and the 5s sync cadence): at least one window batch is
+/// always processed per tick (guaranteed progress), then the loop stops once
+/// the budget is spent. When the sweep is caught up the budget is irrelevant —
+/// the single near-tip window completes in one iteration exactly as before.
+const RECONCILE_TICK_BUDGET_MS_DEFAULT: u64 = 2_000;
+
+/// Parse a `u64` tuning knob from the environment, falling back to `default`
+/// on absence or garbage (never panics at boot for a bad env var).
+fn env_u64(name: &str, default: u64) -> u64 {
+    match std::env::var(name) {
+        Ok(v) => v.parse().unwrap_or_else(|_| {
+            tracing::warn!(var = name, value = %v, default, "unparsable env override — using default");
+            default
+        }),
+        Err(_) => default,
+    }
+}
+
+/// Thin seam over the node's `sync_notes` window fetch, so the catch-up driver
+/// (window batching, concurrent fetch, strict-order low-water-mark cursor
+/// advancement, tick budget) is unit-testable without a live node. The live
+/// implementation is [`RpcReconcileFetcher`]; tests inject failing/slow fakes.
+#[async_trait::async_trait]
+pub(crate) trait ReconcileFetcher: Send + Sync {
+    /// Ids of every tag-0 note committed in Miden blocks `[from, to]`.
+    async fn sync_note_ids(&self, from: u64, to: u64) -> anyhow::Result<Vec<NoteId>>;
+}
+
+/// The live [`ReconcileFetcher`]: one `sync_notes` call over the window. The
+/// underlying tonic client takes `&self`, clones its multiplexed HTTP/2
+/// channel per call and is `Send + Sync`, so a single `Arc` handle is safe to
+/// share across the concurrent window-fetch tasks.
+struct RpcReconcileFetcher(Arc<dyn NodeRpcClient>);
+
+#[async_trait::async_trait]
+impl ReconcileFetcher for RpcReconcileFetcher {
+    async fn sync_note_ids(&self, from: u64, to: u64) -> anyhow::Result<Vec<NoteId>> {
+        let tags: BTreeSet<NoteTag> = BTreeSet::from([NoteTag::from(0u32)]);
+        let blocks = self
+            .0
+            .sync_notes((from as u32).into(), (to as u32).into(), &tags)
+            .await
+            .map_err(|e| anyhow::anyhow!("sync_notes({from}..{to}): {e}"))?;
+        Ok(blocks
+            .iter()
+            .flat_map(|b| b.notes.keys().copied())
+            .collect())
+    }
+}
 
 /// True iff `e` is miden-client's un-recoverable "note is private" import
 /// rejection. A private note imported by [`NoteId`] lacks the details the
@@ -138,6 +205,17 @@ pub struct SyntheticProjector {
     /// and the `--resweep-from-genesis` escape hatch reset the persisted
     /// value to 0 deliberately.
     reconcile_cursor: AtomicU64,
+    /// Reconciler sweep-window size in blocks (`RECONCILE_CHUNK` env override,
+    /// default [`RECONCILE_CHUNK`]).
+    reconcile_chunk: u64,
+    /// Concurrent in-flight window fetches during catch-up
+    /// (`RECONCILE_CONCURRENCY` env override, default
+    /// [`RECONCILE_CONCURRENCY_DEFAULT`], capped at
+    /// [`RECONCILE_CONCURRENCY_MAX`]).
+    reconcile_concurrency: usize,
+    /// Per-tick catch-up time budget (`RECONCILE_TICK_BUDGET_MS` env override,
+    /// default [`RECONCILE_TICK_BUDGET_MS_DEFAULT`]).
+    reconcile_budget: Duration,
     /// Note ids already projected (or attempted) by the late-consumption sweep,
     /// so the per-tick sweep doesn't re-issue `is_note_processed` store queries
     /// for the whole consumed set every 5s.
@@ -201,8 +279,21 @@ impl SyntheticProjector {
         // heal sweep runs — grep target for the e2e restart regression check
         // (scripts/e2e-reconciler-cursor-persistence.sh).
         let start_reconcile = store.get_reconcile_cursor().await?;
+        let reconcile_chunk = env_u64("RECONCILE_CHUNK", RECONCILE_CHUNK).max(1);
+        let reconcile_concurrency = (env_u64(
+            "RECONCILE_CONCURRENCY",
+            RECONCILE_CONCURRENCY_DEFAULT as u64,
+        ) as usize)
+            .clamp(1, RECONCILE_CONCURRENCY_MAX);
+        let reconcile_budget = Duration::from_millis(env_u64(
+            "RECONCILE_TICK_BUDGET_MS",
+            RECONCILE_TICK_BUDGET_MS_DEFAULT,
+        ));
         tracing::info!(
             reconcile_cursor = start_reconcile,
+            chunk = reconcile_chunk,
+            concurrency = reconcile_concurrency,
+            budget_ms = reconcile_budget.as_millis() as u64,
             "note reconciler: sweep cursor loaded — next sweep window starts at block {}",
             start_reconcile + 1
         );
@@ -216,6 +307,9 @@ impl SyntheticProjector {
             cursor: AtomicU64::new(start_cursor),
             node_rpc,
             reconcile_cursor: AtomicU64::new(start_reconcile),
+            reconcile_chunk,
+            reconcile_concurrency,
+            reconcile_budget,
             swept: std::sync::Mutex::new(HashSet::new()),
             direct_recovered: std::sync::Mutex::new(Vec::new()),
         })
@@ -231,37 +325,161 @@ impl SyntheticProjector {
         if from > tip {
             return None;
         }
-        Some((from, (from + RECONCILE_CHUNK - 1).min(tip)))
+        Some((from, (from + self.reconcile_chunk - 1).min(tip)))
+    }
+
+    /// The next batch of up to `reconcile_concurrency` sweep windows —
+    /// [`Self::next_reconcile_window`] extended forward without moving the
+    /// cursor. Empty when the sweep has caught up to `tip`.
+    fn plan_reconcile_windows(&self, tip: u64) -> Vec<(u64, u64)> {
+        let mut windows = Vec::new();
+        let Some((mut from, mut to)) = self.next_reconcile_window(tip) else {
+            return windows;
+        };
+        loop {
+            windows.push((from, to));
+            if to >= tip || windows.len() >= self.reconcile_concurrency {
+                return windows;
+            }
+            from = to + 1;
+            to = (from + self.reconcile_chunk - 1).min(tip);
+        }
     }
 
     /// Note-visibility reconciler (completeness guarantee for externally-created
-    /// network notes). Walks `sync_notes` over the next `RECONCILE_CHUNK` blocks
-    /// and imports any tag-0 note the local store doesn't know. The next
+    /// network notes). Walks `sync_notes` in `reconcile_chunk`-block windows and
+    /// imports any tag-0 note the local store doesn't know. The next
     /// `sync_state` then discovers the (possibly historical) consumption via the
     /// nullifier check, and the late-consumption sweep in `tick` projects it.
     /// Non-B2AGG imports (MINTs to external wallets, etc.) are harmless: every
     /// `project_*` derivation gates on script root + consumer.
+    ///
+    /// Catch-up throughput: when the sweep is behind the tip, this processes
+    /// MULTIPLE windows per tick — window fetches issued concurrently
+    /// (`RECONCILE_CONCURRENCY` in flight), batches repeated until the
+    /// `RECONCILE_TICK_BUDGET_MS` budget is spent — instead of the historical
+    /// one-window-per-5s-tick cadence (a hard ~40 blocks/s ceiling that made
+    /// full-history sweeps take 3+ hours regardless of node speed).
     async fn reconcile_notes(
         &self,
         client: &mut MidenClientLib,
-        rpc: &dyn NodeRpcClient,
+        rpc: &Arc<dyn NodeRpcClient>,
         tip: u64,
     ) -> anyhow::Result<()> {
-        let Some((from, to)) = self.next_reconcile_window(tip) else {
-            return Ok(());
-        };
-        let tags: BTreeSet<NoteTag> = BTreeSet::from([NoteTag::from(0u32)]);
-        let blocks = rpc
-            .sync_notes((from as u32).into(), (to as u32).into(), &tags)
+        let fetcher: Arc<dyn ReconcileFetcher> = Arc::new(RpcReconcileFetcher(Arc::clone(rpc)));
+        self.reconcile_notes_with(Some(client), Some(rpc.as_ref()), &fetcher, tip)
             .await
-            .map_err(|e| anyhow::anyhow!("sync_notes({from}..{to}): {e}"))?;
-        let candidates: Vec<NoteId> = blocks
-            .iter()
-            .flat_map(|b| b.notes.keys().copied())
-            .collect();
-        if !candidates.is_empty() {
+    }
+
+    /// Catch-up driver behind [`Self::reconcile_notes`], with the window fetch
+    /// abstracted behind [`ReconcileFetcher`] so the ordering/budget contract is
+    /// unit-testable. `client`/`rpc` are only touched when a window actually
+    /// has candidate notes (tests drive empty/failed windows with `None`).
+    ///
+    /// ORDERING SAFETY (low-water mark): window results are processed strictly
+    /// in ascending block order, and the persisted cursor advances to a
+    /// window's `to` only after that window — and therefore every window below
+    /// it — completed successfully. A failed fetch aborts the batch at the
+    /// failed window: earlier windows keep their advancement, later (already
+    /// fetched) results are DISCARDED and re-fetched next tick, so the cursor
+    /// can never advance past a gap. Same write-behind persist-then-cache
+    /// ordering per window as before: the durable cursor never runs ahead of
+    /// work actually done, and a crash mid-window redoes that window (the
+    /// sweep is idempotent — known ids are skipped).
+    async fn reconcile_notes_with(
+        &self,
+        mut client: Option<&mut MidenClientLib>,
+        rpc: Option<&dyn NodeRpcClient>,
+        fetcher: &Arc<dyn ReconcileFetcher>,
+        tip: u64,
+    ) -> anyhow::Result<()> {
+        let deadline = Instant::now() + self.reconcile_budget;
+        loop {
+            let windows = self.plan_reconcile_windows(tip);
+            if windows.is_empty() {
+                return Ok(());
+            }
+            // Caught-up fast path: a single (near-tip) window is fetched inline
+            // — identical behavior and cost to the historical per-tick sweep.
+            let mut results: Vec<(u64, u64, anyhow::Result<Vec<NoteId>>)> =
+                if let [(from, to)] = windows[..] {
+                    vec![(from, to, fetcher.sync_note_ids(from, to).await)]
+                } else {
+                    let mut set = tokio::task::JoinSet::new();
+                    for (from, to) in windows {
+                        let fetcher = Arc::clone(fetcher);
+                        set.spawn(async move { (from, to, fetcher.sync_note_ids(from, to).await) });
+                    }
+                    let mut out = Vec::with_capacity(set.len());
+                    while let Some(joined) = set.join_next().await {
+                        out.push(joined.map_err(|e| {
+                            anyhow::anyhow!("reconcile window-fetch task panicked: {e}")
+                        })?);
+                    }
+                    out
+                };
+            results.sort_unstable_by_key(|(from, _, _)| *from);
+            for (from, to, fetched) in results {
+                let candidates = fetched.map_err(|e| {
+                    // Low-water mark: never advance past a failed window. The
+                    // windows before this one already advanced the cursor;
+                    // everything from here on is re-fetched next tick.
+                    anyhow::anyhow!(
+                        "reconcile window {from}..{to} failed — cursor held at {} (retry next tick): {e:#}",
+                        self.reconcile_cursor.load(Ordering::Acquire)
+                    )
+                })?;
+                if !candidates.is_empty() {
+                    let client = client.as_deref_mut().ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "reconcile window {from}..{to}: candidate notes but no client handle"
+                        )
+                    })?;
+                    let rpc = rpc.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "reconcile window {from}..{to}: candidate notes but no rpc handle"
+                        )
+                    })?;
+                    self.import_reconcile_window(client, rpc, from, to, &candidates)
+                        .await?;
+                }
+                // Persist write-behind AFTER the window's work completed, and
+                // BEFORE updating the in-memory cache (same ordering guarantee
+                // as the projection cursor in `tick`): the durable cursor never
+                // runs ahead of work actually done. A persist failure fails
+                // this tick (warn + retry in `tick`), leaving the in-memory
+                // cursor un-advanced so the window is re-swept.
+                self.store.set_reconcile_cursor(to).await?;
+                self.reconcile_cursor.store(to, Ordering::Release);
+                metrics::gauge!("synthetic_reconciler_cursor").set(to as f64);
+            }
+            // Budget check AFTER the batch: at least one batch always runs
+            // (guaranteed progress even under a zero/tiny budget), and
+            // projection — which runs after reconcile in `tick` — is never
+            // starved by a deep catch-up.
+            if Instant::now() >= deadline {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Import the unknown notes of ONE sweep window `[from, to]` given the
+    /// window's candidate note ids. This is the historical per-window body of
+    /// `reconcile_notes`, moved verbatim: unknown-ids diff, atomic batch import
+    /// with the private-note per-note skip fallback (0.15.5 wedge hotfix), and
+    /// the spent-before-import recovery re-query. Runs SEQUENTIALLY per window
+    /// on the single client — only the window fetches are concurrent.
+    async fn import_reconcile_window(
+        &self,
+        client: &mut MidenClientLib,
+        rpc: &dyn NodeRpcClient,
+        from: u64,
+        to: u64,
+        candidates: &[NoteId],
+    ) -> anyhow::Result<()> {
+        {
             let known: HashSet<NoteId> = client
-                .get_input_notes(NoteFilter::List(candidates.clone()))
+                .get_input_notes(NoteFilter::List(candidates.to_vec()))
                 .await
                 .map_err(|e| anyhow::anyhow!("get_input_notes(List): {e}"))?
                 .into_iter()
@@ -376,16 +594,6 @@ impl SyntheticProjector {
                 }
             }
         }
-        // Persist write-behind AFTER the window's work completed, and BEFORE
-        // updating the in-memory cache (same ordering guarantee as the
-        // projection cursor in `tick`): the durable cursor never runs ahead of
-        // work actually done. A crash between the work and this store redoes
-        // the window next boot — safe, the sweep is idempotent. A persist
-        // failure fails this tick (warn + retry in `tick`), leaving the
-        // in-memory cursor un-advanced so the window is re-swept.
-        self.store.set_reconcile_cursor(to).await?;
-        self.reconcile_cursor.store(to, Ordering::Release);
-        metrics::gauge!("synthetic_reconciler_cursor").set(to as f64);
         Ok(())
     }
 
@@ -625,6 +833,16 @@ impl SyntheticProjector {
         self.cursor.load(Ordering::Acquire)
     }
 
+    /// Test-only override of the reconciler catch-up knobs (the live values
+    /// come from the environment in [`Self::new`]).
+    #[cfg(test)]
+    fn with_reconcile_tuning(mut self, chunk: u64, concurrency: usize, budget: Duration) -> Self {
+        self.reconcile_chunk = chunk;
+        self.reconcile_concurrency = concurrency;
+        self.reconcile_budget = budget;
+        self
+    }
+
     /// Project the notes consumed at one Miden block (`miden_block`) into the
     /// single synthetic block `miden_block` (**Miden-1:1**): every synthetic log
     /// derived from this block's notes is written at synthetic block == the Miden
@@ -814,7 +1032,7 @@ impl SyntheticProjector {
         // whenever Miden block production pauses. Failures are transient —
         // warn and retry next tick, never block projection.
         if let Some(rpc) = self.node_rpc.clone()
-            && let Err(e) = self.reconcile_notes(client, rpc.as_ref(), tip).await
+            && let Err(e) = self.reconcile_notes(client, &rpc, tip).await
         {
             tracing::warn!(
                 error = %format!("{e:#}"),
@@ -1230,6 +1448,182 @@ mod tests {
         );
         // Caught-up case: no window when the persisted cursor is at the tip.
         assert_eq!(projector.next_reconcile_window(4_200), None);
+    }
+
+    /// [`ReconcileFetcher`] fake for the catch-up driver tests: records every
+    /// window it is asked for, optionally fails one window (by its `from`
+    /// block), and returns NO candidates — so the driver's window batching,
+    /// ordering, budget and cursor advancement run without a client handle
+    /// (the per-window import is only entered when candidates exist).
+    struct FakeFetcher {
+        calls: std::sync::Mutex<Vec<(u64, u64)>>,
+        fail_from: Option<u64>,
+    }
+
+    impl FakeFetcher {
+        fn new(fail_from: Option<u64>) -> StdArc<Self> {
+            StdArc::new(Self {
+                calls: std::sync::Mutex::new(Vec::new()),
+                fail_from,
+            })
+        }
+
+        fn calls(&self) -> Vec<(u64, u64)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ReconcileFetcher for FakeFetcher {
+        async fn sync_note_ids(&self, from: u64, to: u64) -> anyhow::Result<Vec<NoteId>> {
+            self.calls.lock().unwrap().push((from, to));
+            if self.fail_from == Some(from) {
+                anyhow::bail!("injected window-fetch failure ({from}..{to})");
+            }
+            Ok(Vec::new())
+        }
+    }
+
+    /// Catch-up throughput contract: when the sweep is behind the tip, ONE
+    /// `reconcile_notes` call processes MULTIPLE windows (batches of
+    /// `concurrency`, repeated until caught up) under a sufficient budget —
+    /// instead of the historical one-window-per-tick cadence. And the budget
+    /// actually bounds the work: with a zero budget exactly one batch runs
+    /// (guaranteed progress), leaving the rest for the next tick.
+    #[tokio::test]
+    async fn reconcile_catchup_processes_multiple_windows_per_tick_under_budget() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let block_state = StdArc::new(BlockState::new());
+
+        // Zero budget: exactly one batch (= `concurrency` windows) per tick.
+        let projector = test_projector(&store, &block_state)
+            .await
+            .with_reconcile_tuning(200, 4, Duration::ZERO);
+        let fetcher = FakeFetcher::new(None);
+        let f: StdArc<dyn ReconcileFetcher> = fetcher.clone();
+        projector
+            .reconcile_notes_with(None, None, &f, 2_000)
+            .await
+            .unwrap();
+        // Fetch-task completion order is unspecified — compare as a set.
+        let mut calls = fetcher.calls();
+        calls.sort_unstable();
+        assert_eq!(
+            calls,
+            vec![(1, 200), (201, 400), (401, 600), (601, 800)],
+            "zero budget: one batch of `concurrency` windows, then stop"
+        );
+        assert_eq!(store.get_reconcile_cursor().await.unwrap(), 800);
+
+        // Ample budget: the same call catches all the way up in one tick.
+        let projector = test_projector(&store, &block_state)
+            .await
+            .with_reconcile_tuning(200, 4, Duration::from_secs(60));
+        let fetcher = FakeFetcher::new(None);
+        let f: StdArc<dyn ReconcileFetcher> = fetcher.clone();
+        projector
+            .reconcile_notes_with(None, None, &f, 2_000)
+            .await
+            .unwrap();
+        let mut calls = fetcher.calls();
+        calls.sort_unstable();
+        assert_eq!(calls.len(), 6, "windows 801..2000 in batches of <=4");
+        assert_eq!(calls.first(), Some(&(801, 1_000)));
+        assert_eq!(calls.last(), Some(&(1_801, 2_000)));
+        assert_eq!(
+            store.get_reconcile_cursor().await.unwrap(),
+            2_000,
+            "multiple windows must advance the persisted cursor to the tip in ONE tick"
+        );
+    }
+
+    /// ORDERING SAFETY: the cursor may only advance to block X when ALL windows
+    /// <= X completed successfully. Inject a failure into the middle window of
+    /// a concurrent batch — the windows below it keep their advancement (the
+    /// low-water mark), the windows above it (already fetched) are discarded,
+    /// and the next tick retries FROM the failed window.
+    #[tokio::test]
+    async fn reconcile_cursor_never_advances_past_failed_window() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let block_state = StdArc::new(BlockState::new());
+        let projector = test_projector(&store, &block_state)
+            .await
+            .with_reconcile_tuning(200, 8, Duration::from_secs(60));
+
+        // Window 3 of the batch (blocks 401..600) fails; 1,2 and 4..8 succeed.
+        let fetcher = FakeFetcher::new(Some(401));
+        let f: StdArc<dyn ReconcileFetcher> = fetcher.clone();
+        let err = projector
+            .reconcile_notes_with(None, None, &f, 2_000)
+            .await
+            .expect_err("a failed window must fail the tick (stays loud/transient)");
+        assert!(
+            format!("{err:#}").contains("401..600"),
+            "error must name the failed window: {err:#}"
+        );
+        assert_eq!(fetcher.calls().len(), 8, "the whole batch was fetched");
+        assert_eq!(
+            store.get_reconcile_cursor().await.unwrap(),
+            400,
+            "cursor must stop at the low-water mark (end of the last good window BELOW the failure)"
+        );
+        assert_eq!(
+            projector.reconcile_cursor.load(Ordering::Acquire),
+            400,
+            "in-memory cursor must match the persisted low-water mark"
+        );
+
+        // Next tick (failure cleared): the sweep resumes AT the failed window
+        // and catches up — nothing was skipped.
+        let fetcher = FakeFetcher::new(None);
+        let f: StdArc<dyn ReconcileFetcher> = fetcher.clone();
+        projector
+            .reconcile_notes_with(None, None, &f, 2_000)
+            .await
+            .unwrap();
+        let mut retry_calls = fetcher.calls();
+        retry_calls.sort_unstable();
+        assert_eq!(
+            retry_calls.first(),
+            Some(&(401, 600)),
+            "retry must re-fetch the failed window first"
+        );
+        assert_eq!(store.get_reconcile_cursor().await.unwrap(), 2_000);
+    }
+
+    /// Caught-up steady state must be unchanged from the historical behavior:
+    /// exactly ONE (small) window fetch per tick, no extra batches, and a tick
+    /// at the tip fetches nothing.
+    #[tokio::test]
+    async fn reconcile_caught_up_single_window_unchanged() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let block_state = StdArc::new(BlockState::new());
+        store.set_reconcile_cursor(9_950).await.unwrap();
+        let projector = test_projector(&store, &block_state)
+            .await
+            .with_reconcile_tuning(200, 8, Duration::from_secs(60));
+
+        let fetcher = FakeFetcher::new(None);
+        let f: StdArc<dyn ReconcileFetcher> = fetcher.clone();
+        projector
+            .reconcile_notes_with(None, None, &f, 10_000)
+            .await
+            .unwrap();
+        assert_eq!(
+            fetcher.calls(),
+            vec![(9_951, 10_000)],
+            "near the tip: exactly one partial window, same as the old per-tick sweep"
+        );
+        assert_eq!(store.get_reconcile_cursor().await.unwrap(), 10_000);
+
+        // At the tip: nothing to do, no fetches at all.
+        let fetcher = FakeFetcher::new(None);
+        let f: StdArc<dyn ReconcileFetcher> = fetcher.clone();
+        projector
+            .reconcile_notes_with(None, None, &f, 10_000)
+            .await
+            .unwrap();
+        assert!(fetcher.calls().is_empty(), "caught up: zero RPC work");
     }
 
     async fn register_faucet(store: &StdArc<dyn Store>) {

--- a/src/synthetic_projector.rs
+++ b/src/synthetic_projector.rs
@@ -123,9 +123,20 @@ pub struct SyntheticProjector {
     /// unknown notes so consumption is re-discovered and projected. `None`
     /// disables reconciliation (unit tests).
     node_rpc: Option<Arc<dyn NodeRpcClient>>,
-    /// Last Miden block swept by the reconciler. In-memory only: a restart
-    /// re-sweeps from genesis, which is idempotent (known ids are skipped) and
-    /// doubles as gap-healing for pre-fix history.
+    /// Last Miden block swept by the reconciler — an in-memory cache of the
+    /// persisted `Store::get_reconcile_cursor` (migration 010), mirroring the
+    /// projection `cursor` above. Loaded in `new()` and persisted write-behind
+    /// AFTER each sweep window completes, so the durable cursor never runs
+    /// ahead of work actually done (a crash mid-window redoes that window —
+    /// safe, the sweep is idempotent: known ids are skipped).
+    ///
+    /// History: this used to be memory-only (hardcoded to 0 at boot), so EVERY
+    /// container restart re-walked the sweep from genesis — ~3h of resync and
+    /// node load per restart on prod history. The very first boot (no
+    /// persisted value → 0) still sweeps from genesis: that is the designed
+    /// first-boot heal. Recovery flows (`--restore`, `--reset-miden-store`)
+    /// and the `--resweep-from-genesis` escape hatch reset the persisted
+    /// value to 0 deliberately.
     reconcile_cursor: AtomicU64,
     /// Note ids already projected (or attempted) by the late-consumption sweep,
     /// so the per-tick sweep doesn't re-issue `is_note_processed` store queries
@@ -183,6 +194,18 @@ impl SyntheticProjector {
             .map(|a| a.0)
             .unwrap_or(accounts.service.0);
         let start_cursor = store.get_projector_cursor().await?;
+        // Same pattern for the reconciler's sweep cursor (migration 010): a
+        // restart resumes the sweep after the last persisted window instead of
+        // re-walking from genesis (prod: ~3h resync per restart pre-fix). 0
+        // (fresh deployment or a recovery-flow reset) means the full-history
+        // heal sweep runs — grep target for the e2e restart regression check
+        // (scripts/e2e-reconciler-cursor-persistence.sh).
+        let start_reconcile = store.get_reconcile_cursor().await?;
+        tracing::info!(
+            reconcile_cursor = start_reconcile,
+            "note reconciler: sweep cursor loaded — next sweep window starts at block {}",
+            start_reconcile + 1
+        );
         Ok(Self {
             store,
             block_state,
@@ -192,10 +215,23 @@ impl SyntheticProjector {
             l1_rpc_url,
             cursor: AtomicU64::new(start_cursor),
             node_rpc,
-            reconcile_cursor: AtomicU64::new(0),
+            reconcile_cursor: AtomicU64::new(start_reconcile),
             swept: std::sync::Mutex::new(HashSet::new()),
             direct_recovered: std::sync::Mutex::new(Vec::new()),
         })
+    }
+
+    /// The next sweep window `[from, to]` the note-visibility reconciler will
+    /// walk, or `None` when the sweep has caught up to `tip`. Factored out of
+    /// [`Self::reconcile_notes`] so the restart-resume contract is directly
+    /// unit-testable: `from` is `reconcile_cursor + 1` — persisted-cursor + 1
+    /// after a restart, NOT 1.
+    fn next_reconcile_window(&self, tip: u64) -> Option<(u64, u64)> {
+        let from = self.reconcile_cursor.load(Ordering::Acquire) + 1;
+        if from > tip {
+            return None;
+        }
+        Some((from, (from + RECONCILE_CHUNK - 1).min(tip)))
     }
 
     /// Note-visibility reconciler (completeness guarantee for externally-created
@@ -211,11 +247,9 @@ impl SyntheticProjector {
         rpc: &dyn NodeRpcClient,
         tip: u64,
     ) -> anyhow::Result<()> {
-        let from = self.reconcile_cursor.load(Ordering::Acquire) + 1;
-        if from > tip {
+        let Some((from, to)) = self.next_reconcile_window(tip) else {
             return Ok(());
-        }
-        let to = (from + RECONCILE_CHUNK - 1).min(tip);
+        };
         let tags: BTreeSet<NoteTag> = BTreeSet::from([NoteTag::from(0u32)]);
         let blocks = rpc
             .sync_notes((from as u32).into(), (to as u32).into(), &tags)
@@ -342,7 +376,16 @@ impl SyntheticProjector {
                 }
             }
         }
+        // Persist write-behind AFTER the window's work completed, and BEFORE
+        // updating the in-memory cache (same ordering guarantee as the
+        // projection cursor in `tick`): the durable cursor never runs ahead of
+        // work actually done. A crash between the work and this store redoes
+        // the window next boot — safe, the sweep is idempotent. A persist
+        // failure fails this tick (warn + retry in `tick`), leaving the
+        // in-memory cursor un-advanced so the window is re-swept.
+        self.store.set_reconcile_cursor(to).await?;
         self.reconcile_cursor.store(to, Ordering::Release);
+        metrics::gauge!("synthetic_reconciler_cursor").set(to as f64);
         Ok(())
     }
 
@@ -1149,6 +1192,44 @@ mod tests {
         )
         .await
         .unwrap()
+    }
+
+    /// Regression lock for the prod restart-resync incident: the reconciler's
+    /// sweep cursor was a memory-only AtomicU64 hardcoded to 0 at boot, so
+    /// EVERY container restart (image update, crash, plain restart) re-walked
+    /// the sweep from genesis — ~3h of resync + node load per restart on prod
+    /// history. The cursor is now persisted (`Store::{get,set}_reconcile_cursor`,
+    /// migration 010) and loaded in `SyntheticProjector::new` exactly like the
+    /// projection cursor: a re-constructed projector must start its next
+    /// sweep window at persisted+1, NOT at 1.
+    #[tokio::test]
+    async fn restart_resumes_reconcile_sweep_from_persisted_cursor() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let block_state = StdArc::new(BlockState::new());
+
+        // First boot: nothing persisted → the sweep starts from genesis
+        // (block 1). This is the designed first-boot heal and must not change.
+        let projector = test_projector(&store, &block_state).await;
+        assert_eq!(
+            projector.next_reconcile_window(10_000),
+            Some((1, RECONCILE_CHUNK)),
+            "first boot (no persisted cursor) must sweep from genesis"
+        );
+
+        // Advance the sweep cursor via the persistence API — the same store
+        // write `reconcile_notes` performs after a window completes.
+        store.set_reconcile_cursor(4_200).await.unwrap();
+        drop(projector);
+
+        // "Container restart": re-construct the projector over the SAME store.
+        let projector = test_projector(&store, &block_state).await;
+        assert_eq!(
+            projector.next_reconcile_window(10_000),
+            Some((4_201, 4_200 + RECONCILE_CHUNK)),
+            "restart must resume the sweep at persisted+1, not re-walk from genesis"
+        );
+        // Caught-up case: no window when the persisted cursor is at the tip.
+        assert_eq!(projector.next_reconcile_window(4_200), None);
     }
 
     async fn register_faucet(store: &StdArc<dyn Store>) {


### PR DESCRIPTION
Restart/throughput hardening for the note-visibility reconciler, on top of the private-note wedge hotfix (#110, v0.15.6). Three commits: an e2e regression lock for #110, a persisted sweep cursor, and a concurrent budgeted catch-up.

## 1. Persist the sweep cursor — restart must not re-sweep from genesis
**Prod incident:** the reconciler's sweep cursor (`SyntheticProjector::reconcile_cursor`) was a memory-only `AtomicU64` hardcoded to 0 at boot, while the projection cursor right above it was already persisted (migration 009). So **every** container restart — image update, crash, plain restart — re-walked the `sync_notes` sweep from genesis: ~3h of resync + sustained node load per restart.

Fix (mirrors the projector-cursor pattern):
- `Store::{get,set}_reconcile_cursor` on the trait + InMemoryStore + PgStore; persisted as `service_state.reconcile_cursor` (**migration 010**, idempotent `ADD COLUMN IF NOT EXISTS ... DEFAULT 0`).
- `SyntheticProjector::new()` loads the cursor; `reconcile_notes` persists each advance **write-behind after** the window completes (durable cursor never runs ahead of work done; a crash mid-window redoes that window — safe, the sweep is idempotent). New `synthetic_reconciler_cursor` gauge + boot log.
- Recovery flows **reset the cursor to 0** (a wiped/rebuilt miden store has forgotten its notes — the genesis re-sweep *is* the heal): `--restore` (Phase 4) and `--reset-miden-store` at boot, both logged loudly.
- New `--resweep-from-genesis` (`RESWEEP_FROM_GENESIS`) operator escape hatch for deliberate full-history audits. First boot (no persisted value) sweeps from 0, unchanged.

## 2. Concurrent budgeted catch-up — ~10× sweep throughput
The reconciler advanced at most **one** 200-block `sync_notes` window per ~5s tick — a hard ~40 blocks/s ceiling, so a full-history sweep of prod (~380k blocks) took 3+ hours after any cursor reset.

- **In-tick catch-up loop** with a time budget (`RECONCILE_TICK_BUDGET_MS`, default 2000ms): when behind, process multiple window batches per tick; ≥1 batch always runs (guaranteed progress), projection is never starved. When caught up, behavior is identical to before (one small inline window).
- **Concurrent window fetches** (`RECONCILE_CONCURRENCY`, default 8, cap 16) via `JoinSet` over the shared `Arc<dyn NodeRpcClient>` (tonic client is `Send + Sync`, multiplexed HTTP/2). **Ordering safety:** results processed strictly ascending; the persisted cursor only advances to X once **all** windows ≤ X succeeded (low-water mark); a failed window aborts advancement past it and discards fetched later windows (retried next tick). Per-window import logic (unknown-ids diff, **private-note skip fallback**, spent-before-import recovery) moved verbatim into `import_reconcile_window`, stays sequential on the one client.
- `RECONCILE_CHUNK` now env-tunable; default raised **200 → 1000** on testnet evidence (`sync_notes` is latency-dominated: ~237ms/200-block vs ~315ms/1000), giving ~5× blocks/s/request AND 5× fewer requests — which keeps the concurrent sweep under the public node's rate limiter.

Benchmarks (`note_probe --bench-sweep` vs rpc.testnet.miden.io, fetch+extract only): 7–8× raw pipeline speedup (e.g. chunk 1000: 5.5k → 39.6k blocks/s at ×8). Operator-visible effective rate: **40 blocks/s → ~15.8k blocks/s** at default tuning — a full-history sweep drops from ~2.65h to well under a minute of budget time.

## 3. e2e regression lock for the #110 private-note wedge
Adds `--send-private-note` to `bridge-out-tool` (a private, tag-0, zero-asset P2ID-to-self note — same `sync_notes(tags={0})` family as B2AGG, so the reconciler must confront it) and `scripts/e2e-reconciler-private-note.sh`:
- **Phase A (live):** asserts `synthetic_reconciler_private_skipped_total` increments + the skip WARN fires + zero "is private" tick loops.
- **Phase B (the prod wedge):** bridge-out *after* the private note, then `--reset-miden-store --restore` + restart — the genesis re-sweep must re-walk history *through* the private-note block; asserts the re-skip, no wedge, and the post-private-note BridgeEvent still served.
- Pre-hotfix, this test fails fast with the wedge evidence. (Closes the e2e coverage gap noted in #110.)

## Tests
Unit: cursor persistence round-trips (memory + pg-gated), restart-resumes-from-cursor, restore-resets-to-genesis, and the concurrent-catch-up seam (`ReconcileFetcher`) — multiple-windows-per-tick, cursor-never-advances-past-failed-window, caught-up-single-window-unchanged. Lib 296 / `--features postgres` 320, clippy `-D warnings` clean. E2E: `e2e-reconciler-cursor-persistence.sh`, `e2e-reconciler-private-note.sh` (wired into `e2e-test.sh` + Makefile).

Base: `main`. 3 commits, 0 behind main. Migration 010 is additive/idempotent.
