### PR TITLE
fix(security): fail-closed signer default + configurable bind (audit C2)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,10 @@
 # Runtime + build artefacts that must never enter the proxy image build context.
 # .miden-agglayer-data and .b2agg-store hold root-owned keystores/sqlite stores
 # (created by the proxy / loadtest containers) that the unprivileged build daemon
-# cannot read — including them fails the build with "permission denied". Patterns
-# are anchored with **/ so nested copies (e.g. under Claude Code agent worktrees
-# in .claude/) are excluded too, not just the repo-root copy.
+# cannot read — including them fails the build with "permission denied". The
+# `**/`-prefixed forms use a leading recursive wildcard that matches the pattern
+# at any directory depth, so nested copies (e.g. under Claude Code agent
+# worktrees in .claude/) are excluded too, not just the repo-root copy.
 **/.miden-agglayer-data/
 .miden-agglayer-data/
 **/.b2agg-store/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,17 @@
 # Runtime + build artefacts that must never enter the proxy image build context.
-# .miden-agglayer-data holds a root-owned keystore (created by the proxy
-# container) that the unprivileged build daemon cannot read — including it
-# fails the build with "permission denied".
+# .miden-agglayer-data and .b2agg-store hold root-owned keystores/sqlite stores
+# (created by the proxy / loadtest containers) that the unprivileged build daemon
+# cannot read — including them fails the build with "permission denied". Patterns
+# are anchored with **/ so nested copies (e.g. under Claude Code agent worktrees
+# in .claude/) are excluded too, not just the repo-root copy.
+**/.miden-agglayer-data/
 .miden-agglayer-data/
+**/.b2agg-store/
+.b2agg-store/
+# Claude Code state — agent worktrees under .claude/worktrees each carry their
+# own runtime data dirs (root-owned) and full source checkouts; none of it
+# belongs in the image build context.
+.claude/
 target/
 out/
 cache/

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -271,6 +271,19 @@ services:
       # deterministic 0x133e6a88… orphan). Anvil's history is ~100s of blocks
       # so a from-genesis scan is trivial (max_range chunks it).
       - "--l1-indexer-from-block=1"
+      # Audit C2 — the signer default is now fail-closed: with no
+      # `--allowed-signers` configured, `eth_sendRawTransaction` rejects EVERY
+      # signer. The e2e stack's legitimate submitters (aggoracle/aggsender GER +
+      # exit-root txs, bridge-autoclaim claims, loadtest deposits/claims) are
+      # signed by keys derived from gitignored, per-setup-generated keystores —
+      # their addresses are not stable or knowable at commit time, so a static
+      # `--allowed-signers` list here cannot work. This proxy is bound to
+      # loopback only (`127.0.0.1:8546`, see `ports:` above) with no external
+      # ingress, which is exactly the documented-safe posture for the explicit
+      # legacy open-mode opt-in. Restore open mode for the e2e so tx submission
+      # is accepted. (`--require-hardening` is intentionally NOT set here, so
+      # this flag does not trip the hardening gate.)
+      - "--insecure-allow-any-signer"
       # R1 admin-auth key is supplied via the `ADMIN_API_KEY` env var
       # from `fixtures/.env`, generated fresh per setup by
       # scripts/setup-fixtures.sh (or scripts/ensure-e2e-secrets.sh on

--- a/src/main.rs
+++ b/src/main.rs
@@ -1057,6 +1057,28 @@ mod hardening_tests {
         assert!(check_hardening_invariants(&c).is_ok());
     }
 
+    /// Audit C2 — `--insecure-allow-any-signer` (the legacy open-mode opt-in)
+    /// is refused under `--require-hardening`. Starting from the all-set config
+    /// that otherwise passes, flipping only the insecure opt-in must trip the
+    /// gate with exactly one reason naming the flag.
+    #[test]
+    fn hardening_refuses_insecure_allow_any_signer() {
+        let mut c = cmd(
+            true,
+            Some("strong-admin-key".into()),
+            Some(vec![alloy::primitives::Address::ZERO]),
+            Some(vec!["https://app.example.com".into()]),
+        );
+        c.insecure_allow_any_signer = true;
+        let reasons = check_hardening_invariants(&c).unwrap_err();
+        assert_eq!(
+            reasons.len(),
+            1,
+            "only the insecure opt-in should trip the gate: {reasons:?}"
+        );
+        assert!(reasons[0].contains("--insecure-allow-any-signer"));
+    }
+
     /// When hardening is enabled and the remote prover is unset, the gate
     /// must reject — local proving is the documented bali OOM cause.
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ struct Command {
     /// `0.0.0.0` (all interfaces) for backward compat. Set to `127.0.0.1` to
     /// restrict to loopback — the recommended production posture when the
     /// service sits behind a reverse proxy / sidecar that owns authn.
-    #[arg(long, env = "BIND_ADDR", default_value = "0.0.0.0")]
+    #[arg(long, env = "BIND_ADDR", default_value = "0.0.0.0", value_parser = parse_bind_addr)]
     bind: String,
 
     /// Directory for miden-client data [default: $HOME/.miden]
@@ -281,10 +281,40 @@ fn check_hardening_invariants(command: &Command) -> Result<(), Vec<String>> {
     }
 }
 
+/// clap value parser for `--bind`: validate the value as a bare IP address
+/// (`0.0.0.0`, `127.0.0.1`, `::1`, …) at the CLI boundary. The service port is
+/// a *separate* `--port` arg, so a `host:port` form (`127.0.0.1:8546`) or a
+/// bare IPv6 literal that only fails later at URL construction is rejected here
+/// with a clear message instead of blowing up deep in startup.
+fn parse_bind_addr(s: &str) -> Result<String, String> {
+    s.parse::<std::net::IpAddr>()
+        .map(|_| s.to_string())
+        .map_err(|_| {
+            format!(
+                "`{s}` is not a valid IP address (expected e.g. `0.0.0.0`, `127.0.0.1`, or `::1`; \
+             the listening port is set separately via --port, not appended here)"
+            )
+        })
+}
+
+/// Build the JSON-RPC service URL from a validated bind host + port. IPv6
+/// literals are bracketed (`::1` → `http://[::1]:8546`); without brackets the
+/// colons in the address collide with the port separator and the URL is
+/// invalid (`http://::1:8546`).
+fn build_service_url(bind: &str, port: u16) -> Result<Url, url::ParseError> {
+    let host = if bind.contains(':') {
+        format!("[{bind}]")
+    } else {
+        bind.to_string()
+    };
+    Url::from_str(&format!("http://{host}:{port}"))
+}
+
 impl std::fmt::Debug for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Command")
             .field("port", &self.port)
+            .field("bind", &self.bind)
             .field("miden_store_dir", &self.miden_store_dir)
             .field("miden_node", &self.miden_node)
             .field("chain_id", &self.chain_id)
@@ -897,7 +927,7 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
-    let url = Url::from_str(format!("http://{}:{}", command.bind, command.port).as_str())?;
+    let url = build_service_url(&command.bind, command.port)?;
     service::serve(url, state.clone(), metrics_handle).await?;
 
     // RD-940 Phase 5 — graceful drain. When `service::serve` returns
@@ -1093,5 +1123,53 @@ mod hardening_tests {
         let reasons = check_hardening_invariants(&c).unwrap_err();
         assert_eq!(reasons.len(), 1);
         assert!(reasons[0].contains("--miden-prover-url"));
+    }
+}
+
+#[cfg(test)]
+mod bind_tests {
+    use super::*;
+    use clap::Parser;
+
+    /// A bad `--bind` value (host:port form, not a bare IP) is rejected at the
+    /// CLI by the value parser instead of failing late at URL construction.
+    #[test]
+    fn bad_bind_value_rejected_at_cli() {
+        // host:port is not a bare IpAddr → clap error.
+        let err = Command::try_parse_from(["prog", "--bind", "127.0.0.1:8546"]);
+        assert!(err.is_err(), "host:port bind must be rejected at the CLI");
+
+        // Outright garbage is rejected too.
+        assert!(
+            Command::try_parse_from(["prog", "--bind", "not-an-ip"]).is_err(),
+            "non-IP bind must be rejected at the CLI"
+        );
+    }
+
+    /// The value parser accepts the valid bare-IP forms it documents.
+    #[test]
+    fn good_bind_values_accepted() {
+        assert_eq!(parse_bind_addr("0.0.0.0").unwrap(), "0.0.0.0");
+        assert_eq!(parse_bind_addr("127.0.0.1").unwrap(), "127.0.0.1");
+        assert_eq!(parse_bind_addr("::1").unwrap(), "::1");
+        assert!(parse_bind_addr("127.0.0.1:8546").is_err());
+    }
+
+    /// An IPv6 bind (`::1`) produces a valid, bracketed URL — the unbracketed
+    /// `http://::1:8546` would be an invalid URL.
+    #[test]
+    fn ipv6_bind_builds_valid_bracketed_url() {
+        let url = build_service_url("::1", 8546).expect("::1 must build a valid URL");
+        assert_eq!(url.as_str(), "http://[::1]:8546/");
+        assert_eq!(url.host_str(), Some("::1"));
+        assert_eq!(url.port(), Some(8546));
+    }
+
+    /// IPv4 bind is left unbracketed.
+    #[test]
+    fn ipv4_bind_builds_plain_url() {
+        let url = build_service_url("127.0.0.1", 8546).expect("valid IPv4 URL");
+        assert_eq!(url.as_str(), "http://127.0.0.1:8546/");
+        assert_eq!(url.port(), Some(8546));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,13 @@ struct Command {
     #[arg(long, default_value_t = 8546)]
     port: u16,
 
+    /// Bind address for the JSON-RPC HTTP service (audit H2/C2). Default
+    /// `0.0.0.0` (all interfaces) for backward compat. Set to `127.0.0.1` to
+    /// restrict to loopback — the recommended production posture when the
+    /// service sits behind a reverse proxy / sidecar that owns authn.
+    #[arg(long, env = "BIND_ADDR", default_value = "0.0.0.0")]
+    bind: String,
+
     /// Directory for miden-client data [default: $HOME/.miden]
     #[arg(long)]
     miden_store_dir: Option<PathBuf>,
@@ -124,10 +131,19 @@ struct Command {
 
     /// Allow-list of EVM signer addresses permitted to submit
     /// `eth_sendRawTransaction` (R2). Comma-separated 0x-prefixed addresses
-    /// (case-insensitive). When unset, every well-formed signer is accepted
-    /// (legacy open mode — only safe behind a private network boundary).
+    /// (case-insensitive). When unset, NO signer is accepted (audit C2 —
+    /// fail-closed default; previously the default was open to any signer).
+    /// To explicitly restore legacy open mode (ONLY safe behind a private
+    /// network boundary / loopback bind), set `--insecure-allow-any-signer`.
     #[arg(long, env = "ALLOWED_SIGNERS", value_delimiter = ',')]
     allowed_signers: Option<Vec<alloy::primitives::Address>>,
+
+    /// DANGEROUS: accept `eth_sendRawTransaction` from ANY signer (audit C2).
+    /// Explicit opt-in for the legacy open mode that was the pre-C2 default.
+    /// Refused by `--require-hardening`. Only safe with `--bind 127.0.0.1`
+    /// and/or a network-level boundary.
+    #[arg(long, env = "INSECURE_ALLOW_ANY_SIGNER", default_value_t = false)]
+    insecure_allow_any_signer: bool,
 
     /// Per-IP rate limit, sustained requests per second (R13). Default 500.
     #[arg(long, env = "RATE_LIMIT_PER_SECOND", default_value_t = miden_agglayer_service::service::DEFAULT_RATE_LIMIT_PER_SECOND)]
@@ -225,8 +241,17 @@ fn check_hardening_invariants(command: &Command) -> Result<(), Vec<String>> {
         .is_none_or(|v| v.is_empty())
     {
         reasons.push(
-            "  - --allowed-signers is unset (eth_sendRawTransaction would accept \
-             any signer). Set ALLOWED_SIGNERS to a comma-separated allow-list."
+            "  - --allowed-signers is unset (eth_sendRawTransaction would reject \
+             every signer — audit C2 fail-closed default). Set ALLOWED_SIGNERS \
+             to a comma-separated allow-list."
+                .to_string(),
+        );
+    }
+    if command.insecure_allow_any_signer {
+        reasons.push(
+            "  - --insecure-allow-any-signer is set (eth_sendRawTransaction accepts \
+             ANY signer — audit C2 legacy open mode). This is incompatible with \
+             --require-hardening; remove it and use --allowed-signers instead."
                 .to_string(),
         );
     }
@@ -286,6 +311,7 @@ impl std::fmt::Debug for Command {
             )
             .field("cors_allowed_origins", &self.cors_allowed_origins)
             .field("allowed_signers", &self.allowed_signers)
+            .field("insecure_allow_any_signer", &self.insecure_allow_any_signer)
             .field("require_hardening", &self.require_hardening)
             .field(
                 "miden_api_key",
@@ -666,6 +692,7 @@ async fn main() -> anyhow::Result<()> {
     state.cors_allowed_origins = command.cors_allowed_origins;
     state.admin_api_key = command.admin_api_key;
     state.allowed_signers = command.allowed_signers;
+    state.allow_any_signer = command.insecure_allow_any_signer;
     state.rate_limit_per_second = command.rate_limit_per_second;
     state.rate_limit_burst = command.rate_limit_burst;
     state.reject_zero_padding_addresses = command.reject_zero_padding_addresses;
@@ -870,7 +897,7 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
-    let url = Url::from_str(format!("http://0.0.0.0:{}", command.port).as_str())?;
+    let url = Url::from_str(format!("http://{}:{}", command.bind, command.port).as_str())?;
     service::serve(url, state.clone(), metrics_handle).await?;
 
     // RD-940 Phase 5 — graceful drain. When `service::serve` returns
@@ -953,6 +980,7 @@ mod hardening_tests {
     ) -> Command {
         Command {
             port: 8546,
+            bind: "0.0.0.0".into(),
             miden_store_dir: None,
             miden_node: None,
             chain_id: 1,
@@ -972,6 +1000,7 @@ mod hardening_tests {
             cors_allowed_origins: cors,
             admin_api_key: admin,
             allowed_signers: signers,
+            insecure_allow_any_signer: false,
             rate_limit_per_second: miden_agglayer_service::service::DEFAULT_RATE_LIMIT_PER_SECOND,
             rate_limit_burst: miden_agglayer_service::service::DEFAULT_RATE_LIMIT_BURST,
             reject_zero_padding_addresses: false,

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -456,9 +456,17 @@ pub(crate) async fn worker_handle_ger_insert(
 /// Self-review R2 — pre-fix the proxy accepted any well-formed signed tx, even
 /// though only aggsender / aggoracle / operator-rescue signers have a legitimate
 /// reason to submit `claimAsset` / `insertGlobalExitRoot` / `updateExitRoot`.
+/// Whether `signer` is permitted to submit `eth_sendRawTransaction`.
+///
+/// Audit C2 — pre-fix, `None` (the default) meant OPEN to any signer, which
+/// combined with the `0.0.0.0` bind made the service accept anonymous claims /
+/// GER injections from anyone who could reach the port. `None` now means CLOSED
+/// (fail-closed). Legacy open mode is an explicit opt-in via
+/// `ServiceState::allow_any_signer` (`--insecure-allow-any-signer`), checked at
+/// the call site.
 pub fn is_signer_allowed(allowed: Option<&[Address]>, signer: &Address) -> bool {
     match allowed {
-        None => true,
+        None => false,
         Some(list) => list.iter().any(|a| a == signer),
     }
 }
@@ -640,10 +648,14 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
     // (auto-creates faucets, advances LET, marks GERs injected), letting an
     // attacker burn fees, poison registries, or feed fabricated GERs to
     // bridge-service. Reject any signer not in the configured allow-list.
-    if !is_signer_allowed(service.allowed_signers.as_deref(), &signer) {
+    // Audit C2 — `None` is fail-closed (no signer accepted); legacy open mode
+    // requires the explicit `allow_any_signer` opt-in.
+    if !service.allow_any_signer && !is_signer_allowed(service.allowed_signers.as_deref(), &signer)
+    {
         ::metrics::counter!("rpc_unauthorized_signer_total").increment(1);
         anyhow::bail!(
-            "signer {signer:#x} is not on the allow-list; configure --allowed-signers (or set ALLOWED_SIGNERS) to permit"
+            "signer {signer:#x} is not on the allow-list; configure --allowed-signers (or ALLOWED_SIGNERS), \
+             or set --insecure-allow-any-signer to explicitly opt into open mode"
         );
     }
 
@@ -1398,9 +1410,11 @@ mod tests {
         let _ = shutdown.send(());
     }
 
-    /// Self-review R2 — repro+regression. Pre-fix, every recovered signer was
-    /// accepted unconditionally. Post-fix the predicate must:
-    /// - return true when no allow-list is configured (legacy open mode)
+    /// Self-review R2 + audit C2 — repro+regression. Pre-fix, every recovered
+    /// signer was accepted unconditionally; the allow-list then additionally
+    /// failed OPEN (None => true). Post-C2 the predicate must:
+    /// - return FALSE when no allow-list is configured (fail-closed default —
+    ///   legacy open mode now requires the explicit `allow_any_signer` opt-in)
     /// - return true when the signer is in the allow-list
     /// - return false when an allow-list is configured but the signer isn't in it
     /// - return false for an empty allow-list (explicit refuse-all)
@@ -1416,9 +1430,9 @@ mod tests {
             .parse()
             .unwrap();
 
-        // None = open
-        assert!(is_signer_allowed(None, &alice));
-        assert!(is_signer_allowed(None, &bob));
+        // None = CLOSED (audit C2 — was OPEN pre-fix)
+        assert!(!is_signer_allowed(None, &alice));
+        assert!(!is_signer_allowed(None, &bob));
 
         // Empty list = explicit refuse-all
         assert!(!is_signer_allowed(Some(&[]), &alice));
@@ -1480,6 +1494,9 @@ mod tests {
     #[tokio::test]
     async fn r2_unauthorised_signer_rejected_with_descriptive_error() {
         let mut service = create_test_service();
+        // Audit C2 — disable the test-helper's open mode so the allow-list is
+        // actually enforced here.
+        service.allow_any_signer = false;
         // Configure a non-empty allow-list that does NOT include the test signer.
         let foreign: Address = "0xdeAddeaDdEadDeaDDEaDDeadDEADDeaDDEAdDEaD"
             .parse()
@@ -1502,6 +1519,37 @@ mod tests {
         assert!(
             msg.contains(&format!("{signer:#x}")),
             "must name the signer: {msg}"
+        );
+    }
+
+    /// Audit C2 — the fail-closed default. With NO allow-list configured AND
+    /// `allow_any_signer = false` (the production default), a well-formed signed
+    /// tx MUST be rejected. Pre-fix, `None` meant open and this tx would be
+    /// accepted — letting anyone who could reach the port inject claims / GERs.
+    #[tokio::test]
+    async fn c2_default_fail_closed_rejects_signer_without_allow_list() {
+        let mut service = create_test_service();
+        // Production default: no allow-list, no open-mode opt-in.
+        service.allow_any_signer = false;
+        service.allowed_signers = None;
+
+        let calldata = insertGlobalExitRootCall {
+            root: FixedBytes::from([0xBBu8; 32]),
+        }
+        .abi_encode();
+        let (input_hex, _signer) = encode_legacy_tx(calldata);
+
+        let err = service_send_raw_txn(service, input_hex)
+            .await
+            .expect_err("C2: signer must be rejected under the fail-closed default");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not on the allow-list"),
+            "must cite the allow-list: {msg}"
+        );
+        assert!(
+            msg.contains("--insecure-allow-any-signer"),
+            "must point the operator at the explicit opt-in: {msg}"
         );
     }
 }

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -88,12 +88,17 @@ pub struct ServiceState {
     /// entirely (the safe production default — fail closed). `Some(token)` =
     /// admin requests must carry `Authorization: Bearer <token>`.
     pub admin_api_key: Option<String>,
-    /// Allow-list of EVM signer addresses (R2). `None` = `eth_sendRawTransaction`
-    /// is OPEN to any signer (legacy default; only safe behind a private
-    /// network-level boundary). `Some(list)` = inbound txs must be signed by an
-    /// address in the list. Production must always set this — aggsender,
-    /// aggoracle, and any operator-rescue tool are the only legitimate signers.
+    /// Allow-list of EVM signer addresses (R2). Audit C2 — `None` now means
+    /// CLOSED (fail-closed: no signer is accepted). `Some(list)` = inbound txs
+    /// must be signed by an address in the list. To explicitly enable legacy
+    /// open mode, set `allow_any_signer = true` via `--insecure-allow-any-signer`
+    /// (refused by `--require-hardening`).
     pub allowed_signers: Option<Vec<alloy::primitives::Address>>,
+    /// Audit C2 — explicit opt-in for legacy "accept any signer" mode. When
+    /// true, `eth_sendRawTransaction` accepts any well-formed signer regardless
+    /// of `allowed_signers`. ONLY safe behind a loopback bind / network
+    /// boundary. Refused by `--require-hardening`.
+    pub allow_any_signer: bool,
     /// Per-signer async mutex registry (R4 follow-up) — serialises the
     /// nonce-check critical section so two concurrent same-nonce txs from one
     /// signer cannot both pass the equality check before either increments.
@@ -171,6 +176,7 @@ impl ServiceState {
             cors_allowed_origins: None,
             admin_api_key: None,
             allowed_signers: None,
+            allow_any_signer: false,
             per_signer_locks: PerSignerLocks::new(),
             rate_limit_per_second: crate::service::DEFAULT_RATE_LIMIT_PER_SECOND,
             rate_limit_burst: crate::service::DEFAULT_RATE_LIMIT_BURST,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -53,12 +53,18 @@ pub async fn seed_test_faucets(store: &dyn Store) {
 
 /// Create a `ServiceState` backed by `InMemoryStore` and a test `MidenClient`
 /// stub (no real Miden node connection). Suitable for unit tests.
+///
+/// Audit C2 — `allow_any_signer = true` so tests that exercise the submission
+/// paths don't each have to configure an allow-list. Production defaults remain
+/// fail-closed (`allow_any_signer = false`, `allowed_signers = None`).
 pub fn create_test_service() -> ServiceState {
     let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
     let block_state = Arc::new(BlockState::new());
     let miden_client = MidenClient::new_test();
     let accounts = test_accounts_config();
-    ServiceState::new(miden_client, accounts, 1, 1, store, block_state)
+    let mut state = ServiceState::new(miden_client, accounts, 1, 1, store, block_state);
+    state.allow_any_signer = true;
+    state
 }
 
 /// Build a REAL `MidenClientLib` backed by a throwaway sqlite store and an RPC


### PR DESCRIPTION
## Audit C2 — fail-closed signer default + configurable bind

Pre-fix, `eth_sendRawTransaction` accepted **any** signer when `--allowed-signers` was unset (the default), and the service bound `0.0.0.0` with no loopback option. Combined, anyone who could reach the port could submit claims / GER injections, auto-create faucets, and burn operator-paid Miden gas.

### Signer posture (fail-closed default)
- `is_signer_allowed(None, _)` now returns **false** (was true)
- new `--insecure-allow-any-signer` flag for explicit legacy-open opt-in
- `ServiceState::allow_any_signer` gates the opt-in
- `--require-hardening` **refuses to boot** when the insecure flag is set

### Bind posture
- new `--bind` / `BIND_ADDR` flag (default `0.0.0.0` for backward compat) so deployments can restrict to `127.0.0.1` behind a reverse proxy

### Changes
- `main.rs`: `--bind`, `--insecure-allow-any-signer`, hardening gate updates
- `service_state.rs`: `allow_any_signer` field
- `service_send_raw_txn.rs`: fail-closed `is_signer_allowed` + call site
- `test_helpers.rs`: `create_test_service` sets `allow_any_signer` for tests
- e2e: `docker-compose.e2e.yml` passes `--insecure-allow-any-signer` (proxy is loopback-bound `127.0.0.1:8546`, the documented-safe posture — legitimate submitters use gitignored, per-setup keystores whose addresses aren't knowable at commit time); `.dockerignore` excludes `.b2agg-store/` + `.claude/` worktrees

### Tests
Updated `r2_` pins for the new semantics + `c2_` red→green proving the fail-closed default rejects a signer and points at the opt-in flag; plus the hardening-gate refusal test.
