### PR TITLE
fix(projector): defer late-consumption sweep while caught up

### DIFF
--- a/src/synthetic_projector.rs
+++ b/src/synthetic_projector.rs
@@ -1115,19 +1115,42 @@ impl SyntheticProjector {
                 })
                 .filter(|n| !swept.contains(&n.details_commitment().as_bytes()))
                 .collect();
-            let ids = late
-                .iter()
-                .map(|n| n.details_commitment().as_bytes())
-                .collect();
-            if !late.is_empty() {
+            // #27 (2026-07-09): the late bucket lands at `cursor + 1`, which only
+            // the `while cursor < tip` loop below projects. When the projector is
+            // CAUGHT UP (`cursor == tip` — true on most ticks, since ticks are ~1s
+            // and blocks ~5s), that loop never runs — pre-fix the late ids were
+            // still marked swept afterwards, permanently dropping the note's
+            // BridgeEvent (funds stranded until a restart cleared the in-memory
+            // cache and the sweep retried). Verified live: a load-delayed
+            // consumption (note fd0f5b62…, consumed block 543) sat in the store
+            // unprojected while `deposit_counter` lagged the on-chain LET by 1;
+            // restarting the proxy healed it in 11s. Fix: when caught up, DEFER —
+            // don't bucket, don't mark swept — the next block-advancing tick
+            // projects them (bounded by block cadence).
+            if late.is_empty() || cursor >= tip {
+                if !late.is_empty() {
+                    tracing::debug!(
+                        late = late.len(),
+                        cursor,
+                        tip,
+                        "late-consumption sweep: deferred — projector caught up \
+                         (cursor == tip), retrying when the chain advances"
+                    );
+                }
+                Vec::new()
+            } else {
+                let ids = late
+                    .iter()
+                    .map(|n| n.details_commitment().as_bytes())
+                    .collect();
                 tracing::info!(
                     late = late.len(),
                     first_block = cursor + 1,
                     "late-consumption sweep: projecting notes discovered after their block"
                 );
                 by_block.entry(cursor + 1).or_default().extend(late);
+                ids
             }
-            ids
         };
         // Direct projection of spent-before-import recoveries (same sealed-block
         // rules as the late sweep; see `bucket_direct_notes`).


### PR DESCRIPTION
## Summary

- Defer late-consumption projection when the projector cursor is already at the chain tip.
- Do not mark deferred note IDs as swept before a block-advancing tick can project them.
- Retry automatically on the next advancing tick, keeping the delay bounded by the block cadence.

## Problem

Late note consumptions can enter the client store after the projector cursor has already passed their consumed block. The recovery sweep buckets those notes at cursor + 1, but that bucket is only processed while the cursor advances.

When a tick runs with cursor equal to tip, the projection loop does not execute. Previously, the note IDs were still added to the in-memory swept set, permanently suppressing their BridgeEvents until the process restarted and cleared that cache.

## Fix

When late notes are found while the projector is caught up, leave them unbucketed and unswept. The next block-advancing tick discovers them again, projects the cursor + 1 bucket, and only then records their IDs as swept.

## Validation

Live forensics reproduced the failure under concurrent load: the note was committed, consumed, and visible on-chain, while the synthetic BridgeEvent and deposit counter lagged by one. Restarting the proxy cleared the swept cache and restored both within 11 seconds, confirming the drop mechanism this change removes.

## Scope

One projector code path in src/synthetic_projector.rs; no API, schema, or storage-format changes.