### PR TITLE
chore(deps): bump cmov 0.5.3 → 0.5.4 (GHSA-3rjw-m598-pq24)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "codegen"


### PR DESCRIPTION
Closes Dependabot alert [#14](https://github.com/gateway-fm/miden-agglayer/security/dependabot/14) (moderate).

## What
Bumps the `cmov` crate `0.5.3 → 0.5.4`. Lockfile-only, semver-compatible patch bump — no source changes.

## Why
**GHSA-3rjw-m598-pq24:** `Cmov`/`CmovEq` on **aarch64** can produce wrong results when the high bits of registers are set. Fixed in `0.5.4`.

This is a transitive dependency (constant-time conditional-move primitive used deep in the crypto stack). It matters to us because we publish **linux/arm64 (aarch64)** images alongside amd64 — the affected target.

## Change
```
cmov v0.5.3 -> v0.5.4
```
Only `Cargo.lock` changes (version + checksum). Vulnerable range `>= 0.1.1, < 0.5.4`; patched in `0.5.4`.

## Verification
- [x] CI (`check.yml` + CodeQL) green
- Local `git diff` confirms Cargo.lock is the only file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
