### PR TITLE
fix(h6): use one policy-bound L1 scan for GER admission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,6 +3400,7 @@ dependencies = [
  "alloy",
  "alloy-core",
  "alloy-rpc-types-eth",
+ "alloy-transport",
  "anyhow",
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,11 @@ tokio = { version = "1.48", features = ["test-util"] }
 # Used only by `r5_oversize_error_matches_aggsender_parser` to mirror aggkit's
 # `ParseMaxRangeFromError` regex verbatim and pin the error-format contract.
 regex = "1.10"
+# Mock RPC transport (Asserter) for the L1InfoTreeIndexer poll_once reorg /
+# retryable-batch regressions — drives the REAL poll loop with canned L1
+# responses, no live node. Version-matched to the alloy stack (resolves to the
+# same alloy-transport the provider uses), features off (mock is always built).
+alloy-transport = { version = "1.5", default-features = false }
 
 [profile.dev.package."*"]
 opt-level = 1

--- a/Makefile
+++ b/Makefile
@@ -249,9 +249,11 @@ e2e-clean-data: ## Wipe .miden-agglayer-data/ + .b2agg-store/ + node_data volume
 		echo "e2e-clean-data: WIPE FAILED — leftover state would poison the fresh stack:"; \
 		ls -la .miden-agglayer-data .b2agg-store 2>/dev/null; exit 1; fi
 	mkdir -p .miden-agglayer-data/tmp
-	@out=$$(docker volume rm miden-agglayer_node_data 2>&1) || { \
+	@project="$${COMPOSE_PROJECT_NAME:-$(notdir $(CURDIR))}"; \
+	volume="$${project}_node_data"; \
+	out=$$(docker volume rm "$$volume" 2>&1) || { \
 		echo "$$out" | grep -qi "no such volume" || { \
-			echo "e2e-clean-data: cannot remove node_data volume (stack still up? run 'make e2e-down'): $$out"; exit 1; }; }
+			echo "e2e-clean-data: cannot remove $$volume (stack still up? run 'make e2e-down'): $$out"; exit 1; }; }
 
 .PHONY: e2e-up
 e2e-up: e2e-clean-data ## Start full E2E environment (cleans data dir first)

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -5,7 +5,11 @@ services:
     entrypoint: ["sh", "-c"]
     command:
       - |
-        anvil --host=0.0.0.0 --chain-id=271828 --block-time=1 --base-fee=1 &
+        # AggSender reads RollupManager state at RollupCreationBlockL1. Anvil
+        # 1.7 retains only 3,600 historical states on disk by default, while a
+        # full E2E pass (notably the real H6 timeout) mines beyond that window.
+        # Keep enough history for the full pass plus the N=30 release gate.
+        anvil --host=0.0.0.0 --chain-id=271828 --block-time=1 --base-fee=1 --max-persisted-states=12000 &
         ANVIL_PID=$$!
         sleep 2
         # Fund deployment accounts and replay contract deployment transactions

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -251,6 +251,23 @@ services:
       # the tripwire e2e sets these short (e.g. 5s × 2) to observe the halt quickly.
       FAUCET_RECONCILER_POLL_SECS: "${FAUCET_RECONCILER_POLL_SECS:-30}"
       FAUCET_RECONCILER_GRACE_TICKS: "${FAUCET_RECONCILER_GRACE_TICKS:-3}"
+      # Audit H6 — strict L1 GER corroboration, ON by default in the e2e stack
+      # (the required production posture; merging the H6 code with the flag
+      # off does not close the finding). Rejections are side-effect-free and
+      # transient — the aggoracle's retry succeeds once the from-genesis L1
+      # indexer (--l1-indexer-from-block=1 below) catches up, which on anvil
+      # is seconds. e2e-ger-l1-verification.sh asserts both phases; override
+      # with REJECT_UNVERIFIED_GER_INJECTION=false to run the lenient
+      # (warn + metric only) mode, which makes that script SKIP itself.
+      # Keep the evidence source in environment as well as the normal service
+      # command. `docker compose run ... <one-shot flags>` replaces `command`,
+      # but inherits environment; restore/recovery must therefore retain the
+      # exact policy already bound to this database.
+      L1_RPC_URL: "http://anvil:8545"
+      GER_L1_ADDRESS: "0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674"
+      L1_INDEXER_FROM_BLOCK: "1"
+      L1_EVIDENCE_TAG: "${L1_EVIDENCE_TAG:-confirmations:1}"
+      REJECT_UNVERIFIED_GER_INJECTION: "${REJECT_UNVERIFIED_GER_INJECTION:-true}"
     volumes:
       # Bind mount so `docker compose run --rm --no-deps miden-agglayer --restore`
       # shares the miden-client sqlite store + keystore + bridge_accounts.toml with
@@ -274,6 +291,17 @@ services:
       # deterministic 0x133e6a88… orphan). Anvil's history is ~100s of blocks
       # so a from-genesis scan is trivial (max_range chunks it).
       - "--l1-indexer-from-block=1"
+      # Audit H6 — the SINGLE evidence-finality setting the STRICT gate uses
+      # (there is exactly one knob; the old --l1-indexer-confirmations flag is
+      # gone). Values: `confirmations:<N>` (depth below head), `finalized`, or
+      # `safe`; normal decomposition always uses `latest` and is never delayed.
+      # Production hardened uses `finalized`. The e2e L1 is a single-node anvil
+      # with instant finality and no reorgs, so use the safe MINIMUM depth
+      # `confirmations:1` (strict mode refuses `confirmations:0`). Phase A of
+      # e2e-ger-l1-verification.sh waits for the fresh GER to reach this depth
+      # before submitting. Override via L1_EVIDENCE_TAG (e.g. `finalized`) to
+      # exercise the production posture.
+      - "--l1-evidence-tag=${L1_EVIDENCE_TAG:-confirmations:1}"
       # Audit C2 — the signer default is now fail-closed: with no
       # `--allowed-signers` configured, `eth_sendRawTransaction` rejects EVERY
       # signer. The e2e stack's legitimate submitters (aggoracle/aggsender GER +

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -266,7 +266,7 @@ services:
       L1_RPC_URL: "http://anvil:8545"
       GER_L1_ADDRESS: "0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674"
       L1_INDEXER_FROM_BLOCK: "1"
-      L1_EVIDENCE_TAG: "${L1_EVIDENCE_TAG:-confirmations:1}"
+      L1_EVIDENCE_TAG: "${L1_EVIDENCE_TAG:-latest}"
       REJECT_UNVERIFIED_GER_INJECTION: "${REJECT_UNVERIFIED_GER_INJECTION:-true}"
     volumes:
       # Bind mount so `docker compose run --rm --no-deps miden-agglayer --restore`
@@ -291,17 +291,11 @@ services:
       # deterministic 0x133e6a88… orphan). Anvil's history is ~100s of blocks
       # so a from-genesis scan is trivial (max_range chunks it).
       - "--l1-indexer-from-block=1"
-      # Audit H6 — the SINGLE evidence-finality setting the STRICT gate uses
-      # (there is exactly one knob; the old --l1-indexer-confirmations flag is
-      # gone). Values: `confirmations:<N>` (depth below head), `finalized`, or
-      # `safe`; normal decomposition always uses `latest` and is never delayed.
-      # Production hardened uses `finalized`. The e2e L1 is a single-node anvil
-      # with instant finality and no reorgs, so use the safe MINIMUM depth
-      # `confirmations:1` (strict mode refuses `confirmations:0`). Phase A of
-      # e2e-ger-l1-verification.sh waits for the fresh GER to reach this depth
-      # before submitting. Override via L1_EVIDENCE_TAG (e.g. `finalized`) to
-      # exercise the production posture.
-      - "--l1-evidence-tag=${L1_EVIDENCE_TAG:-confirmations:1}"
+      # Audit H6 — the one frontier used by the entire L1 evidence scan.
+      # Values: `latest`, `safe`, or `finalized`. Hardened deployments must use
+      # `safe` or `finalized`; the single-node anvil e2e defaults to `latest`
+      # for low latency and can be overridden to exercise either hardened tag.
+      - "--l1-evidence-tag=${L1_EVIDENCE_TAG:-latest}"
       # Audit C2 — the signer default is now fail-closed: with no
       # `--allowed-signers` configured, `eth_sendRawTransaction` rejects EVERY
       # signer. The e2e stack's legitimate submitters (aggoracle/aggsender GER +

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -74,6 +74,29 @@ and `zkevm_getExitRootsByGER` returns `null` for them. There is no safe
 latest-root fallback because a combined GER cannot be decomposed after the
 fact. Monitor `l1_indexer_state` and the indexer error metrics.
 
+`L1_EVIDENCE_TAG=latest|safe|finalized` selects the indexer's only L1 frontier;
+the default is `latest`. `REJECT_UNVERIFIED_GER_INJECTION=true` makes GER
+admission wait for roots written by that scan. `REQUIRE_HARDENING=true` implies
+strict admission and requires `safe` or `finalized`.
+
+The database binds its evidence marker and cursor to the exact selected tag.
+Changing it requires stopping the service, clearing the policy-derived marker,
+cursor, and binding in one transaction, then restarting with a trusted
+`L1_INDEXER_FROM_BLOCK`:
+
+```sql
+BEGIN;
+UPDATE ger_entries SET finalized_verified = FALSE;
+UPDATE l1_indexer_state
+SET finalized_block = 0, finalized_scan_cursor = 0, evidence_tag = NULL;
+COMMIT;
+```
+
+The `finalized_*` column names are retained for migration compatibility; they
+store the selected policy's state, not a second scan. On first upgrade,
+`latest` resumes the legacy `last_processed` cursor. `safe` and `finalized`
+never inherit latest-scan progress and require an explicit first backfill.
+
 ### Termination
 
 SIGTERM stops HTTP acceptance and signals the writer. A job already executing

--- a/migrations/013_l1_finalized_block.sql
+++ b/migrations/013_l1_finalized_block.sql
@@ -1,0 +1,17 @@
+-- ============================================================================
+-- L1 finality-tag block tracking (audit H6 BLOCKER 3)
+-- ============================================================================
+--
+-- Strict-H6 authorization of an IRREVERSIBLE GER injection can be qualified
+-- either by a confirmation depth below the head cursor OR by an L1 finality
+-- tag (`finalized` / `safe`). Under `--require-hardening` the `finalized` tag
+-- is MANDATORY. The indexer uses this block as the upper bound of a canonical
+-- finality-tag scan; the gate authorizes only rows marked by that scan.
+--
+-- This block is tracked SEPARATELY from `last_processed` (the head cursor that
+-- drives normal, undelayed decomposition): the indexer records the decomposition
+-- up to LATEST for ordinary bridge readiness, but persists the finality-tag
+-- block here so the canonical scan can advance independently without delaying
+-- normal ops. A stale value only ever DELAYS authorization (fail-closed).
+ALTER TABLE l1_indexer_state
+    ADD COLUMN IF NOT EXISTS finalized_block BIGINT NOT NULL DEFAULT 0;

--- a/migrations/014_finalized_verified.sql
+++ b/migrations/014_finalized_verified.sql
@@ -1,0 +1,25 @@
+-- ============================================================================
+-- Finalized-chain tie for strict-H6 GER evidence (audit H6 BLOCKER 1)
+-- ============================================================================
+--
+-- Recording the (mainnet, rollup) decomposition from a `latest` observation and
+-- authorizing when `evidence.block <= finalized_block` only proved SOME block at
+-- that height was finalized — NOT that THIS decomposition is on the canonical
+-- finalized chain. A row from a later-reorged fork, whose height is still
+-- <= finalized, could authorize an IRREVERSIBLE injection for a GER that never
+-- made it onto canonical finalized L1.
+--
+-- `finalized_verified` is set ONLY by the indexer's FINALIZED-pinned scan (a
+-- scan bounded by the L1 finalized/safe block, whose logs are by definition the
+-- canonical finalized chain's content). The `finalized`/`safe` strict gate
+-- authorizes only rows with this flag, so a latest-observed-then-reorged fork
+-- row (never covered by the finalized scan) can no longer authorize. Normal
+-- (lenient) decomposition is unaffected — it reads the row regardless.
+ALTER TABLE ger_entries
+    ADD COLUMN IF NOT EXISTS finalized_verified BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Progress cursor of the finalized-pinned scan, separate from `last_processed`
+-- (the head/latest scan cursor) so a restart resumes the finalized scan without
+-- re-walking from genesis and without stranding pre-finalized rows.
+ALTER TABLE l1_indexer_state
+    ADD COLUMN IF NOT EXISTS finalized_scan_cursor BIGINT NOT NULL DEFAULT 0;

--- a/migrations/015_l1_evidence_policy.sql
+++ b/migrations/015_l1_evidence_policy.sql
@@ -1,0 +1,9 @@
+-- Bind persisted L1 evidence to the policy that produced it.
+--
+-- `finalized_verified`, `finalized_block`, and `finalized_scan_cursor` are not
+-- interchangeable between `safe` and `finalized`. The service binds this nullable
+-- column on its first clean serving boot and refuses a different setting on later
+-- boots. NULL is retained by the migration so an upgraded database with untagged
+-- markers can be detected and rejected instead of being silently misclassified.
+ALTER TABLE l1_indexer_state
+    ADD COLUMN IF NOT EXISTS evidence_tag TEXT;

--- a/scripts/e2e-dynamic-erc20.sh
+++ b/scripts/e2e-dynamic-erc20.sh
@@ -190,17 +190,20 @@ if [[ "$FAUCET_COUNT" -le "$FAUCETS_BEFORE" ]]; then
     fail "No new faucet was created! Expected faucet count > $FAUCETS_BEFORE"
 fi
 
-# Get the new faucet's ID (look for our token symbol "TT")
+# Symbols are not unique across deployments or cumulative E2E runs. Resolve the
+# faucet by the bridge route identity: (origin_network, origin_address).
 NEW_FAUCET_ID=$(echo "$FAUCETS_AFTER" | python3 -c "
 import json, sys
 r = json.load(sys.stdin)
-for f in r.get('result', []):
-    if f.get('symbol') == 'TT':
-        print(f['faucet_id'])
-        break
+token = \"$TOKEN_ADDR\".lower()
+matches = [f for f in r.get(\"result\", [])
+           if f.get(\"origin_network\") == 0
+           and f.get(\"origin_address\", \"\").lower() == token]
+if len(matches) == 1:
+    print(matches[0][\"faucet_id\"])
 ")
-[[ -z "$NEW_FAUCET_ID" ]] && fail "Could not find TT faucet in admin_listFaucets"
-pass "Faucet auto-created: $NEW_FAUCET_ID (symbol=TT)"
+[[ -z "$NEW_FAUCET_ID" ]] && fail "Could not resolve exactly one faucet for origin (network=0, address=$TOKEN_ADDR)"
+pass "Faucet auto-created: $NEW_FAUCET_ID (origin network=0 address=$TOKEN_ADDR)"
 
 # ── Step 5: Verify L2 wallet balance ──────────────────────────────────────────
 # Convert faucet_id hex to bech32 for bridge-out-tool (it expects bech32)

--- a/scripts/e2e-ger-l1-verification.sh
+++ b/scripts/e2e-ger-l1-verification.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+# Audit H6 — L1 GER corroboration E2E (PR #121).
+#
+# aggoracle-supplied GER bytes (insertGlobalExitRoot / updateExitRoot) were
+# trusted verbatim: a compromised signer could inject a FORGED GER (one whose
+# (mainnet, rollup) decomposition the L1 InfoTree indexer never observed on
+# L1) onto Miden — polluting on-chain state and burning operator gas.
+#
+# insert_ger (and, in writer mode, the request path before try_enqueue) now
+# cross-checks the injected GER against the indexer's observed set: BOTH
+# ger_entries roots must be resolved. Under --reject-unverified-ger-injection
+# (implied by --require-hardening), an unverified GER is refused BEFORE any
+# side effect: no accepted hash, no nonce, no tx row/receipt, no UpdateGerNote.
+#
+# Phases:
+#   A. POSITIVE — prove a FRESH L1-observed GER is accepted and injected by
+#      THIS submission (not a pre-injected one that dedup would wave through):
+#        1. STOP the aggoracle (aggkit container) so it can't win the race and
+#           inject the GER before/instead of us.
+#        2. MINT a new L1 GER: one L1 bridgeAsset(forceUpdateGlobalExitRoot=true)
+#           advances lastMainnetExitRoot → a brand-new (mainnet, rollup) pair.
+#        3. Wait until the proxy's indexer has OBSERVED it on L1
+#           (zkevm_getExitRootsByGER non-null) — the exact H6 evidence predicate.
+#        4. ASSERT the precondition: this GER is NOT yet injected
+#           (ger_entries.is_injected = false / no row, and no prior UpdateGerNote
+#           log for it). This assert FAILS if the GER were already injected — so
+#           the test cannot silently pass on a pre-injected GER via dedup.
+#        5. Submit updateExitRoot(R, M); capture OUR tx hash.
+#        6. Tie every success signal to THAT hash: receipt lands with
+#           status == 0x1, ger_entries.is_injected flips true (the projector
+#           sets it when the UpdateGerNote is CONSUMED), and a proxy log shows
+#           the UpdateGerNote for THIS GER (which did not exist before step 5).
+#   B. NEGATIVE — submit insertGlobalExitRoot with a FORGED 32-byte root that
+#      never appeared in an L1 UpdateL1InfoTree event. Assert the H6 refusal
+#      AND that the rejection is side-effect-free: no result hash, nonce NOT
+#      consumed, re-broadcast of the identical raw tx is refused again (not
+#      dedup-accepted as "known"), no ger_entries row, no UpdateGerNote
+#      created/submitted for the forged root (proxy store + ANSI-stripped
+#      logs), and ger_injection_unverified_total incremented.
+#
+# Requires the full E2E stack up (`make e2e-up`) with the service running
+# strict H6 (the compose default: REJECT_UNVERIFIED_GER_INJECTION=true). If
+# the container is lenient, the script SKIPs (exit 0) with a warning so suite
+# runs with an explicit lenient override don't false-fail.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# fixtures/.env is optional here (only used for defaults if present).
+[[ -f "$PROJECT_DIR/fixtures/.env" ]] && source "$PROJECT_DIR/fixtures/.env"
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[$(date +%H:%M:%S)]${NC} [e2e-ger-l1-verify] $*"; }
+warn() { echo -e "${YELLOW}[$(date +%H:%M:%S)] WARN:${NC} [e2e-ger-l1-verify] $*"; }
+fail() { echo -e "${RED}[$(date +%H:%M:%S)] FAIL:${NC} [e2e-ger-l1-verify] $*" >&2; exit 1; }
+pass() { echo -e "${GREEN}[$(date +%H:%M:%S)] PASS:${NC} [e2e-ger-l1-verify] $*"; }
+step() { echo -e "${CYAN}[$(date +%H:%M:%S)] STEP:${NC} [e2e-ger-l1-verify] $*"; }
+
+# JSON-RPC endpoint of the miden-agglayer proxy (where eth_sendRawTransaction
+# lands and the /metrics scrape lives) — the PROXY on :8546, NOT the
+# bridge-service REST on :18080. BRIDGE_SERVICE_URL kept as back-compat alias.
+L2_RPC_URL="${L2_RPC_URL:-${BRIDGE_SERVICE_URL:-http://localhost:8546}}"
+L1_RPC_URL="${L1_RPC:-${L1_RPC_URL:-http://localhost:8545}}"
+L1_GER_ADDRESS="${L1_GER_ADDRESS:-0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674}"
+L2_GER_ADDRESS="${L2_GER_ADDRESS:-0xa40D5f56745a118D0906a34E69aeC8C0Db1cB8fA}"
+GAS_PRICE_WEI="${GAS_PRICE_WEI:-1000000000}"
+GAS_LIMIT="${GAS_LIMIT:-200000}"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-miden-agglayer}"
+AGGLAYER_CONTAINER="${AGGLAYER_CONTAINER:-${COMPOSE_PROJECT_NAME}-miden-agglayer-1}"
+PG_HOST="${PG_HOST:-localhost}"; PG_PORT="${PG_PORT:-5434}"
+PG_USER="${PG_USER:-agglayer}"; PG_PASS="${PG_PASS:-agglayer}"; PG_DB="${PG_DB:-agglayer_store}"
+
+# Signer of the test txs. The e2e proxy runs --insecure-allow-any-signer, so
+# any key works and per-signer nonces keep it isolated; on an allow-listed
+# deployment set SIGNER_KEY to a permitted key (e.g. the aggoracle key).
+# Default: anvil dev key #9 (unused by the stack's own submitters). The same key
+# funds the L1 bridgeAsset deposit Phase A uses to MINT a fresh L1 GER (all anvil
+# dev keys are pre-funded on the L1 chain).
+SIGNER_KEY="${SIGNER_KEY:-0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6}"
+
+# L1 bridge — Phase A does one bridgeAsset(forceUpdateGlobalExitRoot=true) here
+# to advance lastMainnetExitRoot and thereby MINT a brand-new L1 GER that the
+# aggoracle has NOT yet injected (see Phase A header).
+L1_BRIDGE_ADDRESS="${L1_BRIDGE_ADDRESS:-0xC8cbEBf950B9Df44d987c8619f092beA980fF038}"
+DEPOSIT_WEI="${DEPOSIT_WEI:-10000000000000}"
+
+# The aggoracle lives in the aggkit container. Phase A STOPS it for the duration
+# of the positive test so the proxy's OWN updateExitRoot submission is the tx
+# under test — otherwise the aggoracle races us, injects the fresh GER first,
+# and Phase A would false-pass through RD-940 tx-hash dedup on a GER that was
+# actually injected by someone else. Restarted unconditionally on exit (trap).
+AGGKIT_CONTAINER="${AGGKIT_CONTAINER:-${COMPOSE_PROJECT_NAME}-aggkit-1}"
+AGGKIT_STOPPED=0
+cleanup() {
+    if [[ "$AGGKIT_STOPPED" == "1" ]]; then
+        step "cleanup — restarting aggoracle container $AGGKIT_CONTAINER"
+        docker start "$AGGKIT_CONTAINER" >/dev/null 2>&1 \
+            || warn "could not restart $AGGKIT_CONTAINER — restart it manually (docker start $AGGKIT_CONTAINER)"
+    fi
+}
+trap cleanup EXIT
+
+pgquery() {
+    PGPASSWORD="$PG_PASS" psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -t -A -c "$1" 2>/dev/null
+}
+
+rpc_call() {
+    local method="$1" params="$2"
+    curl -s "$L2_RPC_URL" -H 'Content-Type: application/json' \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$method\",\"params\":$params}"
+}
+
+# ANSI-stripped proxy logs, buffered (set -o pipefail + grep -q closes the
+# pipe → docker logs exits 141 — see e2e-rd940-async-submit.sh).
+proxy_logs() {
+    docker logs "$AGGLAYER_CONTAINER" 2>&1 | sed 's/\x1b\[[0-9;]*m//g'
+}
+
+# ── Pre-flight ───────────────────────────────────────────────────────────────
+command -v cast  >/dev/null || fail "cast (foundry) not found"
+command -v psql  >/dev/null || fail "psql not found"
+command -v python3 >/dev/null || fail "python3 not found"
+CHAIN_PROBE=$(rpc_call eth_chainId "[]")
+grep -q result <<<"$CHAIN_PROBE" || fail "proxy not reachable at $L2_RPC_URL"
+cast block-number --rpc-url "$L1_RPC_URL" >/dev/null 2>&1 || fail "L1 (anvil) not reachable at $L1_RPC_URL"
+pgquery "SELECT 1" >/dev/null || fail "PostgreSQL not reachable on $PG_HOST:$PG_PORT"
+docker inspect "$AGGLAYER_CONTAINER" >/dev/null 2>&1 || fail "container $AGGLAYER_CONTAINER not found (set AGGLAYER_CONTAINER)"
+
+# Strict-mode guard: Phase B only refuses when the container runs strict H6.
+# Detect via the container's args/env; SKIP (not fail) when lenient so a suite
+# run with an explicit REJECT_UNVERIFIED_GER_INJECTION=false override doesn't
+# false-fail.
+if ! docker inspect "$AGGLAYER_CONTAINER" \
+        --format '{{join .Args " "}} {{join .Config.Env " "}}' 2>/dev/null \
+        | grep -Eq -- '--reject-unverified-ger-injection|REJECT_UNVERIFIED_GER_INJECTION=true|REQUIRE_HARDENING=true'; then
+    warn "container $AGGLAYER_CONTAINER is not running strict H6"
+    warn "(set REJECT_UNVERIFIED_GER_INJECTION=true — the compose default — and restart)"
+    warn "SKIPPING e2e-ger-l1-verification"
+    exit 0
+fi
+log "strict H6 active in $AGGLAYER_CONTAINER"
+
+SIGNER=$(cast wallet address --private-key "$SIGNER_KEY")
+CHAIN_HEX=$(cast rpc eth_chainId --rpc-url "$L2_RPC_URL" | tr -d '"')
+CHAIN_DEC=$((CHAIN_HEX))
+
+signer_nonce() {
+    local n
+    n=$(cast rpc eth_getTransactionCount "$SIGNER" "latest" --rpc-url "$L2_RPC_URL" | tr -d '"')
+    echo $((n))
+}
+
+json_field() { # $1 = field (result|error), stdin = JSON body
+    python3 -c "import sys,json; r=json.load(sys.stdin).get('$1'); print('' if r is None else (r if isinstance(r,str) else json.dumps(r)))"
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Phase A — POSITIVE: an L1-observed GER is accepted; UpdateGerNote submitted
+#           and consumed.
+# ══════════════════════════════════════════════════════════════════════════════
+step "Phase A — a FRESH L1-observed GER must be accepted and injected by THIS tx"
+
+# ── A.1 Deconflict the aggoracle ───────────────────────────────────────────
+# Stop it BEFORE minting the GER so it can never observe+inject the new pair.
+step "A.1 stopping aggoracle container $AGGKIT_CONTAINER to deconflict the race"
+if docker inspect -f '{{.State.Running}}' "$AGGKIT_CONTAINER" 2>/dev/null | grep -q true; then
+    docker stop "$AGGKIT_CONTAINER" >/dev/null || fail "could not stop $AGGKIT_CONTAINER"
+    AGGKIT_STOPPED=1
+    pass "aggoracle stopped (will be restarted on exit)"
+else
+    warn "aggoracle container $AGGKIT_CONTAINER not running — proceeding (no race to deconflict)"
+fi
+
+# ── A.2 Mint a brand-new L1 GER ────────────────────────────────────────────
+# One L1 bridgeAsset with forceUpdateGlobalExitRoot=true advances
+# lastMainnetExitRoot, minting a (mainnet, rollup) pair no one has injected yet.
+MAIN_BEFORE=$(cast call "$L1_GER_ADDRESS" "lastMainnetExitRoot()(bytes32)" --rpc-url "$L1_RPC_URL")
+step "A.2 minting a fresh L1 GER via bridgeAsset (forceUpdateGlobalExitRoot=true)"
+cast send --rpc-url "$L1_RPC_URL" --private-key "$SIGNER_KEY" \
+    "$L1_BRIDGE_ADDRESS" \
+    'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+    1 "0x000000000000000000000000000000000000dEaD" "$DEPOSIT_WEI" \
+    0x0000000000000000000000000000000000000000 true 0x \
+    --value "$DEPOSIT_WEI" >/dev/null \
+    || fail "L1 bridgeAsset failed — cannot mint a fresh GER (is $L1_BRIDGE_ADDRESS the L1 bridge?)"
+
+MAIN=$(cast call "$L1_GER_ADDRESS" "lastMainnetExitRoot()(bytes32)" --rpc-url "$L1_RPC_URL")
+ROLL=$(cast call "$L1_GER_ADDRESS" "lastRollupExitRoot()(bytes32)"  --rpc-url "$L1_RPC_URL")
+[[ "$MAIN" != "$MAIN_BEFORE" ]] \
+    || fail "lastMainnetExitRoot did not change after bridgeAsset ($MAIN) — no fresh GER was minted (L1 not auto-mining? wrong bridge addr?)"
+COMB=$(cast keccak "$(cast concat-hex "$MAIN" "$ROLL")")
+COMB_HEX="${COMB#0x}"
+pass "fresh L1 GER minted: mainnet=$MAIN rollup=$ROLL combined=$COMB"
+
+# ── A.3 Wait for the proxy's indexer to OBSERVE it ─────────────────────────
+# Same evidence predicate the H6 gate uses (both ger_entries roots resolved).
+log "waiting for the L1 InfoTree indexer to corroborate $COMB..."
+ELAPSED=0; TIMEOUT=120
+while true; do
+    OBSERVED=$(rpc_call zkevm_getExitRootsByGER "[\"$COMB\"]" | json_field result || true)
+    [[ -n "$OBSERVED" ]] && break
+    ELAPSED=$((ELAPSED + 3))
+    [[ $ELAPSED -ge $TIMEOUT ]] && fail "indexer did not corroborate the fresh L1 GER after ${TIMEOUT}s — is the L1InfoTreeIndexer running?"
+    sleep 3
+done
+pass "indexer corroborated the fresh L1 GER (zkevm_getExitRootsByGER non-null)"
+
+# ── A.3b Wait for the fresh GER to satisfy the strict finality setting ──────
+# The SINGLE evidence-finality setting (`--l1-evidence-tag` / L1_EVIDENCE_TAG)
+# is enforced AT THE GATE; ordinary decomposition (asserted above) is NOT
+# delayed. `confirmations:<N>` authorizes once the indexer cursor is N blocks
+# past the evidence block; `finalized`/`safe` authorize once the finalized-pinned
+# scan has set `ger_entries.finalized_verified` (the finalized-chain tie). Nudge
+# anvil forward so the indexer advances (single-node anvil has instant finality;
+# empty blocks are harmless).
+EVIDENCE_TAG="${L1_EVIDENCE_TAG:-confirmations:1}"
+GER_BLOCK=$(pgquery "SELECT block_number FROM ger_entries WHERE ger_hash = decode('${COMB_HEX}', 'hex')")
+step "A.3b waiting for GER $COMB to satisfy the strict finality setting '$EVIDENCE_TAG' (evidence block ${GER_BLOCK:-?})"
+ELAPSED=0; TIMEOUT=120
+while true; do
+    case "$EVIDENCE_TAG" in
+        finalized|safe)
+            FV=$(pgquery "SELECT finalized_verified FROM ger_entries WHERE ger_hash = decode('${COMB_HEX}', 'hex')" || echo "")
+            [[ "$FV" == "t" ]] && break
+            ;;
+        *)
+            # confirmations:<N> (or bare 'confirmations' → depth 1)
+            DEPTH="${EVIDENCE_TAG#confirmations:}"
+            [[ "$DEPTH" == "$EVIDENCE_TAG" || -z "$DEPTH" ]] && DEPTH=1
+            CURSOR=$(pgquery "SELECT last_processed FROM l1_indexer_state WHERE id = 1" || echo "")
+            [[ -n "$GER_BLOCK" && -n "$CURSOR" && $((CURSOR - GER_BLOCK)) -ge $DEPTH ]] && break
+            ;;
+    esac
+    # Advance L1 so the indexer's next poll moves its cursor / finalized scan.
+    cast rpc anvil_mine 1 --rpc-url "$L1_RPC_URL" >/dev/null 2>&1 \
+        || cast rpc evm_mine --rpc-url "$L1_RPC_URL" >/dev/null 2>&1 || true
+    ELAPSED=$((ELAPSED + 2))
+    [[ $ELAPSED -ge $TIMEOUT ]] \
+        && fail "GER $COMB did not satisfy '$EVIDENCE_TAG' after ${TIMEOUT}s (evidence block '${GER_BLOCK}')"
+    sleep 2
+done
+pass "GER satisfies the strict finality setting ($EVIDENCE_TAG)"
+
+# ── A.4 ASSERT the not-yet-injected precondition ───────────────────────────
+# THE adversarial guard: if this GER were already injected, the whole positive
+# test would be meaningless (dedup would wave a foreign injection through). So
+# refuse to continue unless it is provably fresh. This assert MUST fail on a
+# pre-injected GER.
+INJECTED_BEFORE=$(pgquery "SELECT COUNT(*) FROM ger_entries WHERE ger_hash = decode('${COMB_HEX}', 'hex') AND is_injected")
+[[ "$INJECTED_BEFORE" == "0" ]] \
+    || fail "precondition violated: GER $COMB is ALREADY injected before our submission (is_injected rows=$INJECTED_BEFORE) — the aggoracle race was not deconflicted, so a pass here would be a dedup false-pass. Aborting."
+if grep "UpdateGerNote" <<<"$(proxy_logs)" | grep -qi "$COMB_HEX"; then
+    fail "precondition violated: an UpdateGerNote for $COMB already exists in the logs before our submission — cannot attribute the injection to THIS tx"
+fi
+pass "precondition holds: GER $COMB is L1-observed but NOT yet injected"
+
+# ── A.5 Submit — OUR updateExitRoot is the tx under test ───────────────────
+# updateExitRoot ships BOTH roots in calldata (rollup FIRST — see
+# one-shot-ger-inject.sh for why insertGlobalExitRoot would race L1 here).
+NONCE_A=$(signer_nonce)
+RAW_A=$(cast mktx "$L2_GER_ADDRESS" "updateExitRoot(bytes32,bytes32)" "$ROLL" "$MAIN" \
+    --private-key "$SIGNER_KEY" --chain "$CHAIN_DEC" --nonce "$NONCE_A" \
+    --legacy --gas-price "$GAS_PRICE_WEI" --gas-limit "$GAS_LIMIT")
+OUT_A=$(rpc_call eth_sendRawTransaction "[\"$RAW_A\"]")
+TX_A=$(echo "$OUT_A" | json_field result)
+ERR_A=$(echo "$OUT_A" | json_field error)
+[[ -n "$ERR_A" ]] && fail "fresh L1-observed GER was refused under strict H6 (false negative!): $ERR_A"
+[[ -n "$TX_A" ]] || fail "no tx hash returned for the fresh L1-observed GER: $OUT_A"
+pass "fresh L1-observed GER accepted: $TX_A"
+
+# ── A.6 Tie every success signal to THIS tx hash ───────────────────────────
+# Receipt must land AND carry status == 0x1 (a reverted/status-0 receipt is a
+# failure the old check would have accepted as "non-null").
+log "waiting for the receipt of $TX_A..."
+ELAPSED=0; TIMEOUT=120
+while true; do
+    RCPT=$(rpc_call eth_getTransactionReceipt "[\"$TX_A\"]" | json_field result || true)
+    [[ -n "$RCPT" ]] && break
+    ELAPSED=$((ELAPSED + 3))
+    [[ $ELAPSED -ge $TIMEOUT ]] && fail "receipt for the accepted GER tx $TX_A never landed after ${TIMEOUT}s"
+    sleep 3
+done
+RCPT_STATUS=$(echo "$RCPT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))")
+[[ "$RCPT_STATUS" == "0x1" ]] \
+    || fail "receipt for $TX_A has status=$RCPT_STATUS (expected 0x1) — the accepted GER tx did not succeed"
+pass "receipt landed for $TX_A with status 0x1"
+
+# The UpdateGerNote must have reached Miden and been CONSUMED — the projector
+# flips is_injected only when it observes the consumption. Because we asserted
+# is_injected=false in A.4 and the aggoracle is stopped, this flip is
+# attributable to OUR tx.
+ELAPSED=0; TIMEOUT=120
+while true; do
+    INJECTED=$(pgquery "SELECT COUNT(*) FROM ger_entries WHERE ger_hash = decode('${COMB_HEX}', 'hex') AND is_injected" || true)
+    [[ "$INJECTED" == "1" ]] && break
+    ELAPSED=$((ELAPSED + 3))
+    [[ $ELAPSED -ge $TIMEOUT ]] && fail "ger_entries.is_injected never flipped for the accepted GER $COMB — UpdateGerNote not consumed?"
+    sleep 3
+done
+pass "UpdateGerNote consumed (ger_entries.is_injected = true) — attributable to $TX_A"
+
+# And the proxy must have logged the UpdateGerNote for THIS ger — which did not
+# exist in the logs before A.5 (asserted in A.4), so it is our submission's.
+LOGS=$(proxy_logs)
+grep -q "UpdateGerNote created" <<<"$LOGS" || fail "no 'UpdateGerNote created' log line at all"
+grep "UpdateGerNote" <<<"$LOGS" | grep -qi "$COMB_HEX" \
+    || fail "no UpdateGerNote log line references the accepted GER $COMB"
+pass "Phase A complete — FRESH L1-observed GER accepted and injected by $TX_A"
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Phase B — NEGATIVE: a forged GER is refused with NO side effects.
+# ══════════════════════════════════════════════════════════════════════════════
+step "Phase B — forged GER must be refused, side-effect-free"
+
+# A 32-byte root with no L1 observation: deliberately not a real L1 exit root,
+# so the L1 InfoTree indexer never wrote its (mainnet, rollup) decomposition.
+FORGED=0x$(printf 'cd%.0s' {1..32})
+FORGED_HEX="${FORGED#0x}"
+
+NONCE_B=$(signer_nonce)
+log "signer=$SIGNER nonce=$NONCE_B chainId=$CHAIN_DEC forged=$FORGED"
+
+# Build + sign a REAL insertGlobalExitRoot(bytes32) tx so eth_sendRawTransaction
+# actually reaches the H6 gate (a placeholder string would only ever produce a
+# DECODE error, never the "not observed on L1" refusal → a false-pass). cast
+# mktx signs OFFLINE and does NOT broadcast.
+RAW_B=$(cast mktx "$L2_GER_ADDRESS" "insertGlobalExitRoot(bytes32)" "$FORGED" \
+    --private-key "$SIGNER_KEY" --chain "$CHAIN_DEC" --nonce "$NONCE_B" \
+    --legacy --gas-price "$GAS_PRICE_WEI" --gas-limit "$GAS_LIMIT")
+
+# -s (not -f): the H6 refusal comes back as a JSON-RPC error body over HTTP
+# 200, which -f would swallow.
+OUT_B=$(rpc_call eth_sendRawTransaction "[\"$RAW_B\"]")
+RES_B=$(echo "$OUT_B" | json_field result)
+ERR_B=$(echo "$OUT_B" | json_field error)
+
+grep -q "not observed on L1" <<<"$OUT_B" \
+    || fail "forged GER was not refused (audit H6 regression); response: $OUT_B"
+[[ -z "$RES_B" ]] || fail "refusal must NOT return an accepted tx hash (got $RES_B) — the aggoracle would poll a receipt that can never exist"
+pass "forged GER refused with the H6 error and no accepted hash"
+
+# No nonce burn: the rejection must be invisible to the signer's sequence, so
+# the identical signed tx (same nonce) stays broadcastable.
+NONCE_B_AFTER=$(signer_nonce)
+[[ "$NONCE_B_AFTER" == "$NONCE_B" ]] \
+    || fail "rejection consumed the signer nonce ($NONCE_B → $NONCE_B_AFTER) — ethtxmanager wedge (PR #121 main blocker)"
+pass "signer nonce not consumed ($NONCE_B)"
+
+# Re-broadcast of the IDENTICAL raw tx must be refused again with the same H6
+# error — NOT dedup-accepted as a "known" hash (pre-fix writer mode admitted
+# the hash into the inflight cache before the gate, so the re-broadcast
+# short-circuited to Ok and the caller polled a receipt forever).
+OUT_B2=$(rpc_call eth_sendRawTransaction "[\"$RAW_B\"]")
+grep -q "not observed on L1" <<<"$OUT_B2" \
+    || fail "re-broadcast of the rejected tx was not refused again (dedup admitted a rejected hash?): $OUT_B2"
+pass "identical re-broadcast refused again (no phantom dedup admission)"
+
+# Exact no-submission proof, store side: the forged GER must not exist in
+# ger_entries at all (the indexer never observed it; injection never ran).
+FORGED_ROWS=$(pgquery "SELECT COUNT(*) FROM ger_entries WHERE ger_hash = decode('${FORGED_HEX}', 'hex')")
+[[ "$FORGED_ROWS" == "0" ]] \
+    || fail "forged GER present in ger_entries ($FORGED_ROWS row(s)) — something submitted it"
+
+# Exact no-submission proof, Miden side: no UpdateGerNote was ever created /
+# submitted for the forged root (ANSI-stripped logs; the note-creation log
+# carries the ger hex).
+LOGS=$(proxy_logs)
+if grep -Ei "UpdateGerNote|GER injection: submitting" <<<"$LOGS" | grep -qi "$FORGED_HEX"; then
+    fail "proxy logs show an UpdateGerNote / submission for the FORGED root — the gate did not stop the Miden submission"
+fi
+pass "no UpdateGerNote created or submitted for the forged GER (store + logs)"
+
+# The unverified-GER metric must have incremented (>= 1: prior forged attempts
+# in the same service lifetime, or indexer lag on legitimate GERs, may already
+# have bumped it — an equality check would flake).
+METRICS=$(curl -sf "$L2_RPC_URL/metrics")
+echo "$METRICS" | awk '/^ger_injection_unverified_total /{ if ($2 + 0 >= 1) ok = 1 } END { exit(ok ? 0 : 1) }' \
+    || fail "ger_injection_unverified_total did not increment (>= 1 expected)"
+pass "ger_injection_unverified_total >= 1"
+
+echo ""
+log "======================================================================"
+log "  H6 GER L1-VERIFICATION E2E COMPLETE"
+log "  Phase A: FRESH L1-observed GER accepted+injected by our tx (status 0x1) ✓"
+log "  Phase B: forged GER refused; no hash/nonce/row/note side effects    ✓"
+log "======================================================================"

--- a/scripts/e2e-ger-l1-verification.sh
+++ b/scripts/e2e-ger-l1-verification.sh
@@ -290,7 +290,7 @@ log "signer=$SIGNER nonce=$NONCE_B chainId=$CHAIN_DEC forged=$FORGED"
 
 # Build + sign a REAL insertGlobalExitRoot(bytes32) tx so eth_sendRawTransaction
 # actually reaches the H6 gate (a placeholder string would only ever produce a
-# DECODE error, never the "not observed on L1" refusal → a false-pass). cast
+# DECODE error, never the configured-L1 refusal → a false-pass). cast
 # mktx signs OFFLINE and does NOT broadcast.
 RAW_B=$(cast mktx "$L2_GER_ADDRESS" "insertGlobalExitRoot(bytes32)" "$FORGED" \
     --private-key "$SIGNER_KEY" --chain "$CHAIN_DEC" --nonce "$NONCE_B" \
@@ -302,7 +302,7 @@ OUT_B=$(rpc_call eth_sendRawTransaction "[\"$RAW_B\"]")
 RES_B=$(echo "$OUT_B" | json_field result)
 ERR_B=$(echo "$OUT_B" | json_field error)
 
-grep -q "not observed on L1" <<<"$OUT_B" \
+grep -q "not observed by the configured L1" <<<"$OUT_B" \
     || fail "forged GER was not refused (audit H6 regression); response: $OUT_B"
 [[ -z "$RES_B" ]] || fail "refusal must NOT return an accepted tx hash (got $RES_B) — the aggoracle would poll a receipt that can never exist"
 pass "forged GER refused with the H6 error and no accepted hash"
@@ -319,7 +319,7 @@ pass "signer nonce not consumed ($NONCE_B)"
 # the hash into the inflight cache before the gate, so the re-broadcast
 # short-circuited to Ok and the caller polled a receipt forever).
 OUT_B2=$(rpc_call eth_sendRawTransaction "[\"$RAW_B\"]")
-grep -q "not observed on L1" <<<"$OUT_B2" \
+grep -q "not observed by the configured L1" <<<"$OUT_B2" \
     || fail "re-broadcast of the rejected tx was not refused again (dedup admitted a rejected hash?): $OUT_B2"
 pass "identical re-broadcast refused again (no phantom dedup admission)"
 

--- a/scripts/e2e-ger-l1-verification.sh
+++ b/scripts/e2e-ger-l1-verification.sh
@@ -193,9 +193,11 @@ COMB=$(cast keccak "$(cast concat-hex "$MAIN" "$ROLL")")
 COMB_HEX="${COMB#0x}"
 pass "fresh L1 GER minted: mainnet=$MAIN rollup=$ROLL combined=$COMB"
 
-# ── A.3 Wait for the proxy's indexer to OBSERVE it ─────────────────────────
-# Same evidence predicate the H6 gate uses (both ger_entries roots resolved).
-log "waiting for the L1 InfoTree indexer to corroborate $COMB..."
+# ── A.3 Wait for the selected evidence scan to OBSERVE it ──────────────────
+# The indexer scans exactly one configured frontier, so a resolved row already
+# satisfies the same evidence predicate used by the strict H6 gate.
+EVIDENCE_TAG="${L1_EVIDENCE_TAG:-latest}"
+log "waiting for the L1 InfoTree indexer's '$EVIDENCE_TAG' scan to corroborate $COMB..."
 ELAPSED=0; TIMEOUT=120
 while true; do
     OBSERVED=$(rpc_call zkevm_getExitRootsByGER "[\"$COMB\"]" | json_field result || true)
@@ -204,43 +206,7 @@ while true; do
     [[ $ELAPSED -ge $TIMEOUT ]] && fail "indexer did not corroborate the fresh L1 GER after ${TIMEOUT}s — is the L1InfoTreeIndexer running?"
     sleep 3
 done
-pass "indexer corroborated the fresh L1 GER (zkevm_getExitRootsByGER non-null)"
-
-# ── A.3b Wait for the fresh GER to satisfy the strict finality setting ──────
-# The SINGLE evidence-finality setting (`--l1-evidence-tag` / L1_EVIDENCE_TAG)
-# is enforced AT THE GATE; ordinary decomposition (asserted above) is NOT
-# delayed. `confirmations:<N>` authorizes once the indexer cursor is N blocks
-# past the evidence block; `finalized`/`safe` authorize once the finalized-pinned
-# scan has set `ger_entries.finalized_verified` (the finalized-chain tie). Nudge
-# anvil forward so the indexer advances (single-node anvil has instant finality;
-# empty blocks are harmless).
-EVIDENCE_TAG="${L1_EVIDENCE_TAG:-confirmations:1}"
-GER_BLOCK=$(pgquery "SELECT block_number FROM ger_entries WHERE ger_hash = decode('${COMB_HEX}', 'hex')")
-step "A.3b waiting for GER $COMB to satisfy the strict finality setting '$EVIDENCE_TAG' (evidence block ${GER_BLOCK:-?})"
-ELAPSED=0; TIMEOUT=120
-while true; do
-    case "$EVIDENCE_TAG" in
-        finalized|safe)
-            FV=$(pgquery "SELECT finalized_verified FROM ger_entries WHERE ger_hash = decode('${COMB_HEX}', 'hex')" || echo "")
-            [[ "$FV" == "t" ]] && break
-            ;;
-        *)
-            # confirmations:<N> (or bare 'confirmations' → depth 1)
-            DEPTH="${EVIDENCE_TAG#confirmations:}"
-            [[ "$DEPTH" == "$EVIDENCE_TAG" || -z "$DEPTH" ]] && DEPTH=1
-            CURSOR=$(pgquery "SELECT last_processed FROM l1_indexer_state WHERE id = 1" || echo "")
-            [[ -n "$GER_BLOCK" && -n "$CURSOR" && $((CURSOR - GER_BLOCK)) -ge $DEPTH ]] && break
-            ;;
-    esac
-    # Advance L1 so the indexer's next poll moves its cursor / finalized scan.
-    cast rpc anvil_mine 1 --rpc-url "$L1_RPC_URL" >/dev/null 2>&1 \
-        || cast rpc evm_mine --rpc-url "$L1_RPC_URL" >/dev/null 2>&1 || true
-    ELAPSED=$((ELAPSED + 2))
-    [[ $ELAPSED -ge $TIMEOUT ]] \
-        && fail "GER $COMB did not satisfy '$EVIDENCE_TAG' after ${TIMEOUT}s (evidence block '${GER_BLOCK}')"
-    sleep 2
-done
-pass "GER satisfies the strict finality setting ($EVIDENCE_TAG)"
+pass "the '$EVIDENCE_TAG' scan corroborated the fresh L1 GER (zkevm_getExitRootsByGER non-null)"
 
 # ── A.4 ASSERT the not-yet-injected precondition ───────────────────────────
 # THE adversarial guard: if this GER were already injected, the whole positive

--- a/scripts/e2e-l2l2-clash.sh
+++ b/scripts/e2e-l2l2-clash.sh
@@ -123,8 +123,10 @@ log "  COL bridged from BOTH origins (net 0: $COL_L1_WEI wei, net 2: $COL_L2B_WE
 # exactly like the forward leg — we client-submit a proof-backed claimAsset (proof
 # fetched from the L2B service) to the Miden proxy. nudge_until drives L2B cert cycles
 # so Miden sees the covering GER (proxy C6 has_seen_ger gate).
-wait_for "COL net-2 deposit ready_for_claim" 600 5 \
-    _pred_deposit_ready "$DEST_ADDR" "$L2B_NETWORK_ID" "$COL_LOWER" "" "$L2B_BRIDGE_SERVICE_URL"
+# Source indexing is sufficient to identify the exact deposit. nudge_until below
+# owns the bounded recovery if ready_for_claim missed an L2-before-L1 GER race.
+wait_for "COL net-2 deposit indexed" 120 5 \
+    _pred_deposit_indexed "$DEST_ADDR" "$L2B_NETWORK_ID" "$COL_LOWER" "$L2B_BRIDGE_SERVICE_URL"
 COL_DEP_NET2_SUBMIT=$(find_deposit "$DEST_ADDR" "$L2B_NETWORK_ID" "$COL_LOWER" "$L2B_BRIDGE_SERVICE_URL")
 [[ -n "$COL_DEP_NET2_SUBMIT" ]] || fail "COL net-2 deposit not found in L2B service for claim submission"
 CN2_CNT=$(dep_field "$COL_DEP_NET2_SUBMIT" deposit_cnt)

--- a/scripts/e2e-l2l2-forward.sh
+++ b/scripts/e2e-l2l2-forward.sh
@@ -136,8 +136,10 @@ evidence_settlement "leg2" forward "${COMPOSE_PROJECT_NAME}-aggkit-l2b-1" "$TEST
 # proof-backed claimAsset to the Miden proxy, which accepts it
 # (worker_handle_claim_asset) and auto-creates the foreign faucet + mints.
 step "Leg 2b: submit proof-backed claimAsset to Miden proxy + (OPT0, net $L2B_NETWORK_ID) faucet asserts"
-wait_for "L2B->Miden deposit ready_for_claim in bridge-service" 600 5 \
-    _pred_deposit_ready "$DEST_ADDR" "$L2B_NETWORK_ID" "$OPT0_LOWER" "$MIDEN_NETWORK_ID" "$L2B_BRIDGE_SERVICE_URL"
+# Do not passively wait for ready_for_claim: nudge_until below is the bounded
+# recovery when bridge-service indexes the L2 GER just before the matching L1 GER.
+wait_for "L2B->Miden deposit indexed in bridge-service" 120 5 \
+    _pred_deposit_indexed "$DEST_ADDR" "$L2B_NETWORK_ID" "$OPT0_LOWER" "$L2B_BRIDGE_SERVICE_URL"
 FWD_DEPOSIT=$(find_deposit "$DEST_ADDR" $L2B_NETWORK_ID "$OPT0_LOWER" "$L2B_BRIDGE_SERVICE_URL")
 [[ -n "$FWD_DEPOSIT" ]] || fail "forward deposit vanished from bridge-service"
 FWD_GI=$(dep_field "$FWD_DEPOSIT" global_index)

--- a/scripts/e2e-loadtest-mixed.sh
+++ b/scripts/e2e-loadtest-mixed.sh
@@ -153,10 +153,12 @@ forward_bridge() {
 }
 forward_bridge "$FWD_SEED_WEI" || fail "seed forward bridge failed"
 
-# Client-submit the seed claim on Miden (nudge_until drives L2B cert cycles so the
-# covering GER reaches Miden; the predicate submits claimAsset + checks ClaimEvent).
-wait_for "seed L2B->Miden deposit ready_for_claim" 600 5 \
-    _pred_deposit_ready "$DEST_ADDR" "$L2B_NETWORK_ID" "$MOP_LOWER" "$MIDEN_NETWORK_ID" "$L2B_BRIDGE_SERVICE_URL"
+# Wait only for source-chain indexing. The bounded nudge_until below deliberately
+# drives ready_for_claim too: bridge-service can observe an L2 GER just before its
+# matching L1 GER and needs the next cert cycle to repair that external ordering
+# race. Waiting passively here would deadlock before the recovery loop can start.
+wait_for "seed L2B->Miden deposit indexed" 120 5 \
+    _pred_deposit_indexed "$DEST_ADDR" "$L2B_NETWORK_ID" "$MOP_LOWER" "$L2B_BRIDGE_SERVICE_URL"
 SEED_DEP=$(find_deposit "$DEST_ADDR" "$L2B_NETWORK_ID" "$MOP_LOWER" "$L2B_BRIDGE_SERVICE_URL")
 [[ -n "$SEED_DEP" ]] || fail "seed deposit not indexed on the L2B service"
 SEED_CNT=$(dep_field "$SEED_DEP" deposit_cnt); SEED_GI=$(dep_field "$SEED_DEP" global_index)

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -32,6 +32,11 @@ case "$test_filter" in
         echo ""
         "$SCRIPT_DIR/e2e-ger-decomposition.sh"
         echo ""
+        # Audit H6 — L1 GER corroboration (positive + negative phases). Needs
+        # the compose default REJECT_UNVERIFIED_GER_INJECTION=true; SKIPs
+        # itself (with a warning) when the container runs lenient.
+        "$SCRIPT_DIR/e2e-ger-l1-verification.sh"
+        echo ""
         "$SCRIPT_DIR/e2e-security.sh"
         echo ""
         "$SCRIPT_DIR/e2e-cantina12-getlogs-returns-all.sh"
@@ -124,6 +129,9 @@ case "$test_filter" in
     ger-decomposition)
         "$SCRIPT_DIR/e2e-ger-decomposition.sh"
         ;;
+    ger-l1-verification)
+        "$SCRIPT_DIR/e2e-ger-l1-verification.sh"
+        ;;
     security)
         "$SCRIPT_DIR/e2e-security.sh"
         ;;
@@ -187,7 +195,7 @@ case "$test_filter" in
         ;;
     *)
         echo -e "${RED}Unknown test: $test_filter${NC}" >&2
-        echo "Usage: $0 [all|tip-consistency|l1-to-l2|l2-to-l1|dynamic-erc20|cantina13|cantina10|ger-decomposition|security|cantina12-getlogs-returns-all|cantina6-faucet-identity-restore|fuzz|reconciler-private-note|reconciler-cursor|ger-atomic|claim-provenance|l2l2|l2l2-forward|l2l2-clash|l2l2-back]" >&2
+        echo "Usage: $0 [all|tip-consistency|l1-to-l2|l2-to-l1|dynamic-erc20|cantina13|cantina10|ger-decomposition|ger-l1-verification|security|cantina12-getlogs-returns-all|cantina6-faucet-identity-restore|fuzz|reconciler-private-note|reconciler-cursor|ger-atomic|claim-provenance|l2l2|l2l2-forward|l2l2-clash|l2l2-back]" >&2
         echo "       (l2l2 is optional and not part of 'all' — it needs the docker-compose.l2l2.yml overlay)" >&2
         exit 1
         ;;

--- a/scripts/lib-l2l2.sh
+++ b/scripts/lib-l2l2.sh
@@ -101,6 +101,10 @@ want = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] != '' else None
 sys.exit(0 if bool(d.get('ready_for_claim')) and (want is None or str(d.get('dest_net')) == want) else 1)
 " "${4:-}"
 }
+_pred_deposit_indexed() {                                                        # <dest> <netid> <orig> [service-url]
+    local dep; dep=$(find_deposit "$1" "$2" "$3" "${4:-$BRIDGE_SERVICE_URL}")
+    [[ -n "$dep" ]]
+}
 
 # wait_for <desc> <timeout> <interval> <predicate-fn> [args...]
 # Polls the NAMED predicate function until it succeeds or <timeout>s elapse.

--- a/scripts/verify-event-completeness.sh
+++ b/scripts/verify-event-completeness.sh
@@ -29,6 +29,8 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 L2_RPC="${L2_RPC:-http://localhost:8546}"
 NODE_CONTAINER="${NODE_CONTAINER:-miden-agglayer-miden-node-1}"
 AGGLAYER_CONTAINER="${AGGLAYER_CONTAINER:-miden-agglayer-miden-agglayer-1}"
+PG_HOST="${PG_HOST:-localhost}"; PG_PORT="${PG_PORT:-5434}"
+PG_USER="${PG_USER:-agglayer}"; PG_PASS="${PG_PASS:-agglayer}"; PG_DB="${PG_DB:-agglayer_store}"
 ALLOW_LATE="${ALLOW_LATE:-0}"
 TOOL_BIN="${TOOL_BIN:-$PROJECT_DIR/target/debug/bridge-out-tool}"
 
@@ -80,6 +82,19 @@ docker exec "$NODE_CONTAINER" cat /data/node/miden-store.sqlite3 > "$TMP/node.sq
 docker exec "$NODE_CONTAINER" cat /data/node/miden-store.sqlite3-wal > "$TMP/node.sqlite3-wal" 2>/dev/null \
     || rm -f "$TMP/node.sqlite3-wal"
 
+# An unresolvable destination is intentionally terminal without a Miden CLAIM
+# note: the proxy records the exception durably and emits one ClaimEvent so
+# AggKit stops retrying funds that require operator rescue. Keep these events
+# strict too: match the durable record to the exact receipt block, globalIndex,
+# and transaction hash instead of weakening the generic extra-log check.
+PGPASSWORD="$PG_PASS" psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" \
+    -t -A -F '|' -c \
+    "SELECT u.global_index, COALESCE(t.block_number::text, ''), u.eth_tx_hash
+       FROM unclaimable_claims u
+       LEFT JOIN transactions t ON lower(t.tx_hash) = lower(u.eth_tx_hash)
+      ORDER BY u.global_index" > "$TMP/unclaimable-claims" \
+    || { echo "FAIL: cannot read durable unclaimable-claim records"; exit 1; }
+
 # 3b. Deliberately-DEFERRED bridge-outs are NOT missing. The proxy refuses to emit a
 #     BridgeEvent for a poisoned/unrecoverable faucet-registry row (MA#18; cantina13's
 #     unrecoverable-row scenario) — recovery is via --restore, so the note stays
@@ -122,7 +137,7 @@ done
 sleep "${SETTLE_MARGIN_SECS:-20}"
 
 # 4. Cross-check.
-python3 - "$TMP/node.sqlite3" "$L2_RPC" "$BRIDGE_ID" "$B2AGG_ROOT" "$CLAIM_ROOT" "$GER_ROOT" "$ALLOW_LATE" "$DEFERRED_FAUCETS" <<'PY'
+python3 - "$TMP/node.sqlite3" "$L2_RPC" "$BRIDGE_ID" "$B2AGG_ROOT" "$CLAIM_ROOT" "$GER_ROOT" "$ALLOW_LATE" "$DEFERRED_FAUCETS" "$TMP/unclaimable-claims" <<'PY'
 import json, sqlite3, sys, urllib.request
 from collections import Counter
 
@@ -130,6 +145,7 @@ db, rpc, bridge_id, b2agg_root, claim_root, ger_root, allow_late = sys.argv[1:8]
 # Faucets whose bridge-outs the proxy DELIBERATELY refused to emit (poisoned/
 # unrecoverable registry rows — see step 3b in the shell). Lower-case hex, no 0x.
 deferred_faucets = set((sys.argv[8] if len(sys.argv) > 8 else "").lower().split())
+unclaimable_file = sys.argv[9]
 bridge_hex = bridge_id[2:].upper()
 
 TOPICS = {
@@ -168,6 +184,14 @@ def get_logs(topic0):
         return logs
 
 n = sqlite3.connect(db); n.row_factory = sqlite3.Row
+unclaimable = []
+with open(unclaimable_file, encoding="utf-8") as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        gi, block, tx_hash = line.split("|", 2)
+        unclaimable.append((int(gi, 0), int(block) if block else None, tx_hash.lower()))
 # Consistency cut: the node snapshot's own chain tip. Only notes consumed at or
 # before the cut are expected; only logs at or before the cut can be "extra"
 # (later logs may belong to consumptions that happened after the snapshot).
@@ -176,8 +200,8 @@ overall_fail = False
 total_notes = 0
 total_logs = 0
 print(f"consistency cut: node snapshot tip = block {cut}")
-print(f"{'TYPE':<22} {'notes':>6} {'logs':>6} {'exact':>6} {'late':>5} {'missing':>8} {'defer':>6} {'extra':>6}  verdict")
-print("-" * 85)
+print(f"{'TYPE':<22} {'notes':>6} {'logs':>6} {'exact':>6} {'late':>5} {'missing':>8} {'defer':>6} {'unclaim':>8} {'extra':>6}  verdict")
+print("-" * 96)
 for name, (topic, root) in TOPICS.items():
     rows = list(n.execute(
         "SELECT consumed_at FROM notes WHERE script_root=? AND consumed_at IS NOT NULL "
@@ -185,6 +209,33 @@ for name, (topic, root) in TOPICS.items():
         (bytes.fromhex(root[2:]), cut, bridge_hex)))
     note_blocks = Counter(r["consumed_at"] for r in rows)
     logs = get_logs(topic)
+    all_logs_count = sum(1 for l in logs if int(l["blockNumber"], 16) <= cut)
+
+    # ClaimEvents for durable unclaimable records have no corresponding Miden
+    # CLAIM note. Match and remove only their exact (block, GI, tx-hash) logs;
+    # every other surplus ClaimEvent remains an error.
+    unclaim_exact = 0
+    unclaim_missing = 0
+    if name == "CLAIM->ClaimEvent":
+        expected = Counter(
+            (block, gi, tx_hash)
+            for gi, block, tx_hash in unclaimable
+            if block is not None and block <= cut
+        )
+        unclaim_missing += sum(1 for _, block, _ in unclaimable if block is None)
+        kept = []
+        for log in logs:
+            block = int(log["blockNumber"], 16)
+            data = log.get("data", "")
+            gi = int((data[2:66] or "0"), 16)
+            key = (block, gi, log["transactionHash"].lower())
+            if expected[key] > 0:
+                expected[key] -= 1
+                unclaim_exact += 1
+            else:
+                kept.append(log)
+        unclaim_missing += sum(expected.values())
+        logs = kept
     all_log_blocks = [int(l["blockNumber"], 16) for l in logs]
     log_blocks = Counter(all_log_blocks)            # all logs (for exact/late matching)
     cut_log_blocks = Counter(b for b in all_log_blocks if b <= cut)  # extra-detection
@@ -223,12 +274,14 @@ for name, (topic, root) in TOPICS.items():
                     print(f"    MISSING candidate: note 0x{r['i'].lower()} consumed_at={r['b']}")
         missing -= deferred
     total_notes += n_notes
-    total_logs += n_logs_cut
-    ok = missing == 0 and extra == 0 and (late == 0 or allow_late == "1")
+    total_logs += all_logs_count
+    ok = (missing == 0 and extra == 0 and unclaim_missing == 0
+          and (late == 0 or allow_late == "1"))
     overall_fail |= not ok
-    print(f"{name:<22} {n_notes:>6} {n_logs_cut:>6} {exact:>6} {late:>5} {missing:>8} {deferred:>6} {extra:>6}  {'PASS' if ok else 'FAIL'}")
+    unclaim_col = f"{unclaim_exact}/{unclaim_exact + unclaim_missing}" if name == "CLAIM->ClaimEvent" else "-"
+    print(f"{name:<22} {n_notes:>6} {all_logs_count:>6} {exact:>6} {late:>5} {missing:>8} {deferred:>6} {unclaim_col:>8} {extra:>6}  {'PASS' if ok else 'FAIL'}")
 
-print("-" * 85)
+print("-" * 96)
 if total_notes == 0 and total_logs > 0:
     print("SANITY FAIL: node query matched ZERO consumed notes while logs exist —")
     print(f"almost certainly a wrong/bech32 BRIDGE_ID ({bridge_id}); pass the HEX id.")

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -4,7 +4,30 @@ use alloy::primitives::{Address, TxHash};
 use miden_base_agglayer::{ExitRoot, UpdateGerNote};
 use miden_client::transaction::TransactionRequestBuilder;
 use sha3::{Digest, Keccak256};
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+/// Polling policy for the narrow strict-H6 state where a GER is already
+/// corroborated by the L1 indexer but has not reached the configured finality
+/// yet. Keeping the request pending is side-effect-free (no nonce, tx row, or
+/// Miden submission exists yet) and prevents a one-shot aggoracle broadcast
+/// from being lost in the observation-to-finality race.
+const GER_FINALITY_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const GER_FINALITY_WAIT_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+
+#[derive(Debug, thiserror::Error)]
+enum GerL1GateError {
+    #[error(
+        "GER {ger} was observed on L1 but is not yet final per the `{evidence_tag}` evidence setting (finality guard, audit H6); refusing injection under --reject-unverified-ger-injection. Transient — retry once the L1 observation finalizes."
+    )]
+    NotFinal { ger: String, evidence_tag: String },
+    #[error(
+        "GER {ger} was not observed on L1 by the indexer (exit-root decomposition unresolved); refusing injection under --reject-unverified-ger-injection (audit H6). Retry after the L1 InfoTree indexer catches up."
+    )]
+    NotObserved { ger: String },
+}
 
 alloy_core::sol! {
     // https://github.com/agglayer/agglayer-contracts/blob/main/contracts/v2/sovereignChains/GlobalExitRootManagerL2SovereignChain.sol#L166
@@ -17,6 +40,95 @@ alloy_core::sol! {
     #[derive(Debug)]
     function updateExitRoot(bytes32 newRollupExitRoot, bytes32 newMainnetExitRoot);
 }
+
+/// Default L1 confirmation depth for STRICT H6 GER authorization (audit H6).
+///
+/// A Miden GER injection is IRREVERSIBLE and the evidence store has no
+/// revoke/rollback, so under strict `--reject-unverified-ger-injection` an
+/// observation must be at least this many L1 blocks deep before it authorizes an
+/// injection — a short-lived reorg then cannot leave a stale "observed" row that
+/// permanently authorizes a GER that never truly landed on canonical L1.
+///
+/// This depth is enforced at admission (`wait_for_ger_l1_observed`), NOT at the
+/// indexer cursor: the indexer records the `(mainnet, rollup)` decomposition up
+/// to LATEST so ordinary decomposition / bridge readiness
+/// (`zkevm_getExitRootsByGER`) is never delayed. Only strict authorization waits
+/// for finality. 64 ≈ Sepolia finality (justification ~1 epoch, finality ~2
+/// epochs / 64 slots).
+pub const DEFAULT_CONFIRMATIONS: u64 = 64;
+
+/// The SINGLE strict-H6 evidence-finality setting (audit H6). One value fully
+/// specifies how the gate qualifies an L1 observation as final enough to
+/// authorize an irreversible GER injection — there is no second finality knob.
+/// Parsed from `--l1-evidence-tag` / `L1_EVIDENCE_TAG`:
+///   - `confirmations:<N>` — depth-below-head: the observation must be `N` blocks
+///     below the indexer's head cursor (strict-non-hardened only).
+///   - `finalized`         — the observation's `(mainnet, rollup)` must be on the
+///     L1 FINALIZED canonical chain (BLOCKER 1 finalized-chain tie). MANDATORY
+///     under `--require-hardening`.
+///   - `safe`              — same, against the L1 `safe` block (weaker; not
+///     sufficient for hardened).
+///
+/// Normal (lenient) decomposition (`zkevm_getExitRootsByGER`) never consults
+/// this — it reads the evidence row directly, so bridge readiness is unaffected.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EvidenceTag {
+    /// Depth `N` below the indexer head cursor.
+    Confirmations(u64),
+    /// On the L1 finalized canonical chain.
+    Finalized,
+    /// On the L1 safe canonical chain.
+    Safe,
+}
+
+impl Default for EvidenceTag {
+    fn default() -> Self {
+        Self::Confirmations(DEFAULT_CONFIRMATIONS)
+    }
+}
+
+impl EvidenceTag {
+    /// True for the L1 finality-tag modes (`finalized` / `safe`), which qualify
+    /// evidence against the finalized/safe canonical chain rather than a
+    /// confirmation depth below head.
+    pub fn is_finality_tag(self) -> bool {
+        matches!(self, Self::Finalized | Self::Safe)
+    }
+
+    /// Human/log form, round-trippable through `parse`.
+    pub fn describe(self) -> String {
+        match self {
+            Self::Confirmations(n) => format!("confirmations:{n}"),
+            Self::Finalized => "finalized".to_string(),
+            Self::Safe => "safe".to_string(),
+        }
+    }
+
+    /// Parse the single CLI/env value. Accepts `finalized`, `safe`,
+    /// `confirmations:<N>`, and bare `confirmations` (→ `DEFAULT_CONFIRMATIONS`).
+    /// `None` on an unrecognised token or a malformed depth.
+    pub fn parse(s: &str) -> Option<Self> {
+        let s = s.trim().to_ascii_lowercase();
+        match s.as_str() {
+            "finalized" => return Some(Self::Finalized),
+            "safe" => return Some(Self::Safe),
+            "confirmations" => {
+                return Some(Self::Confirmations(DEFAULT_CONFIRMATIONS));
+            }
+            _ => {}
+        }
+        let rest = s.strip_prefix("confirmations:")?;
+        rest.trim().parse::<u64>().ok().map(Self::Confirmations)
+    }
+}
+
+/// Minimum confirmation depth strict H6 will boot with. Zero would authorize an
+/// irreversible injection from a 0-confirmation (freely reorg-able) observation,
+/// defeating the finality guarantee — so strict mode refuses to start with
+/// `confirmations:<N>` where `N < MIN_STRICT_CONFIRMATIONS` (see
+/// `check_h6_evidence_source`). Production should use `DEFAULT_CONFIRMATIONS` or
+/// higher, or `finalized`; the floor merely forbids the outright-unsafe zero.
+pub const MIN_STRICT_CONFIRMATIONS: u64 = 1;
 
 /// Compute the combined GER from mainnet and rollup exit roots.
 pub fn combined_ger(mainnet: &[u8; 32], rollup: &[u8; 32]) -> [u8; 32] {
@@ -209,16 +321,54 @@ pub(crate) async fn record_ger_submission_handoff(
 /// projector finalises the receipt + emits the GER log on consumption), `false`
 /// if the GER was already injected (a duplicate — the caller completes its
 /// receipt immediately).
+///
+/// Audit H6 — `require_l1_observed` cross-checks the injected GER against the
+/// L1 InfoTree the indexer independently observed. The aggoracle-supplied GER
+/// bytes are otherwise trusted verbatim: a compromised signer could inject a
+/// FORGED GER (one whose `(mainnet, rollup)` decomposition the indexer never saw
+/// on L1) onto Miden. The indexer writes the authoritative decomposition via
+/// `set_ger_exit_roots`; a GER is "resolved" only when BOTH roots are recorded —
+/// the same predicate `zkevm_getExitRootsByGER` answers with (anything less
+/// returns null there so bridge-service retries). When `require_l1_observed` is
+/// set, an unresolved GER is refused before it reaches Miden; otherwise it is
+/// allowed through (to tolerate indexer lag) but flagged via the
+/// `ger_injection_unverified_total` metric + warn.
+///
+/// The duplicate check runs BEFORE the H6 gate: an already-injected GER is a
+/// no-op (`false`) regardless of verification state. The gate exists to stop
+/// NEW submissions to Miden — a duplicate never reaches Miden, and refusing it
+/// would break idempotency: the aggoracle re-submits GERs it cannot confirm
+/// (restart with a stale view, restore replay), and an error here would put it
+/// in a permanent retry loop over an injection that already happened.
+// Two review threads (H6 `require_l1_observed` from #121, envelope+signer handoff
+// from #127) each added a parameter to this already-wide submission entry point.
+#[allow(clippy::too_many_arguments)]
 pub async fn insert_ger(
     ger_bytes: [u8; 32],
     miden_client: &MidenClient,
     accounts: crate::AccountsConfig,
     store: &Arc<dyn crate::store::Store>,
     txn_hash: TxHash,
+    require_l1_observed: bool,
+    evidence_tag: EvidenceTag,
     txn_envelope: TxEnvelope,
     signer: Address,
 ) -> anyhow::Result<bool> {
-    // Check dedup before doing any work.
+    // Audit H6 gate (dedup-first — see `wait_for_ger_l1_observed`). In writer
+    // mode the SAME gate already ran on the request path before
+    // `try_enqueue`/`nonce_increment` (PR #121 review); this run is the sync
+    // path's primary admission decision and the writer path's
+    // defense-in-depth.
+    wait_for_ger_l1_observed(
+        store,
+        &ger_bytes,
+        require_l1_observed,
+        evidence_tag,
+        txn_hash,
+    )
+    .await?;
+
+    // Dedup: decide whether this is a NEW injection.
     //
     // Use `is_ger_injected` (not `has_seen_ger`) because the L1InfoTreeIndexer
     // pre-creates ger_entries rows for every L1 InfoTree pair as it observes
@@ -227,7 +377,10 @@ pub async fn insert_ger(
     // and the synthetic L2 event would never be emitted, leaving deposits
     // stuck `ready_for_claim=false`. Gating on `is_injected = TRUE` correctly
     // reflects "have we already submitted the Miden tx and committed the
-    // synthetic event for this GER?".
+    // synthetic event for this GER?". (`wait_for_ger_l1_observed` above already
+    // short-circuits on the same `is_ger_injected` check, so an already-injected
+    // GER never reaches the gate's finality logic — this read then just decides
+    // the duplicate no-op return value.)
     let is_new = !store.is_ger_injected(&ger_bytes).await?;
 
     if is_new {
@@ -315,9 +468,259 @@ pub async fn insert_ger(
     Ok(is_new)
 }
 
+/// Audit H6 — the pre-admission L1-corroboration gate for GER injections
+/// (PR #121 review: the gate MUST run before every enqueue path, nonce
+/// increment, txn_begin, or receipt creation).
+///
+/// Verifies the GER was observed on L1 by the independent L1InfoTreeIndexer
+/// (it writes the `(mainnet, rollup)` decomposition via `set_ger_exit_roots`).
+/// "Observed" means BOTH roots resolved — the same predicate
+/// `zkevm_getExitRootsByGER` uses (ger_entries rows exist in partial states:
+/// the indexer pre-creates them with roots to be filled in later). A GER with
+/// no resolved decomposition was supplied only by the aggoracle and never
+/// corroborated by an L1 observation — a forged-GER injection signal.
+///
+/// The duplicate check runs FIRST: an already-injected GER never reaches
+/// Miden, so the gate has nothing to stop — and refusing it would break
+/// idempotency (the aggoracle re-submits GERs it cannot confirm after a
+/// restart or restore replay, and an error here would wedge it in a permanent
+/// retry loop over an injection that already happened).
+///
+/// The mandatory-writer path checks twice:
+///   - `service_send_raw_txn` calls it on the request thread
+///     before `try_enqueue` (which would otherwise consume the nonce, admit
+///     the hash into the inflight dedup cache, and return a hash whose
+///     receipt could never be written — the aggoracle/ethtxmanager wedge).
+///   - `insert_ger` repeats it inside the worker immediately before Miden
+///     submission as a defense-in-depth state check.
+///
+/// An unobserved strict-mode refusal stays transient and side-effect-free: no nonce
+/// is consumed, no tx row/receipt is created, and no job is queued. An already
+/// observed but shallow GER instead waits here, also before any side effect,
+/// until the configured evidence finality is reached.
+///
+/// Metric discipline: `ger_injection_unverified_total` increments on every
+/// unverified sighting this function makes. The request path invokes it under
+/// strict mode; a failed admission never reaches the worker, so one rejected
+/// submission is not double-counted.
+pub async fn ensure_ger_l1_observed(
+    store: &Arc<dyn crate::store::Store>,
+    ger_bytes: &[u8; 32],
+    require_l1_observed: bool,
+    evidence_tag: EvidenceTag,
+    txn_hash: TxHash,
+) -> anyhow::Result<()> {
+    // Dedup precedence — duplicates never reach Miden; see doc above.
+    if store.is_ger_injected(ger_bytes).await? {
+        return Ok(());
+    }
+    let entry = store.get_ger_entry(ger_bytes).await?;
+    let roots_observed = entry
+        .as_ref()
+        .is_some_and(|e| e.mainnet_exit_root.is_some() && e.rollup_exit_root.is_some());
+
+    // Finality is checked HERE (at the strict gate), NOT at the indexer cursor.
+    // The indexer records the `(mainnet, rollup)` decomposition up to LATEST, so
+    // ordinary decomposition / bridge readiness (`zkevm_getExitRootsByGER`, which
+    // reads `get_ger_entry` directly and does NOT call this gate) is never
+    // delayed. Only strict authorization of an IRREVERSIBLE injection
+    // additionally requires the observation to be final per the SINGLE
+    // `evidence_tag` setting:
+    //   - Confirmations(N): `l1_head - evidence_block >= N`, using the indexer's
+    //     persisted head cursor (strict-non-hardened only). An evidence row with
+    //     NO recorded L1 block (`block_number == 0`: a legacy/pre-guard row, or
+    //     one seeded by a non-indexer write path) is NOT final — fail-closed —
+    //     which closes the upgrade-state gap.
+    //   - Finalized / Safe (BLOCKER 1 finalized-chain tie): the row must be
+    //     `finalized_verified` — a flag the indexer sets ONLY from a scan pinned
+    //     to the L1 finalized/safe canonical chain. A `latest`-observed row from
+    //     a fork that was later reorged away is never `finalized_verified`, so a
+    //     block-height coincidence (`block <= finalized`) can no longer
+    //     authorize it. MANDATORY under `--require-hardening`.
+    // Lenient mode never gates on finality.
+    let final_enough = if require_l1_observed {
+        match entry.as_ref() {
+            Some(e) => match evidence_tag {
+                EvidenceTag::Confirmations(depth) => {
+                    let l1_head = store.get_l1_indexer_cursor().await?;
+                    e.block_number > 0 && l1_head.saturating_sub(e.block_number) >= depth
+                }
+                EvidenceTag::Finalized | EvidenceTag::Safe => e.finalized_verified,
+            },
+            None => false,
+        }
+    } else {
+        true
+    };
+
+    let l1_verified = roots_observed && final_enough;
+    if !l1_verified {
+        ::metrics::counter!("ger_injection_unverified_total").increment(1);
+        if require_l1_observed {
+            // A resolved-but-not-yet-final observation is a DISTINCT transient
+            // state from an unresolved one; surface it plainly. ("not observed
+            // on L1" stays the stable substring for the unresolved case that the
+            // e2e / callers match; "not yet" for the not-final case.)
+            if roots_observed {
+                return Err(GerL1GateError::NotFinal {
+                    ger: hex::encode(ger_bytes),
+                    evidence_tag: evidence_tag.describe(),
+                }
+                .into());
+            }
+            return Err(GerL1GateError::NotObserved {
+                ger: hex::encode(ger_bytes),
+            }
+            .into());
+        }
+        tracing::warn!(
+            ger = %hex::encode(ger_bytes),
+            tx = %txn_hash,
+            roots_observed,
+            evidence_tag = %evidence_tag.describe(),
+            "GER injection not yet corroborated/finalized by the L1 InfoTree indexer; \
+             allowing through but unverified (lenient mode)"
+        );
+    }
+    Ok(())
+}
+
+/// Wait for an already-observed GER to reach the configured strict-H6 finality.
+///
+/// An unobserved GER is still refused immediately: it may be forged, and the
+/// indexer has supplied no evidence that waiting is justified. Once both roots
+/// are observed, however, finality is only a time-dependent gate. Keeping this
+/// request pending is side-effect-free and closes the race where aggoracle sent
+/// once between observation and the next indexer cursor advance, received a
+/// transient refusal, and never produced another usable submission.
+pub async fn wait_for_ger_l1_observed(
+    store: &Arc<dyn crate::store::Store>,
+    ger_bytes: &[u8; 32],
+    require_l1_observed: bool,
+    evidence_tag: EvidenceTag,
+    txn_hash: TxHash,
+) -> anyhow::Result<()> {
+    wait_for_ger_l1_observed_with_timing(
+        store,
+        ger_bytes,
+        require_l1_observed,
+        evidence_tag,
+        txn_hash,
+        GER_FINALITY_WAIT_TIMEOUT,
+        GER_FINALITY_POLL_INTERVAL,
+    )
+    .await
+}
+
+async fn wait_for_ger_l1_observed_with_timing(
+    store: &Arc<dyn crate::store::Store>,
+    ger_bytes: &[u8; 32],
+    require_l1_observed: bool,
+    evidence_tag: EvidenceTag,
+    txn_hash: TxHash,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> anyhow::Result<()> {
+    let pending_error = match ensure_ger_l1_observed(
+        store,
+        ger_bytes,
+        require_l1_observed,
+        evidence_tag,
+        txn_hash,
+    )
+    .await
+    {
+        Ok(()) => return Ok(()),
+        Err(err)
+            if require_l1_observed
+                && matches!(
+                    err.downcast_ref::<GerL1GateError>(),
+                    Some(GerL1GateError::NotFinal { .. })
+                ) =>
+        {
+            err
+        }
+        Err(err) => return Err(err),
+    };
+
+    tracing::info!(
+        ger = %hex::encode(ger_bytes),
+        tx = %txn_hash,
+        evidence_tag = %evidence_tag.describe(),
+        timeout_secs = timeout.as_secs(),
+        "GER is L1-observed but not final yet; waiting side-effect-free before admission"
+    );
+
+    let started = Instant::now();
+    loop {
+        if ger_l1_finality_reached(store, ger_bytes, evidence_tag).await? {
+            tracing::info!(
+                ger = %hex::encode(ger_bytes),
+                waited_ms = started.elapsed().as_millis() as u64,
+                "GER L1 evidence reached finality; continuing admission"
+            );
+            return Ok(());
+        }
+        if started.elapsed() >= timeout {
+            tracing::warn!(
+                ger = %hex::encode(ger_bytes),
+                waited_secs = started.elapsed().as_secs(),
+                "timed out waiting for GER L1 evidence finality"
+            );
+            return Err(pending_error);
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+async fn ger_l1_finality_reached(
+    store: &Arc<dyn crate::store::Store>,
+    ger_bytes: &[u8; 32],
+    evidence_tag: EvidenceTag,
+) -> anyhow::Result<bool> {
+    if store.is_ger_injected(ger_bytes).await? {
+        return Ok(true);
+    }
+    let Some(entry) = store.get_ger_entry(ger_bytes).await? else {
+        return Ok(false);
+    };
+    if entry.mainnet_exit_root.is_none() || entry.rollup_exit_root.is_none() {
+        return Ok(false);
+    }
+    match evidence_tag {
+        EvidenceTag::Confirmations(depth) => {
+            let l1_head = store.get_l1_indexer_cursor().await?;
+            Ok(entry.block_number > 0 && l1_head.saturating_sub(entry.block_number) >= depth)
+        }
+        EvidenceTag::Finalized | EvidenceTag::Safe => Ok(entry.finalized_verified),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::store::memory::InMemoryStore;
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    /// Minimal signed legacy envelope + signer for `insert_ger` calls (the H6
+    /// gate runs before Miden submission, so the stub client never executes the
+    /// envelope — only its shape/signer matter). Keyed to `tx_hash` so the
+    /// handoff records the real linked hash. Mirrors `restore::test_ger_envelope`.
+    fn h6_test_envelope(tx_hash: TxHash) -> (TxEnvelope, Address) {
+        use alloy::consensus::{Signed, TxLegacy};
+        use alloy::primitives::Signature;
+        let env = TxEnvelope::Legacy(Signed::new_unchecked(
+            TxLegacy {
+                chain_id: Some(1),
+                ..Default::default()
+            },
+            Signature::test_signature(),
+            tx_hash,
+        ));
+        (env, Address::ZERO)
+    }
+
     #[test]
     fn test_combined_ger_keccak256() {
         let mainnet = [0x01u8; 32];
@@ -347,5 +750,397 @@ mod tests {
         let a = [0x01u8; 32];
         let b = [0x02u8; 32];
         assert_ne!(combined_ger(&a, &b), combined_ger(&b, &a));
+    }
+
+    /// Audit H6 — a GER whose `(mainnet, rollup)` decomposition was NOT
+    /// corroborated by the L1 InfoTree indexer MUST be refused when
+    /// `require_l1_observed` is set, BEFORE any Miden submission is attempted.
+    /// Pre-fix, aggoracle-supplied GER bytes were trusted verbatim — a
+    /// compromised signer could inject a forged GER onto Miden (state pollution,
+    /// gas burn, and — with a colluding claim — a mint against an L1 deposit
+    /// that never happened).
+    ///
+    /// The check fires at the top of `insert_ger`, so the MidenClient is never
+    /// reached; a stub client is sufficient.
+    #[tokio::test]
+    async fn h6_unverified_ger_refused_when_strict() {
+        let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
+        let miden_client = crate::test_helpers::create_test_service().miden_client;
+        let accounts = crate::test_helpers::test_accounts_config();
+        let tx_hash = alloy::primitives::TxHash::from_str(
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
+        )
+        .unwrap();
+        let forged_ger = [0xCDu8; 32]; // no ger_entries row → mainnet_exit_root unset
+
+        // Strict mode: the unverified GER must be refused before Miden submission.
+        let (env, signer) = h6_test_envelope(tx_hash);
+        let err = insert_ger(
+            forged_ger,
+            &miden_client,
+            accounts.clone(),
+            &store,
+            tx_hash,
+            true, // require_l1_observed
+            EvidenceTag::Confirmations(0),
+            env.clone(),
+            signer,
+        )
+        .await
+        .expect_err("unverified GER must be refused under require_l1_observed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not observed on L1"),
+            "must cite L1 non-observation: {msg}"
+        );
+
+        // Lenient mode (default): the same GER is allowed through (it may still
+        // Err downstream because the MidenClient stub can't really submit, but
+        // it must NOT bail at the H6 gate). Assert the result is NOT the H6
+        // "not observed on L1" refusal — a bare `let _ =` would pass even if
+        // lenient mode wrongly refused, defeating the point of this test.
+        let lenient = insert_ger(
+            forged_ger,
+            &miden_client,
+            accounts,
+            &store,
+            tx_hash,
+            false, // lenient
+            EvidenceTag::Confirmations(0),
+            env,
+            signer,
+        )
+        .await;
+        if let Err(err) = lenient {
+            assert!(
+                !err.to_string().contains("not observed on L1"),
+                "lenient mode must NOT refuse an unverified GER at the H6 gate: {err}"
+            );
+        }
+    }
+
+    /// Audit H6 (review follow-up) — the duplicate check runs BEFORE the strict
+    /// gate. A GER that is already injected must be a no-op (`Ok(false)`) even
+    /// when its exit-root decomposition never resolved: refusing it would break
+    /// idempotency, and the aggoracle — which re-submits GERs it cannot confirm
+    /// after a restart or restore replay — would loop forever retrying an
+    /// injection that already happened (the gate outcome can never change if
+    /// the roots never resolve).
+    #[tokio::test]
+    async fn h6_already_injected_ger_is_duplicate_not_refused_under_strict() {
+        let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
+        let miden_client = crate::test_helpers::create_test_service().miden_client;
+        let accounts = crate::test_helpers::test_accounts_config();
+        let tx_hash = alloy::primitives::TxHash::from_str(
+            "0x2222222222222222222222222222222222222222222222222222222222222222",
+        )
+        .unwrap();
+        let ger = [0xABu8; 32];
+
+        // Injected on a previous run, decomposition never resolved (None, None)
+        // — the exact state that pre-fix wedged aggoracle in a retry loop.
+        store
+            .commit_ger_event_atomic(1, [0u8; 32], "0xTxDup", &ger, None, None, 0)
+            .await
+            .unwrap();
+
+        let (env, signer) = h6_test_envelope(tx_hash);
+        let result = insert_ger(
+            ger,
+            &miden_client,
+            accounts,
+            &store,
+            tx_hash,
+            true,
+            EvidenceTag::Confirmations(0),
+            env,
+            signer,
+        )
+        .await
+        .expect("already-injected GER must be a duplicate no-op, not an H6 refusal");
+        assert!(
+            !result,
+            "duplicate injection must return false (no new note)"
+        );
+    }
+
+    /// Audit H6 (review follow-up) — the gate uses the SAME resolved predicate
+    /// as `zkevm_getExitRootsByGER`: BOTH roots recorded. An entry the indexer
+    /// fully resolved must pass the strict gate (any downstream error from the
+    /// stub MidenClient must not be the H6 refusal).
+    #[tokio::test]
+    async fn h6_resolved_ger_passes_strict_gate() {
+        let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
+        let miden_client = crate::test_helpers::create_test_service().miden_client;
+        let accounts = crate::test_helpers::test_accounts_config();
+        let tx_hash = alloy::primitives::TxHash::from_str(
+            "0x3333333333333333333333333333333333333333333333333333333333333333",
+        )
+        .unwrap();
+        let mainnet = [0x0Au8; 32];
+        let rollup = [0x0Bu8; 32];
+        let ger = combined_ger(&mainnet, &rollup);
+
+        // The indexer observed the pair on L1 and recorded the decomposition.
+        store
+            .set_ger_exit_roots(&ger, mainnet, rollup, 100, 1_700_000_000)
+            .await
+            .unwrap();
+
+        let (env, signer) = h6_test_envelope(tx_hash);
+        let result = insert_ger(
+            ger,
+            &miden_client,
+            accounts,
+            &store,
+            tx_hash,
+            true,
+            EvidenceTag::Confirmations(0),
+            env,
+            signer,
+        )
+        .await;
+        if let Err(err) = result {
+            assert!(
+                !err.to_string().contains("not observed on L1"),
+                "a fully-resolved GER must pass the strict H6 gate: {err}"
+            );
+        }
+    }
+
+    /// Audit H6 (BLOCKER 1) — finality is enforced AT THE GATE. A resolved
+    /// observation must be at least `confirmations` L1 blocks deep (indexer
+    /// cursor as head) before strict mode authorizes the irreversible injection.
+    /// A not-yet-deep observation is refused (transient), and once the cursor
+    /// advances past the confirmation depth it passes. Ordinary decomposition
+    /// (`get_ger_entry`, unchanged) sees the row regardless — this delay applies
+    /// ONLY to strict authorization.
+    ///
+    /// Mutation check: dropping the `l1_head - block >= confirmations` clause
+    /// (always `final_enough = true`) makes the not-yet-deep case wrongly pass.
+    #[tokio::test]
+    async fn h6_strict_gate_requires_confirmation_depth() {
+        let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
+        let ger = combined_ger(&[0x0Au8; 32], &[0x0Bu8; 32]);
+        let tx_hash = TxHash::from([0x44u8; 32]);
+        // Indexer recorded the pair at L1 block 100 (roots resolved immediately).
+        store
+            .set_ger_exit_roots(&ger, [0x0Au8; 32], [0x0Bu8; 32], 100, 1_700_000_000)
+            .await
+            .unwrap();
+
+        // Cursor at 140 → only 40 deep, < 64 confirmations → refused (transient).
+        store.set_l1_indexer_cursor(140).await.unwrap();
+        let err = ensure_ger_l1_observed(
+            &store,
+            &ger,
+            true,
+            EvidenceTag::Confirmations(DEFAULT_CONFIRMATIONS),
+            tx_hash,
+        )
+        .await
+        .expect_err("a not-yet-confirmation-deep observation must be refused under strict");
+        assert!(
+            err.to_string().contains("not yet"),
+            "must cite the finality guard, not unresolved roots: {err}"
+        );
+        // Normal decomposition is unaffected: the row is present immediately.
+        assert!(store.get_ger_entry(&ger).await.unwrap().is_some());
+
+        // Cursor advances to 170 → 70 deep, >= 64 → authorized.
+        store.set_l1_indexer_cursor(170).await.unwrap();
+        ensure_ger_l1_observed(
+            &store,
+            &ger,
+            true,
+            EvidenceTag::Confirmations(DEFAULT_CONFIRMATIONS),
+            tx_hash,
+        )
+        .await
+        .expect("a confirmation-deep observation must pass the strict gate");
+    }
+
+    /// Audit H6 (BLOCKER 1) — a legacy / pre-guard evidence row that carries NO
+    /// recorded L1 block (`block_number == 0`) but somehow has both roots must be
+    /// treated as unverified under strict (fail-closed), closing the
+    /// upgrade-state gap. Lenient mode still lets it through.
+    ///
+    /// Mutation check: treating a block-less row as final (removing the
+    /// `block_number > 0` guard) makes the strict case wrongly pass.
+    #[tokio::test]
+    async fn h6_strict_gate_refuses_blockless_legacy_row() {
+        let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
+        let ger = [0x77u8; 32];
+        // A row with both roots but block_number 0 (e.g. seeded by a non-indexer
+        // path before this guard existed). commit_ger_event_atomic sets roots +
+        // block 0 here and does NOT set is_injected... so use mark_ger_seen shape.
+        store
+            .mark_ger_seen(
+                &ger,
+                crate::log_synthesis::GerEntry {
+                    mainnet_exit_root: Some([0x01u8; 32]),
+                    rollup_exit_root: Some([0x02u8; 32]),
+                    block_number: 0,
+                    timestamp: 0,
+                    finalized_verified: false,
+                },
+            )
+            .await
+            .unwrap();
+        // Even with a huge cursor, block 0 means "no recorded L1 block" → refused.
+        store.set_l1_indexer_cursor(10_000_000).await.unwrap();
+        let tx_hash = TxHash::from([0x45u8; 32]);
+        let err = ensure_ger_l1_observed(
+            &store,
+            &ger,
+            true,
+            EvidenceTag::Confirmations(DEFAULT_CONFIRMATIONS),
+            tx_hash,
+        )
+        .await
+        .expect_err("a block-less legacy row must be refused under strict");
+        assert!(
+            err.to_string().contains("not yet"),
+            "finality-guard refusal: {err}"
+        );
+        // Lenient mode lets it through (no bail).
+        ensure_ger_l1_observed(
+            &store,
+            &ger,
+            false,
+            EvidenceTag::Confirmations(DEFAULT_CONFIRMATIONS),
+            tx_hash,
+        )
+        .await
+        .expect("lenient mode must not refuse a block-less row");
+    }
+
+    /// Audit H6 BLOCKER 1 (re-review) — the `finalized` evidence tag qualifies an
+    /// observation by the FINALIZED-CHAIN TIE (`finalized_verified`), NOT by a
+    /// block-height coincidence. A `latest`-observed row (roots present, block
+    /// recorded) that the finalized-pinned scan never confirmed — e.g. a row from
+    /// a fork later reorged away — must NOT authorize even with a huge head
+    /// cursor / finalized block. Only after `mark_ger_finalized` (which the
+    /// indexer runs solely from the finalized canonical chain) does it authorize.
+    ///
+    /// Mutation check: making the gate authorize on block-height instead of
+    /// `finalized_verified` (drop the flag requirement) makes the reorged-fork
+    /// row wrongly authorize.
+    #[tokio::test]
+    async fn h6_finalized_tag_gate_requires_finalized_chain_tie() {
+        let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
+        let ger = combined_ger(&[0x1Au8; 32], &[0x1Bu8; 32]);
+        let tx_hash = TxHash::from([0x46u8; 32]);
+        // A `latest`-observed row: roots present, block 100. Set the head cursor
+        // AND finalized block far above it, so a height-only check would pass.
+        store
+            .set_ger_exit_roots(&ger, [0x1Au8; 32], [0x1Bu8; 32], 100, 1_700_000_000)
+            .await
+            .unwrap();
+        store.set_l1_indexer_cursor(10_000).await.unwrap();
+        store.set_l1_finalized_block(10_000).await.unwrap();
+
+        // NOT finalized-verified (the finalized scan never covered it, e.g. a
+        // reorged fork) → refused despite the height coincidence.
+        let err = ensure_ger_l1_observed(&store, &ger, true, EvidenceTag::Finalized, tx_hash)
+            .await
+            .expect_err("a non-finalized-verified row must be refused in finalized mode");
+        assert!(
+            err.to_string().contains("not yet"),
+            "finality-guard refusal: {err}"
+        );
+
+        // The finalized-pinned scan confirms it on the canonical chain.
+        store.mark_ger_finalized(&ger).await.unwrap();
+        ensure_ger_l1_observed(&store, &ger, true, EvidenceTag::Finalized, tx_hash)
+            .await
+            .expect("a finalized-chain-verified observation must pass the strict gate");
+    }
+
+    /// Audit H6 — confirmation-depth mode still works under the SINGLE setting:
+    /// `Confirmations(N)` authorizes iff `head_cursor - block >= N`, and the
+    /// `finalized_verified` flag is irrelevant in this mode.
+    #[tokio::test]
+    async fn h6_confirmations_mode_under_single_setting() {
+        let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
+        let ger = combined_ger(&[0x2Au8; 32], &[0x2Bu8; 32]);
+        let tx_hash = TxHash::from([0x47u8; 32]);
+        store
+            .set_ger_exit_roots(&ger, [0x2Au8; 32], [0x2Bu8; 32], 100, 1_700_000_000)
+            .await
+            .unwrap();
+
+        // 40 deep < 64 → refused.
+        store.set_l1_indexer_cursor(140).await.unwrap();
+        ensure_ger_l1_observed(&store, &ger, true, EvidenceTag::Confirmations(64), tx_hash)
+            .await
+            .expect_err("shallow observation must be refused in confirmations mode");
+        // 70 deep >= 64 → authorized (no finalized_verified needed).
+        store.set_l1_indexer_cursor(170).await.unwrap();
+        ensure_ger_l1_observed(&store, &ger, true, EvidenceTag::Confirmations(64), tx_hash)
+            .await
+            .expect("confirmation-deep observation must pass");
+    }
+
+    /// Regression for task #59: once the indexer has resolved both roots, a
+    /// one-block finality race is held side-effect-free until the cursor advances.
+    /// Before this wait, a one-shot aggoracle submission could be refused in this
+    /// window and the deposit would remain stalled indefinitely.
+    #[tokio::test]
+    async fn h6_observed_ger_waits_for_confirmation_cursor() {
+        let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
+        let ger = combined_ger(&[0x3Au8; 32], &[0x3Bu8; 32]);
+        let tx_hash = TxHash::from([0x48u8; 32]);
+        store
+            .set_ger_exit_roots(&ger, [0x3Au8; 32], [0x3Bu8; 32], 100, 1_700_000_000)
+            .await
+            .unwrap();
+        store.set_l1_indexer_cursor(100).await.unwrap();
+
+        let advancing_store = store.clone();
+        let advance = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            advancing_store.set_l1_indexer_cursor(101).await.unwrap();
+        });
+
+        wait_for_ger_l1_observed_with_timing(
+            &store,
+            &ger,
+            true,
+            EvidenceTag::Confirmations(1),
+            tx_hash,
+            Duration::from_secs(1),
+            Duration::from_millis(5),
+        )
+        .await
+        .expect("an observed GER must be admitted once its confirmation becomes final");
+        advance.await.unwrap();
+        assert_eq!(store.get_l1_indexer_cursor().await.unwrap(), 101);
+    }
+
+    /// Unknown roots are not eligible for the wait: they may be forged and must
+    /// retain the strict H6 immediate-refusal behavior.
+    #[tokio::test]
+    async fn h6_unobserved_ger_does_not_enter_finality_wait() {
+        let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
+        let ger = [0x49u8; 32];
+        let tx_hash = TxHash::from([0x49u8; 32]);
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            wait_for_ger_l1_observed_with_timing(
+                &store,
+                &ger,
+                true,
+                EvidenceTag::Confirmations(1),
+                tx_hash,
+                Duration::from_secs(60),
+                Duration::from_millis(5),
+            ),
+        )
+        .await
+        .expect("an unobserved GER must be rejected without waiting");
+        let err = result.expect_err("an unobserved GER must remain rejected");
+        assert!(err.to_string().contains("not observed on L1"));
     }
 }

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -9,24 +9,26 @@ use std::{
     time::{Duration, Instant},
 };
 
-/// Polling policy for the narrow strict-H6 state where a GER is already
-/// corroborated by the L1 indexer but has not reached the configured finality
-/// yet. Keeping the request pending is side-effect-free (no nonce, tx row, or
-/// Miden submission exists yet) and prevents a one-shot aggoracle broadcast
-/// from being lost in the observation-to-finality race.
-const GER_FINALITY_POLL_INTERVAL: Duration = Duration::from_millis(250);
-const GER_FINALITY_WAIT_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+/// Polling policy while the single configured L1 scan catches up to a GER.
+/// Waiting is side-effect-free: no nonce, transaction row, writer job, or Miden
+/// submission exists until the selected `latest` / `safe` / `finalized` scan
+/// has persisted both roots.
+#[cfg(not(test))]
+const GER_EVIDENCE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+#[cfg(test)]
+const GER_EVIDENCE_POLL_INTERVAL: Duration = Duration::from_millis(1);
+#[cfg(not(test))]
+const GER_EVIDENCE_WAIT_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+// Request-path tests exercise timeout behavior without waiting 15 minutes.
+#[cfg(test)]
+const GER_EVIDENCE_WAIT_TIMEOUT: Duration = Duration::from_millis(100);
 
 #[derive(Debug, thiserror::Error)]
 enum GerL1GateError {
     #[error(
-        "GER {ger} was observed on L1 but is not yet final per the `{evidence_tag}` evidence setting (finality guard, audit H6); refusing injection under --reject-unverified-ger-injection. Transient — retry once the L1 observation finalizes."
+        "GER {ger} was not observed by the configured L1 `{evidence_tag}` scan (exit-root decomposition unresolved); refusing injection under --reject-unverified-ger-injection (audit H6). Retry after that scan catches up."
     )]
-    NotFinal { ger: String, evidence_tag: String },
-    #[error(
-        "GER {ger} was not observed on L1 by the indexer (exit-root decomposition unresolved); refusing injection under --reject-unverified-ger-injection (audit H6). Retry after the L1 InfoTree indexer catches up."
-    )]
-    NotObserved { ger: String },
+    NotObserved { ger: String, evidence_tag: String },
 }
 
 alloy_core::sol! {
@@ -41,94 +43,43 @@ alloy_core::sol! {
     function updateExitRoot(bytes32 newRollupExitRoot, bytes32 newMainnetExitRoot);
 }
 
-/// Default L1 confirmation depth for STRICT H6 GER authorization (audit H6).
-///
-/// A Miden GER injection is IRREVERSIBLE and the evidence store has no
-/// revoke/rollback, so under strict `--reject-unverified-ger-injection` an
-/// observation must be at least this many L1 blocks deep before it authorizes an
-/// injection — a short-lived reorg then cannot leave a stale "observed" row that
-/// permanently authorizes a GER that never truly landed on canonical L1.
-///
-/// This depth is enforced at admission (`wait_for_ger_l1_observed`), NOT at the
-/// indexer cursor: the indexer records the `(mainnet, rollup)` decomposition up
-/// to LATEST so ordinary decomposition / bridge readiness
-/// (`zkevm_getExitRootsByGER`) is never delayed. Only strict authorization waits
-/// for finality. 64 ≈ Sepolia finality (justification ~1 epoch, finality ~2
-/// epochs / 64 slots).
-pub const DEFAULT_CONFIRMATIONS: u64 = 64;
-
-/// The SINGLE strict-H6 evidence-finality setting (audit H6). One value fully
-/// specifies how the gate qualifies an L1 observation as final enough to
-/// authorize an irreversible GER injection — there is no second finality knob.
+/// The single L1 evidence scan setting (audit H6). The indexer scans exactly one
+/// canonical frontier and stores roots only from that frontier:
 /// Parsed from `--l1-evidence-tag` / `L1_EVIDENCE_TAG`:
-///   - `confirmations:<N>` — depth-below-head: the observation must be `N` blocks
-///     below the indexer's head cursor (strict-non-hardened only).
-///   - `finalized`         — the observation's `(mainnet, rollup)` must be on the
-///     L1 FINALIZED canonical chain (BLOCKER 1 finalized-chain tie). MANDATORY
-///     under `--require-hardening`.
-///   - `safe`              — same, against the L1 `safe` block (weaker; not
-///     sufficient for hardened).
+///   - `latest` — lowest latency; may include reorgable L1 blocks.
+///   - `safe` — scan only through the L1 safe head.
+///   - `finalized` — scan only through the L1 finalized head.
 ///
-/// Normal (lenient) decomposition (`zkevm_getExitRootsByGER`) never consults
-/// this — it reads the evidence row directly, so bridge readiness is unaffected.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// `safe` and `finalized` satisfy `--require-hardening`; `latest` does not.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum EvidenceTag {
-    /// Depth `N` below the indexer head cursor.
-    Confirmations(u64),
+    #[default]
+    Latest,
+    Safe,
     /// On the L1 finalized canonical chain.
     Finalized,
-    /// On the L1 safe canonical chain.
-    Safe,
-}
-
-impl Default for EvidenceTag {
-    fn default() -> Self {
-        Self::Confirmations(DEFAULT_CONFIRMATIONS)
-    }
 }
 
 impl EvidenceTag {
-    /// True for the L1 finality-tag modes (`finalized` / `safe`), which qualify
-    /// evidence against the finalized/safe canonical chain rather than a
-    /// confirmation depth below head.
-    pub fn is_finality_tag(self) -> bool {
-        matches!(self, Self::Finalized | Self::Safe)
-    }
-
     /// Human/log form, round-trippable through `parse`.
-    pub fn describe(self) -> String {
+    pub fn describe(self) -> &'static str {
         match self {
-            Self::Confirmations(n) => format!("confirmations:{n}"),
-            Self::Finalized => "finalized".to_string(),
-            Self::Safe => "safe".to_string(),
+            Self::Latest => "latest",
+            Self::Safe => "safe",
+            Self::Finalized => "finalized",
         }
     }
 
-    /// Parse the single CLI/env value. Accepts `finalized`, `safe`,
-    /// `confirmations:<N>`, and bare `confirmations` (→ `DEFAULT_CONFIRMATIONS`).
-    /// `None` on an unrecognised token or a malformed depth.
+    /// Parse the single CLI/env value.
     pub fn parse(s: &str) -> Option<Self> {
-        let s = s.trim().to_ascii_lowercase();
-        match s.as_str() {
-            "finalized" => return Some(Self::Finalized),
-            "safe" => return Some(Self::Safe),
-            "confirmations" => {
-                return Some(Self::Confirmations(DEFAULT_CONFIRMATIONS));
-            }
-            _ => {}
+        match s.trim().to_ascii_lowercase().as_str() {
+            "latest" => Some(Self::Latest),
+            "safe" => Some(Self::Safe),
+            "finalized" => Some(Self::Finalized),
+            _ => None,
         }
-        let rest = s.strip_prefix("confirmations:")?;
-        rest.trim().parse::<u64>().ok().map(Self::Confirmations)
     }
 }
-
-/// Minimum confirmation depth strict H6 will boot with. Zero would authorize an
-/// irreversible injection from a 0-confirmation (freely reorg-able) observation,
-/// defeating the finality guarantee — so strict mode refuses to start with
-/// `confirmations:<N>` where `N < MIN_STRICT_CONFIRMATIONS` (see
-/// `check_h6_evidence_source`). Production should use `DEFAULT_CONFIRMATIONS` or
-/// higher, or `finalized`; the floor merely forbids the outright-unsafe zero.
-pub const MIN_STRICT_CONFIRMATIONS: u64 = 1;
 
 /// Compute the combined GER from mainnet and rollup exit roots.
 pub fn combined_ger(mainnet: &[u8; 32], rollup: &[u8; 32]) -> [u8; 32] {
@@ -327,11 +278,10 @@ pub(crate) async fn record_ger_submission_handoff(
 /// bytes are otherwise trusted verbatim: a compromised signer could inject a
 /// FORGED GER (one whose `(mainnet, rollup)` decomposition the indexer never saw
 /// on L1) onto Miden. The indexer writes the authoritative decomposition via
-/// `set_ger_exit_roots`; a GER is "resolved" only when BOTH roots are recorded —
-/// the same predicate `zkevm_getExitRootsByGER` answers with (anything less
-/// returns null there so bridge-service retries). When `require_l1_observed` is
-/// set, an unresolved GER is refused before it reaches Miden; otherwise it is
-/// allowed through (to tolerate indexer lag) but flagged via the
+/// `set_ger_exit_roots`; strict admission requires BOTH roots plus the
+/// database-bound selected-scan provenance marker. When `require_l1_observed`
+/// is set, a GER without that evidence is refused before it reaches Miden;
+/// otherwise it is allowed through (to tolerate indexer lag) but flagged via the
 /// `ger_injection_unverified_total` metric + warn.
 ///
 /// The duplicate check runs BEFORE the H6 gate: an already-injected GER is a
@@ -379,7 +329,7 @@ pub async fn insert_ger(
     // reflects "have we already submitted the Miden tx and committed the
     // synthetic event for this GER?". (`wait_for_ger_l1_observed` above already
     // short-circuits on the same `is_ger_injected` check, so an already-injected
-    // GER never reaches the gate's finality logic — this read then just decides
+    // GER never reaches the gate's evidence check — this read then just decides
     // the duplicate no-op return value.)
     let is_new = !store.is_ger_injected(&ger_bytes).await?;
 
@@ -473,12 +423,10 @@ pub async fn insert_ger(
 /// increment, txn_begin, or receipt creation).
 ///
 /// Verifies the GER was observed on L1 by the independent L1InfoTreeIndexer
-/// (it writes the `(mainnet, rollup)` decomposition via `set_ger_exit_roots`).
-/// "Observed" means BOTH roots resolved — the same predicate
-/// `zkevm_getExitRootsByGER` uses (ger_entries rows exist in partial states:
-/// the indexer pre-creates them with roots to be filled in later). A GER with
-/// no resolved decomposition was supplied only by the aggoracle and never
-/// corroborated by an L1 observation — a forged-GER injection signal.
+/// (it atomically writes the `(mainnet, rollup)` decomposition and selected-scan
+/// provenance via `set_ger_exit_roots`). A row populated by another path, or by
+/// a pre-upgrade `latest` scan, is not sufficient until the configured scan
+/// rewrites it. Missing selected-scan evidence is a forged-GER injection signal.
 ///
 /// The duplicate check runs FIRST: an already-injected GER never reaches
 /// Miden, so the gate has nothing to stop — and refusing it would break
@@ -494,10 +442,10 @@ pub async fn insert_ger(
 ///   - `insert_ger` repeats it inside the worker immediately before Miden
 ///     submission as a defense-in-depth state check.
 ///
-/// An unobserved strict-mode refusal stays transient and side-effect-free: no nonce
-/// is consumed, no tx row/receipt is created, and no job is queued. An already
-/// observed but shallow GER instead waits here, also before any side effect,
-/// until the configured evidence finality is reached.
+/// A strict-mode wait/refusal stays side-effect-free: no nonce is consumed, no
+/// tx row/receipt is created, and no job is queued. This matters for `safe` and
+/// `finalized`, where a legitimate event is intentionally absent until the
+/// selected L1 frontier reaches it.
 ///
 /// Metric discipline: `ger_injection_unverified_total` increments on every
 /// unverified sighting this function makes. The request path invokes it under
@@ -519,57 +467,19 @@ pub async fn ensure_ger_l1_observed(
         .as_ref()
         .is_some_and(|e| e.mainnet_exit_root.is_some() && e.rollup_exit_root.is_some());
 
-    // Finality is checked HERE (at the strict gate), NOT at the indexer cursor.
-    // The indexer records the `(mainnet, rollup)` decomposition up to LATEST, so
-    // ordinary decomposition / bridge readiness (`zkevm_getExitRootsByGER`, which
-    // reads `get_ger_entry` directly and does NOT call this gate) is never
-    // delayed. Only strict authorization of an IRREVERSIBLE injection
-    // additionally requires the observation to be final per the SINGLE
-    // `evidence_tag` setting:
-    //   - Confirmations(N): `l1_head - evidence_block >= N`, using the indexer's
-    //     persisted head cursor (strict-non-hardened only). An evidence row with
-    //     NO recorded L1 block (`block_number == 0`: a legacy/pre-guard row, or
-    //     one seeded by a non-indexer write path) is NOT final — fail-closed —
-    //     which closes the upgrade-state gap.
-    //   - Finalized / Safe (BLOCKER 1 finalized-chain tie): the row must be
-    //     `finalized_verified` — a flag the indexer sets ONLY from a scan pinned
-    //     to the L1 finalized/safe canonical chain. A `latest`-observed row from
-    //     a fork that was later reorged away is never `finalized_verified`, so a
-    //     block-height coincidence (`block <= finalized`) can no longer
-    //     authorize it. MANDATORY under `--require-hardening`.
-    // Lenient mode never gates on finality.
-    let final_enough = if require_l1_observed {
-        match entry.as_ref() {
-            Some(e) => match evidence_tag {
-                EvidenceTag::Confirmations(depth) => {
-                    let l1_head = store.get_l1_indexer_cursor().await?;
-                    e.block_number > 0 && l1_head.saturating_sub(e.block_number) >= depth
-                }
-                EvidenceTag::Finalized | EvidenceTag::Safe => e.finalized_verified,
-            },
-            None => false,
-        }
-    } else {
-        true
-    };
-
-    let l1_verified = roots_observed && final_enough;
+    // One scan, one policy, one provenance marker. The selected scan writes
+    // roots and the provenance marker together, so old `latest` roots from an
+    // upgraded database cannot be silently reinterpreted as `safe`/`finalized`
+    // evidence. The physical column retains its migration-era name, but now
+    // means "observed by the configured scan" for all three tags.
+    let policy_observed = entry.as_ref().is_some_and(|e| e.evidence_verified);
+    let l1_verified = roots_observed && policy_observed;
     if !l1_verified {
         ::metrics::counter!("ger_injection_unverified_total").increment(1);
         if require_l1_observed {
-            // A resolved-but-not-yet-final observation is a DISTINCT transient
-            // state from an unresolved one; surface it plainly. ("not observed
-            // on L1" stays the stable substring for the unresolved case that the
-            // e2e / callers match; "not yet" for the not-final case.)
-            if roots_observed {
-                return Err(GerL1GateError::NotFinal {
-                    ger: hex::encode(ger_bytes),
-                    evidence_tag: evidence_tag.describe(),
-                }
-                .into());
-            }
             return Err(GerL1GateError::NotObserved {
                 ger: hex::encode(ger_bytes),
+                evidence_tag: evidence_tag.describe().to_string(),
             }
             .into());
         }
@@ -578,21 +488,18 @@ pub async fn ensure_ger_l1_observed(
             tx = %txn_hash,
             roots_observed,
             evidence_tag = %evidence_tag.describe(),
-            "GER injection not yet corroborated/finalized by the L1 InfoTree indexer; \
+            policy_observed,
+            "GER injection not yet corroborated by the configured L1 InfoTree scan; \
              allowing through but unverified (lenient mode)"
         );
     }
     Ok(())
 }
 
-/// Wait for an already-observed GER to reach the configured strict-H6 finality.
-///
-/// An unobserved GER is still refused immediately: it may be forged, and the
-/// indexer has supplied no evidence that waiting is justified. Once both roots
-/// are observed, however, finality is only a time-dependent gate. Keeping this
-/// request pending is side-effect-free and closes the race where aggoracle sent
-/// once between observation and the next indexer cursor advance, received a
-/// transient refusal, and never produced another usable submission.
+/// Wait for the configured single L1 scan to persist a GER. Before the selected
+/// `safe`/`finalized` frontier reaches a legitimate event it is indistinguishable
+/// from an unknown GER, so the bounded wait covers both missing roots and a
+/// missing provenance marker. The signer allow-list and timeout bound exposure.
 pub async fn wait_for_ger_l1_observed(
     store: &Arc<dyn crate::store::Store>,
     ger_bytes: &[u8; 32],
@@ -606,8 +513,8 @@ pub async fn wait_for_ger_l1_observed(
         require_l1_observed,
         evidence_tag,
         txn_hash,
-        GER_FINALITY_WAIT_TIMEOUT,
-        GER_FINALITY_POLL_INTERVAL,
+        GER_EVIDENCE_WAIT_TIMEOUT,
+        GER_EVIDENCE_POLL_INTERVAL,
     )
     .await
 }
@@ -631,15 +538,7 @@ async fn wait_for_ger_l1_observed_with_timing(
     .await
     {
         Ok(()) => return Ok(()),
-        Err(err)
-            if require_l1_observed
-                && matches!(
-                    err.downcast_ref::<GerL1GateError>(),
-                    Some(GerL1GateError::NotFinal { .. })
-                ) =>
-        {
-            err
-        }
+        Err(err) if require_l1_observed && err.downcast_ref::<GerL1GateError>().is_some() => err,
         Err(err) => return Err(err),
     };
 
@@ -648,16 +547,16 @@ async fn wait_for_ger_l1_observed_with_timing(
         tx = %txn_hash,
         evidence_tag = %evidence_tag.describe(),
         timeout_secs = timeout.as_secs(),
-        "GER is L1-observed but not final yet; waiting side-effect-free before admission"
+        "waiting side-effect-free for the configured L1 scan to observe GER"
     );
 
     let started = Instant::now();
     loop {
-        if ger_l1_finality_reached(store, ger_bytes, evidence_tag).await? {
+        if ger_l1_evidence_reached(store, ger_bytes).await? {
             tracing::info!(
                 ger = %hex::encode(ger_bytes),
                 waited_ms = started.elapsed().as_millis() as u64,
-                "GER L1 evidence reached finality; continuing admission"
+                "configured L1 scan observed GER; continuing admission"
             );
             return Ok(());
         }
@@ -665,7 +564,7 @@ async fn wait_for_ger_l1_observed_with_timing(
             tracing::warn!(
                 ger = %hex::encode(ger_bytes),
                 waited_secs = started.elapsed().as_secs(),
-                "timed out waiting for GER L1 evidence finality"
+                "timed out waiting for configured L1 scan evidence"
             );
             return Err(pending_error);
         }
@@ -673,10 +572,9 @@ async fn wait_for_ger_l1_observed_with_timing(
     }
 }
 
-async fn ger_l1_finality_reached(
+async fn ger_l1_evidence_reached(
     store: &Arc<dyn crate::store::Store>,
     ger_bytes: &[u8; 32],
-    evidence_tag: EvidenceTag,
 ) -> anyhow::Result<bool> {
     if store.is_ger_injected(ger_bytes).await? {
         return Ok(true);
@@ -684,16 +582,9 @@ async fn ger_l1_finality_reached(
     let Some(entry) = store.get_ger_entry(ger_bytes).await? else {
         return Ok(false);
     };
-    if entry.mainnet_exit_root.is_none() || entry.rollup_exit_root.is_none() {
-        return Ok(false);
-    }
-    match evidence_tag {
-        EvidenceTag::Confirmations(depth) => {
-            let l1_head = store.get_l1_indexer_cursor().await?;
-            Ok(entry.block_number > 0 && l1_head.saturating_sub(entry.block_number) >= depth)
-        }
-        EvidenceTag::Finalized | EvidenceTag::Safe => Ok(entry.finalized_verified),
-    }
+    Ok(entry.mainnet_exit_root.is_some()
+        && entry.rollup_exit_root.is_some()
+        && entry.evidence_verified)
 }
 
 #[cfg(test)]
@@ -752,6 +643,18 @@ mod tests {
         assert_ne!(combined_ger(&a, &b), combined_ger(&b, &a));
     }
 
+    #[test]
+    fn evidence_tag_accepts_only_scan_frontiers() {
+        assert_eq!(EvidenceTag::parse("latest"), Some(EvidenceTag::Latest));
+        assert_eq!(EvidenceTag::parse(" SAFE "), Some(EvidenceTag::Safe));
+        assert_eq!(
+            EvidenceTag::parse("FINALIZED"),
+            Some(EvidenceTag::Finalized)
+        );
+        assert_eq!(EvidenceTag::parse("confirmations:64"), None);
+        assert_eq!(EvidenceTag::parse("confirmations"), None);
+    }
+
     /// Audit H6 — a GER whose `(mainnet, rollup)` decomposition was NOT
     /// corroborated by the L1 InfoTree indexer MUST be refused when
     /// `require_l1_observed` is set, BEFORE any Miden submission is attempted.
@@ -760,63 +663,27 @@ mod tests {
     /// gas burn, and — with a colluding claim — a mint against an L1 deposit
     /// that never happened).
     ///
-    /// The check fires at the top of `insert_ger`, so the MidenClient is never
-    /// reached; a stub client is sufficient.
     #[tokio::test]
     async fn h6_unverified_ger_refused_when_strict() {
         let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
-        let miden_client = crate::test_helpers::create_test_service().miden_client;
-        let accounts = crate::test_helpers::test_accounts_config();
         let tx_hash = alloy::primitives::TxHash::from_str(
             "0x1111111111111111111111111111111111111111111111111111111111111111",
         )
         .unwrap();
         let forged_ger = [0xCDu8; 32]; // no ger_entries row → mainnet_exit_root unset
 
-        // Strict mode: the unverified GER must be refused before Miden submission.
-        let (env, signer) = h6_test_envelope(tx_hash);
-        let err = insert_ger(
-            forged_ger,
-            &miden_client,
-            accounts.clone(),
-            &store,
-            tx_hash,
-            true, // require_l1_observed
-            EvidenceTag::Confirmations(0),
-            env.clone(),
-            signer,
-        )
-        .await
-        .expect_err("unverified GER must be refused under require_l1_observed");
+        let err = ensure_ger_l1_observed(&store, &forged_ger, true, EvidenceTag::Latest, tx_hash)
+            .await
+            .expect_err("unverified GER must be refused under require_l1_observed");
         let msg = err.to_string();
         assert!(
-            msg.contains("not observed on L1"),
+            msg.contains("not observed by the configured L1 `latest` scan"),
             "must cite L1 non-observation: {msg}"
         );
 
-        // Lenient mode (default): the same GER is allowed through (it may still
-        // Err downstream because the MidenClient stub can't really submit, but
-        // it must NOT bail at the H6 gate). Assert the result is NOT the H6
-        // "not observed on L1" refusal — a bare `let _ =` would pass even if
-        // lenient mode wrongly refused, defeating the point of this test.
-        let lenient = insert_ger(
-            forged_ger,
-            &miden_client,
-            accounts,
-            &store,
-            tx_hash,
-            false, // lenient
-            EvidenceTag::Confirmations(0),
-            env,
-            signer,
-        )
-        .await;
-        if let Err(err) = lenient {
-            assert!(
-                !err.to_string().contains("not observed on L1"),
-                "lenient mode must NOT refuse an unverified GER at the H6 gate: {err}"
-            );
-        }
+        ensure_ger_l1_observed(&store, &forged_ger, false, EvidenceTag::Latest, tx_hash)
+            .await
+            .expect("lenient mode must allow unverified GER evidence");
     }
 
     /// Audit H6 (review follow-up) — the duplicate check runs BEFORE the strict
@@ -852,7 +719,7 @@ mod tests {
             &store,
             tx_hash,
             true,
-            EvidenceTag::Confirmations(0),
+            EvidenceTag::Latest,
             env,
             signer,
         )
@@ -864,10 +731,9 @@ mod tests {
         );
     }
 
-    /// Audit H6 (review follow-up) — the gate uses the SAME resolved predicate
-    /// as `zkevm_getExitRootsByGER`: BOTH roots recorded. An entry the indexer
-    /// fully resolved must pass the strict gate (any downstream error from the
-    /// stub MidenClient must not be the H6 refusal).
+    /// Audit H6 (review follow-up) — an entry fully written by the selected scan
+    /// (both roots plus provenance) must pass the strict gate. Any downstream
+    /// error from the stub MidenClient must not be the H6 refusal.
     #[tokio::test]
     async fn h6_resolved_ger_passes_strict_gate() {
         let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
@@ -895,173 +761,66 @@ mod tests {
             &store,
             tx_hash,
             true,
-            EvidenceTag::Confirmations(0),
+            EvidenceTag::Latest,
             env,
             signer,
         )
         .await;
         if let Err(err) = result {
             assert!(
-                !err.to_string().contains("not observed on L1"),
+                !err.to_string()
+                    .contains("not observed by the configured L1"),
                 "a fully-resolved GER must pass the strict H6 gate: {err}"
             );
         }
     }
 
-    /// Audit H6 (BLOCKER 1) — finality is enforced AT THE GATE. A resolved
-    /// observation must be at least `confirmations` L1 blocks deep (indexer
-    /// cursor as head) before strict mode authorizes the irreversible injection.
-    /// A not-yet-deep observation is refused (transient), and once the cursor
-    /// advances past the confirmation depth it passes. Ordinary decomposition
-    /// (`get_ger_entry`, unchanged) sees the row regardless — this delay applies
-    /// ONLY to strict authorization.
-    ///
-    /// Mutation check: dropping the `l1_head - block >= confirmations` clause
-    /// (always `final_enough = true`) makes the not-yet-deep case wrongly pass.
+    /// Pre-upgrade roots have no selected-scan provenance and must remain
+    /// untrusted until the configured scan rewrites them. This is what prevents
+    /// old `latest` observations being silently relabelled `safe`/`finalized`.
     #[tokio::test]
-    async fn h6_strict_gate_requires_confirmation_depth() {
-        let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
-        let ger = combined_ger(&[0x0Au8; 32], &[0x0Bu8; 32]);
-        let tx_hash = TxHash::from([0x44u8; 32]);
-        // Indexer recorded the pair at L1 block 100 (roots resolved immediately).
-        store
-            .set_ger_exit_roots(&ger, [0x0Au8; 32], [0x0Bu8; 32], 100, 1_700_000_000)
-            .await
-            .unwrap();
-
-        // Cursor at 140 → only 40 deep, < 64 confirmations → refused (transient).
-        store.set_l1_indexer_cursor(140).await.unwrap();
-        let err = ensure_ger_l1_observed(
-            &store,
-            &ger,
-            true,
-            EvidenceTag::Confirmations(DEFAULT_CONFIRMATIONS),
-            tx_hash,
-        )
-        .await
-        .expect_err("a not-yet-confirmation-deep observation must be refused under strict");
-        assert!(
-            err.to_string().contains("not yet"),
-            "must cite the finality guard, not unresolved roots: {err}"
-        );
-        // Normal decomposition is unaffected: the row is present immediately.
-        assert!(store.get_ger_entry(&ger).await.unwrap().is_some());
-
-        // Cursor advances to 170 → 70 deep, >= 64 → authorized.
-        store.set_l1_indexer_cursor(170).await.unwrap();
-        ensure_ger_l1_observed(
-            &store,
-            &ger,
-            true,
-            EvidenceTag::Confirmations(DEFAULT_CONFIRMATIONS),
-            tx_hash,
-        )
-        .await
-        .expect("a confirmation-deep observation must pass the strict gate");
-    }
-
-    /// Audit H6 (BLOCKER 1) — a legacy / pre-guard evidence row that carries NO
-    /// recorded L1 block (`block_number == 0`) but somehow has both roots must be
-    /// treated as unverified under strict (fail-closed), closing the
-    /// upgrade-state gap. Lenient mode still lets it through.
-    ///
-    /// Mutation check: treating a block-less row as final (removing the
-    /// `block_number > 0` guard) makes the strict case wrongly pass.
-    #[tokio::test]
-    async fn h6_strict_gate_refuses_blockless_legacy_row() {
+    async fn h6_strict_gate_requires_selected_scan_provenance() {
         let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
         let ger = [0x77u8; 32];
-        // A row with both roots but block_number 0 (e.g. seeded by a non-indexer
-        // path before this guard existed). commit_ger_event_atomic sets roots +
-        // block 0 here and does NOT set is_injected... so use mark_ger_seen shape.
+        let mainnet = [0x01u8; 32];
+        let rollup = [0x02u8; 32];
         store
             .mark_ger_seen(
                 &ger,
                 crate::log_synthesis::GerEntry {
-                    mainnet_exit_root: Some([0x01u8; 32]),
-                    rollup_exit_root: Some([0x02u8; 32]),
-                    block_number: 0,
-                    timestamp: 0,
-                    finalized_verified: false,
+                    mainnet_exit_root: Some(mainnet),
+                    rollup_exit_root: Some(rollup),
+                    block_number: 100,
+                    timestamp: 1_700_000_000,
+                    evidence_verified: false,
                 },
             )
             .await
             .unwrap();
-        // Even with a huge cursor, block 0 means "no recorded L1 block" → refused.
-        store.set_l1_indexer_cursor(10_000_000).await.unwrap();
         let tx_hash = TxHash::from([0x45u8; 32]);
-        let err = ensure_ger_l1_observed(
-            &store,
-            &ger,
-            true,
-            EvidenceTag::Confirmations(DEFAULT_CONFIRMATIONS),
-            tx_hash,
-        )
-        .await
-        .expect_err("a block-less legacy row must be refused under strict");
+        let err = ensure_ger_l1_observed(&store, &ger, true, EvidenceTag::Safe, tx_hash)
+            .await
+            .expect_err("roots without selected-scan provenance must be refused");
         assert!(
-            err.to_string().contains("not yet"),
-            "finality-guard refusal: {err}"
+            err.to_string()
+                .contains("not observed by the configured L1 `safe` scan"),
+            "selected-scan refusal: {err}"
         );
-        // Lenient mode lets it through (no bail).
-        ensure_ger_l1_observed(
-            &store,
-            &ger,
-            false,
-            EvidenceTag::Confirmations(DEFAULT_CONFIRMATIONS),
-            tx_hash,
-        )
-        .await
-        .expect("lenient mode must not refuse a block-less row");
-    }
 
-    /// Audit H6 BLOCKER 1 (re-review) — the `finalized` evidence tag qualifies an
-    /// observation by the FINALIZED-CHAIN TIE (`finalized_verified`), NOT by a
-    /// block-height coincidence. A `latest`-observed row (roots present, block
-    /// recorded) that the finalized-pinned scan never confirmed — e.g. a row from
-    /// a fork later reorged away — must NOT authorize even with a huge head
-    /// cursor / finalized block. Only after `mark_ger_finalized` (which the
-    /// indexer runs solely from the finalized canonical chain) does it authorize.
-    ///
-    /// Mutation check: making the gate authorize on block-height instead of
-    /// `finalized_verified` (drop the flag requirement) makes the reorged-fork
-    /// row wrongly authorize.
-    #[tokio::test]
-    async fn h6_finalized_tag_gate_requires_finalized_chain_tie() {
-        let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
-        let ger = combined_ger(&[0x1Au8; 32], &[0x1Bu8; 32]);
-        let tx_hash = TxHash::from([0x46u8; 32]);
-        // A `latest`-observed row: roots present, block 100. Set the head cursor
-        // AND finalized block far above it, so a height-only check would pass.
+        // The selected scan atomically rewrites roots plus its provenance marker.
         store
-            .set_ger_exit_roots(&ger, [0x1Au8; 32], [0x1Bu8; 32], 100, 1_700_000_000)
+            .set_ger_exit_roots(&ger, mainnet, rollup, 100, 1_700_000_000)
             .await
             .unwrap();
-        store.set_l1_indexer_cursor(10_000).await.unwrap();
-        store.set_l1_finalized_block(10_000).await.unwrap();
-
-        // NOT finalized-verified (the finalized scan never covered it, e.g. a
-        // reorged fork) → refused despite the height coincidence.
-        let err = ensure_ger_l1_observed(&store, &ger, true, EvidenceTag::Finalized, tx_hash)
+        ensure_ger_l1_observed(&store, &ger, true, EvidenceTag::Safe, tx_hash)
             .await
-            .expect_err("a non-finalized-verified row must be refused in finalized mode");
-        assert!(
-            err.to_string().contains("not yet"),
-            "finality-guard refusal: {err}"
-        );
-
-        // The finalized-pinned scan confirms it on the canonical chain.
-        store.mark_ger_finalized(&ger).await.unwrap();
-        ensure_ger_l1_observed(&store, &ger, true, EvidenceTag::Finalized, tx_hash)
-            .await
-            .expect("a finalized-chain-verified observation must pass the strict gate");
+            .expect("the selected scan's atomic evidence write must authorize the GER");
     }
 
-    /// Audit H6 — confirmation-depth mode still works under the SINGLE setting:
-    /// `Confirmations(N)` authorizes iff `head_cursor - block >= N`, and the
-    /// `finalized_verified` flag is irrelevant in this mode.
+    /// All three settings share the same admission predicate because the
+    /// configured tag controls what the sole indexer scans, not a second gate.
     #[tokio::test]
-    async fn h6_confirmations_mode_under_single_setting() {
+    async fn h6_selected_scan_evidence_authorizes_every_tag() {
         let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
         let ger = combined_ger(&[0x2Au8; 32], &[0x2Bu8; 32]);
         let tx_hash = TxHash::from([0x47u8; 32]);
@@ -1070,77 +829,73 @@ mod tests {
             .await
             .unwrap();
 
-        // 40 deep < 64 → refused.
-        store.set_l1_indexer_cursor(140).await.unwrap();
-        ensure_ger_l1_observed(&store, &ger, true, EvidenceTag::Confirmations(64), tx_hash)
-            .await
-            .expect_err("shallow observation must be refused in confirmations mode");
-        // 70 deep >= 64 → authorized (no finalized_verified needed).
-        store.set_l1_indexer_cursor(170).await.unwrap();
-        ensure_ger_l1_observed(&store, &ger, true, EvidenceTag::Confirmations(64), tx_hash)
-            .await
-            .expect("confirmation-deep observation must pass");
+        for tag in [
+            EvidenceTag::Latest,
+            EvidenceTag::Safe,
+            EvidenceTag::Finalized,
+        ] {
+            ensure_ger_l1_observed(&store, &ger, true, tag, tx_hash)
+                .await
+                .unwrap_or_else(|err| {
+                    panic!("selected-scan evidence must pass for {tag:?}: {err}")
+                });
+        }
     }
 
-    /// Regression for task #59: once the indexer has resolved both roots, a
-    /// one-block finality race is held side-effect-free until the cursor advances.
-    /// Before this wait, a one-shot aggoracle submission could be refused in this
-    /// window and the deposit would remain stalled indefinitely.
+    /// A legitimate GER is absent until the selected scan reaches it. Admission
+    /// waits side-effect-free and succeeds as soon as that atomic evidence write
+    /// lands; there is only the selected scan's cursor.
     #[tokio::test]
-    async fn h6_observed_ger_waits_for_confirmation_cursor() {
+    async fn h6_waits_for_selected_scan_evidence() {
         let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
         let ger = combined_ger(&[0x3Au8; 32], &[0x3Bu8; 32]);
         let tx_hash = TxHash::from([0x48u8; 32]);
-        store
-            .set_ger_exit_roots(&ger, [0x3Au8; 32], [0x3Bu8; 32], 100, 1_700_000_000)
-            .await
-            .unwrap();
-        store.set_l1_indexer_cursor(100).await.unwrap();
 
-        let advancing_store = store.clone();
-        let advance = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(25)).await;
-            advancing_store.set_l1_indexer_cursor(101).await.unwrap();
+        let indexing_store = store.clone();
+        let index = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(15)).await;
+            indexing_store
+                .set_ger_exit_roots(&ger, [0x3Au8; 32], [0x3Bu8; 32], 100, 1_700_000_000)
+                .await
+                .unwrap();
         });
 
         wait_for_ger_l1_observed_with_timing(
             &store,
             &ger,
             true,
-            EvidenceTag::Confirmations(1),
+            EvidenceTag::Finalized,
             tx_hash,
             Duration::from_secs(1),
-            Duration::from_millis(5),
+            Duration::from_millis(1),
         )
         .await
-        .expect("an observed GER must be admitted once its confirmation becomes final");
-        advance.await.unwrap();
-        assert_eq!(store.get_l1_indexer_cursor().await.unwrap(), 101);
+        .expect("a GER must be admitted once the configured scan persists it");
+        index.await.unwrap();
     }
 
-    /// Unknown roots are not eligible for the wait: they may be forged and must
-    /// retain the strict H6 immediate-refusal behavior.
+    /// A forged/unknown GER remains rejected when the bounded wait expires.
     #[tokio::test]
-    async fn h6_unobserved_ger_does_not_enter_finality_wait() {
+    async fn h6_unknown_ger_is_rejected_after_bounded_wait() {
         let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
         let ger = [0x49u8; 32];
         let tx_hash = TxHash::from([0x49u8; 32]);
 
-        let result = tokio::time::timeout(
-            Duration::from_secs(1),
-            wait_for_ger_l1_observed_with_timing(
-                &store,
-                &ger,
-                true,
-                EvidenceTag::Confirmations(1),
-                tx_hash,
-                Duration::from_secs(60),
-                Duration::from_millis(5),
-            ),
+        let err = wait_for_ger_l1_observed_with_timing(
+            &store,
+            &ger,
+            true,
+            EvidenceTag::Safe,
+            tx_hash,
+            Duration::from_millis(10),
+            Duration::from_millis(1),
         )
         .await
-        .expect("an unobserved GER must be rejected without waiting");
-        let err = result.expect_err("an unobserved GER must remain rejected");
-        assert!(err.to_string().contains("not observed on L1"));
+        .expect_err("an unknown GER must remain rejected after the bounded wait");
+        assert!(
+            err.to_string()
+                .contains("not observed by the configured L1 `safe` scan"),
+            "selected-scan refusal: {err}"
+        );
     }
 }

--- a/src/l1_info_tree_indexer.rs
+++ b/src/l1_info_tree_indexer.rs
@@ -92,11 +92,8 @@ pub struct L1InfoTreeIndexer {
     /// cursor advances forward normally; remove the flag for subsequent
     /// boots.
     from_block_override: Option<u64>,
-    /// Strict-H6 evidence qualification tag (audit H6 BLOCKER 3). When a
-    /// finality tag (`finalized`/`safe`) is configured, each poll also fetches
-    /// that L1 block and persists its number via `set_l1_finalized_block`, which
-    /// the strict gate uses to qualify evidence. In `Confirmations` mode the
-    /// indexer does no extra work (the gate uses the head cursor + depth).
+    /// The one L1 frontier this indexer scans. Roots are learned exclusively
+    /// from `latest`, `safe`, or `finalized` according to this setting.
     evidence_tag: crate::ger::EvidenceTag,
 }
 
@@ -113,45 +110,26 @@ impl L1InfoTreeIndexer {
         }
     }
 
-    /// Configure the strict-H6 evidence tag. In `Finalized`/`Safe` mode the
-    /// indexer tracks the corresponding L1 finality block (BLOCKER 3).
+    /// Configure the single L1 scan frontier.
     pub fn with_evidence_tag(mut self, tag: crate::ger::EvidenceTag) -> Self {
         self.evidence_tag = tag;
         self
     }
 
-    /// The L1 block tag to poll for finality tracking, or `None` in
-    /// confirmation-depth mode (no finality block needed).
-    fn finality_block_tag(&self) -> Option<BlockNumberOrTag> {
+    fn scan_block_tag(&self) -> BlockNumberOrTag {
         match self.evidence_tag {
-            crate::ger::EvidenceTag::Confirmations(_) => None,
-            crate::ger::EvidenceTag::Finalized => Some(BlockNumberOrTag::Finalized),
-            crate::ger::EvidenceTag::Safe => Some(BlockNumberOrTag::Safe),
+            crate::ger::EvidenceTag::Latest => BlockNumberOrTag::Latest,
+            crate::ger::EvidenceTag::Safe => BlockNumberOrTag::Safe,
+            crate::ger::EvidenceTag::Finalized => BlockNumberOrTag::Finalized,
         }
     }
 
-    /// Best-effort refresh of the persisted L1 finality-tag block (BLOCKER 3).
-    /// A no-op in confirmation-depth mode. A fetch/persist failure just leaves
-    /// the previous value — the strict gate stays fail-closed (never
-    /// over-authorizes on a stale finality block).
-    async fn refresh_finality_block<P: Provider>(&self, provider: &P) {
-        let Some(tag) = self.finality_block_tag() else {
-            return;
-        };
-        match provider.get_block_by_number(tag).await {
-            Ok(Some(block)) => {
-                let n = block.header.number;
-                if let Err(e) = self.store.set_l1_finalized_block(n).await {
-                    tracing::warn!(error = %e, tag = ?tag, "L1InfoTreeIndexer: failed to persist L1 finality block");
-                }
-            }
-            Ok(None) => {
-                tracing::debug!(tag = ?tag, "L1InfoTreeIndexer: L1 finality block not available yet");
-            }
-            Err(e) => {
-                tracing::debug!(error = %e, tag = ?tag, "L1InfoTreeIndexer: failed to fetch L1 finality block");
-            }
-        }
+    async fn scan_head<P: Provider>(&self, provider: &P) -> anyhow::Result<u64> {
+        let tag = self.scan_block_tag();
+        let block = provider.get_block_by_number(tag).await?.ok_or_else(|| {
+            anyhow::anyhow!("L1 `{}` block is unavailable", self.evidence_tag.describe())
+        })?;
+        Ok(block.header.number)
     }
 
     /// Operator override for the indexer start block. Overrides both the
@@ -161,6 +139,12 @@ impl L1InfoTreeIndexer {
     pub fn with_from_block_override(mut self, from_block: u64) -> Self {
         self.from_block_override = Some(from_block);
         self
+    }
+
+    fn initial_cursor(&self, stored: u64, selected_head: u64) -> u64 {
+        self.from_block_override
+            .map(|from| from.saturating_sub(1))
+            .unwrap_or_else(|| if stored == 0 { selected_head } else { stored })
     }
 
     /// Spawn the indexer as a tokio task. Returns a oneshot sender for graceful
@@ -186,29 +170,29 @@ impl L1InfoTreeIndexer {
                 "L1InfoTreeIndexer starting"
             );
 
-            // Resume from the persisted cursor if we have one, else start at
-            // current L1 head. The persisted cursor closes the gap that
+            // Resume from the selected-policy cursor if we have one, else start
+            // at the configured L1 frontier. The persisted cursor closes the gap that
             // stranded GERs every time the proxy restarted (OOMKills,
             // planned deploys): historic `UpdateL1InfoTree` events emitted
             // during downtime are now indexed on the next boot and the
             // orphan ger_entries rows from that window get their (M, R)
             // filled in by the indexer's `set_ger_exit_roots` UPSERT.
             //
-            // Fresh deployments (cursor = 0) start at head — same behaviour
+            // Fresh lenient deployments (cursor = 0) start at the selected head — same behaviour
             // as before persistence. Pre-existing deployments inherit a 0
             // cursor on first boot after the migration; treat 0 as "no
             // cursor recorded yet" and fall back to head to avoid a
             // multi-million-block backfill on the first boot.
-            let head = provider.get_block_number().await.unwrap_or_else(|e| {
-                tracing::error!(error = %e, "L1InfoTreeIndexer: failed to fetch initial L1 block; starting at 0");
+            let head = self.scan_head(&provider).await.unwrap_or_else(|e| {
+                tracing::error!(error = %e, tag = %self.evidence_tag.describe(), "L1InfoTreeIndexer: failed to fetch initial selected L1 block; starting at 0");
                 0
             });
-            let stored = match self.store.get_l1_indexer_cursor().await {
+            let stored = match self.store.get_l1_evidence_cursor().await {
                 Ok(n) => n,
                 Err(e) => {
                     tracing::error!(
                         error = %e,
-                        "L1InfoTreeIndexer: failed to load persisted cursor; falling back to L1 head"
+                        "L1InfoTreeIndexer: failed to load selected-policy cursor; falling back to selected L1 head"
                     );
                     0
                 }
@@ -217,9 +201,9 @@ impl L1InfoTreeIndexer {
             //   1. Operator override (`--l1-indexer-from-block <N>`) wins
             //      unconditionally — used to backfill historic orphan GERs
             //      whose events predate the persisted cursor.
-            //   2. Else persisted cursor minus reorg margin, if non-zero.
-            //   3. Else current L1 head (fresh deployment).
-            let mut last_processed: u64 = if let Some(forced) = self.from_block_override {
+            //   2. Else the persisted selected-policy cursor, if non-zero.
+            //   3. Else the selected L1 head (fresh lenient deployment).
+            if let Some(forced) = self.from_block_override {
                 tracing::warn!(
                     from_block = forced,
                     stored_cursor = stored,
@@ -227,20 +211,13 @@ impl L1InfoTreeIndexer {
                     "L1InfoTreeIndexer: operator override active — starting from forced block. \
                      Remove --l1-indexer-from-block after this boot's backfill completes."
                 );
-                forced.saturating_sub(1)
-            } else if stored == 0 {
-                head
-            } else {
-                // Re-process a small reorg window so we don't miss reorg'd
-                // events. Sepolia 64 blocks ≈ 12 minutes, well inside what
-                // `get_logs` can chunk through quickly via max_range.
-                const REORG_MARGIN: u64 = 64;
-                stored.saturating_sub(REORG_MARGIN)
-            };
+            }
+            let mut last_processed = self.initial_cursor(stored, head);
             tracing::info!(
                 start_block = last_processed,
                 stored_cursor = stored,
-                l1_head = head,
+                selected_head = head,
+                evidence_tag = %self.evidence_tag.describe(),
                 from_block_override = ?self.from_block_override,
                 "L1InfoTreeIndexer cursor initialized"
             );
@@ -275,26 +252,23 @@ impl L1InfoTreeIndexer {
         provider: &P,
         last_processed: &mut u64,
     ) -> anyhow::Result<()> {
-        // Keep the L1 finality-tag block fresh for the strict gate (no-op in
-        // confirmation-depth mode). Done before the head check so it still
-        // advances while the head is idle.
-        self.refresh_finality_block(provider).await;
-        // BLOCKER 1 — mark finalized-chain evidence (no-op in confirmation-depth
-        // mode). Runs regardless of head progress so finality marking keeps up.
-        self.poll_finalized_scan(provider).await?;
+        let head = self.scan_head(provider).await?;
+        self.poll_to_head(provider, last_processed, head).await
+    }
 
-        let head = provider.get_block_number().await?;
+    async fn poll_to_head<P: Provider>(
+        &self,
+        provider: &P,
+        last_processed: &mut u64,
+        head: u64,
+    ) -> anyhow::Result<()> {
         if head <= *last_processed {
             return Ok(());
         }
 
-        // Index the `(mainnet, rollup)` decomposition up to LATEST — ordinary
-        // decomposition / bridge readiness (`zkevm_getExitRootsByGER`) must not
-        // be delayed. H6 reorg-safety for the IRREVERSIBLE strict injection is
-        // enforced at the gate instead (`ger::ensure_ger_l1_observed` requires
-        // the observation to be `confirmations`-deep on L1, using this indexer's
-        // persisted cursor as the head), so a not-yet-final observation is
-        // recorded for normal use but not trusted for strict authorization.
+        // One configured scan is the sole source of L1 root evidence. In
+        // `safe`/`finalized` mode, decomposition intentionally becomes visible
+        // only when that frontier reaches the event.
         let from = *last_processed + 1;
         let to = head.min(from + self.max_range - 1);
 
@@ -380,91 +354,19 @@ impl L1InfoTreeIndexer {
 
         *last_processed = to;
 
-        // Persist the cursor so a restart resumes from here instead of
-        // jumping back to L1 head. Failure to persist is logged but does
+        // Persist the selected-policy cursor so a restart resumes from here.
+        // Failure to persist is logged but does
         // not abort the loop — we'd rather keep indexing on a transient
         // DB blip than wedge the service.
-        if let Err(e) = self.store.set_l1_indexer_cursor(to).await {
+        if let Err(e) = self.store.set_l1_evidence_cursor(to).await {
             tracing::warn!(
                 error = %e,
                 cursor = to,
-                "L1InfoTreeIndexer: failed to persist cursor; continuing in-memory"
+                "L1InfoTreeIndexer: failed to persist selected-policy cursor; continuing in-memory"
             );
             metrics::counter!("l1_info_tree_indexer_cursor_persist_errors_total").increment(1);
         }
 
-        Ok(())
-    }
-
-    /// Audit H6 BLOCKER 1 — the FINALIZED-pinned scan. In a finality-tag mode,
-    /// scan `(mainnet, rollup)` events over `[finalized_scan_cursor+1,
-    /// finalized_block]` and `mark_ger_finalized` each pair. Because the window
-    /// ends at the L1 finalized/safe block, every log it returns is on the
-    /// canonical finalized chain — a fork's event at a height <= finalized is NOT
-    /// returned, so it is never marked and can never authorize. A no-op in
-    /// confirmation-depth mode. A mark-write failure keeps the batch retryable
-    /// (cursor not advanced), exactly like the latest scan.
-    async fn poll_finalized_scan<P: Provider>(&self, provider: &P) -> anyhow::Result<()> {
-        if !self.evidence_tag.is_finality_tag() {
-            return Ok(());
-        }
-        let finalized = self.store.get_l1_finalized_block().await?;
-        if finalized == 0 {
-            return Ok(());
-        }
-        let cursor = self.store.get_l1_finalized_scan_cursor().await?;
-        if finalized <= cursor {
-            return Ok(());
-        }
-        let from = cursor + 1;
-        let to = finalized.min(from + self.max_range - 1);
-
-        let filter = Filter::new()
-            .address(self.contract_address)
-            .from_block(from)
-            .to_block(to)
-            .event_signature(vec![
-                UpdateL1InfoTree::SIGNATURE_HASH,
-                UpdateGlobalExitRoot::SIGNATURE_HASH,
-            ]);
-        let logs: Vec<Log> = provider.get_logs(&filter).await?;
-
-        let mut marked = 0usize;
-        for log in &logs {
-            let topics = log.topics();
-            if topics.len() < 3 {
-                continue;
-            }
-            let mainnet: [u8; 32] = topics[1].0;
-            let rollup: [u8; 32] = topics[2].0;
-            let combined = combined_ger(&mainnet, &rollup);
-            if let Err(e) = self.store.mark_ger_finalized(&combined).await {
-                metrics::counter!("l1_info_tree_indexer_log_errors_total").increment(1);
-                return Err(e.context(format!(
-                    "L1InfoTreeIndexer: finalized mark failed at block {}; finalized batch \
-                     [{from}, {to}] left unadvanced (retryable)",
-                    log.block_number.unwrap_or(0)
-                )));
-            }
-            marked += 1;
-        }
-
-        if marked > 0 {
-            tracing::info!(
-                from,
-                to,
-                finalized,
-                marked,
-                "L1InfoTreeIndexer: marked finalized-chain evidence"
-            );
-        }
-        if let Err(e) = self.store.set_l1_finalized_scan_cursor(to).await {
-            tracing::warn!(
-                error = %e,
-                cursor = to,
-                "L1InfoTreeIndexer: failed to persist finalized-scan cursor; continuing in-memory"
-            );
-        }
         Ok(())
     }
 
@@ -574,7 +476,7 @@ fn combined_ger(mainnet: &[u8; 32], rollup: &[u8; 32]) -> [u8; 32] {
 mod tests {
     use super::*;
     use crate::store::memory::InMemoryStore;
-    use alloy::primitives::{B256, Bytes, LogData, TxHash, U64};
+    use alloy::primitives::{B256, Bytes, LogData, TxHash};
     use alloy::providers::ProviderBuilder;
     use alloy_transport::mock::Asserter;
 
@@ -636,85 +538,46 @@ mod tests {
         }
     }
 
-    /// BLOCKER 1 — the indexer records the decomposition up to LATEST (NO
-    /// confirmation delay for ordinary decomposition), while the STRICT gate
-    /// enforces finality using the indexer cursor as the L1 head. Drives the
-    /// REAL `poll_once` with a mock L1: a pair only 2 blocks deep is recorded
-    /// immediately (so `get_ger_entry` / `zkevm_getExitRootsByGER` see it with no
-    /// delay), yet the strict gate REFUSES it until the cursor advances past the
-    /// confirmation depth — which is exactly what keeps a short-lived reorg from
-    /// authorizing an irreversible injection while never delaying normal ops.
-    ///
-    /// Mutation check: dropping the gate's `l1_head - block >= confirmations`
-    /// clause makes the shallow observation wrongly authorize (phase-1 pass).
+    /// The one selected scan writes roots and provenance together, then advances
+    /// its one cursor. The strict gate can therefore trust exactly those rows.
     #[tokio::test]
-    async fn h6_indexes_to_latest_but_strict_gate_waits_for_finality() {
+    async fn selected_scan_persists_roots_provenance_and_cursor() {
         let store: Arc<dyn Store> = Arc::new(InMemoryStore::new());
-        let indexer = test_indexer(store.clone());
+        let indexer = test_indexer(store.clone()).with_evidence_tag(crate::ger::EvidenceTag::Safe);
 
         let mainnet = B256::from([0x0Au8; 32]);
         let rollup = B256::from([0x0Bu8; 32]);
         let ger = combined_ger(&mainnet.0, &rollup.0);
-        let tx = TxHash::from([0x01u8; 32]);
-        const CONF: u64 = 64;
 
         let asserter = Asserter::new();
         let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
         let mut last_processed = 0u64;
 
-        // Phase 1 — L1 head 10: poll_once indexes the pair at block 8 IMMEDIATELY
-        // (only 2 deep) and advances the cursor to head. Ordinary decomposition
-        // sees it at once; the strict gate refuses it (2 < 64) — transiently.
-        asserter.push_success(&U64::from(10u64));
         asserter.push_success(&vec![pair_log(mainnet, rollup, 8)]);
         asserter.push_success(&Option::<serde_json::Value>::None); // block ts → 0
         indexer
-            .poll_once(&provider, &mut last_processed)
+            .poll_to_head(&provider, &mut last_processed, 10)
             .await
             .unwrap();
-        assert_eq!(
-            last_processed, 10,
-            "cursor tracks latest (no confirmation delay)"
-        );
+        assert_eq!(last_processed, 10);
+        assert_eq!(store.get_l1_evidence_cursor().await.unwrap(), 10);
         let entry = store
             .get_ger_entry(&ger)
             .await
             .unwrap()
-            .expect("decomposition must be recorded immediately (no delay for normal ops)");
+            .expect("selected scan must persist the decomposition");
         assert!(entry.mainnet_exit_root.is_some() && entry.rollup_exit_root.is_some());
+        assert!(entry.evidence_verified);
 
-        let err = crate::ger::ensure_ger_l1_observed(
-            &store,
-            &ger,
-            true,
-            crate::ger::EvidenceTag::Confirmations(CONF),
-            tx,
-        )
-        .await
-        .expect_err("strict gate must refuse a not-yet-confirmation-deep observation");
-        assert!(
-            err.to_string().contains("not yet"),
-            "must cite the finality guard: {err:#}"
-        );
-
-        // Phase 2 — L1 advances to 80: poll_once moves the cursor to 80, so the
-        // block-8 observation is now 72 deep (>= 64) and the strict gate passes.
-        asserter.push_success(&U64::from(80u64));
-        asserter.push_success(&Vec::<alloy::rpc::types::Log>::new()); // no new events
-        indexer
-            .poll_once(&provider, &mut last_processed)
-            .await
-            .unwrap();
-        assert_eq!(last_processed, 80, "cursor advanced to the new head");
         crate::ger::ensure_ger_l1_observed(
             &store,
             &ger,
             true,
-            crate::ger::EvidenceTag::Confirmations(CONF),
-            tx,
+            crate::ger::EvidenceTag::Safe,
+            TxHash::from([0x01u8; 32]),
         )
         .await
-        .expect("strict gate must authorize once the observation is confirmation-deep");
+        .expect("selected-scan evidence must authorize strict admission");
     }
 
     /// BLOCKER 3 (retryable batch) — a durable evidence-write failure must keep
@@ -739,13 +602,12 @@ mod tests {
 
         let asserter = Asserter::new();
         let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
-        asserter.push_success(&U64::from(100u64));
         asserter.push_success(&vec![pair_log(mainnet, rollup, 8)]);
         asserter.push_success(&Option::<serde_json::Value>::None);
 
         let mut last_processed = 0u64;
         let err = indexer
-            .poll_once(&provider, &mut last_processed)
+            .poll_to_head(&provider, &mut last_processed, 100)
             .await
             .expect_err("a durable evidence-write failure must fail the batch");
         assert!(
@@ -758,67 +620,20 @@ mod tests {
         );
     }
 
-    /// BLOCKER 1 (re-review) — the FINALIZED-pinned scan is the finalized-chain
-    /// tie. In `finalized` mode it scans `[cursor+1, finalized_block]` (whose logs
-    /// ARE the canonical finalized chain) and marks each pair `finalized_verified`
-    /// — which is exactly what the strict `finalized` gate then requires. A
-    /// `latest`-observed pair NOT covered by this scan is never marked and cannot
-    /// authorize (proved in `ger::tests::h6_finalized_tag_gate_requires_finalized_chain_tie`).
-    ///
-    /// Mutation check: making `poll_finalized_scan` a no-op leaves the row
-    /// unverified → the authorize step below fails.
-    #[tokio::test]
-    async fn poll_finalized_scan_marks_finalized_chain_evidence() {
+    #[test]
+    fn one_tag_and_from_block_drive_the_single_cursor() {
         let store: Arc<dyn Store> = Arc::new(InMemoryStore::new());
-        let indexer =
-            test_indexer(store.clone()).with_evidence_tag(crate::ger::EvidenceTag::Finalized);
+        let latest = test_indexer(store.clone());
+        let safe = test_indexer(store.clone()).with_evidence_tag(crate::ger::EvidenceTag::Safe);
+        let finalized = test_indexer(store)
+            .with_evidence_tag(crate::ger::EvidenceTag::Finalized)
+            .with_from_block_override(12_345);
 
-        let mainnet = B256::from([0x0Au8; 32]);
-        let rollup = B256::from([0x0Bu8; 32]);
-        let ger = combined_ger(&mainnet.0, &rollup.0);
-        // The latest scan already recorded roots (block 8); NOT finalized yet.
-        store
-            .set_ger_exit_roots(&ger, mainnet.0, rollup.0, 8, 0)
-            .await
-            .unwrap();
-        assert!(
-            !store
-                .get_ger_entry(&ger)
-                .await
-                .unwrap()
-                .unwrap()
-                .finalized_verified,
-            "must start un-finalized"
-        );
-
-        // The L1 finalized block (100) is well above block 8; the finalized scan
-        // covers [1, 100] and reads the canonical pair.
-        store.set_l1_finalized_block(100).await.unwrap();
-        let asserter = Asserter::new();
-        let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
-        asserter.push_success(&vec![pair_log(mainnet, rollup, 8)]);
-        indexer.poll_finalized_scan(&provider).await.unwrap();
-
-        assert!(
-            store
-                .get_ger_entry(&ger)
-                .await
-                .unwrap()
-                .unwrap()
-                .finalized_verified,
-            "the finalized-pinned scan must mark the canonical pair finalized_verified"
-        );
-        assert_eq!(store.get_l1_finalized_scan_cursor().await.unwrap(), 100);
-
-        // The strict `finalized` gate now authorizes it (roots + finalized_verified).
-        crate::ger::ensure_ger_l1_observed(
-            &store,
-            &ger,
-            true,
-            crate::ger::EvidenceTag::Finalized,
-            TxHash::from([0x01u8; 32]),
-        )
-        .await
-        .expect("a finalized-chain-verified observation must authorize");
+        assert_eq!(latest.scan_block_tag(), BlockNumberOrTag::Latest);
+        assert_eq!(safe.scan_block_tag(), BlockNumberOrTag::Safe);
+        assert_eq!(finalized.scan_block_tag(), BlockNumberOrTag::Finalized);
+        assert_eq!(finalized.initial_cursor(0, 20_000_000), 12_344);
+        assert_eq!(safe.initial_cursor(77, 100), 77);
+        assert_eq!(latest.initial_cursor(0, 100), 100);
     }
 }

--- a/src/l1_info_tree_indexer.rs
+++ b/src/l1_info_tree_indexer.rs
@@ -92,6 +92,12 @@ pub struct L1InfoTreeIndexer {
     /// cursor advances forward normally; remove the flag for subsequent
     /// boots.
     from_block_override: Option<u64>,
+    /// Strict-H6 evidence qualification tag (audit H6 BLOCKER 3). When a
+    /// finality tag (`finalized`/`safe`) is configured, each poll also fetches
+    /// that L1 block and persists its number via `set_l1_finalized_block`, which
+    /// the strict gate uses to qualify evidence. In `Confirmations` mode the
+    /// indexer does no extra work (the gate uses the head cursor + depth).
+    evidence_tag: crate::ger::EvidenceTag,
 }
 
 impl L1InfoTreeIndexer {
@@ -103,6 +109,48 @@ impl L1InfoTreeIndexer {
             poll_interval: DEFAULT_POLL_INTERVAL,
             max_range: DEFAULT_MAX_RANGE,
             from_block_override: None,
+            evidence_tag: crate::ger::EvidenceTag::default(),
+        }
+    }
+
+    /// Configure the strict-H6 evidence tag. In `Finalized`/`Safe` mode the
+    /// indexer tracks the corresponding L1 finality block (BLOCKER 3).
+    pub fn with_evidence_tag(mut self, tag: crate::ger::EvidenceTag) -> Self {
+        self.evidence_tag = tag;
+        self
+    }
+
+    /// The L1 block tag to poll for finality tracking, or `None` in
+    /// confirmation-depth mode (no finality block needed).
+    fn finality_block_tag(&self) -> Option<BlockNumberOrTag> {
+        match self.evidence_tag {
+            crate::ger::EvidenceTag::Confirmations(_) => None,
+            crate::ger::EvidenceTag::Finalized => Some(BlockNumberOrTag::Finalized),
+            crate::ger::EvidenceTag::Safe => Some(BlockNumberOrTag::Safe),
+        }
+    }
+
+    /// Best-effort refresh of the persisted L1 finality-tag block (BLOCKER 3).
+    /// A no-op in confirmation-depth mode. A fetch/persist failure just leaves
+    /// the previous value — the strict gate stays fail-closed (never
+    /// over-authorizes on a stale finality block).
+    async fn refresh_finality_block<P: Provider>(&self, provider: &P) {
+        let Some(tag) = self.finality_block_tag() else {
+            return;
+        };
+        match provider.get_block_by_number(tag).await {
+            Ok(Some(block)) => {
+                let n = block.header.number;
+                if let Err(e) = self.store.set_l1_finalized_block(n).await {
+                    tracing::warn!(error = %e, tag = ?tag, "L1InfoTreeIndexer: failed to persist L1 finality block");
+                }
+            }
+            Ok(None) => {
+                tracing::debug!(tag = ?tag, "L1InfoTreeIndexer: L1 finality block not available yet");
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, tag = ?tag, "L1InfoTreeIndexer: failed to fetch L1 finality block");
+            }
         }
     }
 
@@ -227,11 +275,26 @@ impl L1InfoTreeIndexer {
         provider: &P,
         last_processed: &mut u64,
     ) -> anyhow::Result<()> {
+        // Keep the L1 finality-tag block fresh for the strict gate (no-op in
+        // confirmation-depth mode). Done before the head check so it still
+        // advances while the head is idle.
+        self.refresh_finality_block(provider).await;
+        // BLOCKER 1 — mark finalized-chain evidence (no-op in confirmation-depth
+        // mode). Runs regardless of head progress so finality marking keeps up.
+        self.poll_finalized_scan(provider).await?;
+
         let head = provider.get_block_number().await?;
         if head <= *last_processed {
             return Ok(());
         }
 
+        // Index the `(mainnet, rollup)` decomposition up to LATEST — ordinary
+        // decomposition / bridge readiness (`zkevm_getExitRootsByGER`) must not
+        // be delayed. H6 reorg-safety for the IRREVERSIBLE strict injection is
+        // enforced at the gate instead (`ger::ensure_ger_l1_observed` requires
+        // the observation to be `confirmations`-deep on L1, using this indexer's
+        // persisted cursor as the head), so a not-yet-final observation is
+        // recorded for normal use but not trusted for strict authorization.
         let from = *last_processed + 1;
         let to = head.min(from + self.max_range - 1);
 
@@ -267,16 +330,32 @@ impl L1InfoTreeIndexer {
                 Ok(true) => indexed += 1,
                 Ok(false) => {}
                 Err(e) => {
-                    // Don't fail the whole batch on one bad event; advance the
-                    // cursor anyway so we don't get stuck retrying the same
-                    // poison log forever.
+                    // Audit H6 / BLOCKER 3 — a durable evidence-write failure
+                    // must keep the batch RETRYABLE. `process_log` only returns
+                    // Err from the `set_ger_exit_roots` write (a malformed log
+                    // returns Ok(false), never Err), so this is always a
+                    // transient store failure, NOT a poison log. Advancing the
+                    // cursor past it would drop a legitimate GER's evidence
+                    // permanently, and under strict mode that GER would stay
+                    // unverified forever (the side-effect-free retry never
+                    // clears within the process lifetime). Propagate WITHOUT
+                    // touching `*last_processed`, so the next poll re-runs
+                    // exactly this window; `set_ger_exit_roots` is an idempotent
+                    // UPSERT, so re-indexing already-written pairs is safe.
                     tracing::warn!(
                         error = %e,
                         block = block_number,
                         tx = ?log.transaction_hash,
-                        "L1InfoTreeIndexer: failed to index log"
+                        from,
+                        to,
+                        "L1InfoTreeIndexer: durable evidence write failed; leaving batch \
+                         unadvanced for retry"
                     );
                     metrics::counter!("l1_info_tree_indexer_log_errors_total").increment(1);
+                    return Err(e.context(format!(
+                        "L1InfoTreeIndexer: evidence write failed at block {block_number}; \
+                         batch [{from}, {to}] left unadvanced (retryable)"
+                    )));
                 }
             }
         }
@@ -314,6 +393,78 @@ impl L1InfoTreeIndexer {
             metrics::counter!("l1_info_tree_indexer_cursor_persist_errors_total").increment(1);
         }
 
+        Ok(())
+    }
+
+    /// Audit H6 BLOCKER 1 — the FINALIZED-pinned scan. In a finality-tag mode,
+    /// scan `(mainnet, rollup)` events over `[finalized_scan_cursor+1,
+    /// finalized_block]` and `mark_ger_finalized` each pair. Because the window
+    /// ends at the L1 finalized/safe block, every log it returns is on the
+    /// canonical finalized chain — a fork's event at a height <= finalized is NOT
+    /// returned, so it is never marked and can never authorize. A no-op in
+    /// confirmation-depth mode. A mark-write failure keeps the batch retryable
+    /// (cursor not advanced), exactly like the latest scan.
+    async fn poll_finalized_scan<P: Provider>(&self, provider: &P) -> anyhow::Result<()> {
+        if !self.evidence_tag.is_finality_tag() {
+            return Ok(());
+        }
+        let finalized = self.store.get_l1_finalized_block().await?;
+        if finalized == 0 {
+            return Ok(());
+        }
+        let cursor = self.store.get_l1_finalized_scan_cursor().await?;
+        if finalized <= cursor {
+            return Ok(());
+        }
+        let from = cursor + 1;
+        let to = finalized.min(from + self.max_range - 1);
+
+        let filter = Filter::new()
+            .address(self.contract_address)
+            .from_block(from)
+            .to_block(to)
+            .event_signature(vec![
+                UpdateL1InfoTree::SIGNATURE_HASH,
+                UpdateGlobalExitRoot::SIGNATURE_HASH,
+            ]);
+        let logs: Vec<Log> = provider.get_logs(&filter).await?;
+
+        let mut marked = 0usize;
+        for log in &logs {
+            let topics = log.topics();
+            if topics.len() < 3 {
+                continue;
+            }
+            let mainnet: [u8; 32] = topics[1].0;
+            let rollup: [u8; 32] = topics[2].0;
+            let combined = combined_ger(&mainnet, &rollup);
+            if let Err(e) = self.store.mark_ger_finalized(&combined).await {
+                metrics::counter!("l1_info_tree_indexer_log_errors_total").increment(1);
+                return Err(e.context(format!(
+                    "L1InfoTreeIndexer: finalized mark failed at block {}; finalized batch \
+                     [{from}, {to}] left unadvanced (retryable)",
+                    log.block_number.unwrap_or(0)
+                )));
+            }
+            marked += 1;
+        }
+
+        if marked > 0 {
+            tracing::info!(
+                from,
+                to,
+                finalized,
+                marked,
+                "L1InfoTreeIndexer: marked finalized-chain evidence"
+            );
+        }
+        if let Err(e) = self.store.set_l1_finalized_scan_cursor(to).await {
+            tracing::warn!(
+                error = %e,
+                cursor = to,
+                "L1InfoTreeIndexer: failed to persist finalized-scan cursor; continuing in-memory"
+            );
+        }
         Ok(())
     }
 
@@ -422,6 +573,10 @@ fn combined_ger(mainnet: &[u8; 32], rollup: &[u8; 32]) -> [u8; 32] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::store::memory::InMemoryStore;
+    use alloy::primitives::{B256, Bytes, LogData, TxHash, U64};
+    use alloy::providers::ProviderBuilder;
+    use alloy_transport::mock::Asserter;
 
     #[test]
     fn combined_ger_matches_ger_module() {
@@ -444,5 +599,226 @@ mod tests {
             UpdateL1InfoTree::SIGNATURE_HASH,
             UpdateGlobalExitRoot::SIGNATURE_HASH
         );
+    }
+
+    // ── H6 reorg-safety + retryable-batch regressions (PR #121 re-review) ──
+
+    /// Construct a bare indexer over `store`. The RPC URL is never dialled
+    /// (poll_once is driven with a mock provider).
+    fn test_indexer(store: Arc<dyn Store>) -> L1InfoTreeIndexer {
+        L1InfoTreeIndexer::new(
+            "http://mock.invalid".to_string(),
+            Address::from([0x99u8; 20]),
+            store,
+        )
+    }
+
+    /// Build an `UpdateL1InfoTree` log carrying the `(mainnet, rollup)` pair at
+    /// `block`, shaped exactly as `process_log` decodes it (topic0 = event sig,
+    /// topic1 = mainnet, topic2 = rollup).
+    fn pair_log(mainnet: B256, rollup: B256, block: u64) -> alloy::rpc::types::Log {
+        let data = LogData::new_unchecked(
+            vec![UpdateL1InfoTree::SIGNATURE_HASH, mainnet, rollup],
+            Bytes::new(),
+        );
+        alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: Address::from([0x99u8; 20]),
+                data,
+            },
+            block_hash: None,
+            block_number: Some(block),
+            block_timestamp: None,
+            transaction_hash: None,
+            transaction_index: None,
+            log_index: None,
+            removed: false,
+        }
+    }
+
+    /// BLOCKER 1 — the indexer records the decomposition up to LATEST (NO
+    /// confirmation delay for ordinary decomposition), while the STRICT gate
+    /// enforces finality using the indexer cursor as the L1 head. Drives the
+    /// REAL `poll_once` with a mock L1: a pair only 2 blocks deep is recorded
+    /// immediately (so `get_ger_entry` / `zkevm_getExitRootsByGER` see it with no
+    /// delay), yet the strict gate REFUSES it until the cursor advances past the
+    /// confirmation depth — which is exactly what keeps a short-lived reorg from
+    /// authorizing an irreversible injection while never delaying normal ops.
+    ///
+    /// Mutation check: dropping the gate's `l1_head - block >= confirmations`
+    /// clause makes the shallow observation wrongly authorize (phase-1 pass).
+    #[tokio::test]
+    async fn h6_indexes_to_latest_but_strict_gate_waits_for_finality() {
+        let store: Arc<dyn Store> = Arc::new(InMemoryStore::new());
+        let indexer = test_indexer(store.clone());
+
+        let mainnet = B256::from([0x0Au8; 32]);
+        let rollup = B256::from([0x0Bu8; 32]);
+        let ger = combined_ger(&mainnet.0, &rollup.0);
+        let tx = TxHash::from([0x01u8; 32]);
+        const CONF: u64 = 64;
+
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
+        let mut last_processed = 0u64;
+
+        // Phase 1 — L1 head 10: poll_once indexes the pair at block 8 IMMEDIATELY
+        // (only 2 deep) and advances the cursor to head. Ordinary decomposition
+        // sees it at once; the strict gate refuses it (2 < 64) — transiently.
+        asserter.push_success(&U64::from(10u64));
+        asserter.push_success(&vec![pair_log(mainnet, rollup, 8)]);
+        asserter.push_success(&Option::<serde_json::Value>::None); // block ts → 0
+        indexer
+            .poll_once(&provider, &mut last_processed)
+            .await
+            .unwrap();
+        assert_eq!(
+            last_processed, 10,
+            "cursor tracks latest (no confirmation delay)"
+        );
+        let entry = store
+            .get_ger_entry(&ger)
+            .await
+            .unwrap()
+            .expect("decomposition must be recorded immediately (no delay for normal ops)");
+        assert!(entry.mainnet_exit_root.is_some() && entry.rollup_exit_root.is_some());
+
+        let err = crate::ger::ensure_ger_l1_observed(
+            &store,
+            &ger,
+            true,
+            crate::ger::EvidenceTag::Confirmations(CONF),
+            tx,
+        )
+        .await
+        .expect_err("strict gate must refuse a not-yet-confirmation-deep observation");
+        assert!(
+            err.to_string().contains("not yet"),
+            "must cite the finality guard: {err:#}"
+        );
+
+        // Phase 2 — L1 advances to 80: poll_once moves the cursor to 80, so the
+        // block-8 observation is now 72 deep (>= 64) and the strict gate passes.
+        asserter.push_success(&U64::from(80u64));
+        asserter.push_success(&Vec::<alloy::rpc::types::Log>::new()); // no new events
+        indexer
+            .poll_once(&provider, &mut last_processed)
+            .await
+            .unwrap();
+        assert_eq!(last_processed, 80, "cursor advanced to the new head");
+        crate::ger::ensure_ger_l1_observed(
+            &store,
+            &ger,
+            true,
+            crate::ger::EvidenceTag::Confirmations(CONF),
+            tx,
+        )
+        .await
+        .expect("strict gate must authorize once the observation is confirmation-deep");
+    }
+
+    /// BLOCKER 3 (retryable batch) — a durable evidence-write failure must keep
+    /// the batch retryable: `poll_once` must propagate the error and leave the
+    /// cursor UNADVANCED so the next poll re-attempts the same window (the
+    /// `set_ger_exit_roots` UPSERT makes retries idempotent). Pre-fix the loop
+    /// logged the error and advanced the cursor anyway, dropping the GER's
+    /// evidence permanently — under strict mode that GER stays unverified for
+    /// the whole process lifetime.
+    ///
+    /// Mutation check: reverting to the old "log + continue" arm (no early
+    /// return) makes poll_once return Ok and advance the cursor to 36 — this
+    /// test fails on both assertions.
+    #[tokio::test]
+    async fn h6_evidence_write_failure_leaves_batch_retryable() {
+        let store = Arc::new(InMemoryStore::new());
+        store.test_fail_next_ger_evidence_write();
+        let indexer = test_indexer(store);
+
+        let mainnet = B256::from([0x0Cu8; 32]);
+        let rollup = B256::from([0x0Du8; 32]);
+
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
+        asserter.push_success(&U64::from(100u64));
+        asserter.push_success(&vec![pair_log(mainnet, rollup, 8)]);
+        asserter.push_success(&Option::<serde_json::Value>::None);
+
+        let mut last_processed = 0u64;
+        let err = indexer
+            .poll_once(&provider, &mut last_processed)
+            .await
+            .expect_err("a durable evidence-write failure must fail the batch");
+        assert!(
+            err.to_string().contains("evidence write failed"),
+            "error must identify the retryable batch: {err:#}"
+        );
+        assert_eq!(
+            last_processed, 0,
+            "cursor MUST NOT advance past a batch whose evidence write failed"
+        );
+    }
+
+    /// BLOCKER 1 (re-review) — the FINALIZED-pinned scan is the finalized-chain
+    /// tie. In `finalized` mode it scans `[cursor+1, finalized_block]` (whose logs
+    /// ARE the canonical finalized chain) and marks each pair `finalized_verified`
+    /// — which is exactly what the strict `finalized` gate then requires. A
+    /// `latest`-observed pair NOT covered by this scan is never marked and cannot
+    /// authorize (proved in `ger::tests::h6_finalized_tag_gate_requires_finalized_chain_tie`).
+    ///
+    /// Mutation check: making `poll_finalized_scan` a no-op leaves the row
+    /// unverified → the authorize step below fails.
+    #[tokio::test]
+    async fn poll_finalized_scan_marks_finalized_chain_evidence() {
+        let store: Arc<dyn Store> = Arc::new(InMemoryStore::new());
+        let indexer =
+            test_indexer(store.clone()).with_evidence_tag(crate::ger::EvidenceTag::Finalized);
+
+        let mainnet = B256::from([0x0Au8; 32]);
+        let rollup = B256::from([0x0Bu8; 32]);
+        let ger = combined_ger(&mainnet.0, &rollup.0);
+        // The latest scan already recorded roots (block 8); NOT finalized yet.
+        store
+            .set_ger_exit_roots(&ger, mainnet.0, rollup.0, 8, 0)
+            .await
+            .unwrap();
+        assert!(
+            !store
+                .get_ger_entry(&ger)
+                .await
+                .unwrap()
+                .unwrap()
+                .finalized_verified,
+            "must start un-finalized"
+        );
+
+        // The L1 finalized block (100) is well above block 8; the finalized scan
+        // covers [1, 100] and reads the canonical pair.
+        store.set_l1_finalized_block(100).await.unwrap();
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
+        asserter.push_success(&vec![pair_log(mainnet, rollup, 8)]);
+        indexer.poll_finalized_scan(&provider).await.unwrap();
+
+        assert!(
+            store
+                .get_ger_entry(&ger)
+                .await
+                .unwrap()
+                .unwrap()
+                .finalized_verified,
+            "the finalized-pinned scan must mark the canonical pair finalized_verified"
+        );
+        assert_eq!(store.get_l1_finalized_scan_cursor().await.unwrap(), 100);
+
+        // The strict `finalized` gate now authorizes it (roots + finalized_verified).
+        crate::ger::ensure_ger_l1_observed(
+            &store,
+            &ger,
+            true,
+            crate::ger::EvidenceTag::Finalized,
+            TxHash::from([0x01u8; 32]),
+        )
+        .await
+        .expect("a finalized-chain-verified observation must authorize");
     }
 }

--- a/src/log_synthesis.rs
+++ b/src/log_synthesis.rs
@@ -289,6 +289,13 @@ pub struct GerEntry {
     pub rollup_exit_root: Option<[u8; 32]>,
     pub block_number: u64,
     pub timestamp: u64,
+    /// Audit H6 BLOCKER 1 — the `(mainnet, rollup)` decomposition has been
+    /// confirmed on the L1 FINALIZED (or `safe`) canonical chain by a scan
+    /// pinned to that block tag. Only such rows may authorize a strict injection
+    /// in `finalized`/`safe` mode: a `latest`-observed row from a reorged-away
+    /// fork is NEVER marked, so it cannot authorize despite a block-height
+    /// coincidence. Always `false` for rows recorded only from the latest scan.
+    pub finalized_verified: bool,
 }
 
 // LogStore has been replaced by the Store trait — see src/store/mod.rs

--- a/src/log_synthesis.rs
+++ b/src/log_synthesis.rs
@@ -289,13 +289,9 @@ pub struct GerEntry {
     pub rollup_exit_root: Option<[u8; 32]>,
     pub block_number: u64,
     pub timestamp: u64,
-    /// Audit H6 BLOCKER 1 — the `(mainnet, rollup)` decomposition has been
-    /// confirmed on the L1 FINALIZED (or `safe`) canonical chain by a scan
-    /// pinned to that block tag. Only such rows may authorize a strict injection
-    /// in `finalized`/`safe` mode: a `latest`-observed row from a reorged-away
-    /// fork is NEVER marked, so it cannot authorize despite a block-height
-    /// coincidence. Always `false` for rows recorded only from the latest scan.
-    pub finalized_verified: bool,
+    /// The roots were written by the database-bound selected scan. The
+    /// PostgreSQL column retains its legacy `finalized_verified` name.
+    pub evidence_verified: bool,
 }
 
 // LogStore has been replaced by the Store trait — see src/store/mod.rs

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,23 +111,11 @@ struct Command {
     #[arg(long, env = "L1_INDEXER_FROM_BLOCK")]
     l1_indexer_from_block: Option<u64>,
 
-    /// Audit H6 — the SINGLE strict-H6 evidence-finality setting. One value
-    /// fully specifies how the strict gate qualifies an L1 observation as final
-    /// enough to authorize an IRREVERSIBLE GER injection (there is no separate
-    /// confirmation-depth flag). Values: `confirmations:<N>` = depth below the
-    /// indexer head cursor (`l1_head - evidence_block >= N`), strict-non-hardened
-    /// only; `finalized` = the `(mainnet, rollup)` must be on the L1 FINALIZED
-    /// canonical chain (verified by a finalized-pinned scan; a reorged fork
-    /// cannot authorize), MANDATORY under `--require-hardening`; `safe` = same,
-    /// against the L1 `safe` block (weaker than `finalized`).
-    ///
-    /// Normal (lenient) decomposition always uses `latest` and is unaffected;
-    /// this gates strict authorization only. Under
-    /// `--reject-unverified-ger-injection` a `confirmations:<N>` value must have
-    /// `N >= 1`; under `--require-hardening` the value must be `finalized`, else
-    /// the service refuses to boot. Default `confirmations:64` (≈ Sepolia
-    /// finality).
-    #[arg(long, env = "L1_EVIDENCE_TAG", default_value = "confirmations:64")]
+    /// Audit H6 — the one L1 frontier the evidence indexer scans: `latest`,
+    /// `safe`, or `finalized`. Roots become visible only after the selected
+    /// frontier reaches their event. `--require-hardening` accepts `safe` or
+    /// `finalized` and refuses `latest`. Default `latest` preserves dev latency.
+    #[arg(long, env = "L1_EVIDENCE_TAG", default_value = "latest")]
     l1_evidence_tag: String,
 
     /// Faucet-registry security reconciler poll interval, in seconds. The reconciler is
@@ -418,51 +406,31 @@ fn check_h6_evidence_source(command: &Command) -> Result<(), String> {
             ));
         }
     }
-    // Audit H6 — the SINGLE evidence-finality setting must parse and satisfy the
-    // strict/hardened invariants. There is exactly one knob (`--l1-evidence-tag`).
+    // Audit H6 — one selected L1 scan frontier.
     use miden_agglayer_service::ger::EvidenceTag;
     let Some(tag) = EvidenceTag::parse(&command.l1_evidence_tag) else {
         return Err(format!(
             "strict H6 GER corroboration is enabled via {trigger}, but --l1-evidence-tag \
              (L1_EVIDENCE_TAG) `{}` is not a recognised value (expected: \
-             `confirmations:<N>`, `finalized`, or `safe`).",
+             `latest`, `safe`, or `finalized`).",
             command.l1_evidence_tag
         ));
     };
-    // Hardened MANDATES `finalized` (a finalized L1 block cannot be reorged): a
-    // finalized-chain-verified decomposition is the only evidence strong enough
-    // for hardened authorization. `confirmations:<N>` and `safe` are refused.
-    if command.require_hardening && tag != EvidenceTag::Finalized {
+    // Hardened requires at least the L1 safe head. `finalized` remains the
+    // stronger production choice; `latest` is dev/non-hardened only.
+    if command.require_hardening && tag == EvidenceTag::Latest {
         return Err(format!(
-            "--require-hardening MANDATES `--l1-evidence-tag=finalized`, but it is `{}`. \
-             A finalized L1 block cannot be reorged; confirmation-depth and `safe` are NOT \
-             sufficient for hardened GER authorization. Set --l1-evidence-tag=finalized.",
+            "--require-hardening requires `--l1-evidence-tag=safe` or `finalized`, but it is `{}`. \
+             `latest` may include reorgable L1 blocks and is not sufficient for hardened GER \
+             authorization.",
             tag.describe()
-        ));
-    }
-    // In `confirmations:<N>` mode, strict must NOT authorize an irreversible
-    // injection from a zero-confirmation (freely reorg-able) observation. Refuse
-    // a sub-minimum depth so an operator can't disable the finality guard while
-    // leaving strict on. Finality-tag modes qualify by canonical chain, so no
-    // depth applies there.
-    if let EvidenceTag::Confirmations(n) = tag
-        && n < miden_agglayer_service::ger::MIN_STRICT_CONFIRMATIONS
-    {
-        return Err(format!(
-            "strict H6 GER corroboration is enabled via {trigger}, but --l1-evidence-tag \
-             (L1_EVIDENCE_TAG) `confirmations:{n}` has a depth below the safe minimum of \
-             {}. A zero/sub-minimum depth would authorize an IRREVERSIBLE GER injection \
-             from a 0-confirmation, freely reorg-able L1 observation. Use \
-             `confirmations:{}` (≈ Sepolia finality) or higher, or `finalized`.",
-            miden_agglayer_service::ger::MIN_STRICT_CONFIRMATIONS,
-            miden_agglayer_service::ger::DEFAULT_CONFIRMATIONS,
         ));
     }
     Ok(())
 }
 
 /// Blocker 2 — fresh-database backfill invariant for strict H6. On a fresh
-/// database the persisted L1-indexer cursor is 0, and without an explicit
+/// database the selected-policy cursor is 0, and without an explicit
 /// `--l1-indexer-from-block` the indexer deliberately starts at the CURRENT L1
 /// head to avoid a multi-million-block backfill. That default is safe for a
 /// brand-new chain, but for a strict deployment brought up OVER an existing
@@ -642,7 +610,7 @@ async fn main() -> anyhow::Result<()> {
     )
     .ok_or_else(|| {
         anyhow::anyhow!(
-            "unrecognised --l1-evidence-tag (L1_EVIDENCE_TAG) `{}`; expected `confirmations:<N>`, `finalized`, or `safe`",
+            "unrecognised --l1-evidence-tag (L1_EVIDENCE_TAG) `{}`; expected `latest`, `safe`, or `finalized`",
             command.l1_evidence_tag
         )
     })?;
@@ -792,7 +760,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     store
-        .bind_l1_evidence_policy(&l1_evidence_tag.describe())
+        .bind_l1_evidence_policy(l1_evidence_tag.describe())
         .await
         .context("binding persisted L1 evidence to the configured policy")?;
 
@@ -968,9 +936,9 @@ async fn main() -> anyhow::Result<()> {
     // instead. A store read failure is a startup failure, not an empty cursor.
     {
         let persisted_cursor = store
-            .get_l1_indexer_cursor()
+            .get_l1_evidence_cursor()
             .await
-            .context("loading the persisted L1 indexer cursor")?;
+            .context("loading the persisted L1 evidence cursor")?;
         if let Err(reason) = check_h6_backfill_invariant(
             command.reject_unverified_ger,
             command.require_hardening,
@@ -1063,8 +1031,7 @@ async fn main() -> anyhow::Result<()> {
                 if let Some(from_block) = command.l1_indexer_from_block {
                     indexer = indexer.with_from_block_override(from_block);
                 }
-                // BLOCKER 3 — in a finality-tag mode the indexer tracks the L1
-                // finalized/safe block for the strict gate.
+                // Use the one startup-validated frontier for the entire scan.
                 indexer = indexer.with_evidence_tag(state.l1_evidence_tag);
                 match indexer.spawn() {
                     Ok(shutdown_tx) => {
@@ -1347,7 +1314,7 @@ mod hardening_tests {
             l1_rpc_url: None,
             ger_l1_address: None,
             l1_indexer_from_block: None,
-            l1_evidence_tag: "confirmations:64".to_string(),
+            l1_evidence_tag: "latest".to_string(),
             faucet_reconciler_poll_secs: 30,
             faucet_reconciler_grace_ticks: 3,
             miden_debug: false,
@@ -1555,20 +1522,16 @@ mod hardening_tests {
         c.reject_unverified_ger = true;
         c.l1_rpc_url = Some("http://anvil:8545".into());
         c.ger_l1_address = Some("0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674".into());
-        // hardened (cmd(true, …)) mandates the finalized evidence tag.
+        // Hardened accepts either hardened-compatible frontier.
         c.l1_evidence_tag = "finalized".into();
         assert!(check_h6_evidence_source(&c).is_ok());
     }
 
-    /// BLOCKER 1 (re-review) — strict mode must REFUSE to boot with a
-    /// zero/sub-minimum confirmation depth: it would authorize an irreversible
-    /// injection from a 0-confirmation, freely reorg-able observation, silently
-    /// disabling the finality guard while leaving strict on. An otherwise-valid
-    /// evidence source does not save it.
+    /// The one evidence-policy knob accepts only the three RPC block tags.
     #[test]
-    fn h6_strict_with_zero_confirmations_refused_at_startup() {
+    fn h6_strict_accepts_only_supported_evidence_policies() {
         let mut c = cmd(
-            true,
+            false,
             Some("strong-admin-key".into()),
             Some(vec![alloy::primitives::Address::ZERO]),
             Some(vec!["https://app.example.com".into()]),
@@ -1576,31 +1539,31 @@ mod hardening_tests {
         c.reject_unverified_ger = true;
         c.l1_rpc_url = Some("http://anvil:8545".into());
         c.ger_l1_address = Some("0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674".into());
-        // Exercise the confirmation-depth zero refusal specifically → non-hardened
-        // strict (reject_unverified only), so the finalized-tag mandate (which
-        // hardened would trip first) doesn't preempt the depth check. The depth is
-        // folded into the SINGLE `--l1-evidence-tag` value.
-        c.require_hardening = false;
-        c.l1_evidence_tag = "confirmations:0".into();
-        let reason = check_h6_evidence_source(&c).unwrap_err();
-        assert!(
-            reason.contains("confirmations:0") || reason.contains("safe minimum"),
-            "must name the sub-minimum depth: {reason}"
-        );
-        // A nonzero depth with the same evidence source boots.
-        c.l1_evidence_tag = format!(
-            "confirmations:{}",
-            miden_agglayer_service::ger::MIN_STRICT_CONFIRMATIONS
-        );
-        assert!(check_h6_evidence_source(&c).is_ok());
+
+        for accepted in ["latest", "safe", "finalized"] {
+            c.l1_evidence_tag = accepted.into();
+            assert!(
+                check_h6_evidence_source(&c).is_ok(),
+                "strict non-hardened mode must accept `{accepted}`"
+            );
+        }
+
+        for rejected in ["confirmations", "confirmations:64", "banana"] {
+            c.l1_evidence_tag = rejected.into();
+            let reason = check_h6_evidence_source(&c).unwrap_err();
+            assert!(
+                reason.contains("latest")
+                    && reason.contains("safe")
+                    && reason.contains("finalized"),
+                "unsupported policy `{rejected}` must list the accepted values: {reason}"
+            );
+        }
     }
 
-    /// BLOCKER 3 (re-review) — `--require-hardening` MANDATES the `finalized` L1
-    /// evidence tag. A confirmation-depth or `safe` tag under hardening must
-    /// refuse to boot; `finalized` boots. Also an unparsable tag under strict is
-    /// refused.
+    /// Hardened mode refuses the reorgable `latest` frontier and accepts both
+    /// canonical finality frontiers.
     #[test]
-    fn h6_hardened_requires_finalized_evidence_tag() {
+    fn h6_hardened_requires_safe_or_finalized_evidence_tag() {
         // Hardened base with a valid evidence source.
         let mut c = cmd(
             true,
@@ -1612,25 +1575,24 @@ mod hardening_tests {
         c.ger_l1_address = Some("0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674".into());
         c.require_hardening = true;
 
-        // Default `confirmations` tag under hardening → refuse.
-        c.l1_evidence_tag = "confirmations".into();
+        // `latest` is reorgable and therefore not sufficient for hardening.
+        c.l1_evidence_tag = "latest".into();
         let reason = check_h6_evidence_source(&c).unwrap_err();
         assert!(
-            reason.contains("finalized"),
-            "must demand the finalized tag: {reason}"
+            reason.contains("safe") && reason.contains("finalized"),
+            "must list the hardened policies: {reason}"
         );
 
-        // `safe` is not sufficient for hardened.
+        // Both hardened-compatible frontiers are valid policies.
         c.l1_evidence_tag = "safe".into();
-        assert!(check_h6_evidence_source(&c).is_err());
+        assert!(check_h6_evidence_source(&c).is_ok());
+
+        c.l1_evidence_tag = "finalized".into();
+        assert!(check_h6_evidence_source(&c).is_ok());
 
         // An unparsable tag under strict is refused too.
         c.l1_evidence_tag = "banana".into();
         assert!(check_h6_evidence_source(&c).is_err());
-
-        // `finalized` boots.
-        c.l1_evidence_tag = "finalized".into();
-        assert!(check_h6_evidence_source(&c).is_ok());
     }
 
     // ── Blocker 1: malformed L1 RPC URL → abort; unreachable → keep retrying ──
@@ -1647,9 +1609,8 @@ mod hardening_tests {
         c.reject_unverified_ger = true;
         c.l1_rpc_url = Some(rpc.to_string());
         c.ger_l1_address = Some("0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674".into());
-        // hardened (cmd(true, …)) mandates the finalized evidence tag; set it so these
-        // URL-validation cases isolate the RPC-URL check, not the tag check.
-        c.l1_evidence_tag = "finalized".into();
+        // Use a hardened-compatible policy so these cases isolate the URL check.
+        c.l1_evidence_tag = "safe".into();
         c
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,25 @@ struct Command {
     #[arg(long, env = "L1_INDEXER_FROM_BLOCK")]
     l1_indexer_from_block: Option<u64>,
 
+    /// Audit H6 — the SINGLE strict-H6 evidence-finality setting. One value
+    /// fully specifies how the strict gate qualifies an L1 observation as final
+    /// enough to authorize an IRREVERSIBLE GER injection (there is no separate
+    /// confirmation-depth flag). Values: `confirmations:<N>` = depth below the
+    /// indexer head cursor (`l1_head - evidence_block >= N`), strict-non-hardened
+    /// only; `finalized` = the `(mainnet, rollup)` must be on the L1 FINALIZED
+    /// canonical chain (verified by a finalized-pinned scan; a reorged fork
+    /// cannot authorize), MANDATORY under `--require-hardening`; `safe` = same,
+    /// against the L1 `safe` block (weaker than `finalized`).
+    ///
+    /// Normal (lenient) decomposition always uses `latest` and is unaffected;
+    /// this gates strict authorization only. Under
+    /// `--reject-unverified-ger-injection` a `confirmations:<N>` value must have
+    /// `N >= 1`; under `--require-hardening` the value must be `finalized`, else
+    /// the service refuses to boot. Default `confirmations:64` (≈ Sepolia
+    /// finality).
+    #[arg(long, env = "L1_EVIDENCE_TAG", default_value = "confirmations:64")]
+    l1_evidence_tag: String,
+
     /// Faucet-registry security reconciler poll interval, in seconds. The reconciler is
     /// a TRIPWIRE: it scans the bridge's on-chain faucet registrations and halts the
     /// proxy (fail-closed) if it finds one with no local `faucet_registry` row — the
@@ -159,6 +178,35 @@ struct Command {
     /// and/or a network-level boundary.
     #[arg(long, env = "INSECURE_ALLOW_ANY_SIGNER", default_value_t = false)]
     insecure_allow_any_signer: bool,
+    /// Audit H6 — refuse to inject a GER whose `(mainnet, rollup)` decomposition
+    /// was NOT corroborated by the independent L1 InfoTree indexer (i.e. a GER
+    /// supplied only by the aggoracle with no matching on-chain observation).
+    /// Defends against a compromised aggoracle key forging a GER onto Miden.
+    ///
+    /// PRODUCTION MUST ENABLE THIS. The default is false (lenient: allow
+    /// through + warn + `ger_injection_unverified_total`) only to tolerate
+    /// indexer lag on dev/e2e stacks — merging the H6 code without setting
+    /// `REJECT_UNVERIFIED_GER_INJECTION=true` (or `REQUIRE_HARDENING=true`,
+    /// which implies it) does NOT close audit finding H6. Strict mode
+    /// requires the L1 evidence source (`--l1-rpc-url` + `--ger-l1-address`,
+    /// both syntactically valid) at startup — a malformed L1 RPC URL or GER
+    /// address ABORTS the boot rather than serving with a dead evidence source
+    /// (see `check_h6_evidence_source`). On a FRESH database (no persisted
+    /// indexer cursor) strict mode also requires `--l1-indexer-from-block`
+    /// (`L1_INDEXER_FROM_BLOCK`) set to a block at or before the rollup
+    /// deployment, else the indexer would start at the current L1 head and
+    /// reject every pre-existing GER forever (see `check_h6_backfill_invariant`).
+    ///
+    /// The long flag is spelled `--reject-unverified-ger-injection` (matching
+    /// the bail message in `ger.rs`, the e2e script, and the env var) rather
+    /// than clap's field-derived `--reject-unverified-ger`, so operators
+    /// following the docs can actually enable strict mode.
+    #[arg(
+        long = "reject-unverified-ger-injection",
+        env = "REJECT_UNVERIFIED_GER_INJECTION",
+        default_value_t = false
+    )]
+    reject_unverified_ger: bool,
 
     /// Per-IP rate limit, sustained requests per second (R13). Default 500.
     #[arg(long, env = "RATE_LIMIT_PER_SECOND", default_value_t = miden_agglayer_service::service::DEFAULT_RATE_LIMIT_PER_SECOND)]
@@ -286,6 +334,180 @@ fn check_hardening_invariants(command: &Command) -> Result<(), Vec<String>> {
     }
 }
 
+/// Audit H6 startup invariant (PR #121 review point 2). Strict H6 refuses any
+/// GER the L1 InfoTree indexer has not corroborated — the indexer IS the
+/// evidence source. If strict mode boots with the indexer disabled (missing
+/// L1 RPC / GER address), the proxy "fails closed" by rejecting EVERY new GER
+/// injection: technically safe, but an avoidable production outage that only
+/// surfaces when the first aggoracle injection arrives. Make the evidence
+/// source a startup invariant instead: refuse to boot with a clear error.
+///
+/// Covers BOTH strict triggers: the explicit
+/// `--reject-unverified-ger-injection` flag and `--require-hardening` (which
+/// implies it). Also validates the GER address parses — the indexer spawn
+/// only warns on a bad address and continues without it, which under strict
+/// mode would be the same silent outage.
+fn check_h6_evidence_source(command: &Command) -> Result<(), String> {
+    let strict = command.reject_unverified_ger || command.require_hardening;
+    if !strict {
+        return Ok(());
+    }
+    let trigger = if command.reject_unverified_ger {
+        "--reject-unverified-ger-injection (REJECT_UNVERIFIED_GER_INJECTION)"
+    } else {
+        "--require-hardening (which implies strict H6 GER corroboration)"
+    };
+    if command.l1_rpc_url.is_none() || command.ger_l1_address.is_none() {
+        return Err(format!(
+            "strict H6 GER corroboration is enabled via {trigger}, but its evidence \
+             source — the L1 InfoTree indexer — is not configured: set BOTH \
+             --l1-rpc-url (L1_RPC_URL) and --ger-l1-address (GER_L1_ADDRESS). \
+             Without the indexer no GER can ever be corroborated, so EVERY new GER \
+             injection would be rejected: a fail-closed production outage. \
+             Cursor/backfill posture: on a fresh database also set \
+             --l1-indexer-from-block (L1_INDEXER_FROM_BLOCK) to a block at or before \
+             the rollup deployment so historic UpdateL1InfoTree leaves are indexed — \
+             GERs older than the indexer's first scanned block would otherwise stay \
+             unverified and be refused."
+        ));
+    }
+    if let Some(addr) = command.ger_l1_address.as_deref()
+        && addr.parse::<alloy::primitives::Address>().is_err()
+    {
+        return Err(format!(
+            "strict H6 GER corroboration is enabled via {trigger}, but --ger-l1-address \
+             `{addr}` is not a valid EVM address. The L1 InfoTree indexer would fail to \
+             start (it only WARNS and continues), leaving strict mode with no evidence \
+             source — every new GER injection would be rejected (fail-closed outage). \
+             Fix the address before boot."
+        ));
+    }
+    // Blocker 1 — a MALFORMED L1 RPC URL is a config error, not a transient
+    // outage: `L1InfoTreeIndexer::spawn()` parses the URL synchronously and
+    // returns Err (which `main` previously only LOGGED before continuing to
+    // serve, leaving strict mode with a permanently-dead evidence source that
+    // rejects every fresh GER forever). Catch the unparsable URL here so strict
+    // startup ABORTS. This is the "config/spawn invalid → abort" half of the
+    // distinction; a syntactically-valid but currently-UNREACHABLE RPC parses
+    // fine here, `spawn()` builds its provider without connecting, and the
+    // indexer task retries the connection — the intended fail-closed-and-retry
+    // posture, NOT a startup abort. `url::Url` is exactly what alloy's
+    // `connect_http` parses the string into, so "parses here" ⟺ "spawn won't
+    // reject the URL".
+    if let Some(rpc) = command.l1_rpc_url.as_deref() {
+        // `Url::parse` alone is too weak: it accepts `file:///…`, `ws://…`,
+        // hostless URLs, and custom schemes (the common `anvil:8545` typo parses
+        // as scheme=`anvil`). `connect_http` does NOT reject those synchronously
+        // at spawn — the indexer starts and then retries failed HTTP posts
+        // forever while strict mode refuses every fresh GER. So require an
+        // http(s) scheme AND a host. A syntactically valid but currently
+        // UNREACHABLE http(s) endpoint still passes (it spawns and retries — the
+        // intended fail-closed posture).
+        let usable_http = rpc.parse::<Url>().ok().is_some_and(|u| {
+            matches!(u.scheme(), "http" | "https") && u.host_str().is_some_and(|h| !h.is_empty())
+        });
+        if !usable_http {
+            return Err(format!(
+                "strict H6 GER corroboration is enabled via {trigger}, but --l1-rpc-url \
+                 `{rpc}` is not a usable HTTP(S) RPC endpoint: it must have an `http` or \
+                 `https` scheme AND a host (rejected examples: `file:///…`, `ws://…`, a \
+                 hostless URL, or the `anvil:8545` custom-scheme typo). The L1 InfoTree \
+                 indexer would start against it and retry failed HTTP posts forever while \
+                 strict mode refuses every fresh GER — a fail-closed outage. A valid but \
+                 temporarily-unreachable http(s) endpoint is fine; fix the URL before boot."
+            ));
+        }
+    }
+    // Audit H6 — the SINGLE evidence-finality setting must parse and satisfy the
+    // strict/hardened invariants. There is exactly one knob (`--l1-evidence-tag`).
+    use miden_agglayer_service::ger::EvidenceTag;
+    let Some(tag) = EvidenceTag::parse(&command.l1_evidence_tag) else {
+        return Err(format!(
+            "strict H6 GER corroboration is enabled via {trigger}, but --l1-evidence-tag \
+             (L1_EVIDENCE_TAG) `{}` is not a recognised value (expected: \
+             `confirmations:<N>`, `finalized`, or `safe`).",
+            command.l1_evidence_tag
+        ));
+    };
+    // Hardened MANDATES `finalized` (a finalized L1 block cannot be reorged): a
+    // finalized-chain-verified decomposition is the only evidence strong enough
+    // for hardened authorization. `confirmations:<N>` and `safe` are refused.
+    if command.require_hardening && tag != EvidenceTag::Finalized {
+        return Err(format!(
+            "--require-hardening MANDATES `--l1-evidence-tag=finalized`, but it is `{}`. \
+             A finalized L1 block cannot be reorged; confirmation-depth and `safe` are NOT \
+             sufficient for hardened GER authorization. Set --l1-evidence-tag=finalized.",
+            tag.describe()
+        ));
+    }
+    // In `confirmations:<N>` mode, strict must NOT authorize an irreversible
+    // injection from a zero-confirmation (freely reorg-able) observation. Refuse
+    // a sub-minimum depth so an operator can't disable the finality guard while
+    // leaving strict on. Finality-tag modes qualify by canonical chain, so no
+    // depth applies there.
+    if let EvidenceTag::Confirmations(n) = tag
+        && n < miden_agglayer_service::ger::MIN_STRICT_CONFIRMATIONS
+    {
+        return Err(format!(
+            "strict H6 GER corroboration is enabled via {trigger}, but --l1-evidence-tag \
+             (L1_EVIDENCE_TAG) `confirmations:{n}` has a depth below the safe minimum of \
+             {}. A zero/sub-minimum depth would authorize an IRREVERSIBLE GER injection \
+             from a 0-confirmation, freely reorg-able L1 observation. Use \
+             `confirmations:{}` (≈ Sepolia finality) or higher, or `finalized`.",
+            miden_agglayer_service::ger::MIN_STRICT_CONFIRMATIONS,
+            miden_agglayer_service::ger::DEFAULT_CONFIRMATIONS,
+        ));
+    }
+    Ok(())
+}
+
+/// Blocker 2 — fresh-database backfill invariant for strict H6. On a fresh
+/// database the persisted L1-indexer cursor is 0, and without an explicit
+/// `--l1-indexer-from-block` the indexer deliberately starts at the CURRENT L1
+/// head to avoid a multi-million-block backfill. That default is safe for a
+/// brand-new chain, but for a strict deployment brought up OVER an existing
+/// chain it means every pre-existing / currently-observed GER sits BELOW the
+/// indexer's first scanned block and can never be corroborated — so the first
+/// current or replayed GER is rejected forever. Make the operator choose:
+/// either a non-zero persisted cursor (an existing indexed database) OR an
+/// explicit safe from-block. Non-strict behavior is unchanged.
+///
+/// Takes the relevant Copy fields by value rather than `&Command` because it is
+/// evaluated only after the store exists (well past the point where non-Copy
+/// command fields such as `miden_store_dir` have already been moved out), so the
+/// whole struct can no longer be borrowed.
+fn check_h6_backfill_invariant(
+    reject_unverified_ger: bool,
+    require_hardening: bool,
+    l1_indexer_from_block: Option<u64>,
+    persisted_cursor: u64,
+) -> Result<(), String> {
+    let strict = reject_unverified_ger || require_hardening;
+    if !strict {
+        return Ok(());
+    }
+    if persisted_cursor == 0 && l1_indexer_from_block.is_none() {
+        let trigger = if reject_unverified_ger {
+            "--reject-unverified-ger-injection (REJECT_UNVERIFIED_GER_INJECTION)"
+        } else {
+            "--require-hardening (which implies strict H6 GER corroboration)"
+        };
+        return Err(format!(
+            "strict H6 GER corroboration is enabled via {trigger} on a FRESH database \
+             (persisted L1-indexer cursor = 0) with no --l1-indexer-from-block \
+             (L1_INDEXER_FROM_BLOCK) set. The indexer would start at the CURRENT L1 head, \
+             so every GER emitted at or before that head — i.e. every pre-existing or \
+             replayed GER when deploying over an existing chain — is permanently below \
+             the indexer's first scanned block and can never be corroborated: strict mode \
+             would reject the first current/replayed GER forever. Set \
+             --l1-indexer-from-block to a block at or before the rollup deployment so the \
+             historic UpdateL1InfoTree leaves are indexed, OR boot against a database that \
+             already carries a non-zero persisted cursor."
+        ));
+    }
+    Ok(())
+}
+
 /// clap value parser for `--bind`: validate the value as a bare IP address
 /// (`0.0.0.0`, `127.0.0.1`, `::1`, …) at the CLI boundary. The service port is
 /// a *separate* `--port` arg, so a `host:port` form (`127.0.0.1:8546`) or a
@@ -347,6 +569,7 @@ impl std::fmt::Debug for Command {
             .field("cors_allowed_origins", &self.cors_allowed_origins)
             .field("allowed_signers", &self.allowed_signers)
             .field("insecure_allow_any_signer", &self.insecure_allow_any_signer)
+            .field("reject_unverified_ger", &self.reject_unverified_ger)
             .field("require_hardening", &self.require_hardening)
             .field(
                 "miden_api_key",
@@ -404,6 +627,25 @@ async fn main() -> anyhow::Result<()> {
             reasons.join("\n")
         );
     }
+
+    // Audit H6 startup invariant — strict GER corroboration requires its
+    // evidence source (the L1 InfoTree indexer) to be configured, or every
+    // new GER injection would be rejected (fail-closed outage). See
+    // `check_h6_evidence_source`.
+    if let Err(reason) = check_h6_evidence_source(&command) {
+        anyhow::bail!("{reason}");
+    }
+    // Parse once for every serving mode. Silently defaulting an invalid value
+    // would bind the database to evidence the operator did not configure.
+    let l1_evidence_tag = miden_agglayer_service::ger::EvidenceTag::parse(
+        &command.l1_evidence_tag,
+    )
+    .ok_or_else(|| {
+        anyhow::anyhow!(
+            "unrecognised --l1-evidence-tag (L1_EVIDENCE_TAG) `{}`; expected `confirmations:<N>`, `finalized`, or `safe`",
+            command.l1_evidence_tag
+        )
+    })?;
 
     // Startup probe — when --require-hardening is set AND a remote prover is
     // configured, dial the gRPC endpoint once at boot so a misconfigured
@@ -548,6 +790,11 @@ async fn main() -> anyhow::Result<()> {
     } else {
         Arc::new(InMemoryStore::new())
     };
+
+    store
+        .bind_l1_evidence_policy(&l1_evidence_tag.describe())
+        .await
+        .context("binding persisted L1 evidence to the configured policy")?;
 
     // Reset the persisted note-reconciler sweep cursor BEFORE the
     // SyntheticProjector is constructed (it loads the cursor in `new()`):
@@ -713,6 +960,27 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    // Blocker 2 — fresh-database backfill invariant. Runs only on the serving
+    // path (restore has already returned above), before `store` is moved into
+    // ServiceState. Under strict H6 a fresh DB (cursor 0) with no explicit
+    // from-block would silently start the indexer at the L1 head and reject
+    // every pre-existing GER forever; abort with an operator-actionable error
+    // instead. A store read failure is a startup failure, not an empty cursor.
+    {
+        let persisted_cursor = store
+            .get_l1_indexer_cursor()
+            .await
+            .context("loading the persisted L1 indexer cursor")?;
+        if let Err(reason) = check_h6_backfill_invariant(
+            command.reject_unverified_ger,
+            command.require_hardening,
+            command.l1_indexer_from_block,
+            persisted_cursor,
+        ) {
+            anyhow::bail!("{reason}");
+        }
+    }
+
     let mut state = ServiceState::new(
         client,
         accounts,
@@ -727,6 +995,11 @@ async fn main() -> anyhow::Result<()> {
     state.admin_api_key = command.admin_api_key;
     state.allowed_signers = command.allowed_signers;
     state.allow_any_signer = command.insecure_allow_any_signer;
+    // H6 — strict L1 GER corroboration is implied by --require-hardening.
+    state.reject_unverified_ger = command.reject_unverified_ger || command.require_hardening;
+    // H6 — the canonical, startup-validated setting is also persisted by the
+    // store binding above, so its markers cannot be reused under another tag.
+    state.l1_evidence_tag = l1_evidence_tag;
     state.rate_limit_per_second = command.rate_limit_per_second;
     state.rate_limit_burst = command.rate_limit_burst;
     state.reject_zero_padding_addresses = command.reject_zero_padding_addresses;
@@ -765,6 +1038,17 @@ async fn main() -> anyhow::Result<()> {
     // GER lands on L2. Idempotent UPSERT: no-op if both code paths populate
     // the same ger_entries row. See `l1_info_tree_indexer.rs` for the full
     // race analysis and store-ordering guarantees.
+    // Blocker 1 — under strict H6 the indexer IS the sole GER evidence source,
+    // so a config/spawn failure here (unparsable GER address, malformed L1 RPC
+    // URL) must ABORT startup rather than log-and-continue: continuing would
+    // leave the process serving with a permanently-dead evidence source that
+    // rejects every fresh GER forever. This is the "config/spawn invalid →
+    // abort" branch; a valid-but-unreachable RPC does NOT trip it — `spawn()`
+    // builds its provider without connecting and returns Ok, and the indexer
+    // task retries the connection (fail-closed-and-retry). `check_h6_evidence_source`
+    // already fails these cases at the earlier startup gate; this is the
+    // defense-in-depth backstop at the actual spawn site.
+    let strict_h6 = command.reject_unverified_ger || command.require_hardening;
     if let (Some(l1_rpc_url), Some(ger_addr_str)) =
         (state.l1_rpc_url.clone(), state.ger_l1_address.clone())
     {
@@ -779,6 +1063,9 @@ async fn main() -> anyhow::Result<()> {
                 if let Some(from_block) = command.l1_indexer_from_block {
                     indexer = indexer.with_from_block_override(from_block);
                 }
+                // BLOCKER 3 — in a finality-tag mode the indexer tracks the L1
+                // finalized/safe block for the strict gate.
+                indexer = indexer.with_evidence_tag(state.l1_evidence_tag);
                 match indexer.spawn() {
                     Ok(shutdown_tx) => {
                         // The indexer runs for the lifetime of the tokio
@@ -792,11 +1079,29 @@ async fn main() -> anyhow::Result<()> {
                         tracing::info!("L1InfoTreeIndexer spawned");
                     }
                     Err(e) => {
+                        if strict_h6 {
+                            anyhow::bail!(
+                                "strict H6 GER corroboration is enabled, but the L1 InfoTree \
+                                 indexer (its sole evidence source) failed to spawn: {e}. This is \
+                                 a config/spawn error (e.g. a malformed L1 RPC URL), not a \
+                                 transient outage — aborting rather than serving with a dead \
+                                 evidence source that would reject every fresh GER forever."
+                            );
+                        }
                         tracing::error!(error = %e, "failed to spawn L1InfoTreeIndexer");
                     }
                 }
             }
             Err(e) => {
+                if strict_h6 {
+                    anyhow::bail!(
+                        "strict H6 GER corroboration is enabled, but --ger-l1-address \
+                         `{ger_addr_str}` is not a valid EVM address ({e}); the L1 InfoTree \
+                         indexer (its sole evidence source) cannot start. Aborting rather than \
+                         serving with a dead evidence source that would reject every fresh GER \
+                         forever."
+                    );
+                }
                 tracing::error!(
                     address = %ger_addr_str,
                     error = %e,
@@ -1042,6 +1347,7 @@ mod hardening_tests {
             l1_rpc_url: None,
             ger_l1_address: None,
             l1_indexer_from_block: None,
+            l1_evidence_tag: "confirmations:64".to_string(),
             faucet_reconciler_poll_secs: 30,
             faucet_reconciler_grace_ticks: 3,
             miden_debug: false,
@@ -1049,6 +1355,7 @@ mod hardening_tests {
             admin_api_key: admin,
             allowed_signers: signers,
             insecure_allow_any_signer: false,
+            reject_unverified_ger: false,
             rate_limit_per_second: miden_agglayer_service::service::DEFAULT_RATE_LIMIT_PER_SECOND,
             rate_limit_burst: miden_agglayer_service::service::DEFAULT_RATE_LIMIT_BURST,
             reject_zero_padding_addresses: false,
@@ -1140,6 +1447,316 @@ mod hardening_tests {
         let reasons = check_hardening_invariants(&c).unwrap_err();
         assert_eq!(reasons.len(), 1);
         assert!(reasons[0].contains("--miden-prover-url"));
+    }
+
+    /// Regression: the H6 strict-mode flag must be spelled
+    /// `--reject-unverified-ger-injection` (matching the bail message, the e2e
+    /// script, and the env var). Before the explicit `long = ...`, clap derived
+    /// `--reject-unverified-ger` from the field name and this exact invocation
+    /// would fail with "unexpected argument", so operators following the docs
+    /// could never enable strict mode.
+    #[test]
+    fn reject_unverified_ger_injection_flag_parses() {
+        let c = Command::try_parse_from(["miden-agglayer", "--reject-unverified-ger-injection"])
+            .expect("--reject-unverified-ger-injection must be an accepted flag");
+        assert!(
+            c.reject_unverified_ger,
+            "the documented long flag must set reject_unverified_ger"
+        );
+    }
+
+    // ── Audit H6 startup invariant (PR #121 review point 2) ────────────────
+
+    /// Lenient mode (neither strict trigger) needs no L1 evidence source.
+    #[test]
+    fn h6_evidence_source_not_required_when_lenient() {
+        let c = cmd(false, None, None, None);
+        assert!(check_h6_evidence_source(&c).is_ok());
+    }
+
+    /// Strict H6 via the explicit flag with NO L1 indexer configured must be
+    /// a startup failure (previously it booted and rejected every GER —
+    /// a fail-closed production outage discovered only at the first
+    /// injection).
+    #[test]
+    fn h6_strict_flag_without_l1_indexer_refused_at_startup() {
+        let mut c = cmd(false, None, None, None);
+        c.reject_unverified_ger = true;
+        let reason = check_h6_evidence_source(&c).unwrap_err();
+        assert!(
+            reason.contains("--l1-rpc-url"),
+            "must name the fix: {reason}"
+        );
+        assert!(
+            reason.contains("--ger-l1-address"),
+            "must name the fix: {reason}"
+        );
+        assert!(
+            reason.contains("--reject-unverified-ger-injection"),
+            "must name the trigger: {reason}"
+        );
+        assert!(
+            reason.contains("--l1-indexer-from-block"),
+            "must state the cursor/backfill posture: {reason}"
+        );
+    }
+
+    /// `--require-hardening` implies strict H6, so it too requires the
+    /// evidence source — even with every classic hardening flag satisfied.
+    #[test]
+    fn h6_require_hardening_without_l1_indexer_refused_at_startup() {
+        let c = cmd(
+            true,
+            Some("strong-admin-key".into()),
+            Some(vec![alloy::primitives::Address::ZERO]),
+            Some(vec!["https://app.example.com".into()]),
+        );
+        let reason = check_h6_evidence_source(&c).unwrap_err();
+        assert!(
+            reason.contains("--require-hardening"),
+            "must name the trigger: {reason}"
+        );
+    }
+
+    /// Half a configuration (RPC without the GER address) is still refused.
+    #[test]
+    fn h6_strict_with_only_l1_rpc_refused_at_startup() {
+        let mut c = cmd(false, None, None, None);
+        c.reject_unverified_ger = true;
+        c.l1_rpc_url = Some("http://anvil:8545".into());
+        assert!(check_h6_evidence_source(&c).is_err());
+    }
+
+    /// A GER address that does not parse would leave the indexer unspawned
+    /// (its runtime path only WARNS) — under strict mode that is the same
+    /// silent outage, so it must fail at startup.
+    #[test]
+    fn h6_strict_with_unparsable_ger_address_refused_at_startup() {
+        let mut c = cmd(false, None, None, None);
+        c.reject_unverified_ger = true;
+        c.l1_rpc_url = Some("http://anvil:8545".into());
+        c.ger_l1_address = Some("not-an-address".into());
+        let reason = check_h6_evidence_source(&c).unwrap_err();
+        assert!(
+            reason.contains("not a valid EVM address"),
+            "must cite the parse failure: {reason}"
+        );
+    }
+
+    /// Fully configured evidence source passes under both strict triggers.
+    #[test]
+    fn h6_strict_with_l1_indexer_configured_passes() {
+        let mut c = cmd(
+            true,
+            Some("strong-admin-key".into()),
+            Some(vec![alloy::primitives::Address::ZERO]),
+            Some(vec!["https://app.example.com".into()]),
+        );
+        c.reject_unverified_ger = true;
+        c.l1_rpc_url = Some("http://anvil:8545".into());
+        c.ger_l1_address = Some("0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674".into());
+        // hardened (cmd(true, …)) mandates the finalized evidence tag.
+        c.l1_evidence_tag = "finalized".into();
+        assert!(check_h6_evidence_source(&c).is_ok());
+    }
+
+    /// BLOCKER 1 (re-review) — strict mode must REFUSE to boot with a
+    /// zero/sub-minimum confirmation depth: it would authorize an irreversible
+    /// injection from a 0-confirmation, freely reorg-able observation, silently
+    /// disabling the finality guard while leaving strict on. An otherwise-valid
+    /// evidence source does not save it.
+    #[test]
+    fn h6_strict_with_zero_confirmations_refused_at_startup() {
+        let mut c = cmd(
+            true,
+            Some("strong-admin-key".into()),
+            Some(vec![alloy::primitives::Address::ZERO]),
+            Some(vec!["https://app.example.com".into()]),
+        );
+        c.reject_unverified_ger = true;
+        c.l1_rpc_url = Some("http://anvil:8545".into());
+        c.ger_l1_address = Some("0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674".into());
+        // Exercise the confirmation-depth zero refusal specifically → non-hardened
+        // strict (reject_unverified only), so the finalized-tag mandate (which
+        // hardened would trip first) doesn't preempt the depth check. The depth is
+        // folded into the SINGLE `--l1-evidence-tag` value.
+        c.require_hardening = false;
+        c.l1_evidence_tag = "confirmations:0".into();
+        let reason = check_h6_evidence_source(&c).unwrap_err();
+        assert!(
+            reason.contains("confirmations:0") || reason.contains("safe minimum"),
+            "must name the sub-minimum depth: {reason}"
+        );
+        // A nonzero depth with the same evidence source boots.
+        c.l1_evidence_tag = format!(
+            "confirmations:{}",
+            miden_agglayer_service::ger::MIN_STRICT_CONFIRMATIONS
+        );
+        assert!(check_h6_evidence_source(&c).is_ok());
+    }
+
+    /// BLOCKER 3 (re-review) — `--require-hardening` MANDATES the `finalized` L1
+    /// evidence tag. A confirmation-depth or `safe` tag under hardening must
+    /// refuse to boot; `finalized` boots. Also an unparsable tag under strict is
+    /// refused.
+    #[test]
+    fn h6_hardened_requires_finalized_evidence_tag() {
+        // Hardened base with a valid evidence source.
+        let mut c = cmd(
+            true,
+            Some("strong-admin-key".into()),
+            Some(vec![alloy::primitives::Address::ZERO]),
+            Some(vec!["https://app.example.com".into()]),
+        );
+        c.l1_rpc_url = Some("http://anvil:8545".into());
+        c.ger_l1_address = Some("0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674".into());
+        c.require_hardening = true;
+
+        // Default `confirmations` tag under hardening → refuse.
+        c.l1_evidence_tag = "confirmations".into();
+        let reason = check_h6_evidence_source(&c).unwrap_err();
+        assert!(
+            reason.contains("finalized"),
+            "must demand the finalized tag: {reason}"
+        );
+
+        // `safe` is not sufficient for hardened.
+        c.l1_evidence_tag = "safe".into();
+        assert!(check_h6_evidence_source(&c).is_err());
+
+        // An unparsable tag under strict is refused too.
+        c.l1_evidence_tag = "banana".into();
+        assert!(check_h6_evidence_source(&c).is_err());
+
+        // `finalized` boots.
+        c.l1_evidence_tag = "finalized".into();
+        assert!(check_h6_evidence_source(&c).is_ok());
+    }
+
+    // ── Blocker 1: malformed L1 RPC URL → abort; unreachable → keep retrying ──
+
+    /// A base config with a valid GER address and a strict trigger, tunable
+    /// only in the L1 RPC URL — isolates the URL-syntax check.
+    fn strict_cmd_with_rpc(rpc: &str) -> Command {
+        let mut c = cmd(
+            true,
+            Some("strong-admin-key".into()),
+            Some(vec![alloy::primitives::Address::ZERO]),
+            Some(vec!["https://app.example.com".into()]),
+        );
+        c.reject_unverified_ger = true;
+        c.l1_rpc_url = Some(rpc.to_string());
+        c.ger_l1_address = Some("0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674".into());
+        // hardened (cmd(true, …)) mandates the finalized evidence tag; set it so these
+        // URL-validation cases isolate the RPC-URL check, not the tag check.
+        c.l1_evidence_tag = "finalized".into();
+        c
+    }
+
+    /// A MALFORMED L1 RPC URL under strict mode aborts startup: the indexer
+    /// would fail to spawn, leaving strict mode with a permanently-dead
+    /// evidence source. This is a config error, not a transient outage.
+    #[test]
+    fn h6_strict_with_malformed_rpc_url_refused_at_startup() {
+        // A string with no scheme and a space is not a valid URL.
+        let c = strict_cmd_with_rpc("not a url");
+        let reason = check_h6_evidence_source(&c).unwrap_err();
+        assert!(
+            reason.contains("--l1-rpc-url"),
+            "must name the offending flag: {reason}"
+        );
+        assert!(
+            reason.contains("HTTP(S)"),
+            "must cite the HTTP(S) requirement: {reason}"
+        );
+    }
+
+    /// Non-HTTP schemes that `Url::parse` accepts but `connect_http` can never
+    /// use must abort strict startup (else the indexer retries forever while
+    /// every fresh GER is refused).
+    #[test]
+    fn h6_strict_with_non_http_scheme_refused_at_startup() {
+        for bad in ["file:///tmp/rpc", "ws://anvil:8545", "wss://l1:8546"] {
+            let c = strict_cmd_with_rpc(bad);
+            let reason = check_h6_evidence_source(&c).expect_err(bad);
+            assert!(
+                reason.contains("--l1-rpc-url") && reason.contains("HTTP(S)"),
+                "`{bad}` must be refused as non-HTTP(S): {reason}"
+            );
+        }
+    }
+
+    /// Hostless / custom-scheme values (notably the common `anvil:8545` typo,
+    /// which parses as scheme=`anvil` with no host) must abort strict startup.
+    #[test]
+    fn h6_strict_with_hostless_or_custom_scheme_refused_at_startup() {
+        // `anvil:8545` parses as a custom scheme with host=None; `https://` and
+        // `http://` are special schemes with an empty authority → url rejects
+        // them (no host).
+        for bad in ["anvil:8545", "https://", "http://"] {
+            let c = strict_cmd_with_rpc(bad);
+            let reason = check_h6_evidence_source(&c).expect_err(bad);
+            assert!(
+                reason.contains("--l1-rpc-url") && reason.contains("HTTP(S)"),
+                "`{bad}` must be refused (no usable host/scheme): {reason}"
+            );
+        }
+    }
+
+    /// A syntactically-VALID but (in this environment) UNREACHABLE L1 RPC does
+    /// NOT abort startup — it stays a retrying fail-closed condition. The
+    /// address is a non-routable RFC-5737 test host; the point is that URL
+    /// *syntax* is fine, so the config gate passes and the runtime indexer
+    /// retries the connection rather than the process refusing to boot.
+    #[test]
+    fn h6_strict_with_valid_but_unreachable_rpc_does_not_abort() {
+        let c = strict_cmd_with_rpc("http://203.0.113.1:8545");
+        assert!(
+            check_h6_evidence_source(&c).is_ok(),
+            "a valid-but-unreachable RPC must not abort startup — it stays fail-closed and retries"
+        );
+    }
+
+    // ── Blocker 2: fresh-DB backfill is an invariant, not advisory ───────────
+
+    /// Non-strict mode never enforces the backfill invariant, even on a fresh
+    /// DB with no from-block.
+    #[test]
+    fn h6_backfill_not_required_when_lenient() {
+        // reject_unverified_ger=false, require_hardening=false → lenient.
+        assert!(check_h6_backfill_invariant(false, false, None, 0).is_ok());
+    }
+
+    /// Strict + fresh DB (cursor 0) + no --l1-indexer-from-block must abort:
+    /// the indexer would start at the current L1 head and miss every
+    /// pre-existing GER forever.
+    #[test]
+    fn h6_backfill_strict_fresh_db_without_from_block_refused() {
+        let reason = check_h6_backfill_invariant(true, false, None, 0).unwrap_err();
+        assert!(
+            reason.contains("--l1-indexer-from-block"),
+            "must name the fix: {reason}"
+        );
+        assert!(
+            reason.contains("FRESH database"),
+            "must state the fresh-DB precondition: {reason}"
+        );
+        // `--require-hardening` is the other strict trigger and must also trip it.
+        assert!(check_h6_backfill_invariant(false, true, None, 0).is_err());
+    }
+
+    /// Strict + fresh DB (cursor 0) + explicit --l1-indexer-from-block passes:
+    /// the operator has chosen a safe start block.
+    #[test]
+    fn h6_backfill_strict_fresh_db_with_from_block_ok() {
+        assert!(check_h6_backfill_invariant(true, false, Some(0), 0).is_ok());
+    }
+
+    /// Strict + non-zero persisted cursor passes even without a from-block:
+    /// an existing indexed database already covers the historic leaves.
+    #[test]
+    fn h6_backfill_strict_nonzero_cursor_ok() {
+        assert!(check_h6_backfill_invariant(true, false, None, 42).is_ok());
     }
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -410,8 +410,8 @@ async fn json_rpc_handler(service: ServiceState, request: JsonRpcExtractor) -> J
             //
             // `store.nonce_get` is the next-accepted nonce (`pending`). For
             // committed tags, use the oldest durable pending row as the
-            // boundary. This works in sync mode and survives a writer restart;
-            // the old DashMap subtraction lost both properties.
+            // boundary. This survives a writer restart; the old DashMap
+            // subtraction did not.
             //
             // claim-sponsor's `nonce_cache.go:35` LRU reads `latest`; without
             // this branch it sees queued/submitting txs leak into `latest`

--- a/src/service_estimate_gas.rs
+++ b/src/service_estimate_gas.rs
@@ -272,7 +272,7 @@ mod tests {
                     rollup_exit_root: Some([0x22; 32]),
                     block_number: 1,
                     timestamp: 0,
-                    finalized_verified: false,
+                    evidence_verified: false,
                 },
             )
             .await

--- a/src/service_estimate_gas.rs
+++ b/src/service_estimate_gas.rs
@@ -272,6 +272,7 @@ mod tests {
                     rollup_exit_root: Some([0x22; 32]),
                     block_number: 1,
                     timestamp: 0,
+                    finalized_verified: false,
                 },
             )
             .await

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -1291,10 +1291,11 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         anyhow::bail!("single writer handle missing from production ServiceState");
     }
 
-    // Strict-H6 GER preflight may wait for configured L1 finality. Keep it
-    // outside the signer lock so one lagging GER cannot block unrelated
-    // submissions. The mandatory writer repeats the stateful gate immediately
-    // before Miden submission, after durable admission, to close landing races.
+    // Strict-H6 GER preflight may wait for the configured L1 scan to reach the
+    // GER. Keep it outside the signer lock so one lagging GER cannot block
+    // unrelated submissions. The mandatory writer repeats the stateful gate
+    // immediately before Miden submission, after durable admission, to close
+    // landing races.
     //
     // The optimistic stale-nonce check is deliberately scoped to this waiting
     // path. Applying it to every call would bypass #140's authoritative
@@ -1999,10 +2000,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn h6_finality_wait_does_not_hold_the_signer_nonce_lock() {
+    async fn h6_evidence_wait_does_not_hold_the_signer_nonce_lock() {
         let mut service = create_test_service();
         service.reject_unverified_ger = true;
-        service.l1_evidence_tag = crate::ger::EvidenceTag::Finalized;
+        service.l1_evidence_tag = crate::ger::EvidenceTag::Safe;
         let (handle, shutdown) = crate::writer_worker::WriterWorker::spawn(
             service.clone(),
             8,
@@ -2011,12 +2012,6 @@ mod tests {
         service.writer_handle = Some(std::sync::Arc::new(handle));
 
         let ger = [0xD7; 32];
-        service
-            .store
-            .set_ger_exit_roots(&ger, [0x11; 32], [0x22; 32], 10, 20)
-            .await
-            .unwrap();
-
         let signer = alloy::signers::local::PrivateKeySigner::random();
         let waiting_input = encode_legacy_tx_signed(
             &signer,
@@ -2048,10 +2043,10 @@ mod tests {
         let waiting_service = service.clone();
         let waiting =
             tokio::spawn(async move { service_send_raw_txn(waiting_service, waiting_input).await });
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         assert!(
             !waiting.is_finished(),
-            "observed-but-unfinalized GER must wait"
+            "a GER not yet reached by the selected scan must wait"
         );
 
         let ready = tokio::time::timeout(
@@ -2059,7 +2054,7 @@ mod tests {
             service_send_raw_txn(service, ready_input),
         )
         .await
-        .expect("same-signer ready work must not wait behind L1 finality");
+        .expect("same-signer ready work must not wait behind L1 evidence");
         assert!(
             ready.is_ok(),
             "ready same-signer call should be admitted: {ready:?}"
@@ -2116,7 +2111,7 @@ mod tests {
             .await
             .expect_err("writer mode must reject an unverified GER at admission");
         assert!(
-            format!("{err}").contains("not observed on L1"),
+            format!("{err}").contains("not observed by the configured L1"),
             "unexpected: {err}"
         );
 
@@ -2150,15 +2145,13 @@ mod tests {
             "no job may be queued (channel must remain at full capacity)"
         );
 
-        // The indexer catches up (writes the (mainnet, rollup) decomposition
-        // it observed on L1 at block 100, and its cursor advances past the
-        // strict confirmation depth) — the IDENTICAL signed transaction, same
+        // The configured scan catches up and atomically writes the roots plus
+        // provenance marker. The IDENTICAL signed transaction, with the same
         // nonce, must now be accepted.
         store
             .set_ger_exit_roots(&ger, mainnet, rollup, 100, 1_700_000_000)
             .await
             .unwrap();
-        store.set_l1_indexer_cursor(1_000).await.unwrap();
         let accepted_hash = service_send_raw_txn(service.clone(), input_hex)
             .await
             .expect("the identical signed tx must be accepted after the indexer catches up");
@@ -2236,7 +2229,7 @@ mod tests {
             .await
             .expect_err("the handler must reject an unverified GER under strict H6");
         assert!(
-            format!("{err}").contains("not observed on L1"),
+            format!("{err}").contains("not observed by the configured L1"),
             "unexpected: {err}"
         );
 
@@ -2255,13 +2248,12 @@ mod tests {
             "H6 rejection must not create a receipt"
         );
 
-        // Indexer catches up (decomposition at block 100, cursor advances past
-        // the strict confirmation depth) → the identical tx (same nonce) succeeds.
+        // The configured scan catches up and atomically writes roots plus its
+        // provenance marker; the identical tx (same nonce) now succeeds.
         store
             .set_ger_exit_roots(&ger, mainnet, rollup, 100, 1_700_000_000)
             .await
             .unwrap();
-        store.set_l1_indexer_cursor(1_000).await.unwrap();
         let accepted_hash = service_send_raw_txn(service.clone(), input_hex)
             .await
             .expect("the identical signed tx must be accepted after the indexer catches up");
@@ -4483,7 +4475,6 @@ mod tests {
             .set_ger_exit_roots(&[0xc7; 32], [0x11; 32], [0x22; 32], 100, 1_700_000_000)
             .await
             .unwrap();
-        concrete.set_l1_indexer_cursor(1_000).await.unwrap();
         let NonceReservation::Won { .. } = concrete
             .reserve_nonce(&signer_str, 0, tx_hash, reservation_lease())
             .await

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -132,9 +132,8 @@ async fn handle_ger_result(
                 // re-broadcast racing the closure would miss dedup, hit the R4
                 // nonce check against the already-advanced nonce, and wedge
                 // ethtxmanager. Idempotent: a no-op when the closure already
-                // produced the row (production sync mode, and the writer path
-                // once the worker has run it — where the inflight cache covers
-                // the accept-path gap regardless); it materialises the row
+                // produced the row once the writer has run it (the inflight
+                // cache covers the accept-path gap regardless); it materialises the row
                 // only when the boundary handoff hasn't. Production therefore
                 // always writes link+receipt behind the boundary; this is a
                 // synchronous dedup safety net, never a second write.
@@ -294,13 +293,13 @@ async fn accept_and_revert_landed_claim(
 
 /// #55 BLOCKER C/D — idempotent crash-gap nonce repair via store-level CAS.
 ///
-/// On the sync accept path the durable receipt write and the nonce advance are
+/// On the accept path the durable receipt write and the nonce advance are
 /// separate steps; a crash / store error BETWEEN them leaves the tx KNOWN (receipt
 /// persisted) but the signer's expected nonce STALE at that tx's nonce. Called from
 /// the RD-940 same-hash dedup path on a rebroadcast: the store-level
 /// `nonce_advance_cas(signer, tx_nonce)` advances the nonce EXACTLY ONCE iff it is
 /// still stuck at `tx_nonce` (the crash-gap signature — a normally-advanced tx has
-/// `expected > tx.nonce`, and async mode advances at enqueue so likewise), so the
+/// `expected > tx.nonce`, and admission advances before returning), so the
 /// rebroadcast HEALS the nonce rather than serving stale forever.
 ///
 /// The CAS is atomic at the store level, so this is correct even when two replicas
@@ -1065,9 +1064,9 @@ async fn publish_and_record_claim(
     }
 }
 
-/// Unified GER-insert / updateExitRoot dispatcher used by both the legacy sync
-/// path and the writer-worker path. **Does NOT advance the per-signer
-/// nonce** — see the matching note on `worker_handle_claim_asset`.
+/// GER-insert / updateExitRoot dispatcher used by the mandatory writer worker.
+/// **Does NOT advance the per-signer nonce** — admission already did that; see
+/// the matching note on `worker_handle_claim_asset`.
 ///
 /// The GER synthetic log (and the decomposed exit roots it carried) is now
 /// emitted by the `SyntheticProjector` from the consumed `UpdateGerNote`, so
@@ -1087,6 +1086,8 @@ pub(crate) async fn worker_handle_ger_insert(
             service.accounts.clone(),
             &service.store,
             txn_hash,
+            service.reject_unverified_ger,
+            service.l1_evidence_tag,
             // The envelope + signer ride into `insert_ger` so the pending
             // receipt row is created INSIDE the serialized Miden-client
             // closure, together with the tx↔note link (handoff-before-
@@ -1290,12 +1291,43 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         anyhow::bail!("single writer handle missing from production ServiceState");
     }
 
+    // Strict-H6 GER preflight may wait for configured L1 finality. Keep it
+    // outside the signer lock so one lagging GER cannot block unrelated
+    // submissions. The mandatory writer repeats the stateful gate immediately
+    // before Miden submission, after durable admission, to close landing races.
+    //
+    // The optimistic stale-nonce check is deliberately scoped to this waiting
+    // path. Applying it to every call would bypass #140's authoritative
+    // same-hash durable-intent recovery below (where nonce N has already
+    // advanced to N+1 but the exact accepted envelope still needs enqueue).
+    if service.reject_unverified_ger
+        && let crate::writer_worker::DecodedWriteCall::Ger { ger_bytes } = &decoded
+    {
+        if !known_durable_intent {
+            let expected_before_preflight = service.store.nonce_get(&signer_str).await?;
+            if tx_nonce < expected_before_preflight {
+                ::metrics::counter!("rpc_nonce_mismatch_total").increment(1);
+                anyhow::bail!(
+                    "nonce mismatch for {signer_str}: tx.nonce = {tx_nonce}, expected {expected_before_preflight}; this guards against replay and out-of-order submission (R4)"
+                );
+            }
+        }
+        crate::ger::wait_for_ger_l1_observed(
+            &service.store,
+            ger_bytes,
+            true,
+            service.l1_evidence_tag,
+            txn_hash,
+        )
+        .await?;
+    }
+
     // R4 follow-up — serialise the entire nonce-check + enqueue/handler
     // critical section for this signer. Without the mutex, two concurrent
     // same-nonce txs both pass the equality check before either calls
     // `nonce_increment`.
     //
-    // With the writer worker enabled, also tolerate bounded future-nonce
+    // The mandatory writer also tolerates bounded future-nonce
     // reordering from concurrent HTTP delivery: if nonce N+1 reaches us before
     // nonce N, release the lock, wait briefly for N to be accepted, then
     // re-check. This is a small in-process txpool behavior; stale/replay nonces
@@ -1964,6 +1996,285 @@ mod tests {
         service_send_raw_txn(service, input_hex)
             .await
             .expect("zero-amount claim must not be GER-gated at admission");
+    }
+
+    #[tokio::test]
+    async fn h6_finality_wait_does_not_hold_the_signer_nonce_lock() {
+        let mut service = create_test_service();
+        service.reject_unverified_ger = true;
+        service.l1_evidence_tag = crate::ger::EvidenceTag::Finalized;
+        let (handle, shutdown) = crate::writer_worker::WriterWorker::spawn(
+            service.clone(),
+            8,
+            std::time::Duration::from_secs(60),
+        );
+        service.writer_handle = Some(std::sync::Arc::new(handle));
+
+        let ger = [0xD7; 32];
+        service
+            .store
+            .set_ger_exit_roots(&ger, [0x11; 32], [0x22; 32], 10, 20)
+            .await
+            .unwrap();
+
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+        let waiting_input = encode_legacy_tx_signed(
+            &signer,
+            insertGlobalExitRootCall {
+                root: FixedBytes::from(ger),
+            }
+            .abi_encode(),
+            1,
+        );
+        let ready_input = encode_legacy_tx_signed(
+            &signer,
+            claimAssetCall {
+                smtProofLocalExitRoot: [FixedBytes::ZERO; 32],
+                smtProofRollupExitRoot: [FixedBytes::ZERO; 32],
+                globalIndex: U256::from(902u64),
+                mainnetExitRoot: FixedBytes::ZERO,
+                rollupExitRoot: FixedBytes::ZERO,
+                originNetwork: 0,
+                originTokenAddress: Address::ZERO,
+                destinationNetwork: 1,
+                destinationAddress: Address::ZERO,
+                amount: U256::ZERO,
+                metadata: Default::default(),
+            }
+            .abi_encode(),
+            2,
+        );
+
+        let waiting_service = service.clone();
+        let waiting =
+            tokio::spawn(async move { service_send_raw_txn(waiting_service, waiting_input).await });
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(
+            !waiting.is_finished(),
+            "observed-but-unfinalized GER must wait"
+        );
+
+        let ready = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            service_send_raw_txn(service, ready_input),
+        )
+        .await
+        .expect("same-signer ready work must not wait behind L1 finality");
+        assert!(
+            ready.is_ok(),
+            "ready same-signer call should be admitted: {ready:?}"
+        );
+
+        waiting.abort();
+        let _ = shutdown.send(());
+    }
+
+    /// Audit H6, PR #121 review (MAIN blocker) — mandatory writer. Pre-fix, the
+    /// H6 L1-corroboration gate only ran inside the worker, AFTER
+    /// `try_enqueue` had consumed the nonce, admitted
+    /// the tx hash into the inflight dedup cache, and returned the hash to the
+    /// caller; the worker's failure-receipt `txn_commit` then updated zero
+    /// rows (no prior `txn_begin`), so `eth_getTransactionReceipt` stayed null
+    /// forever — an aggoracle/ethtxmanager wedge on a NORMAL indexer-lag
+    /// rejection.
+    ///
+    /// The gate must run on the REQUEST path: a strict-mode rejection returns
+    /// no accepted hash and leaves NOTHING behind — no nonce, no tx
+    /// row/receipt, no inflight admission, no queued job — and the IDENTICAL
+    /// signed transaction (same nonce) is accepted once the indexer catches
+    /// up.
+    #[tokio::test]
+    async fn h6_writer_mode_unverified_ger_rejected_before_enqueue_then_retryable() {
+        let mut service = create_test_service();
+        // Strict H6 — set BEFORE spawn so the worker clone shares the posture.
+        service.reject_unverified_ger = true;
+        let (handle, _shutdown) = crate::writer_worker::WriterWorker::spawn(
+            service.clone(),
+            8,
+            std::time::Duration::from_secs(60),
+        );
+        let handle = std::sync::Arc::new(handle);
+        service.writer_handle = Some(handle.clone());
+        let store = service.store.clone();
+
+        let mainnet = [0x0Eu8; 32];
+        let rollup = [0x0Fu8; 32];
+        let ger = crate::ger::combined_ger(&mainnet, &rollup);
+        let calldata = insertGlobalExitRootCall {
+            root: FixedBytes::from(ger),
+        }
+        .abi_encode();
+        let (input_hex, signer) = encode_legacy_tx(calldata);
+        let payload = crate::hex::hex_decode_prefixed(&input_hex).unwrap();
+        let envelope = TxEnvelope::decode_2718(&mut payload.as_slice()).unwrap();
+        let tx_hash = *envelope.tx_hash();
+
+        // The indexer has NOT observed this GER on L1 (no resolved
+        // ger_entries decomposition) → strict rejection at admission, before
+        // any side-effect.
+        let err = service_send_raw_txn(service.clone(), input_hex.clone())
+            .await
+            .expect_err("writer mode must reject an unverified GER at admission");
+        assert!(
+            format!("{err}").contains("not observed on L1"),
+            "unexpected: {err}"
+        );
+
+        // Side-effect-free rejection: nothing left behind.
+        assert_eq!(
+            store.nonce_get(&format!("{signer:#x}")).await.unwrap(),
+            0,
+            "pre-admission failure must not consume the nonce"
+        );
+        assert!(
+            store.txn_get(tx_hash).await.unwrap().is_none(),
+            "pre-admission failure must not create a tx row"
+        );
+        assert!(
+            store.txn_receipt(tx_hash).await.unwrap().is_none(),
+            "pre-admission failure must not create a receipt"
+        );
+        assert!(
+            !handle.is_inflight(&tx_hash),
+            "pre-admission failure must not admit the hash into the inflight cache \
+             (a re-broadcast would short-circuit as 'known' and never retry)"
+        );
+        assert_eq!(
+            handle.inflight_len(),
+            0,
+            "no job may be tracked after a pre-admission rejection"
+        );
+        assert_eq!(
+            handle.available_capacity(),
+            handle.queue_depth(),
+            "no job may be queued (channel must remain at full capacity)"
+        );
+
+        // The indexer catches up (writes the (mainnet, rollup) decomposition
+        // it observed on L1 at block 100, and its cursor advances past the
+        // strict confirmation depth) — the IDENTICAL signed transaction, same
+        // nonce, must now be accepted.
+        store
+            .set_ger_exit_roots(&ger, mainnet, rollup, 100, 1_700_000_000)
+            .await
+            .unwrap();
+        store.set_l1_indexer_cursor(1_000).await.unwrap();
+        let accepted_hash = service_send_raw_txn(service.clone(), input_hex)
+            .await
+            .expect("the identical signed tx must be accepted after the indexer catches up");
+        assert_eq!(accepted_hash, tx_hash);
+        assert_eq!(
+            store.nonce_get(&format!("{signer:#x}")).await.unwrap(),
+            1,
+            "acceptance advances the nonce exactly once"
+        );
+        assert!(
+            handle.is_inflight(&tx_hash),
+            "accepted GER insert must be admitted to the writer queue"
+        );
+    }
+
+    /// Audit H6 — request-path gate precedence mirror: an ALREADY-INJECTED
+    /// GER must not be refused at admission even under strict mode with an
+    /// unresolved decomposition (dedup runs before the gate, exactly as in
+    /// `insert_ger`). Refusing it would wedge the aggoracle's idempotent
+    /// re-submissions after a restart/restore replay.
+    #[tokio::test]
+    async fn h6_writer_mode_already_injected_ger_not_refused_under_strict() {
+        let mut service = create_test_service();
+        service.reject_unverified_ger = true;
+        let (handle, _shutdown) = crate::writer_worker::WriterWorker::spawn(
+            service.clone(),
+            8,
+            std::time::Duration::from_secs(60),
+        );
+        service.writer_handle = Some(std::sync::Arc::new(handle));
+        let store = service.store.clone();
+
+        // Injected on a previous run, decomposition never resolved — the
+        // exact state that must stay a duplicate no-op, not an H6 refusal.
+        let ger = [0xABu8; 32];
+        store
+            .commit_ger_event_atomic(1, [0u8; 32], "0xTxDup", &ger, None, None, 0)
+            .await
+            .unwrap();
+
+        let calldata = insertGlobalExitRootCall {
+            root: FixedBytes::from(ger),
+        }
+        .abi_encode();
+        let (input_hex, _) = encode_legacy_tx(calldata);
+        service_send_raw_txn(service, input_hex)
+            .await
+            .expect("already-injected GER must pass admission as a duplicate, not an H6 refusal");
+    }
+
+    /// Audit H6, PR #121 review — deterministic test-only dispatch helper. The
+    /// production service always has the writer; tests without a handle use the
+    /// lower-level helper to pin the handler's defense-in-depth gate. Rejection
+    /// happens before nonce advancement and `txn_begin`, so the identical
+    /// signed transaction retries after the indexer catches up.
+    #[tokio::test]
+    async fn h6_test_dispatch_unverified_ger_rejected_side_effect_free_then_retryable() {
+        let mut service = create_test_service();
+        service.reject_unverified_ger = true;
+        let store = service.store.clone();
+
+        let mainnet = [0x1Eu8; 32];
+        let rollup = [0x1Fu8; 32];
+        let ger = crate::ger::combined_ger(&mainnet, &rollup);
+        let calldata = insertGlobalExitRootCall {
+            root: FixedBytes::from(ger),
+        }
+        .abi_encode();
+        let (input_hex, signer) = encode_legacy_tx(calldata);
+        let payload = crate::hex::hex_decode_prefixed(&input_hex).unwrap();
+        let envelope = TxEnvelope::decode_2718(&mut payload.as_slice()).unwrap();
+        let tx_hash = *envelope.tx_hash();
+
+        let err = service_send_raw_txn(service.clone(), input_hex.clone())
+            .await
+            .expect_err("the handler must reject an unverified GER under strict H6");
+        assert!(
+            format!("{err}").contains("not observed on L1"),
+            "unexpected: {err}"
+        );
+
+        // Side-effect-free rejection.
+        assert_eq!(
+            store.nonce_get(&format!("{signer:#x}")).await.unwrap(),
+            0,
+            "H6 rejection must not consume the nonce"
+        );
+        assert!(
+            store.txn_get(tx_hash).await.unwrap().is_none(),
+            "H6 rejection must not create a tx row (a retry would dedup as 'known')"
+        );
+        assert!(
+            store.txn_receipt(tx_hash).await.unwrap().is_none(),
+            "H6 rejection must not create a receipt"
+        );
+
+        // Indexer catches up (decomposition at block 100, cursor advances past
+        // the strict confirmation depth) → the identical tx (same nonce) succeeds.
+        store
+            .set_ger_exit_roots(&ger, mainnet, rollup, 100, 1_700_000_000)
+            .await
+            .unwrap();
+        store.set_l1_indexer_cursor(1_000).await.unwrap();
+        let accepted_hash = service_send_raw_txn(service.clone(), input_hex)
+            .await
+            .expect("the identical signed tx must be accepted after the indexer catches up");
+        assert_eq!(accepted_hash, tx_hash);
+        assert_eq!(
+            store.nonce_get(&format!("{signer:#x}")).await.unwrap(),
+            1,
+            "acceptance advances the nonce exactly once"
+        );
+        assert!(
+            store.txn_get(tx_hash).await.unwrap().is_some(),
+            "acceptance records the pending tx row (receipt lands on note consumption)"
+        );
     }
 
     #[tokio::test]
@@ -4158,6 +4469,7 @@ mod tests {
         use crate::store::NonceReservation;
         let concrete = std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
         let mut service = crate::test_helpers::create_test_service_with_store(concrete.clone());
+        service.reject_unverified_ger = true;
         let calldata = insertGlobalExitRootCall {
             root: FixedBytes::from([0xc7u8; 32]),
         }
@@ -4167,6 +4479,11 @@ mod tests {
         let envelope = TxEnvelope::decode_2718(&mut raw.as_slice()).unwrap();
         let tx_hash = unwrap_txn_envelope(envelope.clone()).unwrap().hash;
         let signer_str = format!("{signer:#x}");
+        concrete
+            .set_ger_exit_roots(&[0xc7; 32], [0x11; 32], [0x22; 32], 100, 1_700_000_000)
+            .await
+            .unwrap();
+        concrete.set_l1_indexer_cursor(1_000).await.unwrap();
         let NonceReservation::Won { .. } = concrete
             .reserve_nonce(&signer_str, 0, tx_hash, reservation_lease())
             .await

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -99,6 +99,22 @@ pub struct ServiceState {
     /// of `allowed_signers`. ONLY safe behind a loopback bind / network
     /// boundary. Refused by `--require-hardening`.
     pub allow_any_signer: bool,
+    /// Audit H6 — refuse to inject a GER whose `(mainnet, rollup)`
+    /// decomposition was NOT corroborated by the independent L1 InfoTree
+    /// indexer. Defends against a compromised aggoracle key injecting a forged
+    /// GER onto Miden. Default false (allow through, but flag via the
+    /// `ger_injection_unverified_total` metric) to tolerate indexer lag;
+    /// `--require-hardening` implies true.
+    pub reject_unverified_ger: bool,
+    /// Audit H6 — the SINGLE strict-H6 evidence-finality setting (parsed from
+    /// `--l1-evidence-tag` / `L1_EVIDENCE_TAG`): `confirmations:<N>` (depth below
+    /// the indexer head cursor), `finalized`, or `safe`. This one value fully
+    /// specifies how the gate qualifies an L1 observation as final — there is no
+    /// second confirmation-depth knob. Enforced at the gate
+    /// (`ger::ensure_ger_l1_observed`); normal decomposition is unaffected.
+    /// Mandatory `finalized` under `--require-hardening`. Defaults to
+    /// `confirmations:DEFAULT_CONFIRMATIONS`.
+    pub l1_evidence_tag: crate::ger::EvidenceTag,
     /// Per-signer async mutex registry (R4 follow-up) — serialises the
     /// nonce-check critical section so two concurrent same-nonce txs from one
     /// signer cannot both pass the equality check before either increments.
@@ -166,6 +182,8 @@ impl ServiceState {
             admin_api_key: None,
             allowed_signers: None,
             allow_any_signer: false,
+            reject_unverified_ger: false,
+            l1_evidence_tag: crate::ger::EvidenceTag::default(),
             per_signer_locks: PerSignerLocks::new(),
             rate_limit_per_second: crate::service::DEFAULT_RATE_LIMIT_PER_SECOND,
             rate_limit_burst: crate::service::DEFAULT_RATE_LIMIT_BURST,

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -106,14 +106,10 @@ pub struct ServiceState {
     /// `ger_injection_unverified_total` metric) to tolerate indexer lag;
     /// `--require-hardening` implies true.
     pub reject_unverified_ger: bool,
-    /// Audit H6 — the SINGLE strict-H6 evidence-finality setting (parsed from
-    /// `--l1-evidence-tag` / `L1_EVIDENCE_TAG`): `confirmations:<N>` (depth below
-    /// the indexer head cursor), `finalized`, or `safe`. This one value fully
-    /// specifies how the gate qualifies an L1 observation as final — there is no
-    /// second confirmation-depth knob. Enforced at the gate
-    /// (`ger::ensure_ger_l1_observed`); normal decomposition is unaffected.
-    /// Mandatory `finalized` under `--require-hardening`. Defaults to
-    /// `confirmations:DEFAULT_CONFIRMATIONS`.
+    /// Audit H6 — the single L1 frontier scanned for evidence: `latest`,
+    /// `safe`, or `finalized`. Roots are persisted only from this scan, so row
+    /// provenance and the scan cursor always share one setting. Hardened mode
+    /// accepts `safe` or `finalized`; the default is `latest`.
     pub l1_evidence_tag: crate::ger::EvidenceTag,
     /// Per-signer async mutex registry (R4 follow-up) — serialises the
     /// nonce-check critical section so two concurrent same-nonce txs from one

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -83,6 +83,9 @@ pub struct InMemoryStore {
     hash_chain_value: RwLock<[u8; 32]>,
     injected_gers: RwLock<HashSet<[u8; 32]>>,
 
+    #[cfg(test)]
+    test_fail_next_ger_evidence_write: std::sync::atomic::AtomicBool,
+
     // Transactions
     transactions: Mutex<LruCache<TxHash, TxnReceipt>>,
 
@@ -159,6 +162,25 @@ pub struct InMemoryStore {
     // Store::get_reconcile_cursor.
     reconcile_cursor: RwLock<u64>,
 
+    // L1 InfoTree indexer cursor — last L1 block the indexer processed
+    // (field-backed mirror of the PgStore `l1_indexer_state.last_processed`
+    // column, migration 005). Persisted here (not left on the default no-op
+    // impl) so the strict-H6 finality gate can read the observed L1 head via
+    // `get_l1_indexer_cursor` even on an in-memory deployment.
+    l1_indexer_cursor: RwLock<u64>,
+
+    // Last observed L1 `finalized`/`safe` block (audit H6 BLOCKER 3) — tracked
+    // separately from the head cursor so the strict gate can qualify evidence by
+    // finality tag. Field-backed mirror of the PgStore `l1_indexer_state
+    // .finalized_block` column (migration 013).
+    l1_finalized_block: RwLock<u64>,
+
+    // Progress cursor of the indexer's finalized-pinned scan (audit H6 BLOCKER 1).
+    l1_finalized_scan_cursor: RwLock<u64>,
+
+    // Canonical EvidenceTag that produced the persisted finality state.
+    l1_evidence_policy: RwLock<Option<String>>,
+
     // Receipts map (synthetic-indexer redesign, Phase 2b substrate) —
     // first-write-wins evm_tx_hash -> note_commitment, with the reverse index
     // mirrored alongside it. UNUSED in Phase 2a. See Store::record_tx_note_link.
@@ -188,6 +210,8 @@ impl InMemoryStore {
             latest_ger: RwLock::new(None),
             hash_chain_value: RwLock::new([0u8; 32]),
             injected_gers: RwLock::new(HashSet::new()),
+            #[cfg(test)]
+            test_fail_next_ger_evidence_write: std::sync::atomic::AtomicBool::new(false),
             transactions: Mutex::new(LruCache::new(NonZeroUsize::new(10_000).unwrap())),
             nonces: RwLock::new(HashMap::new()),
             nonce_reservations: RwLock::new(HashMap::new()),
@@ -209,6 +233,10 @@ impl InMemoryStore {
             monitor_expected_mints: RwLock::new(HashMap::new()),
             projector_cursor: RwLock::new(0),
             reconcile_cursor: RwLock::new(0),
+            l1_indexer_cursor: RwLock::new(0),
+            l1_finalized_block: RwLock::new(0),
+            l1_finalized_scan_cursor: RwLock::new(0),
+            l1_evidence_policy: RwLock::new(None),
             tx_note_links: RwLock::new(HashMap::new()),
             note_tx_links: RwLock::new(HashMap::new()),
         }
@@ -256,6 +284,12 @@ impl InMemoryStore {
     #[cfg(test)]
     pub fn test_land_gi_after_next_has_claim_miss(&self, global_index: [u8; 32]) {
         *self.test_land_after_next_has_claim_miss.write() = Some(global_index);
+    }
+
+    #[cfg(test)]
+    pub fn test_fail_next_ger_evidence_write(&self) {
+        self.test_fail_next_ger_evidence_write
+            .store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
     /// Test hook (#55 BLOCKER B): arm the store so the NEXT `nonce_advance_cas`
@@ -368,6 +402,61 @@ impl Store for InMemoryStore {
 
     async fn set_reconcile_cursor(&self, block: u64) -> anyhow::Result<()> {
         *self.reconcile_cursor.write() = block;
+        Ok(())
+    }
+
+    // ── L1 InfoTree indexer cursor ───────────────────────────────
+
+    async fn get_l1_indexer_cursor(&self) -> anyhow::Result<u64> {
+        Ok(*self.l1_indexer_cursor.read())
+    }
+
+    async fn set_l1_indexer_cursor(&self, block: u64) -> anyhow::Result<()> {
+        *self.l1_indexer_cursor.write() = block;
+        Ok(())
+    }
+
+    async fn get_l1_finalized_block(&self) -> anyhow::Result<u64> {
+        Ok(*self.l1_finalized_block.read())
+    }
+
+    async fn set_l1_finalized_block(&self, block: u64) -> anyhow::Result<()> {
+        *self.l1_finalized_block.write() = block;
+        Ok(())
+    }
+
+    async fn get_l1_finalized_scan_cursor(&self) -> anyhow::Result<u64> {
+        Ok(*self.l1_finalized_scan_cursor.read())
+    }
+
+    async fn set_l1_finalized_scan_cursor(&self, block: u64) -> anyhow::Result<()> {
+        *self.l1_finalized_scan_cursor.write() = block;
+        Ok(())
+    }
+
+    async fn bind_l1_evidence_policy(&self, policy: &str) -> anyhow::Result<()> {
+        let mut bound = self.l1_evidence_policy.write();
+        match bound.as_deref() {
+            Some(existing) if existing == policy => return Ok(()),
+            Some(existing) => anyhow::bail!(
+                "L1 evidence policy mismatch: store is bound to `{existing}`, configured `{policy}`; stop the service and reset/rebuild finality markers before changing policy"
+            ),
+            None => {}
+        }
+
+        let has_untagged_state = *self.l1_finalized_block.read() != 0
+            || *self.l1_finalized_scan_cursor.read() != 0
+            || self
+                .seen_gers
+                .read()
+                .values()
+                .any(|entry| entry.finalized_verified);
+        if has_untagged_state {
+            anyhow::bail!(
+                "L1 finality state exists without an evidence policy; reset/rebuild finality markers before serving"
+            );
+        }
+        *bound = Some(policy.to_owned());
         Ok(())
     }
 
@@ -753,19 +842,43 @@ impl Store for InMemoryStore {
         l1_block_number: u64,
         l1_timestamp: u64,
     ) -> anyhow::Result<()> {
+        #[cfg(test)]
+        if self
+            .test_fail_next_ger_evidence_write
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+        {
+            anyhow::bail!("injected fault: durable evidence write failed");
+        }
         let mut seen = self.seen_gers.write();
         let entry = seen.entry(*ger).or_insert(GerEntry {
             mainnet_exit_root: None,
             rollup_exit_root: None,
             block_number: 0,
             timestamp: 0,
+            finalized_verified: false,
         });
+        // NOTE: `finalized_verified` is deliberately NOT touched here — the
+        // latest scan (this method) must never reset a flag the finalized scan
+        // set (monotone). New rows default to `false` via `or_insert` above.
         entry.mainnet_exit_root = Some(mainnet_exit_root);
         entry.rollup_exit_root = Some(rollup_exit_root);
         // Mirror the PgStore semantics: indexer is authoritative for L1
         // origin metadata, so overwrite unconditionally on every call.
         entry.block_number = l1_block_number;
         entry.timestamp = l1_timestamp;
+        Ok(())
+    }
+
+    async fn mark_ger_finalized(&self, ger: &[u8; 32]) -> anyhow::Result<()> {
+        let mut seen = self.seen_gers.write();
+        let entry = seen.entry(*ger).or_insert(GerEntry {
+            mainnet_exit_root: None,
+            rollup_exit_root: None,
+            block_number: 0,
+            timestamp: 0,
+            finalized_verified: false,
+        });
+        entry.finalized_verified = true;
         Ok(())
     }
 
@@ -807,6 +920,7 @@ impl Store for InMemoryStore {
                         rollup_exit_root,
                         block_number,
                         timestamp,
+                        finalized_verified: false,
                     },
                 );
                 *self.latest_ger.write() = Some(*global_exit_root);
@@ -944,25 +1058,44 @@ impl Store for InMemoryStore {
             let Some(receipt) = txns.get_mut(&tx_hash) else {
                 anyhow::bail!("Store: transaction {tx_hash} not found");
             };
-            receipt.result = Some(result);
-            receipt.block_num = block_num;
-
-            match &receipt.result {
-                Some(Ok(_)) => {
+            // A real Miden landing must always beat a failure observation, and a
+            // landed success must never be clobbered. Pending failures are
+            // terminal; a later real landing may still heal one to success.
+            enum St {
+                Pending,
+                Failed,
+                Success,
+            }
+            let st = match &receipt.result {
+                None => St::Pending,
+                Some(Ok(_)) => St::Success,
+                Some(Err(_)) => St::Failed,
+            };
+            let apply = match (&st, result.is_ok()) {
+                (St::Success, _) => false,
+                (_, true) => true,
+                (St::Pending, false) => true,
+                (St::Failed, false) => false,
+            };
+            if !apply {
+                tracing::debug!(
+                    "Store: txn {tx_hash} terminal transition ignored (success-always-wins CAS)"
+                );
+                None
+            } else {
+                let is_ok = result.is_ok();
+                receipt.result = Some(result);
+                receipt.block_num = block_num;
+                if is_ok {
                     tracing::info!(
                         "Store: committed txn {tx_hash}; miden txn: {:?}",
                         receipt.id
                     );
                     Some(receipt.logs.clone())
-                }
-                Some(Err(err)) => {
-                    tracing::error!(
-                        "Store: failed txn {tx_hash}; miden txn: {:?}; reason: {err}",
-                        receipt.id
-                    );
+                } else {
+                    tracing::error!("Store: failed txn {tx_hash}; miden txn: {:?}", receipt.id);
                     None
                 }
-                None => None,
             }
         }; // Mutex dropped before any .await
 
@@ -1961,6 +2094,36 @@ mod tests {
     use crate::log_synthesis::{CLAIM_EVENT_TOPIC, TopicFilter};
 
     #[tokio::test]
+    async fn l1_evidence_policy_binding_is_immutable() {
+        let store = InMemoryStore::new();
+        store.bind_l1_evidence_policy("finalized").await.unwrap();
+        store.bind_l1_evidence_policy("finalized").await.unwrap();
+
+        let err = store
+            .bind_l1_evidence_policy("safe")
+            .await
+            .expect_err("a database policy change must fail closed");
+        assert!(format!("{err:#}").contains("bound to `finalized`"));
+    }
+
+    #[tokio::test]
+    async fn untagged_finality_markers_are_rejected() {
+        let store = InMemoryStore::new();
+        let ger = [0xA7; 32];
+        store
+            .set_ger_exit_roots(&ger, [1; 32], [2; 32], 10, 20)
+            .await
+            .unwrap();
+        store.mark_ger_finalized(&ger).await.unwrap();
+
+        let err = store
+            .bind_l1_evidence_policy("finalized")
+            .await
+            .expect_err("untagged verification evidence is ambiguous");
+        assert!(format!("{err:#}").contains("without an evidence policy"));
+    }
+
+    #[tokio::test]
     async fn set_ger_exit_roots_persists_l1_block_and_timestamp() {
         // Before this change, both columns were hardcoded to 0 in PgStore and
         // ignored in InMemoryStore. The indexer is the authoritative writer
@@ -2658,6 +2821,151 @@ mod tests {
         );
         // And it must not have invented a receipt.
         assert!(store.txn_receipt(tx_hash).await.unwrap().is_none());
+    }
+
+    /// Build a minimal pending `txn_begin` entry for the CAS tests below.
+    async fn seed_pending_txn(store: &InMemoryStore, tx_hash: TxHash) {
+        use alloy::consensus::{Signed, TxLegacy};
+        use alloy::primitives::Signature;
+        let envelope = alloy::consensus::TxEnvelope::Legacy(Signed::new_unchecked(
+            TxLegacy::default(),
+            Signature::test_signature(),
+            tx_hash,
+        ));
+        store
+            .txn_begin(
+                tx_hash,
+                TxnEntry {
+                    id: None,
+                    envelope,
+                    signer: Address::ZERO,
+                    expires_at: None,
+                    logs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    /// BLOCKER 2 (success-always-wins CAS) — a SUCCESS receipt must survive a
+    /// later failure commit. Models the TTL-sweeper race: the worker commits
+    /// SUCCESS (status 0x1) first, then the sweeper's `write_failure_receipt`
+    /// fires `txn_commit(Err)` for the same hash. Pre-fix the Err overwrote the
+    /// success (status 0x1 → 0x0) and aggkit resubmitted a Miden op that had
+    /// already landed. The success must be preserved verbatim.
+    ///
+    /// Mutation check: dropping the `(Some(Ok(_)), _) => Cas::NoOp` arm in
+    /// `txn_commit` makes this assertion fail (the failure clobbers success).
+    #[tokio::test]
+    async fn test_txn_commit_terminal_success_not_clobbered_by_failure() {
+        let store = InMemoryStore::new();
+        let tx_hash = TxHash::from([0x51u8; 32]);
+        seed_pending_txn(&store, tx_hash).await;
+
+        // Worker commits SUCCESS at block 7.
+        store
+            .txn_commit(tx_hash, Ok(()), 7, [0xAAu8; 32])
+            .await
+            .unwrap();
+
+        // TTL sweeper races in with a failure commit for the same hash.
+        store
+            .txn_commit(
+                tx_hash,
+                Err("TTL expired (>300s in non-terminal state)".to_string()),
+                9,
+                [0xBBu8; 32],
+            )
+            .await
+            .expect("late failure commit must be an accepted no-op, not an error");
+
+        // The landed success is preserved: status stays 0x1, block unchanged.
+        let (res, block_num) = store.txn_receipt(tx_hash).await.unwrap().unwrap();
+        assert!(
+            res.is_ok(),
+            "first terminal (success) must win; got failure: {res:?}"
+        );
+        assert_eq!(block_num, 7, "success block must be preserved");
+    }
+
+    /// BLOCKER 2 (success-always-wins CAS) — a REAL Miden landing supersedes a
+    /// prior (TTL/timeout) FAILURE, and the ClaimEvent the failure suppressed is
+    /// re-materialised. Models the reverse race: the TTL sweeper commits a
+    /// terminal FAILURE for a job whose worker is still running; Miden then
+    /// LANDS; the projector's later `txn_commit(Ok)` must win so the durable
+    /// receipt ends SUCCESS (status 0x1) WITH its ClaimEvent — never a stuck
+    /// TTL-failure for a claim that actually landed.
+    ///
+    /// Mutation check: revert the override (make `(Some(Err(_)), true)` a
+    /// `Cas::NoOp` / first-terminal-wins) → the receipt stays failed and the
+    /// ClaimEvent is missing, failing both assertions.
+    #[tokio::test]
+    async fn test_txn_commit_success_supersedes_prior_failure_with_claimevent() {
+        use alloy::primitives::{B256, Bytes, LogData};
+        let store = InMemoryStore::new();
+        let tx_hash = TxHash::from([0x52u8; 32]);
+
+        // Pending row carrying a ClaimEvent-shaped attached log.
+        let claim_topic = B256::from([0xC1u8; 32]);
+        let envelope =
+            alloy::consensus::TxEnvelope::Legacy(alloy::consensus::Signed::new_unchecked(
+                alloy::consensus::TxLegacy::default(),
+                alloy::primitives::Signature::test_signature(),
+                tx_hash,
+            ));
+        store
+            .txn_begin(
+                tx_hash,
+                TxnEntry {
+                    id: None,
+                    envelope,
+                    signer: Address::ZERO,
+                    expires_at: None,
+                    logs: vec![LogData::new_unchecked(
+                        vec![claim_topic],
+                        Bytes::from(vec![0xAB]),
+                    )],
+                },
+            )
+            .await
+            .unwrap();
+
+        // TTL sweeper fails the still-running job first.
+        store
+            .txn_commit(tx_hash, Err("TTL expired".to_string()), 3, [0u8; 32])
+            .await
+            .unwrap();
+        assert!(
+            store
+                .get_logs_for_tx(&format!("{tx_hash:#x}"))
+                .await
+                .unwrap()
+                .is_empty(),
+            "a failure must NOT materialise the ClaimEvent"
+        );
+
+        // Miden actually landed → the projector commits success for the SAME hash.
+        store
+            .txn_commit(tx_hash, Ok(()), 5, [0u8; 32])
+            .await
+            .expect("a real landing must supersede the provisional failure");
+
+        let (res, block_num) = store.txn_receipt(tx_hash).await.unwrap().unwrap();
+        assert!(
+            res.is_ok(),
+            "success must supersede the TTL failure; got {res:?}"
+        );
+        assert_eq!(block_num, 5, "success block must win");
+        let logs = store
+            .get_logs_for_tx(&format!("{tx_hash:#x}"))
+            .await
+            .unwrap();
+        assert_eq!(
+            logs.len(),
+            1,
+            "the ClaimEvent the failure suppressed must be materialised on the success override"
+        );
+        assert_eq!(logs[0].topics[0], format!("{claim_topic:#x}"));
     }
 
     #[tokio::test]

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -162,23 +162,11 @@ pub struct InMemoryStore {
     // Store::get_reconcile_cursor.
     reconcile_cursor: RwLock<u64>,
 
-    // L1 InfoTree indexer cursor — last L1 block the indexer processed
-    // (field-backed mirror of the PgStore `l1_indexer_state.last_processed`
-    // column, migration 005). Persisted here (not left on the default no-op
-    // impl) so the strict-H6 finality gate can read the observed L1 head via
-    // `get_l1_indexer_cursor` even on an in-memory deployment.
-    l1_indexer_cursor: RwLock<u64>,
+    // Cursor of the one configured L1 evidence scan. PostgreSQL stores this in
+    // the legacy `finalized_scan_cursor` column for upgrade-safe provenance.
+    l1_evidence_cursor: RwLock<u64>,
 
-    // Last observed L1 `finalized`/`safe` block (audit H6 BLOCKER 3) — tracked
-    // separately from the head cursor so the strict gate can qualify evidence by
-    // finality tag. Field-backed mirror of the PgStore `l1_indexer_state
-    // .finalized_block` column (migration 013).
-    l1_finalized_block: RwLock<u64>,
-
-    // Progress cursor of the indexer's finalized-pinned scan (audit H6 BLOCKER 1).
-    l1_finalized_scan_cursor: RwLock<u64>,
-
-    // Canonical EvidenceTag that produced the persisted finality state.
+    // Canonical EvidenceTag that produced the persisted selected-scan state.
     l1_evidence_policy: RwLock<Option<String>>,
 
     // Receipts map (synthetic-indexer redesign, Phase 2b substrate) —
@@ -233,9 +221,7 @@ impl InMemoryStore {
             monitor_expected_mints: RwLock::new(HashMap::new()),
             projector_cursor: RwLock::new(0),
             reconcile_cursor: RwLock::new(0),
-            l1_indexer_cursor: RwLock::new(0),
-            l1_finalized_block: RwLock::new(0),
-            l1_finalized_scan_cursor: RwLock::new(0),
+            l1_evidence_cursor: RwLock::new(0),
             l1_evidence_policy: RwLock::new(None),
             tx_note_links: RwLock::new(HashMap::new()),
             note_tx_links: RwLock::new(HashMap::new()),
@@ -405,32 +391,14 @@ impl Store for InMemoryStore {
         Ok(())
     }
 
-    // ── L1 InfoTree indexer cursor ───────────────────────────────
+    // ── Selected L1 evidence scan ────────────────────────────────
 
-    async fn get_l1_indexer_cursor(&self) -> anyhow::Result<u64> {
-        Ok(*self.l1_indexer_cursor.read())
+    async fn get_l1_evidence_cursor(&self) -> anyhow::Result<u64> {
+        Ok(*self.l1_evidence_cursor.read())
     }
 
-    async fn set_l1_indexer_cursor(&self, block: u64) -> anyhow::Result<()> {
-        *self.l1_indexer_cursor.write() = block;
-        Ok(())
-    }
-
-    async fn get_l1_finalized_block(&self) -> anyhow::Result<u64> {
-        Ok(*self.l1_finalized_block.read())
-    }
-
-    async fn set_l1_finalized_block(&self, block: u64) -> anyhow::Result<()> {
-        *self.l1_finalized_block.write() = block;
-        Ok(())
-    }
-
-    async fn get_l1_finalized_scan_cursor(&self) -> anyhow::Result<u64> {
-        Ok(*self.l1_finalized_scan_cursor.read())
-    }
-
-    async fn set_l1_finalized_scan_cursor(&self, block: u64) -> anyhow::Result<()> {
-        *self.l1_finalized_scan_cursor.write() = block;
+    async fn set_l1_evidence_cursor(&self, block: u64) -> anyhow::Result<()> {
+        *self.l1_evidence_cursor.write() = block;
         Ok(())
     }
 
@@ -439,21 +407,20 @@ impl Store for InMemoryStore {
         match bound.as_deref() {
             Some(existing) if existing == policy => return Ok(()),
             Some(existing) => anyhow::bail!(
-                "L1 evidence policy mismatch: store is bound to `{existing}`, configured `{policy}`; stop the service and reset/rebuild finality markers before changing policy"
+                "L1 evidence policy mismatch: store is bound to `{existing}`, configured `{policy}`; stop the service and reset/rebuild L1 evidence before changing policy"
             ),
             None => {}
         }
 
-        let has_untagged_state = *self.l1_finalized_block.read() != 0
-            || *self.l1_finalized_scan_cursor.read() != 0
+        let has_untagged_state = *self.l1_evidence_cursor.read() != 0
             || self
                 .seen_gers
                 .read()
                 .values()
-                .any(|entry| entry.finalized_verified);
+                .any(|entry| entry.evidence_verified);
         if has_untagged_state {
             anyhow::bail!(
-                "L1 finality state exists without an evidence policy; reset/rebuild finality markers before serving"
+                "L1 evidence state exists without an evidence policy; reset/rebuild L1 evidence before serving"
             );
         }
         *bound = Some(policy.to_owned());
@@ -855,30 +822,17 @@ impl Store for InMemoryStore {
             rollup_exit_root: None,
             block_number: 0,
             timestamp: 0,
-            finalized_verified: false,
+            evidence_verified: false,
         });
-        // NOTE: `finalized_verified` is deliberately NOT touched here — the
-        // latest scan (this method) must never reset a flag the finalized scan
-        // set (monotone). New rows default to `false` via `or_insert` above.
         entry.mainnet_exit_root = Some(mainnet_exit_root);
         entry.rollup_exit_root = Some(rollup_exit_root);
         // Mirror the PgStore semantics: indexer is authoritative for L1
         // origin metadata, so overwrite unconditionally on every call.
         entry.block_number = l1_block_number;
         entry.timestamp = l1_timestamp;
-        Ok(())
-    }
-
-    async fn mark_ger_finalized(&self, ger: &[u8; 32]) -> anyhow::Result<()> {
-        let mut seen = self.seen_gers.write();
-        let entry = seen.entry(*ger).or_insert(GerEntry {
-            mainnet_exit_root: None,
-            rollup_exit_root: None,
-            block_number: 0,
-            timestamp: 0,
-            finalized_verified: false,
-        });
-        entry.finalized_verified = true;
+        // Legacy physical name: this now means "written by the configured
+        // latest/safe/finalized scan".
+        entry.evidence_verified = true;
         Ok(())
     }
 
@@ -920,7 +874,7 @@ impl Store for InMemoryStore {
                         rollup_exit_root,
                         block_number,
                         timestamp,
-                        finalized_verified: false,
+                        evidence_verified: false,
                     },
                 );
                 *self.latest_ger.write() = Some(*global_exit_root);
@@ -2107,14 +2061,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn untagged_finality_markers_are_rejected() {
+    async fn untagged_evidence_state_is_rejected() {
         let store = InMemoryStore::new();
         let ger = [0xA7; 32];
         store
             .set_ger_exit_roots(&ger, [1; 32], [2; 32], 10, 20)
             .await
             .unwrap();
-        store.mark_ger_finalized(&ger).await.unwrap();
 
         let err = store
             .bind_l1_evidence_policy("finalized")
@@ -2144,6 +2097,7 @@ mod tests {
         assert_eq!(entry.rollup_exit_root, Some(rollup));
         assert_eq!(entry.block_number, 10_900_000);
         assert_eq!(entry.timestamp, 1_779_300_000);
+        assert!(entry.evidence_verified);
 
         // Second write at a later L1 block (same GER hash): indexer is
         // authoritative, so the new L1 origin metadata overwrites the old.

--- a/src/store/migrator.rs
+++ b/src/store/migrator.rs
@@ -94,6 +94,18 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "012_submission_handoffs.sql",
         include_str!("../../migrations/012_submission_handoffs.sql"),
     ),
+    (
+        "013_l1_finalized_block.sql",
+        include_str!("../../migrations/013_l1_finalized_block.sql"),
+    ),
+    (
+        "014_finalized_verified.sql",
+        include_str!("../../migrations/014_finalized_verified.sql"),
+    ),
+    (
+        "015_l1_evidence_policy.sql",
+        include_str!("../../migrations/015_l1_evidence_policy.sql"),
+    ),
 ];
 
 /// Postgres advisory-lock key. Arbitrary 64-bit int; just needs to be

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -366,6 +366,43 @@ pub trait Store: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Last observed L1 `finalized` (or `safe`) block number — tracked SEPARATELY
+    /// from the head cursor (audit H6 BLOCKER 3). The `L1InfoTreeIndexer` updates
+    /// this each poll when configured with a finality evidence tag; the strict-H6
+    /// indexer's canonical finality scan uses this as its upper bound and marks
+    /// the evidence rows it observes. Returns 0 if never recorded (fresh
+    /// deployment or confirmation-depth mode), so the scan remains idle and the
+    /// strict gate stays fail-closed.
+    async fn get_l1_finalized_block(&self) -> anyhow::Result<u64> {
+        Ok(0)
+    }
+    /// Persist the last observed L1 finality-tag block. Written best-effort by
+    /// the indexer; a stale value only ever DELAYS strict authorization
+    /// (fail-closed), never over-authorizes.
+    async fn set_l1_finalized_block(&self, _block: u64) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Progress cursor of the indexer's FINALIZED-pinned scan (audit H6 BLOCKER
+    /// 1) — the last block it has scanned for finalized `(mainnet, rollup)` pairs
+    /// and marked via `mark_ger_finalized`. Distinct from `l1_indexer_cursor`
+    /// (the head/latest scan). Returns 0 if never persisted.
+    async fn get_l1_finalized_scan_cursor(&self) -> anyhow::Result<u64> {
+        Ok(0)
+    }
+    async fn set_l1_finalized_scan_cursor(&self, _block: u64) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Bind finality markers and their scan cursor to the configured evidence
+    /// policy. The first clean serving boot records `policy`; later boots must
+    /// present the exact same canonical value. Implementations must reject an
+    /// unbound store that already contains finality progress or verified markers,
+    /// because the policy that produced them cannot be inferred safely.
+    async fn bind_l1_evidence_policy(&self, _policy: &str) -> anyhow::Result<()> {
+        anyhow::bail!("store does not support persistent L1 evidence-policy binding")
+    }
+
     // === Synthetic projector cursor (synthetic-indexer redesign, Phase 2a) ===
     /// Last fully-projected Miden block height owned by the `SyntheticProjector`
     /// (`docs/SYNTHETIC-INDEXER-REDESIGN.md`). Returns 0 if the projector has
@@ -508,6 +545,18 @@ pub trait Store: Send + Sync + 'static {
         l1_block_number: u64,
         l1_timestamp: u64,
     ) -> anyhow::Result<()>;
+    /// Audit H6 BLOCKER 1 — mark a GER's `(mainnet, rollup)` decomposition as
+    /// confirmed on the L1 FINALIZED / `safe` canonical chain. Called by the
+    /// `L1InfoTreeIndexer`'s finalized-pinned scan for each pair it reads at/below
+    /// the finality block; the `finalized`/`safe` strict gate authorizes ONLY
+    /// rows for which this ran, so a `latest`-observed-then-reorged fork row (this
+    /// never ran for it) cannot authorize. Monotone: once set, stays set. Upserts
+    /// the row so an ordering where the finalized scan runs before the latest scan
+    /// still records the flag (roots are filled by the latest scan). Default
+    /// no-op so test-double stores compile.
+    async fn mark_ger_finalized(&self, _ger: &[u8; 32]) -> anyhow::Result<()> {
+        Ok(())
+    }
     async fn is_ger_injected(&self, ger: &[u8; 32]) -> anyhow::Result<bool>;
     /// Atomically, in a single all-or-nothing operation: mark the GER seen,
     /// idempotently roll the hash chain + emit the `UpdateHashChainValue`

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -354,51 +354,25 @@ pub trait Store: Send + Sync + 'static {
     /// Increment block number by 1 and return the new value.
     async fn advance_block_number(&self) -> anyhow::Result<u64>;
 
-    // === L1 indexer cursor (RD-862 follow-up) ===
-    /// Last successfully-polled L1 block. Returns 0 if the indexer has
-    /// never persisted a cursor on this deployment.
-    async fn get_l1_indexer_cursor(&self) -> anyhow::Result<u64> {
+    // === Selected L1 evidence scan ===
+    /// Last block processed by the one configured scan. PostgreSQL uses the
+    /// legacy `finalized_scan_cursor` column for upgrade-safe provenance.
+    async fn get_l1_evidence_cursor(&self) -> anyhow::Result<u64> {
         Ok(0)
     }
     /// Persist the last-processed L1 block. Called after each successful
     /// batch so a restart resumes from here instead of jumping to L1 head.
-    async fn set_l1_indexer_cursor(&self, _block: u64) -> anyhow::Result<()> {
+    async fn set_l1_evidence_cursor(&self, _block: u64) -> anyhow::Result<()> {
         Ok(())
     }
 
-    /// Last observed L1 `finalized` (or `safe`) block number — tracked SEPARATELY
-    /// from the head cursor (audit H6 BLOCKER 3). The `L1InfoTreeIndexer` updates
-    /// this each poll when configured with a finality evidence tag; the strict-H6
-    /// indexer's canonical finality scan uses this as its upper bound and marks
-    /// the evidence rows it observes. Returns 0 if never recorded (fresh
-    /// deployment or confirmation-depth mode), so the scan remains idle and the
-    /// strict gate stays fail-closed.
-    async fn get_l1_finalized_block(&self) -> anyhow::Result<u64> {
-        Ok(0)
-    }
-    /// Persist the last observed L1 finality-tag block. Written best-effort by
-    /// the indexer; a stale value only ever DELAYS strict authorization
-    /// (fail-closed), never over-authorizes.
-    async fn set_l1_finalized_block(&self, _block: u64) -> anyhow::Result<()> {
-        Ok(())
-    }
-
-    /// Progress cursor of the indexer's FINALIZED-pinned scan (audit H6 BLOCKER
-    /// 1) — the last block it has scanned for finalized `(mainnet, rollup)` pairs
-    /// and marked via `mark_ger_finalized`. Distinct from `l1_indexer_cursor`
-    /// (the head/latest scan). Returns 0 if never persisted.
-    async fn get_l1_finalized_scan_cursor(&self) -> anyhow::Result<u64> {
-        Ok(0)
-    }
-    async fn set_l1_finalized_scan_cursor(&self, _block: u64) -> anyhow::Result<()> {
-        Ok(())
-    }
-
-    /// Bind finality markers and their scan cursor to the configured evidence
+    /// Bind the selected-scan marker and cursor to the configured evidence
     /// policy. The first clean serving boot records `policy`; later boots must
     /// present the exact same canonical value. Implementations must reject an
-    /// unbound store that already contains finality progress or verified markers,
-    /// because the policy that produced them cannot be inferred safely.
+    /// unbound store that already contains scan progress or verified evidence,
+    /// because the policy that produced it cannot be inferred safely. A
+    /// persistent implementation may bootstrap `latest` from its legacy latest
+    /// cursor; safe/finalized must never inherit that cursor.
     async fn bind_l1_evidence_policy(&self, _policy: &str) -> anyhow::Result<()> {
         anyhow::bail!("store does not support persistent L1 evidence-policy binding")
     }
@@ -529,14 +503,14 @@ pub trait Store: Send + Sync + 'static {
     async fn mark_ger_seen(&self, ger: &[u8; 32], entry: GerEntry) -> anyhow::Result<bool>;
     async fn get_latest_ger(&self) -> anyhow::Result<Option<[u8; 32]>>;
     async fn get_ger_entry(&self, ger: &[u8; 32]) -> anyhow::Result<Option<GerEntry>>;
-    /// Set the `(mainnet, rollup)` decomposition and L1 origin metadata for a
-    /// GER. Called by `L1InfoTreeIndexer` after observing the source
+    /// Atomically set the `(mainnet, rollup)` decomposition, L1 origin metadata,
+    /// and selected-scan provenance marker for a GER. Called by the one
+    /// configured `L1InfoTreeIndexer` scan after observing the source
     /// `UpdateL1InfoTree` / `UpdateGlobalExitRoot` event on L1, so the
     /// `l1_block_number` / `l1_timestamp` here are the L1 block where the
     /// event was emitted (the authoritative source for `zkevm_getExitRootsByGER`).
-    /// UPSERTs: on conflict, all four columns are overwritten — the indexer's
-    /// L1-sourced view supersedes any earlier hardcoded-0 row that may have
-    /// been left by an L2-side write path that didn't know the L1 origin yet.
+    /// UPSERTs roots and provenance together so pre-upgrade unqualified roots
+    /// cannot be trusted under a different policy.
     async fn set_ger_exit_roots(
         &self,
         ger: &[u8; 32],
@@ -545,18 +519,6 @@ pub trait Store: Send + Sync + 'static {
         l1_block_number: u64,
         l1_timestamp: u64,
     ) -> anyhow::Result<()>;
-    /// Audit H6 BLOCKER 1 — mark a GER's `(mainnet, rollup)` decomposition as
-    /// confirmed on the L1 FINALIZED / `safe` canonical chain. Called by the
-    /// `L1InfoTreeIndexer`'s finalized-pinned scan for each pair it reads at/below
-    /// the finality block; the `finalized`/`safe` strict gate authorizes ONLY
-    /// rows for which this ran, so a `latest`-observed-then-reorged fork row (this
-    /// never ran for it) cannot authorize. Monotone: once set, stays set. Upserts
-    /// the row so an ordering where the finalized scan runs before the latest scan
-    /// still records the flag (roots are filled by the latest scan). Default
-    /// no-op so test-double stores compile.
-    async fn mark_ger_finalized(&self, _ger: &[u8; 32]) -> anyhow::Result<()> {
-        Ok(())
-    }
     async fn is_ger_injected(&self, ger: &[u8; 32]) -> anyhow::Result<bool>;
     /// Atomically, in a single all-or-nothing operation: mark the GER seen,
     /// idempotently roll the hash chain + emit the `UpdateHashChainValue`

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -96,57 +96,7 @@ impl Store for PgStore {
         Ok(val as u64)
     }
 
-    async fn get_l1_indexer_cursor(&self) -> anyhow::Result<u64> {
-        let client = self.pool.get().await?;
-        let row = client
-            .query_opt(
-                "SELECT last_processed FROM l1_indexer_state WHERE id = 1",
-                &[],
-            )
-            .await?;
-        match row {
-            Some(r) => {
-                let val: i64 = r.get(0);
-                Ok(val as u64)
-            }
-            None => Ok(0),
-        }
-    }
-
-    async fn set_l1_indexer_cursor(&self, block: u64) -> anyhow::Result<()> {
-        let client = self.pool.get().await?;
-        client
-            .execute(
-                "UPDATE l1_indexer_state SET last_processed = $1, updated_at = now() WHERE id = 1",
-                &[&(block as i64)],
-            )
-            .await?;
-        Ok(())
-    }
-
-    async fn get_l1_finalized_block(&self) -> anyhow::Result<u64> {
-        let client = self.pool.get().await?;
-        let row = client
-            .query_opt(
-                "SELECT finalized_block FROM l1_indexer_state WHERE id = 1",
-                &[],
-            )
-            .await?;
-        Ok(row.map(|r| r.get::<_, i64>(0) as u64).unwrap_or(0))
-    }
-
-    async fn set_l1_finalized_block(&self, block: u64) -> anyhow::Result<()> {
-        let client = self.pool.get().await?;
-        client
-            .execute(
-                "UPDATE l1_indexer_state SET finalized_block = $1, updated_at = now() WHERE id = 1",
-                &[&(block as i64)],
-            )
-            .await?;
-        Ok(())
-    }
-
-    async fn get_l1_finalized_scan_cursor(&self) -> anyhow::Result<u64> {
+    async fn get_l1_evidence_cursor(&self) -> anyhow::Result<u64> {
         let client = self.pool.get().await?;
         let row = client
             .query_opt(
@@ -157,7 +107,7 @@ impl Store for PgStore {
         Ok(row.map(|r| r.get::<_, i64>(0) as u64).unwrap_or(0))
     }
 
-    async fn set_l1_finalized_scan_cursor(&self, block: u64) -> anyhow::Result<()> {
+    async fn set_l1_evidence_cursor(&self, block: u64) -> anyhow::Result<()> {
         let client = self.pool.get().await?;
         client
             .execute(
@@ -173,7 +123,8 @@ impl Store for PgStore {
         let tx = client.transaction().await?;
         let row = tx
             .query_one(
-                "SELECT evidence_tag, finalized_block, finalized_scan_cursor FROM l1_indexer_state WHERE id = 1 FOR UPDATE",
+                "SELECT evidence_tag, finalized_block, finalized_scan_cursor, last_processed \
+                 FROM l1_indexer_state WHERE id = 1 FOR UPDATE",
                 &[],
             )
             .await?;
@@ -185,12 +136,13 @@ impl Store for PgStore {
             }
             tx.rollback().await?;
             anyhow::bail!(
-                "L1 evidence policy mismatch: database is bound to `{existing}`, configured `{policy}`; stop the service and reset/rebuild finality markers before changing policy"
+                "L1 evidence policy mismatch: database is bound to `{existing}`, configured `{policy}`; stop the service and reset/rebuild L1 evidence before changing policy"
             );
         }
 
         let finalized_block: i64 = row.get(1);
         let finalized_scan_cursor: i64 = row.get(2);
+        let legacy_latest_cursor: i64 = row.get(3);
         let has_verified: bool = tx
             .query_one(
                 "SELECT EXISTS (SELECT 1 FROM ger_entries WHERE finalized_verified = TRUE)",
@@ -201,14 +153,28 @@ impl Store for PgStore {
         if finalized_block != 0 || finalized_scan_cursor != 0 || has_verified {
             tx.rollback().await?;
             anyhow::bail!(
-                "L1 finality state exists without an evidence policy; reset/rebuild finality markers before serving"
+                "L1 evidence state exists without an evidence policy; reset/rebuild L1 evidence before serving"
             );
         }
-        tx.execute(
-            "UPDATE l1_indexer_state SET evidence_tag = $1, updated_at = now() WHERE id = 1",
-            &[&policy],
-        )
-        .await?;
+        if policy == "latest" {
+            // Migration 005 already persisted the old sole latest-scan cursor
+            // in `last_processed`. Preserve that progress on upgrade so events
+            // emitted during the restart are not skipped. Safe/finalized must
+            // never inherit a latest frontier.
+            tx.execute(
+                "UPDATE l1_indexer_state \
+                 SET evidence_tag = $1, finalized_scan_cursor = $2, updated_at = now() \
+                 WHERE id = 1",
+                &[&policy, &legacy_latest_cursor],
+            )
+            .await?;
+        } else {
+            tx.execute(
+                "UPDATE l1_indexer_state SET evidence_tag = $1, updated_at = now() WHERE id = 1",
+                &[&policy],
+            )
+            .await?;
+        }
         tx.commit().await?;
         Ok(())
     }
@@ -877,7 +843,7 @@ impl Store for PgStore {
                 rollup_exit_root: rollup.filter(|v| v.len() == 32).map(bytes_to_array_32),
                 block_number: r.get::<_, i64>(2) as u64,
                 timestamp: r.get::<_, i64>(3) as u64,
-                finalized_verified: r.get::<_, bool>(4),
+                evidence_verified: r.get::<_, bool>(4),
             }
         }))
     }
@@ -895,13 +861,14 @@ impl Store for PgStore {
         let rollup = rollup_exit_root.to_vec();
         client
             .execute(
-                "INSERT INTO ger_entries (ger_hash, mainnet_exit_root, rollup_exit_root, block_number, timestamp)
-                 VALUES ($1, $2, $3, $4, $5)
+                "INSERT INTO ger_entries (ger_hash, mainnet_exit_root, rollup_exit_root, block_number, timestamp, finalized_verified)
+                 VALUES ($1, $2, $3, $4, $5, TRUE)
                  ON CONFLICT (ger_hash) DO UPDATE
                  SET mainnet_exit_root = EXCLUDED.mainnet_exit_root,
                      rollup_exit_root  = EXCLUDED.rollup_exit_root,
                      block_number      = EXCLUDED.block_number,
-                     timestamp         = EXCLUDED.timestamp",
+                     timestamp         = EXCLUDED.timestamp,
+                     finalized_verified = TRUE",
                 &[
                     &ger.as_slice(),
                     &mainnet,
@@ -909,24 +876,6 @@ impl Store for PgStore {
                     &(l1_block_number as i64),
                     &(l1_timestamp as i64),
                 ],
-            )
-            .await?;
-        Ok(())
-    }
-
-    async fn mark_ger_finalized(&self, ger: &[u8; 32]) -> anyhow::Result<()> {
-        let client = self.pool.get().await?;
-        // Row should already exist (roots from the latest scan). The explicit
-        // block_number/timestamp 0 satisfy the NOT NULL columns for the safety-net
-        // insert path; DO UPDATE only flips the flag (monotone), never resets
-        // roots. The `finalized`/`safe` gate also requires roots present, so a
-        // flag-only row cannot authorize until the latest scan fills the roots.
-        client
-            .execute(
-                "INSERT INTO ger_entries (ger_hash, block_number, timestamp, finalized_verified)
-                 VALUES ($1, 0, 0, TRUE)
-                 ON CONFLICT (ger_hash) DO UPDATE SET finalized_verified = TRUE",
-                &[&ger.as_slice()],
             )
             .await?;
         Ok(())

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -124,6 +124,95 @@ impl Store for PgStore {
         Ok(())
     }
 
+    async fn get_l1_finalized_block(&self) -> anyhow::Result<u64> {
+        let client = self.pool.get().await?;
+        let row = client
+            .query_opt(
+                "SELECT finalized_block FROM l1_indexer_state WHERE id = 1",
+                &[],
+            )
+            .await?;
+        Ok(row.map(|r| r.get::<_, i64>(0) as u64).unwrap_or(0))
+    }
+
+    async fn set_l1_finalized_block(&self, block: u64) -> anyhow::Result<()> {
+        let client = self.pool.get().await?;
+        client
+            .execute(
+                "UPDATE l1_indexer_state SET finalized_block = $1, updated_at = now() WHERE id = 1",
+                &[&(block as i64)],
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn get_l1_finalized_scan_cursor(&self) -> anyhow::Result<u64> {
+        let client = self.pool.get().await?;
+        let row = client
+            .query_opt(
+                "SELECT finalized_scan_cursor FROM l1_indexer_state WHERE id = 1",
+                &[],
+            )
+            .await?;
+        Ok(row.map(|r| r.get::<_, i64>(0) as u64).unwrap_or(0))
+    }
+
+    async fn set_l1_finalized_scan_cursor(&self, block: u64) -> anyhow::Result<()> {
+        let client = self.pool.get().await?;
+        client
+            .execute(
+                "UPDATE l1_indexer_state SET finalized_scan_cursor = $1, updated_at = now() WHERE id = 1",
+                &[&(block as i64)],
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn bind_l1_evidence_policy(&self, policy: &str) -> anyhow::Result<()> {
+        let mut client = self.pool.get().await?;
+        let tx = client.transaction().await?;
+        let row = tx
+            .query_one(
+                "SELECT evidence_tag, finalized_block, finalized_scan_cursor FROM l1_indexer_state WHERE id = 1 FOR UPDATE",
+                &[],
+            )
+            .await?;
+        let existing: Option<String> = row.get(0);
+        if let Some(existing) = existing {
+            if existing == policy {
+                tx.commit().await?;
+                return Ok(());
+            }
+            tx.rollback().await?;
+            anyhow::bail!(
+                "L1 evidence policy mismatch: database is bound to `{existing}`, configured `{policy}`; stop the service and reset/rebuild finality markers before changing policy"
+            );
+        }
+
+        let finalized_block: i64 = row.get(1);
+        let finalized_scan_cursor: i64 = row.get(2);
+        let has_verified: bool = tx
+            .query_one(
+                "SELECT EXISTS (SELECT 1 FROM ger_entries WHERE finalized_verified = TRUE)",
+                &[],
+            )
+            .await?
+            .get(0);
+        if finalized_block != 0 || finalized_scan_cursor != 0 || has_verified {
+            tx.rollback().await?;
+            anyhow::bail!(
+                "L1 finality state exists without an evidence policy; reset/rebuild finality markers before serving"
+            );
+        }
+        tx.execute(
+            "UPDATE l1_indexer_state SET evidence_tag = $1, updated_at = now() WHERE id = 1",
+            &[&policy],
+        )
+        .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
     // ── Synthetic projector cursor (Phase 2a) ────────────────────
     //
     // Persisted as a column on the single-row service_state table, mirroring
@@ -774,7 +863,7 @@ impl Store for PgStore {
         let client = self.pool.get().await?;
         let rows = client
             .query(
-                "SELECT mainnet_exit_root, rollup_exit_root, block_number, timestamp FROM ger_entries WHERE ger_hash = $1",
+                "SELECT mainnet_exit_root, rollup_exit_root, block_number, timestamp, finalized_verified FROM ger_entries WHERE ger_hash = $1",
                 &[&ger.as_slice()],
             )
             .await
@@ -788,6 +877,7 @@ impl Store for PgStore {
                 rollup_exit_root: rollup.filter(|v| v.len() == 32).map(bytes_to_array_32),
                 block_number: r.get::<_, i64>(2) as u64,
                 timestamp: r.get::<_, i64>(3) as u64,
+                finalized_verified: r.get::<_, bool>(4),
             }
         }))
     }
@@ -819,6 +909,24 @@ impl Store for PgStore {
                     &(l1_block_number as i64),
                     &(l1_timestamp as i64),
                 ],
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn mark_ger_finalized(&self, ger: &[u8; 32]) -> anyhow::Result<()> {
+        let client = self.pool.get().await?;
+        // Row should already exist (roots from the latest scan). The explicit
+        // block_number/timestamp 0 satisfy the NOT NULL columns for the safety-net
+        // insert path; DO UPDATE only flips the flag (monotone), never resets
+        // roots. The `finalized`/`safe` gate also requires roots present, so a
+        // flag-only row cannot authorize until the latest scan fills the roots.
+        client
+            .execute(
+                "INSERT INTO ger_entries (ger_hash, block_number, timestamp, finalized_verified)
+                 VALUES ($1, 0, 0, TRUE)
+                 ON CONFLICT (ger_hash) DO UPDATE SET finalized_verified = TRUE",
+                &[&ger.as_slice()],
             )
             .await?;
         Ok(())
@@ -1109,54 +1217,79 @@ impl Store for PgStore {
         // any partial log inserts.
         let tx = client.transaction().await?;
 
-        let updated = tx
-            .execute(
-                "UPDATE transactions
-                 SET status = $1, error_message = $2, block_number = $3, updated_at = now()
-                 WHERE tx_hash = $4
-                   AND ($1 <> 'failed' OR NOT EXISTS (
-                       SELECT 1 FROM tx_note_links WHERE tx_note_links.tx_hash = $4
-                   ))",
-                &[
-                    &status,
-                    &error_msg as &(dyn ToSql + Sync),
-                    &(block_num as i64),
-                    &hash_str,
-                ],
+        // BLOCKER 2 (re-review) — SINGLE-SNAPSHOT success-always-wins CAS. Pin
+        // the row with `SELECT ... FOR UPDATE` inside this transaction so the
+        // "absent vs present" classification AND the conditional UPDATE both
+        // come from ONE consistent, row-locked snapshot. The previous
+        // UPDATE-then-separate-SELECT could, under READ COMMITTED, observe two
+        // DIFFERENT committed snapshots: a concurrent `txn_begin` committing
+        // between the UPDATE and the existence SELECT was visible only to the
+        // SELECT, so a row genuinely missing at decision time was misclassified
+        // as an existing terminal and wrongly returned Ok (the caller's
+        // failure/success was silently dropped, leaving the receipt pending).
+        // FOR UPDATE takes the decision off ONE read; the subsequent UPDATE
+        // runs against the locked row, so no interleaving can flip the class.
+        let current_status: Option<String> = tx
+            .query_opt(
+                "SELECT status FROM transactions WHERE tx_hash = $1 FOR UPDATE",
+                &[&hash_str],
             )
-            .await?;
+            .await?
+            .map(|r| r.get::<_, String>(0));
 
-        // PR #127 review — finalising a transaction that has no `txn_begin`
-        // row must be an ERROR, matching `InMemoryStore::txn_commit`
-        // ("transaction {tx_hash} not found"). Pre-fix this UPDATE silently
-        // affected zero rows and the method still committed the synthetic
-        // logs below and returned Ok — so a projector racing a submitter
-        // could "finalise" a receipt that was never durably begun, and the
-        // late `txn_begin` would then park the real receipt as pending
-        // forever. Every caller either creates the row first or explicitly
-        // tolerates this error (`project_ger_note` / `project_claim_note`
-        // use `let _ = ... inspect_err`, the pending/expiry sweeps log and
-        // continue), so erroring here is safe and makes the two stores
-        // behave identically. Bailing before `tx.commit()` rolls the whole
-        // transaction back — no partial log/counter writes escape.
-        if updated == 0 && result.is_err() {
-            let protected = tx
-                .query_opt(
-                    "SELECT 1 FROM transactions t
-                     JOIN tx_note_links l ON l.tx_hash = t.tx_hash
-                     WHERE t.tx_hash = $1",
-                    &[&hash_str],
-                )
-                .await?
-                .is_some();
-            if protected {
-                tx.commit().await?;
-                return Ok(());
-            }
-        }
-        if updated == 0 {
+        let Some(current_status) = current_status else {
+            // No row at the locked snapshot → contract error (PR #127):
+            // finalising a receipt that was never durably begun must fail so a
+            // projector racing a submitter cannot silently "finalise" a phantom.
+            // A concurrent `txn_begin` that commits AFTER this read cannot flip
+            // us to a wrong Ok — the classification is fixed here. Callers either
+            // create the row first or tolerate this error (`project_ger_note` /
+            // `project_claim_note` use `let _ = ... inspect_err`; the
+            // pending/expiry sweeps log and continue).
+            tx.rollback().await?;
             anyhow::bail!("PgStore: transaction {tx_hash} not found");
+        };
+
+        // Once an exact handoff exists, a dispatch error is outcome-ambiguous.
+        // Keep the receipt pending for projection/reconciliation; the dedicated
+        // confirmed-duplicate commit is the only failure path allowed to close it.
+        let has_handoff = if result.is_err() {
+            tx.query_opt(
+                "SELECT 1 FROM tx_note_links WHERE tx_hash = $1",
+                &[&hash_str],
+            )
+            .await?
+            .is_some()
+        } else {
+            false
+        };
+
+        // A real landing may heal a pending/failed observation to success;
+        // success itself is monotonic and the first failure remains stable.
+        let apply = match (current_status.as_str(), result.is_ok()) {
+            ("success", _) => false,
+            (_, true) => true,
+            ("pending", false) => !has_handoff,
+            (_, false) => false,
+        };
+        if !apply {
+            tx.rollback().await?;
+            tracing::debug!(
+                "PgStore: txn {tx_hash} terminal transition ignored or deferred (monotonic/handoff CAS)"
+            );
+            return Ok(());
         }
+
+        tx.execute(
+            "UPDATE transactions SET status = $1, error_message = $2, block_number = $3, updated_at = now() WHERE tx_hash = $4",
+            &[
+                &status,
+                &error_msg as &(dyn ToSql + Sync),
+                &(block_num as i64),
+                &hash_str,
+            ],
+        )
+        .await?;
 
         if result.is_ok() {
             // C11 — fold the latest_block_number advance into the same

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -152,6 +152,7 @@ async fn test_pgstore_ger_lifecycle() {
         rollup_exit_root: Some([0x02; 32]),
         block_number: 100,
         timestamp: 1234567890,
+        finalized_verified: false,
     };
 
     // Initially not seen
@@ -488,6 +489,291 @@ async fn test_pgstore_confirmed_duplicate_finalizes_linked_pending() {
     assert!(result.is_err());
     assert_eq!(block, 11);
     assert!(store.get_logs_for_tx(&tx_key).await.unwrap().is_empty());
+}
+
+/// BLOCKER 2 (success-always-wins CAS) — PG twin of
+/// `memory::tests::test_txn_commit_terminal_success_not_clobbered_by_failure`.
+/// Once a receipt is 'success', the failure-commit CAS predicate
+/// (`status = 'pending'`) excludes it, so a later failure is a zero-row no-op
+/// that returns Ok, preserving status 0x1. Models the TTL sweeper racing a
+/// worker that already landed the Miden op — the pre-fix overwrite made aggkit
+/// resubmit a landed op. PG-gated: skips when `DATABASE_URL` is unset.
+#[tokio::test]
+async fn test_pgstore_terminal_success_not_clobbered_by_failure() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    reset_state(&store).await;
+
+    let tx_hash = TxHash::from([0x5Au8; 32]);
+    store.txn_begin(tx_hash, dummy_txn_entry()).await.unwrap();
+    store
+        .txn_commit(tx_hash, Ok(()), 12, [0u8; 32])
+        .await
+        .unwrap();
+
+    // Late failure commit for the already-terminal (success) row: accepted,
+    // but a NO-OP — the success must survive.
+    store
+        .txn_commit(
+            tx_hash,
+            Err("TTL expired (>300s in non-terminal state)".to_string()),
+            15,
+            [0u8; 32],
+        )
+        .await
+        .expect("late failure commit must be an accepted no-op, not an error");
+
+    let (res, block) = store.txn_receipt(tx_hash).await.unwrap().unwrap();
+    assert!(res.is_ok(), "success must win; got failure: {res:?}");
+    assert_eq!(block, 12, "success block preserved");
+}
+
+/// BLOCKER 2 (success-always-wins CAS) — PG twin of
+/// `memory::tests::test_txn_commit_success_supersedes_prior_failure_with_claimevent`.
+/// A real Miden landing supersedes a prior (TTL) failure: the success-commit CAS
+/// predicate (`status <> 'success'`) updates the 'failed' row to 'success' and
+/// materialises the attached ClaimEvent. Guarantees a claim that actually landed
+/// never ends stuck at a TTL-failure. PG-gated: skips when `DATABASE_URL` unset.
+#[tokio::test]
+async fn test_pgstore_success_supersedes_prior_failure() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    reset_state(&store).await;
+
+    let tx_hash = TxHash::from([0x5Bu8; 32]);
+    // Attach a ClaimEvent-shaped log so the override's materialisation is checked.
+    let mut entry = dummy_txn_entry();
+    entry.logs = vec![alloy::primitives::LogData::new_unchecked(
+        vec![alloy::primitives::B256::from([0xC1u8; 32])],
+        alloy::primitives::Bytes::from(vec![0xAB]),
+    )];
+    store.txn_begin(tx_hash, entry).await.unwrap();
+
+    // TTL sweeper fails the still-running job first (no logs materialised).
+    store
+        .txn_commit(tx_hash, Err("TTL expired".to_string()), 3, [0u8; 32])
+        .await
+        .unwrap();
+    assert!(
+        store
+            .get_logs_for_tx(&format!("{tx_hash:#x}"))
+            .await
+            .unwrap()
+            .is_empty(),
+        "a failure must NOT materialise the ClaimEvent"
+    );
+
+    // Miden landed → projector commits success for the same hash → override.
+    store
+        .txn_commit(tx_hash, Ok(()), 5, [0u8; 32])
+        .await
+        .expect("a real landing must supersede the provisional failure");
+
+    let (res, block) = store.txn_receipt(tx_hash).await.unwrap().unwrap();
+    assert!(
+        res.is_ok(),
+        "success must supersede the TTL failure; got {res:?}"
+    );
+    assert_eq!(block, 5, "success block wins");
+    assert_eq!(
+        store
+            .get_logs_for_tx(&format!("{tx_hash:#x}"))
+            .await
+            .unwrap()
+            .len(),
+        1,
+        "the ClaimEvent must be materialised on the success override"
+    );
+}
+
+/// BLOCKER 2 (re-review) — single-snapshot CAS under concurrency. Many
+/// `txn_commit`s race `txn_begin`s for distinct hashes. The invariant that the
+/// old UPDATE-then-separate-SELECT could violate under READ COMMITTED: a
+/// `txn_commit` returning Ok must correspond to a row that is ACTUALLY terminal
+/// (never a silent wrong-Ok that leaves the row pending). The SELECT ... FOR
+/// UPDATE takes the classify + update off one locked snapshot, so this holds.
+/// PG-gated: skips when `DATABASE_URL` is unset.
+#[tokio::test]
+async fn test_pgstore_txn_commit_concurrent_begin_single_snapshot() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    reset_state(&store).await;
+    let store = std::sync::Arc::new(store);
+
+    let mut handles = Vec::new();
+    for i in 0..64u8 {
+        let store = store.clone();
+        handles.push(tokio::spawn(async move {
+            let tx_hash = TxHash::from([i; 32]);
+            // Racer A: begin then a failure commit.
+            let a = {
+                let store = store.clone();
+                tokio::spawn(async move {
+                    store.txn_begin(tx_hash, dummy_txn_entry()).await.ok();
+                    store
+                        .txn_commit(tx_hash, Err("x".into()), 1, [0u8; 32])
+                        .await
+                })
+            };
+            // Racer B: a failure commit that may observe the row missing or present.
+            let b = {
+                let store = store.clone();
+                tokio::spawn(async move {
+                    store
+                        .txn_commit(tx_hash, Err("y".into()), 1, [0u8; 32])
+                        .await
+                })
+            };
+            let (ra, rb) = (a.await.unwrap(), b.await.unwrap());
+            // INVARIANT: any commit that returned Ok must have left a terminal
+            // receipt — never a wrong-Ok over a still-pending/absent row.
+            if ra.is_ok() || rb.is_ok() {
+                let receipt = store.txn_receipt(tx_hash).await.unwrap();
+                assert!(
+                    receipt.is_some(),
+                    "a committed-Ok hash must have a terminal receipt (no wrong-Ok): {tx_hash}"
+                );
+            }
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+}
+
+/// BLOCKER 3 — the L1 finalized/safe block round-trips through the new
+/// `l1_indexer_state.finalized_block` column (migration 013), separate from the
+/// head cursor. PG-gated: skips when `DATABASE_URL` is unset.
+#[tokio::test]
+async fn test_pgstore_l1_finalized_block_roundtrip() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    reset_state(&store).await;
+
+    assert_eq!(
+        store.get_l1_finalized_block().await.unwrap(),
+        0,
+        "default 0"
+    );
+    store.set_l1_finalized_block(12_345).await.unwrap();
+    assert_eq!(store.get_l1_finalized_block().await.unwrap(), 12_345);
+    // Independent of the head cursor.
+    store.set_l1_indexer_cursor(99).await.unwrap();
+    assert_eq!(store.get_l1_finalized_block().await.unwrap(), 12_345);
+    assert_eq!(store.get_l1_indexer_cursor().await.unwrap(), 99);
+    // And of the finalized-scan cursor (migration 014).
+    store.set_l1_finalized_scan_cursor(50).await.unwrap();
+    assert_eq!(store.get_l1_finalized_scan_cursor().await.unwrap(), 50);
+    assert_eq!(store.get_l1_finalized_block().await.unwrap(), 12_345);
+}
+
+/// Evidence provenance binding requires a dedicated freshly-migrated database
+/// because the singleton policy is intentionally immutable.
+#[tokio::test]
+#[ignore = "requires a dedicated fresh PostgreSQL database"]
+async fn test_pgstore_l1_evidence_policy_binding_is_immutable() {
+    let store = pg_store().await.expect("DATABASE_URL must be set");
+    store.bind_l1_evidence_policy("finalized").await.unwrap();
+    store.bind_l1_evidence_policy("finalized").await.unwrap();
+    let err = store
+        .bind_l1_evidence_policy("safe")
+        .await
+        .expect_err("a PostgreSQL evidence policy change must fail closed");
+    assert!(format!("{err:#}").contains("bound to `finalized`"));
+}
+
+/// An upgraded database with policy-derived state but no provenance is
+/// ambiguous and must not be silently labelled with the current setting.
+#[tokio::test]
+#[ignore = "requires a dedicated fresh PostgreSQL database"]
+async fn test_pgstore_untagged_finality_state_is_rejected() {
+    let db_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let (client, connection) = tokio_postgres::connect(&db_url, tokio_postgres::NoTls)
+        .await
+        .expect("connect for test setup");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+        .batch_execute(
+            "UPDATE l1_indexer_state
+             SET evidence_tag = NULL, finalized_block = 1, finalized_scan_cursor = 0;
+             UPDATE ger_entries SET finalized_verified = FALSE;",
+        )
+        .await
+        .expect("seed ambiguous pre-policy state");
+
+    let store = PgStore::new(&db_url).await.expect("create PgStore");
+    let err = store
+        .bind_l1_evidence_policy("finalized")
+        .await
+        .expect_err("untagged finality progress must fail closed");
+    assert!(format!("{err:#}").contains("without an evidence policy"));
+
+    client
+        .execute(
+            "UPDATE l1_indexer_state
+             SET evidence_tag = NULL, finalized_block = 0, finalized_scan_cursor = 0",
+            &[],
+        )
+        .await
+        .expect("restore clean singleton state");
+}
+
+/// BLOCKER 1 (re-review) — `mark_ger_finalized` sets the finalized-chain tie
+/// flag (migration 014), and `set_ger_exit_roots` (the latest scan) never resets
+/// it (monotone). PG-gated: skips when `DATABASE_URL` is unset.
+#[tokio::test]
+async fn test_pgstore_mark_ger_finalized_monotone() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    reset_state(&store).await;
+
+    let ger = [0x3Au8; 32];
+    store
+        .set_ger_exit_roots(&ger, [0x01u8; 32], [0x02u8; 32], 100, 1_700_000_000)
+        .await
+        .unwrap();
+    assert!(
+        !store
+            .get_ger_entry(&ger)
+            .await
+            .unwrap()
+            .unwrap()
+            .finalized_verified,
+        "latest scan leaves finalized_verified false"
+    );
+
+    store.mark_ger_finalized(&ger).await.unwrap();
+    assert!(
+        store
+            .get_ger_entry(&ger)
+            .await
+            .unwrap()
+            .unwrap()
+            .finalized_verified,
+        "mark_ger_finalized sets the flag"
+    );
+
+    // A later latest-scan re-observation must NOT reset the flag (monotone).
+    store
+        .set_ger_exit_roots(&ger, [0x01u8; 32], [0x02u8; 32], 100, 1_700_000_050)
+        .await
+        .unwrap();
+    assert!(
+        store
+            .get_ger_entry(&ger)
+            .await
+            .unwrap()
+            .unwrap()
+            .finalized_verified,
+        "set_ger_exit_roots must preserve finalized_verified"
+    );
 }
 
 // ── Nonces ───────────────────────────────────────────────────

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -152,7 +152,7 @@ async fn test_pgstore_ger_lifecycle() {
         rollup_exit_root: Some([0x02; 32]),
         block_number: 100,
         timestamp: 1234567890,
-        finalized_verified: false,
+        evidence_verified: false,
     };
 
     // Initially not seen
@@ -644,31 +644,20 @@ async fn test_pgstore_txn_commit_concurrent_begin_single_snapshot() {
     }
 }
 
-/// BLOCKER 3 — the L1 finalized/safe block round-trips through the new
-/// `l1_indexer_state.finalized_block` column (migration 013), separate from the
-/// head cursor. PG-gated: skips when `DATABASE_URL` is unset.
+/// The one selected evidence-scan cursor round-trips through the legacy
+/// `l1_indexer_state.finalized_scan_cursor` column. PG-gated: skips when
+/// `DATABASE_URL` is unset.
 #[tokio::test]
-async fn test_pgstore_l1_finalized_block_roundtrip() {
+async fn test_pgstore_l1_evidence_cursor_roundtrip() {
     let Some(store) = pg_store().await else {
         return;
     };
     reset_state(&store).await;
 
-    assert_eq!(
-        store.get_l1_finalized_block().await.unwrap(),
-        0,
-        "default 0"
-    );
-    store.set_l1_finalized_block(12_345).await.unwrap();
-    assert_eq!(store.get_l1_finalized_block().await.unwrap(), 12_345);
-    // Independent of the head cursor.
-    store.set_l1_indexer_cursor(99).await.unwrap();
-    assert_eq!(store.get_l1_finalized_block().await.unwrap(), 12_345);
-    assert_eq!(store.get_l1_indexer_cursor().await.unwrap(), 99);
-    // And of the finalized-scan cursor (migration 014).
-    store.set_l1_finalized_scan_cursor(50).await.unwrap();
-    assert_eq!(store.get_l1_finalized_scan_cursor().await.unwrap(), 50);
-    assert_eq!(store.get_l1_finalized_block().await.unwrap(), 12_345);
+    store.set_l1_evidence_cursor(0).await.unwrap();
+    assert_eq!(store.get_l1_evidence_cursor().await.unwrap(), 0);
+    store.set_l1_evidence_cursor(12_345).await.unwrap();
+    assert_eq!(store.get_l1_evidence_cursor().await.unwrap(), 12_345);
 }
 
 /// Evidence provenance binding requires a dedicated freshly-migrated database
@@ -690,7 +679,7 @@ async fn test_pgstore_l1_evidence_policy_binding_is_immutable() {
 /// ambiguous and must not be silently labelled with the current setting.
 #[tokio::test]
 #[ignore = "requires a dedicated fresh PostgreSQL database"]
-async fn test_pgstore_untagged_finality_state_is_rejected() {
+async fn test_pgstore_untagged_evidence_state_is_rejected() {
     let db_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let (client, connection) = tokio_postgres::connect(&db_url, tokio_postgres::NoTls)
         .await
@@ -701,7 +690,7 @@ async fn test_pgstore_untagged_finality_state_is_rejected() {
     client
         .batch_execute(
             "UPDATE l1_indexer_state
-             SET evidence_tag = NULL, finalized_block = 1, finalized_scan_cursor = 0;
+             SET evidence_tag = NULL, finalized_block = 0, finalized_scan_cursor = 1;
              UPDATE ger_entries SET finalized_verified = FALSE;",
         )
         .await
@@ -711,7 +700,7 @@ async fn test_pgstore_untagged_finality_state_is_rejected() {
     let err = store
         .bind_l1_evidence_policy("finalized")
         .await
-        .expect_err("untagged finality progress must fail closed");
+        .expect_err("untagged evidence progress must fail closed");
     assert!(format!("{err:#}").contains("without an evidence policy"));
 
     client
@@ -724,11 +713,11 @@ async fn test_pgstore_untagged_finality_state_is_rejected() {
         .expect("restore clean singleton state");
 }
 
-/// BLOCKER 1 (re-review) — `mark_ger_finalized` sets the finalized-chain tie
-/// flag (migration 014), and `set_ger_exit_roots` (the latest scan) never resets
-/// it (monotone). PG-gated: skips when `DATABASE_URL` is unset.
+/// The configured scan writes roots, L1 metadata, and its provenance marker in
+/// one UPSERT. The PostgreSQL marker retains its legacy physical column name.
+/// PG-gated: skips when `DATABASE_URL` is unset.
 #[tokio::test]
-async fn test_pgstore_mark_ger_finalized_monotone() {
+async fn test_pgstore_set_ger_exit_roots_verifies_evidence() {
     let Some(store) = pg_store().await else {
         return;
     };
@@ -739,41 +728,15 @@ async fn test_pgstore_mark_ger_finalized_monotone() {
         .set_ger_exit_roots(&ger, [0x01u8; 32], [0x02u8; 32], 100, 1_700_000_000)
         .await
         .unwrap();
+    let entry = store.get_ger_entry(&ger).await.unwrap().unwrap();
     assert!(
-        !store
-            .get_ger_entry(&ger)
-            .await
-            .unwrap()
-            .unwrap()
-            .finalized_verified,
-        "latest scan leaves finalized_verified false"
+        entry.evidence_verified,
+        "the selected scan must set its provenance marker with the roots"
     );
-
-    store.mark_ger_finalized(&ger).await.unwrap();
-    assert!(
-        store
-            .get_ger_entry(&ger)
-            .await
-            .unwrap()
-            .unwrap()
-            .finalized_verified,
-        "mark_ger_finalized sets the flag"
-    );
-
-    // A later latest-scan re-observation must NOT reset the flag (monotone).
-    store
-        .set_ger_exit_roots(&ger, [0x01u8; 32], [0x02u8; 32], 100, 1_700_000_050)
-        .await
-        .unwrap();
-    assert!(
-        store
-            .get_ger_entry(&ger)
-            .await
-            .unwrap()
-            .unwrap()
-            .finalized_verified,
-        "set_ger_exit_roots must preserve finalized_verified"
-    );
+    assert_eq!(entry.mainnet_exit_root, Some([0x01u8; 32]));
+    assert_eq!(entry.rollup_exit_root, Some([0x02u8; 32]));
+    assert_eq!(entry.block_number, 100);
+    assert_eq!(entry.timestamp, 1_700_000_000);
 }
 
 // ── Nonces ───────────────────────────────────────────────────

--- a/src/writer_worker.rs
+++ b/src/writer_worker.rs
@@ -115,11 +115,9 @@ pub fn write_drop_snapshot(count: u64) {
 // ─── DecodedWriteCall ───────────────────────────────────────────────────────
 
 /// Method-decoded `eth_sendRawTransaction` payload — the *output* of
-/// `service_send_raw_txn`'s request-thread decode step, the *input* to either
-/// the legacy sync dispatch or the writer-worker enqueue. Decoupling the
-/// dispatch shape from the wire shape lets the worker fork in
-/// `service_send_raw_txn` be a single `match` instead of duplicating selector
-/// detection.
+/// `service_send_raw_txn`'s request-thread decode step and the input to the
+/// mandatory writer-worker enqueue. Keeping this shape separate from the wire
+/// representation avoids duplicating selector detection in the worker.
 // `claimAssetCall` is much larger than the Ger payload (multiple FixedBytes<32>
 // arrays + U256 + addresses, ~1 KB worst case). Box it so the enum variant size
 // stays small — clippy::large_enum_variant gates this above 200 bytes and the
@@ -420,7 +418,7 @@ impl WriterWorkerHandle {
 
     /// Count process-local non-terminal jobs for diagnostics and drain tests.
     /// Transaction-count RPCs use the store's durable pending frontier, which
-    /// also covers sync mode and survives process restart.
+    /// survives process restart.
     pub fn count_non_terminal_for_signer(&self, signer: &Address) -> usize {
         self.inflight
             .iter()
@@ -885,9 +883,9 @@ impl WriterWorker {
 }
 
 /// Dispatch a `WriteJob` to the matching Phase-1 translator in
-/// `service_send_raw_txn`. Each variant calls the same publish/insert path the
-/// legacy sync handler does, minus the per-signer `nonce_increment` (the
-/// request thread durably admitted the envelope and advanced the nonce before enqueue.
+/// `service_send_raw_txn`. Each variant calls the corresponding publish/insert
+/// handler without a per-signer `nonce_increment`: the request thread durably
+/// admitted the envelope and advanced the nonce before enqueue.
 async fn dispatch_job(service: &ServiceState, job: WriteJob) -> anyhow::Result<()> {
     match job {
         WriteJob::Claim {


### PR DESCRIPTION
## Summary

Adds opt-in strict admission for aggoracle-supplied Global Exit Roots (GERs). Before the proxy submits an irreversible `UpdateGerNote` to Miden, the GER must have both exit roots written by the configured L1 evidence scan.

This revision deliberately uses **one scan, one policy, and one cursor**. `L1_EVIDENCE_TAG=latest|safe|finalized` selects the only L1 frontier scanned; there is no parallel latest/finality scan and no confirmation-depth mode. Hardened deployments accept `safe` or `finalized`, while `latest` remains the low-latency non-hardened default.

```mermaid
flowchart LR
    RPC[L1 RPC] -->|selected block tag| Scan[One L1 evidence scan]
    Policy[L1_EVIDENCE_TAG<br/>latest / safe / finalized] --> Scan
    Scan -->|roots + provenance, atomically| DB[(GER evidence)]
    Scan -->|one cursor| Cursor[(Policy-bound cursor)]
    Oracle[Aggoracle GER tx] --> Gate{Strict H6 gate}
    DB --> Gate
    Gate -->|not reached yet| Wait[Bounded side-effect-free wait]
    Wait --> Gate
    Gate -->|verified or duplicate| Writer[Mandatory single writer]
    Writer --> Miden[Miden UpdateGerNote]
```

## What changed

- accepts only `latest`, `safe`, or `finalized`; default is `latest`;
- makes the selected tag control the entire L1 evidence scan;
- persists one policy-bound cursor and writes roots plus provenance atomically;
- requires both roots and selected-scan provenance under strict admission;
- keeps duplicate GER submissions idempotent before the strict gate;
- waits up to 15 minutes for the selected frontier before any nonce, tx row, receipt, queue, or Miden side effect;
- keeps evidence-write failures retryable without advancing the cursor;
- requires `safe` or `finalized` under `REQUIRE_HARDENING=true`;
- preserves the database's legacy physical columns/migration checksums while giving them single-scan semantics;
- binds a database to the exact evidence tag and fails closed on policy reuse;
- on first `latest` upgrade, atomically inherits the legacy durable `last_processed` cursor so restart-window events are not skipped;
- never lets `safe` or `finalized` inherit latest progress; their first deployment requires `L1_INDEXER_FROM_BLOCK` for a trusted backfill;
- preserves #140's mandatory writer and crash-safe exact-note handoff.

## Operations

| Setting | Default | Behavior |
|---|---:|---|
| `REJECT_UNVERIFIED_GER_INJECTION` | `false` | Enables strict H6 admission. |
| `REQUIRE_HARDENING` | `false` | Implies strict H6; requires `safe` or `finalized`. |
| `L1_EVIDENCE_TAG` | `latest` | Selects the only scanned L1 frontier. |
| `L1_RPC_URL` + `GER_L1_ADDRESS` | unset | Required and validated in strict mode. |
| `L1_INDEXER_FROM_BLOCK` | unset | Required for a fresh strict DB and first `safe`/`finalized` backfill. |

The evidence tag is immutable for a populated database. Changing it requires the documented stop/reset/backfill procedure; existing roots are not silently relabelled under a stronger policy.

## Validation at `e1911fb`

- `make lint` — pass
- `make test-unit` — pass (430 passed, 1 intentionally ignored)
- final read-only production audit — no remaining blocker
- E2E intentionally not run in this patch

GitHub CI is rerunning for the new head.
