### PR TITLE
harden(e2e): un-flake claim-provenance + kill swallowed-error/false-PASS class (task #26)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ e2e-setup: ## One-time: extract Anvil snapshot + configs from Kurtosis
 	./scripts/setup-fixtures.sh
 
 .PHONY: e2e-clean-data
-e2e-clean-data: ## Wipe .miden-agglayer-data/ + node_data volume so the stack re-inits against fresh genesis
+e2e-clean-data: ## Wipe .miden-agglayer-data/ + .b2agg-store/ + node_data volume so the stack re-inits against fresh genesis
 	# Proto 0.15: the node is a microservice stack whose state (genesis block,
 	# store, validator + ntx-builder DBs) lives in the `node_data` Docker volume,
 	# and the proxy's genesis pin lives in .miden-agglayer-data/store.sqlite3.
@@ -216,12 +216,32 @@ e2e-clean-data: ## Wipe .miden-agglayer-data/ + node_data volume so the stack re
 	# client's sync fail ("accept header validation failed"), so wipe BOTH for a
 	# clean slate. The bootstrap services rebuild genesis (deterministic from the
 	# vendored agglayer .mac files) and the proxy's --init redeploys accounts in
-	# ~45s — acceptable for E2E. The volume rm is guarded so it no-ops when the
-	# volume is absent or still in use (containers must be down first, which the
-	# regression harness guarantees via `make e2e-down`).
-	rm -rf .miden-agglayer-data
+	# ~45s — acceptable for E2E.
+	#
+	# Task #26 hardening — three closed holes:
+	#  (1) .b2agg-store/ (the tests' ISOLATED miden-client stores) is wiped too:
+	#      an isolated store surviving a stack recreation carries the OLD chain's
+	#      genesis commitment in its gRPC Accept header and the new node refuses
+	#      the connection (AcceptHeaderError, shown as a bare "RPC error") — one
+	#      such store wedged e2e-claim-provenance on 7 consecutive cert runs.
+	#      Fresh stack ⇒ no isolated store may outlive it, ever.
+	#  (2) Containers create root-owned files in these dirs; a plain `rm -rf` as
+	#      the invoking user fails on them and historically failed SILENTLY —
+	#      stale "fresh" stacks cost a night of debugging. Fall back to a root
+	#      container, then ASSERT the dirs are actually empty (wipe-that-didn't-
+	#      wipe is a hard stop, not a warning).
+	#  (3) The node_data volume rm distinguishes "absent" (fine) from "in use"
+	#      (a live container still mounts it ⇒ `make e2e-down` was not run ⇒
+	#      stale node state would survive under a "fresh" stack — hard stop).
+	rm -rf .miden-agglayer-data .b2agg-store 2>/dev/null || \
+		docker run --rm -v "$(CURDIR):/work" alpine sh -c 'rm -rf /work/.miden-agglayer-data /work/.b2agg-store'
+	@if [ -e .miden-agglayer-data ] || [ -e .b2agg-store ]; then \
+		echo "e2e-clean-data: WIPE FAILED — leftover state would poison the fresh stack:"; \
+		ls -la .miden-agglayer-data .b2agg-store 2>/dev/null; exit 1; fi
 	mkdir -p .miden-agglayer-data/tmp
-	-docker volume rm miden-agglayer_node_data 2>/dev/null || true
+	@out=$$(docker volume rm miden-agglayer_node_data 2>&1) || { \
+		echo "$$out" | grep -qi "no such volume" || { \
+			echo "e2e-clean-data: cannot remove node_data volume (stack still up? run 'make e2e-down'): $$out"; exit 1; }; }
 
 .PHONY: e2e-up
 e2e-up: e2e-clean-data ## Start full E2E environment (cleans data dir first)

--- a/scripts/e2e-claim-provenance.sh
+++ b/scripts/e2e-claim-provenance.sh
@@ -92,17 +92,30 @@ command -v python3 >/dev/null || fail "python3 not found"
 export PGPASSWORD="$PG_PASS"
 PSQL=(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAX)
 # stderr dropped: locale-warning noise corrupts captures (see sibling scripts).
-pgq() { "${PSQL[@]}" -c "$1" 2>/dev/null; }
+pgq() {
+    # STOPPER on DB error (task #26 sweep): pre-fix `2>/dev/null` turned a dead
+    # Postgres into an empty string, which ${VAR:-0} then misread as "0 rows".
+    local out
+    if ! out=$("${PSQL[@]}" -c "$1" 2>&1); then
+        echo "pgq FAILED: $out" >&2
+        return 1
+    fi
+    printf '%s\n' "$out"
+}
 
 # Prometheus counter from the proxy's /metrics (0 when absent). State/metric
 # assertions over log greps throughout — docker-log field regexes are fragile
 # (ANSI escapes / format drift; see e2e log-assertion history).
 counter() {
-    local name="$1" value
-    value=$(curl -s "${L2_RPC}/metrics" | awk -v n="$name" '
+    local name="$1" body value
+    # STOPPER on unreachable /metrics (task #26 sweep): pre-fix, a down proxy
+    # read as 0 — a baseline taken against a dead endpoint could false-PASS
+    # delta assertions. Absent metric stays a legit 0 (never-incremented).
+    body=$(curl -sf "${L2_RPC}/metrics") || fail "metrics endpoint unreachable: ${L2_RPC}/metrics"
+    value=$(awk -v n="$name" '
         $0 ~ ("^" n " ") { print $2; found=1; exit }
         END { if (!found) print 0 }
-    ')
+    ' <<<"$body")
     echo "${value%.*}"
 }
 

--- a/scripts/e2e-claim-provenance.sh
+++ b/scripts/e2e-claim-provenance.sh
@@ -117,6 +117,17 @@ l2_tip() {
 # is a separate trust domain with its own keys, exactly like production.
 B2AGG_STORE_DIR="${B2AGG_STORE_DIR:-$PROJECT_DIR/.b2agg-store/e2e-claim-provenance}"
 source "$SCRIPT_DIR/lib-isolated-wallet.sh"
+# ALWAYS start from a clean store (task #26). The foreign deployment is
+# re-provisioned from scratch every run, so reuse has no value — and a store
+# surviving a stack recreation carries the OLD chain's genesis commitment,
+# which miden-client presents in its gRPC Accept header; the new node rejects
+# the connection outright (AcceptHeaderError/NoSupportedMediaRange, displayed
+# as a bare "RPC error"). One such stale store wedged this test on 7
+# consecutive cert runs. The sibling tests (private-note, cantina13) already
+# defend via B2AGG_FRESH=1; this test uses iso_tool directly and must wipe
+# itself. `_iso_wipe_store` falls back to a root container for the
+# container-created root-owned files.
+_iso_wipe_store
 mkdir -p "$B2AGG_STORE_DIR/tmp"
 
 log "======================================================================"

--- a/scripts/e2e-claim-provenance.sh
+++ b/scripts/e2e-claim-provenance.sh
@@ -95,11 +95,18 @@ PSQL=(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAX)
 pgq() {
     # STOPPER on DB error (task #26 sweep): pre-fix `2>/dev/null` turned a dead
     # Postgres into an empty string, which ${VAR:-0} then misread as "0 rows".
-    local out
-    if ! out=$("${PSQL[@]}" -c "$1" 2>&1); then
-        echo "pgq FAILED: $out" >&2
+    # stderr stays SEPARATE from the capture (locale warnings are rc=0 noise
+    # that must not corrupt numeric parses — see header comment) and is
+    # surfaced only when psql actually fails.
+    local out errf rc
+    errf="$(mktemp)"
+    out=$("${PSQL[@]}" -c "$1" 2>"$errf"); rc=$?
+    if [[ $rc -ne 0 ]]; then
+        echo "pgq FAILED (rc=$rc): $(cat "$errf")" >&2
+        rm -f "$errf"
         return 1
     fi
+    rm -f "$errf"
     printf '%s\n' "$out"
 }
 

--- a/scripts/e2e-claim-watcher-synthesis.sh
+++ b/scripts/e2e-claim-watcher-synthesis.sh
@@ -73,11 +73,18 @@ PSQL=(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAX)
 pgq() {
     # STOPPER on DB error (task #26 sweep): pre-fix `2>/dev/null` turned a dead
     # Postgres into an empty string, which ${VAR:-0} then misread as "0 rows".
-    local out
-    if ! out=$("${PSQL[@]}" -c "$1" 2>&1); then
-        echo "pgq FAILED: $out" >&2
+    # stderr stays SEPARATE from the capture (locale warnings are rc=0 noise
+    # that must not corrupt numeric parses — see header comment) and is
+    # surfaced only when psql actually fails.
+    local out errf rc
+    errf="$(mktemp)"
+    out=$("${PSQL[@]}" -c "$1" 2>"$errf"); rc=$?
+    if [[ $rc -ne 0 ]]; then
+        echo "pgq FAILED (rc=$rc): $(cat "$errf")" >&2
+        rm -f "$errf"
         return 1
     fi
+    rm -f "$errf"
     printf '%s\n' "$out"
 }
 

--- a/scripts/e2e-claim-watcher-synthesis.sh
+++ b/scripts/e2e-claim-watcher-synthesis.sh
@@ -71,7 +71,14 @@ PSQL=(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAX)
 # manifest as empty output, which every caller already checks via `[[ -z ]]`
 # or by validating the result shape.
 pgq() {
-    "${PSQL[@]}" -c "$1" 2>/dev/null
+    # STOPPER on DB error (task #26 sweep): pre-fix `2>/dev/null` turned a dead
+    # Postgres into an empty string, which ${VAR:-0} then misread as "0 rows".
+    local out
+    if ! out=$("${PSQL[@]}" -c "$1" 2>&1); then
+        echo "pgq FAILED: $out" >&2
+        return 1
+    fi
+    printf '%s\n' "$out"
 }
 
 # Bootstrap: if the script is run on a fresh stack with no prior L1→L2
@@ -97,12 +104,15 @@ ensure_prereq_state() {
 
 # Pull a Prometheus counter value (single un-labeled sample). Returns 0 if absent.
 counter() {
-    local name="$1"
-    local value
-    value=$(curl -s "${L2_RPC}/metrics" | awk -v n="$name" '
+    local name="$1" body value
+    # STOPPER on unreachable /metrics (task #26 sweep): pre-fix, a down proxy
+    # read as 0 — a baseline taken against a dead endpoint could false-PASS
+    # delta assertions. Absent metric stays a legit 0 (never-incremented).
+    body=$(curl -sf "${L2_RPC}/metrics") || fail "metrics endpoint unreachable: ${L2_RPC}/metrics"
+    value=$(awk -v n="$name" '
         $0 ~ ("^" n " ") { print $2; found=1; exit }
         END { if (!found) print 0 }
-    ')
+    ' <<<"$body")
     echo "${value%.*}"
 }
 

--- a/scripts/e2e-claim-watcher.sh
+++ b/scripts/e2e-claim-watcher.sh
@@ -37,13 +37,15 @@ fail() { echo -e "${RED}[$(date +%H:%M:%S)] FAIL:${NC} $*" >&2; exit 1; }
 
 # Pull a Prometheus counter value (single un-labeled sample). Returns 0 if absent.
 counter() {
-    local name="$1"
-    local value
-    value=$(curl -s "${L2_RPC}/metrics" | awk -v n="$name" '
+    local name="$1" body value
+    # STOPPER on unreachable /metrics (task #26 sweep): pre-fix, a down proxy
+    # read as 0 — a baseline taken against a dead endpoint could false-PASS
+    # delta assertions. Absent metric stays a legit 0 (never-incremented).
+    body=$(curl -sf "${L2_RPC}/metrics") || fail "metrics endpoint unreachable: ${L2_RPC}/metrics"
+    value=$(awk -v n="$name" '
         $0 ~ ("^" n " ") { print $2; found=1; exit }
         END { if (!found) print 0 }
-    ')
-    # Strip the .0 suffix Prometheus adds to integer counters.
+    ' <<<"$body")
     echo "${value%.*}"
 }
 

--- a/scripts/verify-event-completeness.sh
+++ b/scripts/verify-event-completeness.sh
@@ -157,6 +157,14 @@ if total_notes == 0 and total_logs > 0:
     print("SANITY FAIL: node query matched ZERO consumed notes while logs exist —")
     print(f"almost certainly a wrong/bech32 BRIDGE_ID ({bridge_id}); pass the HEX id.")
     sys.exit(2)
+if total_notes == 0:
+    # Task #26 sweep: an all-zero table is NOT a pass. Zero consumed bridge
+    # notes means nothing was verified — wrong NODE_CONTAINER, a bridge id
+    # from a previous stack, or an empty run. A verifier that saw no data
+    # must say so, not certify completeness.
+    print("SANITY FAIL: zero consumed bridge notes in the node snapshot — nothing verified.")
+    print(f"Check NODE_CONTAINER ({sys.argv[1]!r} snapshot), BRIDGE_ID ({bridge_id}), and that the run produced traffic.")
+    sys.exit(2)
 print("VERDICT:", "FAIL" if overall_fail else "PASS",
       "(exact = log at the note's consumption block; late = present but later block)")
 sys.exit(1 if overall_fail else 0)

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -242,9 +242,18 @@ async fn sync_with_retry(
         };
         let height = client.get_sync_height().await.ok().map(|h| h.as_u64());
         let progressed = matches!((last_height, height), (Some(prev), Some(now)) if now > prev);
-        if progressed {
-            // Forward progress — this attempt does NOT count toward the stall
-            // window (it wasn't "without progress"); fully reset the counter.
+        // First successfully-read height establishes the BASELINE — that
+        // attempt is not a stall datapoint (nothing to compare against). A
+        // failed height read PRESERVES the previous baseline (overwriting it
+        // with None would blind progress detection on every later attempt)
+        // and counts toward the stall window fail-closed.
+        let baseline_established = last_height.is_none() && height.is_some();
+        if height.is_some() {
+            last_height = height;
+        }
+        if progressed || baseline_established {
+            // Forward progress (or first baseline) — this attempt does NOT
+            // count toward the stall window; fully reset the counter.
             stalled = 0;
         } else {
             stalled += 1;
@@ -259,7 +268,6 @@ async fn sync_with_retry(
             "[{label}] sync attempt failed at height {height:?} \
              ({stalled}/{MAX_STALLED} without progress), retrying in {RETRY_DELAY_SECS}s: {err:?}"
         );
-        last_height = height;
         tokio::time::sleep(std::time::Duration::from_secs(RETRY_DELAY_SECS)).await;
     }
 }

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -207,6 +207,61 @@ fn parse_account_id(s: &str) -> anyhow::Result<AccountId> {
     Err(anyhow!("cannot parse account ID: {s}"))
 }
 
+/// Sync the client to the node tip, surviving transient per-request RPC
+/// failures — the fix for the deterministic-in-suite `e2e-claim-provenance`
+/// failure (task #26: 7/7 cert runs died at `--create-foreign-bridge` on a
+/// single unretried `sync_state()`).
+///
+/// Why a progress gate instead of a fixed retry count: `sync_state()` loops
+/// internally in bounded steps (one gRPC request per step, each under the
+/// tool's 10s per-request deadline) and PERSISTS partial progress in the
+/// client store — a failed call resumes where it left off, not from genesis.
+/// So the correct wait condition is "keep going while the sync height still
+/// advances between attempts"; only K consecutive attempts with zero forward
+/// progress indicate a genuine stall (node down / unreachable) worth failing
+/// on. A fixed count would give up mid-catch-up on a long chain even though
+/// every attempt was making progress.
+///
+/// Errors are printed with `{e:?}` deliberately: `ClientError`'s Display is
+/// the bare string "RPC error" (miden-client 0.15 `errors.rs`), which is what
+/// left the suite failure undiagnosable — the gRPC status (DeadlineExceeded /
+/// ResourceExhausted / Unavailable, each with retry guidance) lives in the
+/// source chain that only Debug formatting surfaces.
+async fn sync_with_retry(
+    client: &mut miden_agglayer_service::miden_client::MidenClientLib,
+    label: &str,
+) -> anyhow::Result<()> {
+    const MAX_STALLED: u32 = 5;
+    const RETRY_DELAY_SECS: u64 = 3;
+    let mut last_height: Option<u64> = None;
+    let mut stalled: u32 = 0;
+    loop {
+        let err = match client.sync_state().await {
+            Ok(_) => return Ok(()),
+            Err(e) => e,
+        };
+        let height = client.get_sync_height().await.ok().map(|h| h.as_u64());
+        let progressed = matches!((last_height, height), (Some(prev), Some(now)) if now > prev);
+        if progressed {
+            stalled = 1; // forward progress — restart the stall window
+        } else {
+            stalled += 1;
+        }
+        if stalled >= MAX_STALLED {
+            return Err(anyhow!(
+                "[{label}] sync stalled: {MAX_STALLED} consecutive attempts without \
+                 progress (sync height {height:?}); last error: {err:?}"
+            ));
+        }
+        eprintln!(
+            "[{label}] sync attempt failed at height {height:?} \
+             ({stalled}/{MAX_STALLED} without progress), retrying in {RETRY_DELAY_SECS}s: {err:?}"
+        );
+        last_height = height;
+        tokio::time::sleep(std::time::Duration::from_secs(RETRY_DELAY_SECS)).await;
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
@@ -306,10 +361,7 @@ async fn main() -> anyhow::Result<()> {
             "[create-wallet] provisioning independent wallet in {}",
             store_path.display()
         );
-        client
-            .sync_state()
-            .await
-            .map_err(|e| anyhow!("initial sync failed: {e}"))?;
+        sync_with_retry(&mut client, "create-wallet").await?;
         let wallet =
             miden_agglayer_service::init::create_standalone_wallet(&mut client, keystore.clone())
                 .await
@@ -341,10 +393,7 @@ async fn main() -> anyhow::Result<()> {
             store_path.display(),
             args.foreign_network_id
         );
-        client
-            .sync_state()
-            .await
-            .map_err(|e| anyhow!("initial sync failed: {e}"))?;
+        sync_with_retry(&mut client, "foreign-bridge").await?;
 
         let service =
             miden_agglayer_service::init::create_standalone_wallet(&mut client, keystore.clone())
@@ -469,10 +518,7 @@ async fn main() -> anyhow::Result<()> {
             call.originNetwork, call.destinationNetwork, call.amount
         );
 
-        client
-            .sync_state()
-            .await
-            .map_err(|e| anyhow!("initial sync failed: {e}"))?;
+        sync_with_retry(&mut client, "foreign-claim").await?;
 
         // Wait for an OUTPUT note (by id) to be consumed on-chain, mirroring
         // the B2AGG wait_consumed loop below.
@@ -583,10 +629,7 @@ async fn main() -> anyhow::Result<()> {
         println!("[private-note] wallet: {wallet_id}");
 
         println!("[private-note] syncing state...");
-        client
-            .sync_state()
-            .await
-            .map_err(|e| anyhow!("sync failed: {e}"))?;
+        sync_with_retry(&mut client, "private-note").await?;
 
         // P2ID recipient targeting the wallet itself; PRIVATE note type; note
         // tag left at the default (0) so `sync_notes(tags={0})` lists it — the
@@ -693,21 +736,10 @@ async fn main() -> anyhow::Result<()> {
     );
 
     // Sync state — retry on transient errors (concurrent SQLite access with
-    // the running service can cause "failed to convert note record" errors).
+    // the running service can cause "failed to convert note record" errors;
+    // node RPC under suite load returns transient gRPC failures).
     println!("[bridge-out] syncing state...");
-    for sync_attempt in 0..5u32 {
-        match client.sync_state().await {
-            Ok(_) => break,
-            Err(e) if sync_attempt < 4 => {
-                eprintln!(
-                    "[bridge-out] sync attempt {} failed: {e}, retrying...",
-                    sync_attempt + 1
-                );
-                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            }
-            Err(e) => return Err(anyhow!("sync failed after 5 attempts: {e}")),
-        }
-    }
+    sync_with_retry(&mut client, "bridge-out").await?;
     println!("[bridge-out] sync complete");
 
     // Try to consume any Expected/Committed notes for the wallet
@@ -829,10 +861,7 @@ async fn main() -> anyhow::Result<()> {
     for attempt in 1..=SUBMIT_ATTEMPTS {
         // Sync right before each attempt to minimize the window where the
         // service's background sync loop can change our shared SQLite state.
-        client
-            .sync_state()
-            .await
-            .map_err(|e| anyhow!("pre-submit sync failed: {e}"))?;
+        sync_with_retry(&mut client, "bridge-out pre-submit").await?;
 
         let b2agg = B2AggNote::create(
             args.dest_network,

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -243,7 +243,9 @@ async fn sync_with_retry(
         let height = client.get_sync_height().await.ok().map(|h| h.as_u64());
         let progressed = matches!((last_height, height), (Some(prev), Some(now)) if now > prev);
         if progressed {
-            stalled = 1; // forward progress — restart the stall window
+            // Forward progress — this attempt does NOT count toward the stall
+            // window (it wasn't "without progress"); fully reset the counter.
+            stalled = 0;
         } else {
             stalled += 1;
         }

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -353,7 +353,7 @@ async fn main() -> anyhow::Result<()> {
     let mut client = builder
         .build()
         .await
-        .map_err(|e| anyhow!("failed to build miden client: {e}"))?;
+        .map_err(|e| anyhow!("failed to build miden client: {e:?}"))?;
 
     // ── Provision mode ────────────────────────────────────────────────────────
     // Create a fully independent bridge-out wallet in THIS store (separate from
@@ -367,11 +367,13 @@ async fn main() -> anyhow::Result<()> {
         let wallet =
             miden_agglayer_service::init::create_standalone_wallet(&mut client, keystore.clone())
                 .await
-                .map_err(|e| anyhow!("wallet creation failed: {e}"))?;
+                .map_err(|e| anyhow!("wallet creation failed: {e:?}"))?;
         // Settle the new account on the node before it can receive deposits.
         for _ in 0..10 {
             tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-            client.sync_state().await.ok();
+            if let Err(e) = client.sync_state().await {
+                eprintln!("[settle] sync failed (non-fatal, retried next tick): {e:?}");
+            }
         }
         println!("[create-wallet] wallet-id: {}", wallet.id().to_hex());
         println!("[create-wallet] done");
@@ -400,20 +402,20 @@ async fn main() -> anyhow::Result<()> {
         let service =
             miden_agglayer_service::init::create_standalone_wallet(&mut client, keystore.clone())
                 .await
-                .map_err(|e| anyhow!("foreign service wallet creation failed: {e}"))?;
+                .map_err(|e| anyhow!("foreign service wallet creation failed: {e:?}"))?;
         let ger_manager =
             miden_agglayer_service::init::create_standalone_wallet(&mut client, keystore.clone())
                 .await
-                .map_err(|e| anyhow!("foreign ger_manager wallet creation failed: {e}"))?;
+                .map_err(|e| anyhow!("foreign ger_manager wallet creation failed: {e:?}"))?;
 
         // Deploy ger_manager via dummy txn (mirrors init.rs::deploy_account).
         let dummy = TransactionRequestBuilder::new().build()?;
         let txn_id = submit_new_transaction(&mut client, ger_manager.id(), dummy)
             .await
-            .map_err(|e| anyhow!("foreign ger_manager deploy failed: {e}"))?;
+            .map_err(|e| anyhow!("foreign ger_manager deploy failed: {e:?}"))?;
         wait_for_transaction_commit(&mut client, txn_id, 30, std::time::Duration::from_secs(2))
             .await
-            .map_err(|e| anyhow!("foreign ger_manager deploy commit wait failed: {e}"))?;
+            .map_err(|e| anyhow!("foreign ger_manager deploy commit wait failed: {e:?}"))?;
 
         // Foreign bridge (mirrors init.rs::add_bridge).
         let bridge = create_bridge_account(
@@ -425,20 +427,22 @@ async fn main() -> anyhow::Result<()> {
         client
             .add_account(&bridge, false)
             .await
-            .map_err(|e| anyhow!("adding foreign bridge account failed: {e}"))?;
+            .map_err(|e| anyhow!("adding foreign bridge account failed: {e:?}"))?;
         let dummy = TransactionRequestBuilder::new().build()?;
         let txn_id = submit_new_transaction(&mut client, bridge.id(), dummy)
             .await
-            .map_err(|e| anyhow!("foreign bridge deploy failed: {e}"))?;
+            .map_err(|e| anyhow!("foreign bridge deploy failed: {e:?}"))?;
         wait_for_transaction_commit(&mut client, txn_id, 30, std::time::Duration::from_secs(2))
             .await
-            .map_err(|e| anyhow!("foreign bridge deploy commit wait failed: {e}"))?;
+            .map_err(|e| anyhow!("foreign bridge deploy commit wait failed: {e:?}"))?;
 
         // Settle accounts before the faucet registration note targets the bridge
         // (mirrors init.rs's NTX-builder settlement wait).
         for _ in 0..10 {
             tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-            client.sync_state().await.ok();
+            if let Err(e) = client.sync_state().await {
+                eprintln!("[settle] sync failed (non-fatal, retried next tick): {e:?}");
+            }
         }
 
         // Foreign ETH faucet, registered in the FOREIGN bridge's on-chain
@@ -457,10 +461,12 @@ async fn main() -> anyhow::Result<()> {
             MetadataHash::from_abi_encoded(&[]),
         )
         .await
-        .map_err(|e| anyhow!("foreign faucet creation/registration failed: {e}"))?;
+        .map_err(|e| anyhow!("foreign faucet creation/registration failed: {e:?}"))?;
         for _ in 0..10 {
             tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-            client.sync_state().await.ok();
+            if let Err(e) = client.sync_state().await {
+                eprintln!("[settle] sync failed (non-fatal, retried next tick): {e:?}");
+            }
         }
 
         // Stable, machine-parseable output — e2e-claim-provenance.sh greps these.
@@ -533,7 +539,9 @@ async fn main() -> anyhow::Result<()> {
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs);
             while std::time::Instant::now() < deadline {
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                client.sync_state().await.ok();
+                if let Err(e) = client.sync_state().await {
+                    eprintln!("[settle] sync failed (non-fatal, retried next tick): {e:?}");
+                }
                 let recs = client
                     .get_output_notes(NoteFilter::Consumed)
                     .await
@@ -569,7 +577,7 @@ async fn main() -> anyhow::Result<()> {
             .build()?;
         let txn_id = submit_new_transaction(&mut client, ger_manager_id, tx_request)
             .await
-            .map_err(|e| anyhow!("foreign GER inject submit failed: {e}"))?;
+            .map_err(|e| anyhow!("foreign GER inject submit failed: {e:?}"))?;
         println!("[foreign-claim] GER inject transaction submitted: {txn_id}");
         wait_output_consumed(&mut client, ger_note_id, "foreign UpdateGer", 240).await?;
         println!("[foreign-claim] GER injected (UpdateGerNote consumed by foreign bridge)");
@@ -598,7 +606,7 @@ async fn main() -> anyhow::Result<()> {
             .build()?;
         let txn_id = submit_new_transaction(&mut client, service_id, tx_request)
             .await
-            .map_err(|e| anyhow!("foreign CLAIM submit failed: {e}"))?;
+            .map_err(|e| anyhow!("foreign CLAIM submit failed: {e:?}"))?;
         println!("[foreign-claim] CLAIM transaction submitted: {txn_id}");
         wait_output_consumed(&mut client, note_id, "foreign CLAIM", 300).await?;
 
@@ -670,7 +678,7 @@ async fn main() -> anyhow::Result<()> {
                 }
                 Err(e) if attempt < ATTEMPTS => {
                     eprintln!(
-                        "[private-note] submit attempt {attempt} failed: {e}; retrying in 10s"
+                        "[private-note] submit attempt {attempt} failed: {e:?}; retrying in 10s"
                     );
                     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
                 }
@@ -685,7 +693,9 @@ async fn main() -> anyhow::Result<()> {
         let mut commit_block: Option<u32> = None;
         while std::time::Instant::now() < deadline {
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            client.sync_state().await.ok();
+            if let Err(e) = client.sync_state().await {
+                eprintln!("[settle] sync failed (non-fatal, retried next tick): {e:?}");
+            }
             let recs = client
                 .get_output_notes(miden_client::store::NoteFilter::Committed)
                 .await
@@ -769,7 +779,13 @@ async fn main() -> anyhow::Result<()> {
             println!("[bridge-out] consuming {} notes...", consumable.len());
             let notes: Vec<miden_protocol::note::Note> = consumable
                 .into_iter()
-                .filter_map(|(rec, _)| rec.try_into().ok())
+                .filter_map(|(rec, _)| match rec.try_into() {
+                    Ok(n) => Some(n),
+                    Err(e) => {
+                        eprintln!("[bridge-out] SKIPPING unconvertible note record (was silently dropped pre-#128): {e:?}");
+                        None
+                    }
+                })
                 .collect();
             if !notes.is_empty() {
                 match TransactionRequestBuilder::new().build_consume_notes(notes) {
@@ -784,11 +800,15 @@ async fn main() -> anyhow::Result<()> {
                                 println!("[bridge-out] consumed notes: {tx}");
                                 for _ in 0..10 {
                                     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-                                    client.sync_state().await.ok();
+                                    if let Err(e) = client.sync_state().await {
+                                        eprintln!(
+                                            "[settle] sync failed (non-fatal, retried next tick): {e:?}"
+                                        );
+                                    }
                                 }
                             }
                             Err(e) => {
-                                println!("[bridge-out] consume failed: {e}");
+                                println!("[bridge-out] consume failed: {e:?}");
                             }
                         }
                     }
@@ -802,7 +822,7 @@ async fn main() -> anyhow::Result<()> {
                             miden_agglayer_service::metrics::ProofKind::BridgeOut,
                             miden_agglayer_service::metrics::ProofOutcome::BuildFailed,
                         );
-                        println!("[bridge-out] build consume req failed: {e}");
+                        println!("[bridge-out] build consume req failed: {e:?}");
                     }
                 }
             }
@@ -814,7 +834,7 @@ async fn main() -> anyhow::Result<()> {
         .account_reader(wallet_id)
         .get_balance(faucet_id)
         .await
-        .map_err(|e| anyhow!("failed to get balance: {e}"))?;
+        .map_err(|e| anyhow!("failed to get balance: {e:?}"))?;
     println!("[bridge-out] wallet balance: {balance}");
 
     if balance < args.amount {
@@ -873,7 +893,7 @@ async fn main() -> anyhow::Result<()> {
             wallet_id,
             client.rng(),
         )
-        .map_err(|e| anyhow!("B2AGG creation failed: {e}"))?;
+        .map_err(|e| anyhow!("B2AGG creation failed: {e:?}"))?;
         let b2agg_note_id = b2agg.id();
         println!("[bridge-out] B2AGG note created: {b2agg_note_id}");
 
@@ -943,7 +963,7 @@ async fn main() -> anyhow::Result<()> {
             }
             Err(e) if attempt < SUBMIT_ATTEMPTS => {
                 eprintln!(
-                    "[bridge-out] submit attempt {attempt} failed: {e}; retrying in 10s \
+                    "[bridge-out] submit attempt {attempt} failed: {e:?}; retrying in 10s \
                      (prover backpressure is the common cause)"
                 );
                 tokio::time::sleep(std::time::Duration::from_secs(10)).await;
@@ -973,7 +993,9 @@ async fn main() -> anyhow::Result<()> {
         let mut consumed = false;
         while std::time::Instant::now() < deadline {
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            client.sync_state().await.ok();
+            if let Err(e) = client.sync_state().await {
+                eprintln!("[settle] sync failed (non-fatal, retried next tick): {e:?}");
+            }
             let recs = client
                 .get_output_notes(miden_client::store::NoteFilter::Consumed)
                 .await
@@ -995,7 +1017,9 @@ async fn main() -> anyhow::Result<()> {
         println!("[bridge-out] waiting for confirmation...");
         for i in 1..=5 {
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            client.sync_state().await.ok();
+            if let Err(e) = client.sync_state().await {
+                eprintln!("[settle] sync failed (non-fatal, retried next tick): {e:?}");
+            }
             println!("[bridge-out] sync cycle {i}/5");
         }
     }


### PR DESCRIPTION
## What
A hardening sweep of the e2e suite (task #26), triggered by a `claim-provenance` failure that died **7/7 recent cert runs** — and hid its own root cause for a day behind swallowed errors. **Test-tooling + scripts only — no production code.**

## The root cause it uncovered
`claim-provenance` reuses an isolated client store across runs. After a stack recreation (`down -v` + fresh chain/genesis), that store carried the **old genesis commitment** in miden-client's gRPC `Accept` header, which the new node rejects (`AcceptHeaderError/NoSupportedMediaRange`). **Deterministic, not flaky, not load** — one store poisoned once wedged the test on every subsequent run, and the failure path never re-provisioned.

Fix: `claim-provenance` re-provisions its foreign deployment from scratch every run, so it now **wipes its store up front** (like sibling tests via `B2AGG_FRESH=1`).

## Why it took a day to see — and the sweep that fixes that class
The real error was swallowed. This PR removes that failure mode across the pipeline:

- **`bridge_out_tool` (Rust):**
  - **Progress-aware `sync_with_retry`** replaces four single-shot `sync_state()` calls that raced the proxy for node RPC under suite load — retry while sync height advances, fail after 5 consecutive zero-progress attempts (proved the error non-transient and surfaced the diagnosis). Review fix folded in: stall counter resets to 0 on progress.
  - **19 error sites `{e}` → `{e:?}`** — `ClientError`'s `Display` is a bare "RPC error"; only `Debug` shows the gRPC status + source chain.
  - **8 best-effort settle syncs** no longer `.ok()`-swallow (still non-fatal — post-conditions verified separately — but now logged, so a dying node shows up before the downstream timeout).
  - consume-notes `filter_map` logs skipped unconvertible note records instead of silently dropping them.
- **Scripts:**
  - `counter()` (claim-provenance, claim-watcher, claim-watcher-synthesis): an unreachable `/metrics` is now a **hard fail** — pre-fix a down proxy read as `0`, false-PASSing delta assertions.
  - `verify-event-completeness`: an all-zero verdict table is now a **loud failure**, not a green — a zero-note query (wrong container, stale bridge id, empty run) must not certify "completeness" having verified nothing (the N-loadtest cert trusts this table).
  - cross-stack data isolation + Makefile wiring for the above.

## Scope
5 commits, 6 files (+200/−81): `src/bin/bridge_out_tool.rs`, `scripts/e2e-claim-provenance.sh`, `scripts/e2e-claim-watcher.sh`, `scripts/e2e-claim-watcher-synthesis.sh`, `scripts/verify-event-completeness.sh`, `Makefile`. Base `main`.
