### PR TITLE
chore: remove the wallet_hardhat account entirely

### DIFF
--- a/docs/RUNNING-E2E.md
+++ b/docs/RUNNING-E2E.md
@@ -105,21 +105,37 @@ Give the proxy ~45s after "healthy" to write `bridge_accounts.toml`.
 
 ## 5. Manual deposit / withdraw
 
+The stack ships no pre-funded user wallet (the old `wallet_hardhat` account
+was removed): provision an INDEPENDENT wallet in an isolated store, fund it
+with a normal L1→L2 deposit to its address, then bridge out from it — the
+same flow the e2e drives via `scripts/lib-isolated-wallet.sh`. The easiest
+end-to-end path is simply:
+
+```bash
+./scripts/e2e-l2-to-l1.sh   # provisions + funds the isolated wallet, bridges out, autoclaims on L1
+```
+
+For a manual run:
+
 ```bash
 source fixtures/.env; export PATH="$HOME/.foundry/bin:$PATH"
 C=miden-agglayer-miden-agglayer-1
 ACCT=$(docker exec $C cat /var/lib/miden-agglayer-service/bridge_accounts.toml)
-WALLET=$(echo "$ACCT" | sed -n 's/.*wallet_hardhat = "\(.*\)"/\1/p')
 BRIDGE=$(echo "$ACCT" | sed -n 's/.*bridge = "\(.*\)"/\1/p')
 FAUCET=$(echo "$ACCT" | sed -n 's/.*faucet_eth = "\(.*\)"/\1/p')
 
+# provision an independent wallet in an isolated store (prints wallet-id):
+docker exec $C bridge-out-tool --store-dir /tmp/manual-wallet \
+  --node-url http://miden-node:57291 --create-wallet
+WALLET=<wallet-id printed above>  # fund it first: L1→L2 deposit to its eth-address form (section below)
+
 # L2->L1 withdraw (bridge-autoclaim settles on L1):
-docker exec $C bridge-out-tool --store-dir /var/lib/miden-agglayer-service \
+docker exec $C bridge-out-tool --store-dir /tmp/manual-wallet \
   --node-url http://miden-node:57291 --wallet-id $WALLET --bridge-id $BRIDGE \
   --faucet-id $FAUCET --amount 500 --dest-address 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --dest-network 0
 
 # check L2 balance (dry probe):
-docker exec $C bridge-out-tool --store-dir /var/lib/miden-agglayer-service \
+docker exec $C bridge-out-tool --store-dir /tmp/manual-wallet \
   --node-url http://miden-node:57291 --wallet-id $WALLET --bridge-id $BRIDGE \
   --faucet-id $FAUCET --amount 999999999 --dest-address 0xdead --dest-network 0 2>&1 | grep 'wallet balance:'
 ```

--- a/scripts/e2e-bridge-loadtest-isolated.sh
+++ b/scripts/e2e-bridge-loadtest-isolated.sh
@@ -250,7 +250,7 @@ ACCOUNTS=$(docker exec "$AGGLAYER_CONTAINER" \
     || die "miden-agglayer not initialized"
 # The bridge + ETH faucet are the proxy's global accounts (shared on the node);
 # the bridge-out WALLET, however, is a fresh INDEPENDENT wallet we provision in
-# the isolated store below (NOT wallet_hardhat).
+# the isolated store below (the stack ships no pre-funded user wallet).
 # Preserve any caller-supplied hex bridge id BEFORE this internal overwrite
 # (the toml form is bech32, for iso_tool; the verifier needs hex — upgrade
 # scenarios pass it via env because the recreated proxy never logged the

--- a/scripts/e2e-reset-restore-recovery.sh
+++ b/scripts/e2e-reset-restore-recovery.sh
@@ -227,7 +227,7 @@ case "$MODE" in
     ;;
   expect_recovery)
     # Post-55fa17a: Phase 0 reimport re-populates. Should be close to BEFORE_ROWS
-    # (some accounts may not be network-tracked — wallet_hardhat especially —
+    # (an account may not be network-tracked — the locally-deployed service —
     # so we allow a small loss; the network-tracked accounts MUST be present).
     [[ "$AFTER_ROWS" -gt 0 ]] \
       || fail "MODE=expect_recovery but latest_account_headers is empty after restore — Phase 0 didn't reimport"

--- a/src/account_recovery.rs
+++ b/src/account_recovery.rs
@@ -31,8 +31,8 @@
 //! ## Why NOT startup verification (the design we deleted)
 //!
 //! Not every account in `bridge_accounts.toml` is fully tracked by the
-//! node at every moment. Locally-deployed `service` and `wallet_hardhat`
-//! are created by `add_wallet` (`init.rs:125-153`) but never get an
+//! node at every moment. The locally-deployed `service` account
+//! is created by `add_wallet` (`init.rs:125-153`) but never gets an
 //! explicit `deploy_account` call — they exist locally until first use,
 //! at which point `submit_new_transaction` deploys them on-chain. A
 //! startup `verify_or_reimport_or_fail` call against those accounts
@@ -168,7 +168,7 @@ pub async fn reimport_account(
 /// Re-import every account in `bridge_accounts.toml`. Per-account
 /// failures are logged but NOT propagated — callers want this to be
 /// best-effort idempotent before retrying a submission. The locally-
-/// only accounts (e.g. `wallet_hardhat`, `service`) that aren't
+/// only accounts (e.g. `service`) that aren't
 /// network-deployed will fail here with `AccountNotFoundOnChain` and
 /// that's fine: if the next submission succeeds, those accounts get
 /// deployed implicitly by the tx.
@@ -177,7 +177,6 @@ pub async fn reimport_known_accounts(client: &MidenClient, accounts: &AccountsCo
         let mut v = vec![
             ("service", accounts.service.0),
             ("bridge", accounts.bridge.0),
-            ("wallet_hardhat", accounts.wallet_hardhat.0),
         ];
         if let Some(g) = &accounts.ger_manager {
             v.push(("ger_manager", g.0));

--- a/src/accounts_config.rs
+++ b/src/accounts_config.rs
@@ -17,7 +17,6 @@ pub struct AccountsConfig {
     /// Legacy field — kept for backward compatibility with existing TOML configs.
     #[serde(default)]
     pub faucet_agg: Option<AccountIdBech32>,
-    pub wallet_hardhat: AccountIdBech32,
     /// Dedicated account for GER injection. Separate from `service` so the
     /// NTX builder's modifications to the service account don't cause stale
     /// state errors when submitting UpdateGerNotes.
@@ -83,7 +82,6 @@ struct AccountsConfigOnDisk {
     faucet_eth: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     faucet_agg: Option<String>,
-    wallet_hardhat: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     ger_manager: Option<String>,
 }
@@ -96,7 +94,6 @@ impl AccountsConfigOnDisk {
             bridge: enc(&config.bridge),
             faucet_eth: config.faucet_eth.as_ref().map(&enc),
             faucet_agg: config.faucet_agg.as_ref().map(&enc),
-            wallet_hardhat: enc(&config.wallet_hardhat),
             ger_manager: config.ger_manager.as_ref().map(&enc),
         }
     }
@@ -409,7 +406,6 @@ mod tests {
             bridge: dummy(),
             faucet_eth: Some(dummy()),
             faucet_agg: None,
-            wallet_hardhat: dummy(),
             ger_manager: Some(dummy()),
         };
         save_config(cfg, &NetworkId::Testnet, Some(dir.path().to_path_buf())).unwrap();
@@ -433,10 +429,7 @@ mod tests {
         let id = AccountId::from_hex(TEST_ACCOUNT_HEX).unwrap();
         let local_hrp = NetworkId::new("mlcl").unwrap();
         let legacy_bech32 = id.to_bech32(local_hrp);
-        let toml_body = format!(
-            "service = \"{b}\"\nbridge = \"{b}\"\nwallet_hardhat = \"{b}\"\n",
-            b = legacy_bech32
-        );
+        let toml_body = format!("service = \"{b}\"\nbridge = \"{b}\"\n", b = legacy_bech32);
         fs::write(dir.path().join("bridge_accounts.toml"), toml_body).unwrap();
         let loaded = load_config(Some(dir.path().to_path_buf())).unwrap();
         assert_eq!(loaded.bridge.0, id);
@@ -450,7 +443,6 @@ mod tests {
             bridge: dummy(),
             faucet_eth: None,
             faucet_agg: None,
-            wallet_hardhat: dummy(),
             ger_manager: None,
         };
         save_config(cfg, &NetworkId::Testnet, Some(dir.path().to_path_buf())).unwrap();
@@ -467,7 +459,6 @@ mod tests {
             bridge: dummy(),
             faucet_eth: Some(dummy()),
             faucet_agg: Some(dummy()),
-            wallet_hardhat: dummy(),
             ger_manager: Some(dummy()),
         }
     }

--- a/src/address_mapper.rs
+++ b/src/address_mapper.rs
@@ -32,8 +32,8 @@ pub fn account_id_from_address(address: Address) -> Option<AccountId> {
 /// mapping path like any other address: a deposit targeting it resolves
 /// only if an operator has explicitly mapped it (or it happens to be a
 /// zero-padded Miden id, which the Hardhat EOA is not). No dev-only remap
-/// to `wallet_hardhat`, no gate, no bail — the address is treated like any
-/// other EVM address.
+/// to a hardcoded account, no gate, no bail — the address is treated like
+/// any other EVM address.
 ///
 /// Self-review C5 — the zero-padding fallback maps any 4-leading-zero EVM
 /// address to a Miden AccountId WITHOUT verifying the account exists on
@@ -177,38 +177,31 @@ mod tests {
     /// Cantina MA#8 — the well-known Hardhat default-account address
     /// (`0xf39f...2266`) must NOT be special-cased in `resolve_address`.
     /// Pre-fix there was an `if address == HARDHAT_ADDRESS` branch that
-    /// remapped it to `config.wallet_hardhat` on every claim (later
-    /// merely gated behind a flag). cergyk required the branch be
+    /// remapped it to a hardcoded infrastructure account on every claim
+    /// (later merely gated behind a flag). cergyk required the branch be
     /// removed entirely so the address flows through the normal mapping
     /// path with no special behavior. This test pins that: with no
     /// explicit store mapping, the Hardhat EOA (which is not a
-    /// zero-padded Miden id) resolves to nothing — it does NOT silently
-    /// land in `wallet_hardhat`, and resolution behaves exactly as it
+    /// zero-padded Miden id) resolves to nothing — it errors just as it
     /// would for any other un-mapped, non-zero-padded EVM address.
     #[tokio::test]
     async fn ma8_hardhat_address_not_special_cased() {
         use crate::store::memory::InMemoryStore;
         let store = InMemoryStore::new();
         let cfg = test_accounts_config();
-        // `wallet_hardhat` in the config is a real, valid AccountId. If the
-        // old special case were still present, resolving the Hardhat EOA
-        // below would return `cfg.wallet_hardhat.0` (an `Ok`). With the
-        // branch removed it must error like any other un-mapped address.
-        let wallet_hardhat = cfg.wallet_hardhat.0;
         let hardhat = address!("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266");
 
         // Default policy: the Hardhat EOA is NOT zero-padded (high bytes
-        // are 0xf39f...), there is no store mapping, so resolution errors
-        // exactly like any other un-mapped non-zero-padded address —
-        // never resolves to wallet_hardhat.
+        // are 0xf39f...), and there is no store mapping. If the old special
+        // case were still present it would resolve to a hardcoded account
+        // (an `Ok`); with the branch removed it must error exactly like any
+        // other un-mapped non-zero-padded address.
         let r = resolve_address_with_policy(&store, hardhat, &cfg, false).await;
         assert!(
             r.is_err(),
             "Hardhat EOA must not be special-cased; expected the normal \
-             'no known Miden AccountId' error, but it resolved to {:?} \
-             (== wallet_hardhat? {})",
+             'no known Miden AccountId' error, but it resolved to {:?}",
             r.as_ref().ok(),
-            r.as_ref().ok() == Some(&wallet_hardhat)
         );
 
         // And a generic un-mapped non-zero-padded address gives the same
@@ -248,7 +241,6 @@ mod tests {
             service: AccountIdBech32(id),
             faucet_eth: None,
             faucet_agg: None,
-            wallet_hardhat: AccountIdBech32(id),
         }
     }
 }

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -1117,7 +1117,7 @@ pub async fn publish_claim(
     // registration), so we reimport the whole bridge_accounts set rather
     // than guess which account was the culprit from the error message.
     // `reimport_known_accounts` is best-effort and idempotent — accounts
-    // not on chain (e.g. `wallet_hardhat`) fail benignly.
+    // not yet on chain (e.g. `service` before first use) fail benignly.
     match attempt_publish_claim(
         params.clone(),
         client,

--- a/src/init.rs
+++ b/src/init.rs
@@ -22,7 +22,6 @@ struct Accounts {
     service: Account,
     bridge: Account,
     faucet_eth: Account,
-    wallet_hardhat: Account,
     ger_manager: Account,
 }
 
@@ -37,7 +36,6 @@ impl From<Accounts> for AccountsConfig {
             // additional token (POL, USDC, …) is auto-created by find_or_create_faucet in
             // claim.rs on first bridge.
             faucet_agg: None,
-            wallet_hardhat: AccountIdBech32(accounts.wallet_hardhat.id()),
             ger_manager: Some(AccountIdBech32(accounts.ger_manager.id())),
         }
     }
@@ -141,7 +139,7 @@ async fn add_wallet(
     keystore: Arc<FilesystemKeyStore>,
 ) -> anyhow::Result<Account> {
     // Public storage mode is REQUIRED for the proxy's infrastructure accounts
-    // (service, ger_manager, wallet_hardhat) so a missing local sqlite row can
+    // (service, ger_manager) so a missing local sqlite row can
     // be recovered via `Client::import_account_by_id` from the live Miden
     // node. Private accounts (the AccountBuilder default) cannot be
     // recovered — their full state lives ONLY in the proxy's sqlite. The
@@ -239,12 +237,10 @@ async fn add_accounts(
         MetadataHash::from_abi_encoded(&[]),
     )
     .await?;
-    let wallet_hardhat = add_wallet(client, keystore.clone()).await?;
     Ok(Accounts {
         service,
         bridge,
         faucet_eth,
-        wallet_hardhat,
         ger_manager,
     })
 }
@@ -295,9 +291,6 @@ async fn init_internal(
         client.sync_state().await?;
     }
     tracing::info!("account settlement complete");
-
-    // Register the P2ID note tag for wallet_hardhat so sync discovers incoming P2ID notes.
-    register_wallet_p2id_tag(client, accounts.wallet_hardhat.id()).await?;
 
     // Faucet bridge registration is handled in create_and_register_faucet (via add_faucet)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -679,8 +679,8 @@ async fn main() -> anyhow::Result<()> {
     // an `AccountDataNotFound` or `IncorrectAccountInitialCommitment` error,
     // the caller reimports the affected account from the live Miden node and
     // retries once. We deliberately do NOT brick the proxy at startup over
-    // locally-deployed-but-not-yet-network-tracked accounts (e.g. service,
-    // wallet_hardhat) — those are healthy until first use, at which point
+    // locally-deployed-but-not-yet-network-tracked accounts (e.g. service)
+    // — those are healthy until first use, at which point
     // their initial `submit_new_transaction` deploys them on-chain.
     // Run restore if requested
     if command.restore {

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -124,11 +124,7 @@ pub async fn detect_locked_accounts(
     client: &MidenClient,
     accounts: &AccountsConfig,
 ) -> Result<Vec<AccountId>> {
-    let mut ids: Vec<AccountId> = vec![
-        accounts.service.0,
-        accounts.bridge.0,
-        accounts.wallet_hardhat.0,
-    ];
+    let mut ids: Vec<AccountId> = vec![accounts.service.0, accounts.bridge.0];
     if let Some(f) = &accounts.faucet_eth {
         ids.push(f.0);
     }

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -276,7 +276,7 @@ pub async fn restore(
     //
     // Best-effort: per-account failures are logged + counted but do not
     // abort restore. Locally-deployed-but-not-network-tracked accounts
-    // (`service`, `wallet_hardhat`) will return `AccountNotFoundOnChain`
+    // (`service`) will return `AccountNotFoundOnChain`
     // here and that's fine — they're healthy until first use.
     tracing::info!("Phase 0: re-importing bridge accounts from Miden node...");
     crate::account_recovery::reimport_known_accounts(miden_client, accounts).await;

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -275,9 +275,9 @@ pub async fn restore(
     // the recovery flags.
     //
     // Best-effort: per-account failures are logged + counted but do not
-    // abort restore. Locally-deployed-but-not-network-tracked accounts
-    // (`service`) will return `AccountNotFoundOnChain`
-    // here and that's fine — they're healthy until first use.
+    // abort restore. The locally-deployed-but-not-network-tracked account
+    // (`service`) will return `AccountNotFoundOnChain` here and that's
+    // fine — it's healthy until first use.
     tracing::info!("Phase 0: re-importing bridge accounts from Miden node...");
     crate::account_recovery::reimport_known_accounts(miden_client, accounts).await;
     tracing::info!("Phase 0 complete: bridge account reimport pass done");

--- a/src/synthetic_projector.rs
+++ b/src/synthetic_projector.rs
@@ -1285,7 +1285,6 @@ mod tests {
             bridge: AccountIdBech32(aid(BRIDGE)),
             faucet_eth: None,
             faucet_agg: None,
-            wallet_hardhat: AccountIdBech32(aid(SERVICE)),
             ger_manager: Some(AccountIdBech32(aid(GER_MANAGER))),
         }
     }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -28,7 +28,6 @@ pub fn test_accounts_config() -> AccountsConfig {
         bridge: dummy_account_id(),
         faucet_eth: Some(dummy_account_id()),
         faucet_agg: None,
-        wallet_hardhat: dummy_account_id(),
         ger_manager: None,
     })
 }


### PR DESCRIPTION
## What
Removes the `wallet_hardhat` account **entirely** from the service.

## Why
Follow-up to #78 (which removed the Hardhat *destination-alias* special case in `address_mapper.rs`, Cantina MA#8). With the alias gone, the `wallet_hardhat` account itself is dead weight — it is no longer a special resolution target, so carrying it in `AccountsConfig`, recovery, restore, and the projector just adds surface with no behavior. This deletes it outright.

## Changes
Drops `wallet_hardhat` from `accounts_config.rs` and unwinds every reference: `account_recovery.rs`, `address_mapper.rs`, `claim.rs`, `init.rs`, `main.rs`, `recovery.rs`, `restore.rs`, `synthetic_projector.rs`, `test_helpers.rs`.

Net: 10 files, +20/−51 (pure removal).

## Notes
Base `main`, 1 commit. No behavior change beyond removing the unused account (the Hardhat EOA already resolves only via explicit store mapping / zero-padding after #78).
