### PR TITLE
fix(projector): gate synthetic block sealing on reconciliation frontier

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -63,6 +63,16 @@ pub fn init_metrics() {
     describe_counter!("rpc_requests_total", "Total JSON-RPC requests by method");
     describe_counter!("claims_processed_total", "Total claims processed");
     describe_counter!("ger_injections_total", "Total GER injections");
+    describe_gauge!(
+        "projector_visibility_barrier_held_blocks",
+        "#30 visibility barrier: blocks the projector is holding because the reconciler \
+         sweep cursor is behind the Miden tip (0 in steady state; >0 signals reconciler lag)"
+    );
+    describe_counter!(
+        "projector_late_sweep_anomaly_total",
+        "#30: notes the late-consumption sweep found for an already-sealed block — the \
+         visibility barrier should make this impossible, so any increment is a bug signal"
+    );
     describe_counter!("bridge_outs_total", "Total bridge-out operations");
     describe_counter!("store_errors_total", "Total store operation errors");
     describe_histogram!("rpc_request_duration_seconds", "JSON-RPC request duration");

--- a/src/synthetic_projector.rs
+++ b/src/synthetic_projector.rs
@@ -1055,7 +1055,41 @@ impl SyntheticProjector {
                 "note reconciler failed (transient — will retry next tick)"
             );
         }
-        if cursor >= tip {
+        // #30 VISIBILITY BARRIER: never seal a synthetic block the reconciler
+        // has not fully swept. `reconcile_notes` (above) advances
+        // `reconcile_cursor` to its last completed sweep window; every external
+        // bridge-out note at a block <= reconcile_cursor is therefore already in
+        // the client store. Capping the projection loop at `min(tip,
+        // reconcile_cursor)` makes exact-block emission a GUARANTEE for all event
+        // types: a note is always visible BEFORE its block is projected, so
+        // nothing is ever "late" (proxy-created CLAIM/GER notes are instant-
+        // visible and were never late; B2AGG lateness was purely import lag,
+        // eliminated here by construction — the late sweep below becomes an
+        // alarm). In steady state the reconciler reaches `tip` every tick
+        // (sub-second ~1000-block windows), so the barrier is a no-op; it only
+        // bites when the reconciler falls behind, and then holding is the
+        // correct failure mode — a late synthetic tip is benign (aggkit reads
+        // block ranges and just sees the chain pause), an event at the wrong
+        // block is poison. No reconciler wired (node_rpc = None, pure unit
+        // tests / a non-reconciling deployment) => no barrier, legacy behavior.
+        let project_to = if self.node_rpc.is_some() {
+            let reconcile_cursor = self.reconcile_cursor.load(Ordering::Acquire);
+            let held = tip.saturating_sub(reconcile_cursor);
+            ::metrics::gauge!("projector_visibility_barrier_held_blocks").set(held as f64);
+            if held > 0 {
+                tracing::debug!(
+                    tip,
+                    reconcile_cursor,
+                    held,
+                    "visibility barrier: holding projection at the reconcile frontier \
+                     (reconciler behind tip)"
+                );
+            }
+            tip.min(reconcile_cursor)
+        } else {
+            tip
+        };
+        if cursor >= project_to {
             return Ok(cursor);
         }
         // Perf-critical: fetch the consumed-note feed + output-note metadata ONCE
@@ -1127,36 +1161,43 @@ impl SyntheticProjector {
             // restarting the proxy healed it in 11s. Fix: when caught up, DEFER —
             // don't bucket, don't mark swept — the next block-advancing tick
             // projects them (bounded by block cadence).
-            if late.is_empty() || cursor >= tip {
-                if !late.is_empty() {
-                    tracing::debug!(
-                        late = late.len(),
-                        cursor,
-                        tip,
-                        "late-consumption sweep: deferred — projector caught up \
-                         (cursor == tip), retrying when the chain advances"
-                    );
-                }
+            // With the #30 visibility barrier a note can no longer be late: its
+            // block is projected only after the reconciler swept it, so it was
+            // present on time. The sweep is kept as a fail-safe + ALARM — any
+            // non-empty `late` here means the barrier's invariant was violated
+            // (a note surfaced for an already-sealed block), which is a bug
+            // signal, not routine. Emit the anomaly metric + WARN, then still
+            // recover it (bucket at cursor+1, honoring the #27 caught-up defer
+            // against `project_to`) so no funds strand even in the anomaly case.
+            if !late.is_empty() {
+                ::metrics::counter!("projector_late_sweep_anomaly_total")
+                    .increment(late.len() as u64);
+                tracing::warn!(
+                    late = late.len(),
+                    cursor,
+                    project_to,
+                    "late-consumption sweep found notes AFTER their sealed block — the \
+                     visibility barrier should make this impossible; recovering them but \
+                     investigate (projector_late_sweep_anomaly_total)"
+                );
+            }
+            if late.is_empty() || cursor >= project_to {
                 Vec::new()
             } else {
                 let ids = late
                     .iter()
                     .map(|n| n.details_commitment().as_bytes())
                     .collect();
-                tracing::info!(
-                    late = late.len(),
-                    first_block = cursor + 1,
-                    "late-consumption sweep: projecting notes discovered after their block"
-                );
                 by_block.entry(cursor + 1).or_default().extend(late);
                 ids
             }
         };
         // Direct projection of spent-before-import recoveries (same sealed-block
         // rules as the late sweep; see `bucket_direct_notes`).
-        let direct_done = Self::bucket_direct_notes(&direct_notes, &mut by_block, cursor, tip);
+        let direct_done =
+            Self::bucket_direct_notes(&direct_notes, &mut by_block, cursor, project_to);
         let no_notes: Vec<&InputNoteRecord> = Vec::new();
-        while cursor < tip {
+        while cursor < project_to {
             let next = cursor + 1;
             let bucket = by_block.get(&next).unwrap_or(&no_notes);
             self.project_block_notes(bucket, &output_metadata, next, Some(client))


### PR DESCRIPTION
## Summary

Gate synthetic block sealing on the note reconciler's completed frontier.

When node RPC reconciliation is enabled, the projector now advances only through:

```
min(Miden sync tip, reconcile cursor)
```

This prevents future synthetic blocks from being sealed before the public tag-0 note sweep for those blocks has completed. The change also adds reconciliation-backlog and late-sweep observability metrics.

## Problem this helps with

An externally created public B2AGG note can be committed and consumed between local client sync points. The reconciler can recover that note later, but if the projector has already sealed its Miden block, the resulting BridgeEvent must be emitted in a later synthetic block.

That preserves eventual delivery but breaks the Miden-1:1 block-placement contract used by forward-only log consumers. Holding the synthetic frontier converts that case into visible head lag: reconciliation completes first, then the original block is projected with the note available.

## Operational tradeoff

This is deliberately safety over liveness:

- normal caught-up operation is unchanged
- reconciliation lag or errors hold eth_blockNumber and synthetic-log visibility
- projection throughput is bounded by reconciliation throughput
- the held-block gauge surfaces that backlog

## Scope and non-goals

- Forward-looking only: it cannot repair events in blocks already sealed before the barrier became active.
- Requires node RPC reconciliation; node_rpc=None keeps legacy behavior.
- Covers notes observable through the reconciler's public tag-0 scan; it does not make erased or otherwise node-invisible notes visible.
- Does not add multi-replica projector safety.
- CLAIM and GER notes were already locally visible; the primary benefit is external B2AGG visibility and exact placement.

## Known review gaps

This is a draft because the early review found issues that must be resolved before the guarantee is trustworthy:

- the persisted reconcile cursor can advance past a spent-before-import recovery held only in memory; a crash in that window can lose the queued event
- omitting --miden-node is a valid localhost configuration for MidenClient but currently gives the projector node_rpc=None, silently bypassing the barrier
- receipts are still finalized at the raw Miden sync height, so a held synthetic head can expose a receipt for a block above eth_blockNumber
- projector_late_sweep_anomaly_total currently classifies normal already-projected notes as anomalies, especially after restart
- a persisted reconcile cursor ahead of the current node tip is treated as caught up and fails open
- persistent reconciliation failure becomes an indefinite projection freeze and needs an explicit readiness/alerting contract
- no barrier-specific regression tests are included yet

## Dependency

Stacked on #130 / fix/late-sweep-caught-up-drop so this PR contains only the visibility-barrier commit. PR #130 remains the late-sweep fail-safe path and is still under review.

## Validation

- cargo fmt --all -- --check: pass
- git diff --check: pass
- inherited synthetic-projector tests: 14/14 pass
- inherited metrics tests: 14/14 pass
- the inherited tests do not exercise the new tick barrier path; no live barrier/fault-injection validation is claimed
