### PR TITLE
test(e2e): add proxy-fault and adversarial-input chaos soak

### DIFF
--- a/scripts/chaos-garbo.sh
+++ b/scripts/chaos-garbo.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# chaos-garbo.sh — ADVERSARIAL "garbo" injector: at random intervals during the
+# soak it fires JUNK / adversarial traffic at Miden using the SHIPPED tooling,
+# each with a benign EXPECTED outcome (skipped / quarantined / never projected).
+# The caller asserts CONTAINMENT afterwards: no garbo input ever became a real
+# BridgeEvent/ClaimEvent, never advanced deposit_counter, and each provenance
+# gate fired.
+#
+# Garbo classes (self-contained, no permanent corruption):
+#   private   — bridge-out-tool --send-private-note: a PRIVATE tag-0 note the
+#               note-visibility reconciler must SKIP (not wedge). Metric
+#               synthetic_reconciler_private_skipped_total; never projected.
+#               Doubles as the "random tag-0 spam" class (fired repeatedly).
+#   foreign   — a fully independent FOREIGN agglayer deployment on the same
+#               Miden chain drives a claim through ITS OWN bridge
+#               (--create-foreign-bridge + --submit-foreign-claim). Our proxy's
+#               provenance gate must skip it: claim_event_foreign_skipped_total;
+#               ZERO synthetic_logs ClaimEvent rows for the foreign global index.
+#
+# (The "unknown-faucet quarantine" class is intentionally NOT automated here:
+#  deleting a faucet_registry row does NOT reliably reach UnknownFaucet because
+#  the metadata-recovery path REBUILDS the row from the bridge's authoritative
+#  faucet_metadata_map (src/metadata_recovery.rs finding_6) — a genuinely
+#  unknown faucet can't be produced with the shipped bridge-out-tool. See the
+#  soak report punch list.)
+#
+# Emits: GARBO_LOG (human timeline) + GARBO_SUMMARY (env-parseable: counts,
+# foreign global indexes, baselines) for the soak's containment verdict.
+#
+# Usage: GARBO_DURATION=600 ./scripts/chaos-garbo.sh
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GARBO_DURATION="${GARBO_DURATION:-600}"
+GARBO_MIN_GAP="${GARBO_MIN_GAP:-30}"
+GARBO_MAX_GAP="${GARBO_MAX_GAP:-70}"
+GARBO_LOG="${GARBO_LOG:-/tmp/chaos-garbo.log}"
+GARBO_SUMMARY="${GARBO_SUMMARY:-/tmp/chaos-garbo-summary.env}"
+GARBO_FOREIGN="${GARBO_FOREIGN:-1}"     # fire the (heavy) foreign-claim class once
+FOREIGN_NETWORK_ID="${FOREIGN_NETWORK_ID:-3}"   # an id our stack does NOT serve (1=Miden,2=L2B)
+SEED="${GARBO_SEED:-$$}"; RANDOM=$SEED
+
+B2AGG_STORE_DIR="${B2AGG_STORE_DIR:-$PROJECT_DIR/.b2agg-store/chaos-garbo}"
+GARBO_WALLET_STORE="$B2AGG_STORE_DIR"
+FOREIGN_STORE="$PROJECT_DIR/.b2agg-store/chaos-garbo-foreign"
+
+source "$SCRIPT_DIR/lib-l2l2.sh"          # constants, pgq, log helpers, containers
+source "$SCRIPT_DIR/lib-isolated-wallet.sh"
+
+FUNDED_KEY="${FUNDED_KEY:-0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625}"
+DEST_NETWORK=1
+FUND_WEI="${FUND_WEI:-100000000000000}"        # 1e14 wei -> 10000 units for private-note sends
+DEPOSIT_AMOUNT="10000000000000"                # foreign-claim leaf amount (10^13 wei)
+
+glog() { echo "[$(date '+%H:%M:%S')] $*" | tee -a "$GARBO_LOG"; }
+
+counter() {
+    local name="$1" body value
+    body=$(curl -sf "${L2_RPC}/metrics" 2>/dev/null) || { echo 0; return; }
+    value=$(awk -v n="$name" '$0 ~ ("^" n " ") { print $2; found=1; exit } END { if (!found) print 0 }' <<<"$body")
+    echo "${value%.*}"
+}
+
+PRIVATE_FIRED=0
+FOREIGN_FIRED=0
+FOREIGN_GIS=""
+
+# ── setup: provision + fund a garbo wallet (for private-note sends) ──────────
+setup_garbo() {
+    local accounts=""
+    for _ in $(seq 1 30); do
+        accounts=$(docker exec "$AGGLAYER_CONTAINER" \
+            cat /var/lib/miden-agglayer-service/bridge_accounts.toml 2>/dev/null) && break
+        sleep 5
+    done
+    [[ -n "$accounts" ]] || { glog "GARBO setup FAILED: bridge_accounts.toml absent"; return 1; }
+    BRIDGE_ID=$(echo "$accounts" | grep 'bridge = ' | sed 's/.*= "//;s/"//')
+    FAUCET_ETH=$(echo "$accounts" | grep faucet_eth | sed 's/.*= "//;s/"//')
+    B2AGG_STORE_DIR="$GARBO_WALLET_STORE"
+    provision_isolated_wallet "$BRIDGE_ID" "$FAUCET_ETH" || { glog "GARBO wallet provisioning failed"; return 1; }
+    glog "garbo wallet $WALLET_ID (store $GARBO_WALLET_STORE)"
+    local bal; bal=$(iso_wallet_balance "$BRIDGE_ID" "$FAUCET_ETH"); bal="${bal:-0}"
+    if [[ "$bal" -eq 0 ]]; then
+        glog "funding garbo wallet via L1->L2 native deposit ($FUND_WEI wei)"
+        cast send --rpc-url "$L1_RPC" --private-key "$FUNDED_KEY" "$BRIDGE_ADDRESS" \
+            'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+            "$DEST_NETWORK" "$DEST_ADDR" "$FUND_WEI" \
+            0x0000000000000000000000000000000000000000 true 0x --value "$FUND_WEI" >/dev/null 2>&1
+        for _ in $(seq 1 30); do
+            sleep 10
+            bal=$(iso_wallet_balance "$BRIDGE_ID" "$FAUCET_ETH"); bal="${bal:-0}"
+            [[ "$bal" -gt 0 ]] && break
+        done
+    fi
+    [[ "$bal" -gt 0 ]] || { glog "GARBO wallet not funded (bal=$bal) — private-note class disabled"; return 1; }
+    GARBO_FAUCET_ETH="$FAUCET_ETH"
+    glog "garbo wallet funded (balance $bal)"
+    return 0
+}
+
+# ── class: private / tag-0 spam note ─────────────────────────────────────────
+garbo_private_note() {
+    B2AGG_STORE_DIR="$GARBO_WALLET_STORE"
+    local out note_id
+    out=$(iso_tool --send-private-note --wallet-id "$WALLET_ID" 2>&1) || {
+        glog "GARBO private-note: send FAILED (transient?) — $(echo "$out" | tail -1)"; return; }
+    note_id=$(echo "$out" | grep '\[private-note\] note-id:' | awk '{print $NF}')
+    PRIVATE_FIRED=$((PRIVATE_FIRED + 1))
+    glog "GARBO private-note #$PRIVATE_FIRED id=${note_id:-?} — EXPECT: reconciler skips (synthetic_reconciler_private_skipped_total++), NEVER projected as a BridgeEvent/ClaimEvent"
+}
+
+# ── class: foreign-deployment claim (provenance gate) ────────────────────────
+garbo_foreign_claim() {
+    B2AGG_STORE_DIR="$FOREIGN_STORE"
+    _iso_wipe_store; mkdir -p "$B2AGG_STORE_DIR/tmp"
+    local fb_out fs fg fbid ffaucet
+    fb_out=$(iso_tool --create-foreign-bridge --foreign-network-id "$FOREIGN_NETWORK_ID" 2>&1) || {
+        glog "GARBO foreign-claim: --create-foreign-bridge FAILED — $(echo "$fb_out" | tail -2)"; return; }
+    fs=$(echo "$fb_out" | grep "service-id:" | awk '{print $NF}')
+    fg=$(echo "$fb_out" | grep "ger-manager-id:" | awk '{print $NF}')
+    fbid=$(echo "$fb_out" | grep -w "bridge-id:" | awk '{print $NF}')
+    [[ -n "$fs" && -n "$fg" && -n "$fbid" ]] || { glog "GARBO foreign-claim: could not parse foreign ids"; return; }
+    local fs_inner="${fs#0x}"
+    local fdest="0x00000000${fs_inner:0:16}${fs_inner:16:14}00"
+
+    # Fabricate the foreign leaf + depth-32 proof + exit roots (see e2e-claim-provenance.sh).
+    local dcnt gi zero empty_meta amt_hex leaf_packed leaf node idx mner rer smt calldata
+    dcnt=$(date +%s); gi=$(python3 -c "print(2**64 + $dcnt)")
+    zero="$(printf '0%.0s' {1..64})"
+    empty_meta=$(cast keccak 0x)
+    amt_hex=$(printf '%064x' "$DEPOSIT_AMOUNT")
+    leaf_packed="0x00$(printf '%08x' 0)$(printf '0%.0s' {1..40})$(printf '%08x' "$FOREIGN_NETWORK_ID")${fdest#0x}${amt_hex}${empty_meta#0x}"
+    [[ ${#leaf_packed} -eq 228 ]] || { glog "GARBO foreign-claim: bad packed leaf len"; return; }
+    leaf=$(cast keccak "$leaf_packed")
+    node="${leaf#0x}"; idx="$dcnt"
+    for _ in $(seq 1 32); do
+        if (( idx & 1 )); then node=$(cast keccak "0x${zero}${node}"); else node=$(cast keccak "0x${node}${zero}"); fi
+        node="${node#0x}"; idx=$(( idx >> 1 ))
+    done
+    mner="0x${node}"; rer="0x${zero}"
+    smt=$(python3 -c "print('[' + ','.join(['0x' + '00'*32]*32) + ']')")
+    calldata=$(cast calldata \
+        'claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)' \
+        "$smt" "$smt" "$gi" "$mner" "$rer" 0 0x0000000000000000000000000000000000000000 \
+        "$FOREIGN_NETWORK_ID" "$fdest" "$DEPOSIT_AMOUNT" 0x)
+    echo "$calldata" > "$B2AGG_STORE_DIR/foreign-claim-calldata.hex"
+    local fc_out fgi
+    fc_out=$(iso_tool --submit-foreign-claim \
+        --claim-calldata-file /store/foreign-claim-calldata.hex \
+        --foreign-bridge-id "$fbid" --foreign-service-id "$fs" --foreign-ger-manager-id "$fg" \
+        --scale-exp 10 2>&1) || { glog "GARBO foreign-claim: --submit-foreign-claim FAILED — $(echo "$fc_out" | tail -3)"; return; }
+    fgi=$(echo "$fc_out" | grep "global-index:" | awk '{print $NF}')
+    [[ -n "$fgi" ]] || { glog "GARBO foreign-claim: could not parse foreign global index"; return; }
+    FOREIGN_FIRED=$((FOREIGN_FIRED + 1))
+    FOREIGN_GIS="$FOREIGN_GIS ${fgi#0x}"
+    glog "GARBO foreign-claim #$FOREIGN_FIRED bridge=$fbid net=$FOREIGN_NETWORK_ID gi=$fgi — EXPECT: our proxy skips it (claim_event_foreign_skipped_total++), ZERO synthetic_logs ClaimEvent rows for gi ${fgi#0x}"
+    B2AGG_STORE_DIR="$GARBO_WALLET_STORE"
+}
+
+write_summary() {
+    {
+        echo "# chaos-garbo summary $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo "GARBO_PRIVATE_FIRED=$PRIVATE_FIRED"
+        echo "GARBO_FOREIGN_FIRED=$FOREIGN_FIRED"
+        echo "GARBO_FOREIGN_GIS=\"$(echo $FOREIGN_GIS | xargs)\""
+    } > "$GARBO_SUMMARY"
+    glog "summary -> $GARBO_SUMMARY (private=$PRIVATE_FIRED foreign=$FOREIGN_FIRED)"
+}
+trap write_summary EXIT
+
+: > "$GARBO_LOG"
+glog "=== chaos-garbo start (dur=${GARBO_DURATION}s seed=$SEED foreign=$GARBO_FOREIGN net=$FOREIGN_NETWORK_ID) ==="
+if ! setup_garbo; then
+    glog "setup incomplete — running with whatever classes are available"
+fi
+
+START=$(date +%s)
+# Fire the heavy foreign-claim class ONCE early (it needs several minutes).
+if [[ "$GARBO_FOREIGN" == "1" ]]; then garbo_foreign_claim; fi
+# Then spam private / tag-0 notes at random intervals for the rest of the window.
+while [ $(( $(date +%s) - START )) -lt "$GARBO_DURATION" ]; do
+    gap=$(( GARBO_MIN_GAP + RANDOM % (GARBO_MAX_GAP - GARBO_MIN_GAP + 1) ))
+    sleep "$gap"
+    [ $(( $(date +%s) - START )) -ge "$GARBO_DURATION" ] && break
+    [[ -n "${WALLET_ID:-}" ]] && garbo_private_note
+done
+glog "=== chaos-garbo done: private=$PRIVATE_FIRED foreign=$FOREIGN_FIRED ==="
+# EXIT trap writes the summary.

--- a/scripts/chaos-seeder.sh
+++ b/scripts/chaos-seeder.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# chaos-seeder.sh — randomized, external fault injection against the PROXY and
+# its dependencies while a loadtest drives real traffic. External only (docker
+# pause/kill/network) — no in-binary failpoints, so we fault the SHIPPED artifact.
+#
+# Runs a fault loop for CHAOS_DURATION seconds, one random fault per cycle, and
+# ALWAYS restores every fault it applied (bounded per-fault, plus an EXIT trap
+# that unpauses/reconnects/restarts anything left in a faulted state). Each fault
+# event is logged with a timestamp to CHAOS_LOG. The caller asserts correctness
+# (zero lost events) with verify-event-completeness AFTER this exits + settles.
+#
+# The fault menu targets the proxy's resilience contracts proven this week:
+#   pause-pg    -> proxy store stall           (tests store retry / atomicity, H1/H2)
+#   kill-prover -> prover death mid-proof       (tests remote-prover retry)
+#   restart-proxy -> crash mid-flight           (tests cursor persistence + late-sweep heal, #27)
+#   partition-node -> proxy<->node net cut      (tests sync_with_retry, #26)
+# Deliberately does NOT fault the node/anvil/aggkit destructively — those are the
+# chain-of-record; we certify the PROXY's survival, not the chain's.
+#
+# Usage: CHAOS_DURATION=600 PROJECT=miden-agglayer ./scripts/chaos-seeder.sh
+set -uo pipefail
+
+PROJECT="${PROJECT:-miden-agglayer}"
+CHAOS_DURATION="${CHAOS_DURATION:-600}"
+CHAOS_MIN_GAP="${CHAOS_MIN_GAP:-25}"    # min seconds between faults
+CHAOS_MAX_GAP="${CHAOS_MAX_GAP:-55}"    # max seconds between faults
+CHAOS_LOG="${CHAOS_LOG:-/tmp/chaos-events.log}"
+SEED="${CHAOS_SEED:-$$}"                # reproducible-ish ordering per run
+RANDOM=$SEED
+
+# The Miden proxy's store lives in the agglayer_store DB on the "agglayer-postgres"
+# container (published :5434) — NOT a "miden-agglayer-postgres" container (which
+# does not exist). Pausing it stalls the proxy's store writes (the intended
+# fault). Overridable via PG_CONTAINER for non-standard topologies.
+PG="${PG_CONTAINER:-${PROJECT}-agglayer-postgres-1}"
+PROVER="${PROJECT}-tx-prover-1"
+PROXY="${PROJECT}-miden-agglayer-1"
+NODE="${PROJECT}-miden-node-1"
+# the docker network the proxy<->node talk over (compose default)
+NET="$(docker inspect "$PROXY" --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}' 2>/dev/null | awk '{print $1}')"
+# CRITICAL: a plain `docker network connect` does NOT restore the compose service
+# alias (e.g. 'miden-node') — only the container-name alias — so after a
+# partition fault nothing could resolve the node and the whole stack wedges
+# permanently. Capture the node's non-container-name aliases on this net and
+# ALWAYS reconnect with them. (Default to the compose service name 'miden-node'.)
+_node_aliases() {
+    docker inspect "$NODE" --format \
+      "{{range \$k,\$v := .NetworkSettings.Networks}}{{if eq \$k \"$NET\"}}{{range \$v.Aliases}}{{.}} {{end}}{{end}}{{end}}" 2>/dev/null \
+      | tr ' ' '\n' | grep -vx "$NODE" | grep -v '^$'
+}
+NODE_ALIASES="$(_node_aliases)"
+[ -z "$NODE_ALIASES" ] && NODE_ALIASES="miden-node"
+_reconnect_node() {
+    local a args=()
+    for a in $NODE_ALIASES; do args+=(--alias "$a"); done
+    docker network connect "${args[@]}" "$NET" "$NODE" >/dev/null 2>&1
+}
+
+log() { echo "[$(date '+%H:%M:%S')] $*" | tee -a "$CHAOS_LOG"; }
+
+# ── restore-everything safety net (runs on ANY exit) ────────────────────────
+restore_all() {
+    docker unpause "$PG" >/dev/null 2>&1 || true
+    [ -n "${NET:-}" ] && _reconnect_node || true
+    # ensure the faultable services are running
+    for c in "$PROVER" "$PROXY"; do
+        docker start "$c" >/dev/null 2>&1 || true
+    done
+    log "restore_all: unpaused pg, reconnected node, ensured prover+proxy up"
+}
+trap restore_all EXIT
+
+# ── individual faults (each self-bounded + self-restoring) ──────────────────
+fault_pause_pg() {
+    local dur=$(( 4 + RANDOM % 8 ))   # 4-11s stall
+    log "FAULT pause-pg ($dur s) — proxy store unavailable"
+    docker pause "$PG" >/dev/null 2>&1
+    sleep "$dur"
+    docker unpause "$PG" >/dev/null 2>&1
+    log "  -> pg unpaused"
+}
+fault_kill_prover() {
+    log "FAULT kill-prover — restart tx-prover mid-proof"
+    docker restart -t 2 "$PROVER" >/dev/null 2>&1
+    log "  -> prover restarted"
+}
+fault_restart_proxy() {
+    log "FAULT restart-proxy — crash the proxy mid-flight (tests cursor persist + late-sweep heal)"
+    docker restart -t 2 "$PROXY" >/dev/null 2>&1
+    log "  -> proxy restarted"
+}
+fault_partition_node() {
+    local dur=$(( 5 + RANDOM % 10 ))  # 5-14s partition
+    [ -z "${NET:-}" ] && { log "FAULT partition-node SKIPPED (no network found)"; return; }
+    log "FAULT partition-node ($dur s) — cut proxy<->node link"
+    docker network disconnect "$NET" "$NODE" >/dev/null 2>&1
+    sleep "$dur"
+    _reconnect_node    # restore WITH the compose alias(es) — else name resolution stays broken
+    log "  -> node reconnected (aliases: $NODE_ALIASES)"
+}
+
+FAULTS=(fault_pause_pg fault_kill_prover fault_restart_proxy fault_partition_node)
+
+log "=== chaos-seeder start (project=$PROJECT dur=${CHAOS_DURATION}s net=${NET:-?} seed=$SEED) ==="
+log "  targets: pg=$PG prover=$PROVER proxy=$PROXY node=$NODE"
+START=$(date +%s)
+count=0
+while [ $(( $(date +%s) - START )) -lt "$CHAOS_DURATION" ]; do
+    gap=$(( CHAOS_MIN_GAP + RANDOM % (CHAOS_MAX_GAP - CHAOS_MIN_GAP + 1) ))
+    sleep "$gap"
+    [ $(( $(date +%s) - START )) -ge "$CHAOS_DURATION" ] && break
+    f="${FAULTS[$(( RANDOM % ${#FAULTS[@]} ))]}"
+    "$f"
+    count=$(( count + 1 ))
+done
+log "=== chaos-seeder done: $count faults injected over ${CHAOS_DURATION}s ==="
+# EXIT trap restores everything

--- a/scripts/chaos-seeder.sh
+++ b/scripts/chaos-seeder.sh
@@ -71,32 +71,48 @@ restore_all() {
 trap restore_all EXIT
 
 # ── individual faults (each self-bounded + self-restoring) ──────────────────
+# The soak counts INJECTED faults via `grep -c "FAULT "`. This script runs WITHOUT
+# `set -e` and docker exit codes are otherwise unchecked, so the "FAULT " (counted)
+# marker is emitted ONLY AFTER the docker operation that actually injects the fault
+# SUCCEEDS. A failed docker pause/restart/disconnect logs "SKIP" (not counted), so a
+# fault that never took effect can't satisfy the soak's CHAOS_OK "chaos actually fired"
+# gate. Recovery ops (unpause/reconnect) are best-effort and don't gate the count.
 fault_pause_pg() {
     local dur=$(( 4 + RANDOM % 8 ))   # 4-11s stall
-    log "FAULT pause-pg ($dur s) — proxy store unavailable"
-    docker pause "$PG" >/dev/null 2>&1
-    sleep "$dur"
-    docker unpause "$PG" >/dev/null 2>&1
-    log "  -> pg unpaused"
+    if docker pause "$PG" >/dev/null 2>&1; then
+        log "FAULT pause-pg ($dur s) — proxy store unavailable (injected)"
+        sleep "$dur"
+        docker unpause "$PG" >/dev/null 2>&1 || log "  WARN: pg unpause failed"
+        log "  -> pg unpaused"
+    else
+        log "SKIP pause-pg (docker pause $PG failed — not injected)"
+    fi
 }
 fault_kill_prover() {
-    log "FAULT kill-prover — restart tx-prover mid-proof"
-    docker restart -t 2 "$PROVER" >/dev/null 2>&1
-    log "  -> prover restarted"
+    if docker restart -t 2 "$PROVER" >/dev/null 2>&1; then
+        log "FAULT kill-prover — restart tx-prover mid-proof (injected)"
+    else
+        log "SKIP kill-prover (docker restart $PROVER failed — not injected)"
+    fi
 }
 fault_restart_proxy() {
-    log "FAULT restart-proxy — crash the proxy mid-flight (tests cursor persist + late-sweep heal)"
-    docker restart -t 2 "$PROXY" >/dev/null 2>&1
-    log "  -> proxy restarted"
+    if docker restart -t 2 "$PROXY" >/dev/null 2>&1; then
+        log "FAULT restart-proxy — crash the proxy mid-flight (injected; tests cursor persist + late-sweep heal)"
+    else
+        log "SKIP restart-proxy (docker restart $PROXY failed — not injected)"
+    fi
 }
 fault_partition_node() {
     local dur=$(( 5 + RANDOM % 10 ))  # 5-14s partition
-    [ -z "${NET:-}" ] && { log "FAULT partition-node SKIPPED (no network found)"; return; }
-    log "FAULT partition-node ($dur s) — cut proxy<->node link"
-    docker network disconnect "$NET" "$NODE" >/dev/null 2>&1
-    sleep "$dur"
-    _reconnect_node    # restore WITH the compose alias(es) — else name resolution stays broken
-    log "  -> node reconnected (aliases: $NODE_ALIASES)"
+    [ -z "${NET:-}" ] && { log "SKIP partition-node (no network found — not injected)"; return; }
+    if docker network disconnect "$NET" "$NODE" >/dev/null 2>&1; then
+        log "FAULT partition-node ($dur s) — cut proxy<->node link (injected)"
+        sleep "$dur"
+        _reconnect_node    # restore WITH the compose alias(es) — else name resolution stays broken
+        log "  -> node reconnected (aliases: $NODE_ALIASES)"
+    else
+        log "SKIP partition-node (docker network disconnect failed — not injected)"
+    fi
 }
 
 FAULTS=(fault_pause_pg fault_kill_prover fault_restart_proxy fault_partition_node)

--- a/scripts/e2e-chaos-soak.sh
+++ b/scripts/e2e-chaos-soak.sh
@@ -39,7 +39,7 @@ POST_CHAOS_SETTLE="${POST_CHAOS_SETTLE:-150}"
 L2L2_FWD="${L2L2_FWD:-2}"
 L2L2_BACK="${L2L2_BACK:-2}"
 FRESH="${FRESH:-0}"
-TOOL_BIN="${TOOL_BIN:-/home/mandrigin/miden-agglayer/target/debug/bridge-out-tool}"
+TOOL_BIN="${TOOL_BIN:-$PROJECT_DIR/target/debug/bridge-out-tool}"   # repo-local default; override with $TOOL_BIN
 
 CHAOS_LOG="${CHAOS_LOG:-/tmp/chaos-events.log}"
 GARBO_LOG="${GARBO_LOG:-/tmp/chaos-garbo.log}"
@@ -104,7 +104,10 @@ NET="$(docker inspect "$AGGLAYER_CONTAINER" --format '{{range $k,$v := .NetworkS
 # reconnect WITH the compose alias (a plain connect drops 'miden-node' resolution)
 [ -n "$NET" ] && docker network connect --alias miden-node "$NET" "${PROJECT}-miden-node-1" >/dev/null 2>&1 || true
 for c in tx-prover-1 miden-agglayer-1; do docker start "${PROJECT}-$c" >/dev/null 2>&1 || true; done
-FAULTS_DONE=$(grep -c "FAULT " "$CHAOS_LOG" 2>/dev/null || echo 0)
+# grep -c prints "0" AND exits 1 on no match; `|| echo 0` would then append a second "0"
+# (FAULTS_DONE="0\n0", non-numeric). `|| true` swallows the exit and keeps the single count.
+# Excludes SKIPPED faults (see chaos-seeder.sh: skipped faults are logged without "FAULT ").
+FAULTS_DONE=$(grep -c "FAULT " "$CHAOS_LOG" 2>/dev/null || true); FAULTS_DONE="${FAULTS_DONE:-0}"
 say "chaos stopped: $FAULTS_DONE faults injected (log: $CHAOS_LOG)"
 # shellcheck disable=SC1090
 [[ -f "$GARBO_SUMMARY" ]] && source "$GARBO_SUMMARY" || true
@@ -167,9 +170,17 @@ say "    loadtest_rc=$LT_RC  verify_rc=$VC_RC  store_locks=$LOCKS  foreign_leak=
 # crashed driver means the full mixed load never ran, so it must NOT green even
 # if the (reduced) traffic verifies — else a dead driver false-passes.
 LEGIT_OK=0; [[ "$VC_RC" == "0" && "${LOCKS:-1}" == "0" && "$LT_RC" == "0" ]] && LEGIT_OK=1
+# (c) chaos ACTUALLY happened — a soak that injected no infra faults or fired no garbo
+# class would otherwise false-pass on an empty run. Require >=1 injected fault AND each
+# enabled garbo class fired (private always; foreign only when GARBO_FOREIGN=1).
+CHAOS_OK=1
+[[ "${FAULTS_DONE:-0}" -ge 1 ]]              || CHAOS_OK=0
+[[ "${GARBO_PRIVATE_FIRED:-0}" -ge 1 ]]      || CHAOS_OK=0
+[[ "${GARBO_FOREIGN:-1}" != "1" || "${GARBO_FOREIGN_FIRED:-0}" -ge 1 ]] || CHAOS_OK=0
 say "    (a) LEGIT completeness: $([[ $LEGIT_OK == 1 ]] && echo PASS || echo FAIL)  (verify_rc=$VC_RC locks=$LOCKS loadtest_rc=$LT_RC)"
 say "    (b) GARBO containment:  $([[ $GARBO_OK == 1 ]] && echo PASS || echo FAIL)  (foreign_leak=$FOREIGN_LEAK)"
-if [[ "$LEGIT_OK" == "1" && "$GARBO_OK" == "1" ]]; then
+say "    (c) CHAOS actually fired: $([[ $CHAOS_OK == 1 ]] && echo PASS || echo FAIL)  (faults=${FAULTS_DONE:-0} private=${GARBO_PRIVATE_FIRED:-0} foreign=${GARBO_FOREIGN_FIRED:-0})"
+if [[ "$LEGIT_OK" == "1" && "$GARBO_OK" == "1" && "$CHAOS_OK" == "1" ]]; then
     say "  >>> CHAOS SOAK PASS — every legit event survived exact-block; every garbo input contained <<<"
     say "======================================================================"
     exit 0

--- a/scripts/e2e-chaos-soak.sh
+++ b/scripts/e2e-chaos-soak.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# e2e-chaos-soak.sh — TIER 3: the unified WEEKEND CHAOS SOAK, the highest-trust
+# pre-release test. Miden runs under BOTH mixed real traffic (L1<->Miden AND
+# L2<->L2, including same-address clashes) AND adversarial "garbo" input AND
+# infrastructure chaos — then a TWO-SIDED verdict asserts:
+#   (a) every LEGITIMATE event still landed exact-block (verify-event-completeness:
+#       0 missing / 0 extra / 0 store-locks on the healed stack), AND
+#   (b) every GARBO input was correctly contained (skipped/quarantined/never
+#       projected): the foreign-claim global indexes produced ZERO synthetic
+#       ClaimEvent rows, and no garbo note leaked as a real BridgeEvent (the
+#       verify's extra==0 proves it).
+# PASS only if BOTH hold.
+#
+# Sequence:
+#   1. L2<->L2 stack (fresh with FRESH=1, else reuse a live one)
+#   2. concurrent STORM window:
+#        - chaos-seeder  (infra faults: pause pg / kill prover / restart proxy /
+#          partition node — external, self-restoring)
+#        - chaos-garbo   (adversarial: private/tag-0 notes + a foreign-deployment
+#          claim — each with a benign EXPECTED outcome)
+#        - e2e-loadtest-mixed (L1<->Miden bulk + L2<->L2 fwd/back + address clash)
+#   3. stop injectors + FULL restore (unpause/reconnect/restart)
+#   4. post-chaos heal window (late-sweep / cursor catch-up / reconciler)
+#   5. two-sided verdict
+#
+# Usage: N=60 CHAOS_DURATION=300 GARBO_DURATION=300 ./scripts/e2e-chaos-soak.sh
+#        FRESH=1 to bring up a clean stack first (requires NO other e2e stack up —
+#        the compose network 'miden-e2e' and host ports are shared).
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_DIR="$REPO"
+cd "$REPO"
+
+N="${N:-60}"
+CHAOS_DURATION="${CHAOS_DURATION:-300}"
+GARBO_DURATION="${GARBO_DURATION:-300}"
+POST_CHAOS_SETTLE="${POST_CHAOS_SETTLE:-150}"
+L2L2_FWD="${L2L2_FWD:-2}"
+L2L2_BACK="${L2L2_BACK:-2}"
+FRESH="${FRESH:-0}"
+TOOL_BIN="${TOOL_BIN:-/home/mandrigin/miden-agglayer/target/debug/bridge-out-tool}"
+
+CHAOS_LOG="${CHAOS_LOG:-/tmp/chaos-events.log}"
+GARBO_LOG="${GARBO_LOG:-/tmp/chaos-garbo.log}"
+GARBO_SUMMARY="${GARBO_SUMMARY:-/tmp/chaos-garbo-summary.env}"
+: > "$CHAOS_LOG"; : > "$GARBO_LOG"; : > "$GARBO_SUMMARY"
+
+say() { echo "[$(date '+%H:%M:%S')] CHAOS-SOAK: $*"; }
+
+CLAIM_EVENT_TOPIC="0x1df3f2a973a00d6635911755c260704e95e8a5876997546798770f76396fda4d"
+
+# ── 1. stack ─────────────────────────────────────────────────────────────────
+if [[ "$FRESH" == "1" ]]; then
+    say "=== FRESH stack (down -v + make e2e-up + L2B overlay) ==="
+    docker compose -f docker-compose.e2e.yml -f docker-compose.l2l2.yml --env-file fixtures/.env down -v --remove-orphans >/dev/null 2>&1
+    if ! timeout 1200 make e2e-up >/tmp/chaos-up.out 2>&1; then say "e2e-up FAILED"; tail -20 /tmp/chaos-up.out; exit 4; fi
+fi
+
+# lib-l2l2 auto-detects the compose project from the live proxy container
+# (FIX for known bug #1: never hardcode 'miden-agglayer'). It also brings up the
+# L2B overlay idempotently (FIX for known bug #2: the soak now runs against the
+# L2L2 stack so L2B exists).
+source "$SCRIPT_DIR/lib-l2l2.sh"
+say "compose project detected: $COMPOSE_PROJECT_NAME"
+l2l2_ensure_stack || { say "L2B overlay bring-up FAILED"; exit 4; }
+PROJECT="$COMPOSE_PROJECT_NAME"
+say "stack up: $(docker ps --filter name=${PROJECT}- -q | wc -l) containers (proxy=$AGGLAYER_CONTAINER)"
+
+# Baseline the garbo-containment metrics + the persistent quarantine table.
+counter() { local n="$1" b; b=$(curl -sf "${L2_RPC}/metrics" 2>/dev/null) || { echo 0; return; }; awk -v n="$n" '$0 ~ ("^" n " "){print $2; f=1; exit} END{if(!f)print 0}' <<<"$b" | sed 's/\..*//'; }
+BASE_PRIV_SKIP=$(counter synthetic_reconciler_private_skipped_total)
+BASE_FOREIGN_SKIP=$(counter claim_event_foreign_skipped_total)
+say "garbo baselines: private_skipped=$BASE_PRIV_SKIP foreign_skipped=$BASE_FOREIGN_SKIP"
+
+# ── 2. STORM: chaos-seeder + chaos-garbo + mixed loadtest, concurrent ────────
+say "=== STORM: chaos-seeder (${CHAOS_DURATION}s) + chaos-garbo (${GARBO_DURATION}s) + mixed loadtest (N=$N) ==="
+PROJECT="$PROJECT" CHAOS_DURATION="$CHAOS_DURATION" CHAOS_LOG="$CHAOS_LOG" \
+    "$SCRIPT_DIR/chaos-seeder.sh" >/tmp/chaos-seeder.out 2>&1 &
+SEEDER_PID=$!
+GARBO_DURATION="$GARBO_DURATION" GARBO_LOG="$GARBO_LOG" GARBO_SUMMARY="$GARBO_SUMMARY" \
+    "$SCRIPT_DIR/chaos-garbo.sh" >/tmp/chaos-garbo.out 2>&1 &
+GARBO_PID=$!
+
+# The mixed loadtest drives all the legit traffic; suppress its internal verify
+# (MIX_VERIFY=0) — the soak runs ONE authoritative verify post-heal. The new mixed
+# loadtest takes a per-direction L1 split (N_L1_FWD/N_L1_BACK) instead of a single N;
+# split the soak's N evenly across L1->Miden / Miden->L1.
+say "=== mixed loadtest under storm (L1 ${N} split $((N / 2))/$((N - N / 2)), L2<->L2 $L2L2_FWD/$L2L2_BACK) ==="
+N_L1_FWD=$((N / 2)) N_L1_BACK=$((N - N / 2)) L2L2_FWD="$L2L2_FWD" L2L2_BACK="$L2L2_BACK" \
+    MIX_VERIFY=0 ALLOW_LATE=1 COMPOSE_PROJECT_NAME="$PROJECT" \
+    timeout 3600 "$SCRIPT_DIR/e2e-loadtest-mixed.sh" >/tmp/chaos-lt.out 2>&1
+LT_RC=$?
+say "mixed loadtest exited rc=$LT_RC"
+grep -aE "MIXED LOADTEST RESULT|forward ops|back ops|address clash|L1<->Miden rc" /tmp/chaos-lt.out | tail -6 || true
+
+# ── 3. stop injectors + FULL restore ─────────────────────────────────────────
+say "=== stopping injectors + restoring all faults ==="
+kill "$SEEDER_PID" 2>/dev/null || true; wait "$SEEDER_PID" 2>/dev/null || true
+kill "$GARBO_PID" 2>/dev/null || true;  wait "$GARBO_PID" 2>/dev/null || true
+# belt-and-suspenders restore in case a trap raced (correct container names)
+docker unpause "${PROJECT}-agglayer-postgres-1" >/dev/null 2>&1 || true
+NET="$(docker inspect "$AGGLAYER_CONTAINER" --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}' 2>/dev/null | awk '{print $1}')"
+# reconnect WITH the compose alias (a plain connect drops 'miden-node' resolution)
+[ -n "$NET" ] && docker network connect --alias miden-node "$NET" "${PROJECT}-miden-node-1" >/dev/null 2>&1 || true
+for c in tx-prover-1 miden-agglayer-1; do docker start "${PROJECT}-$c" >/dev/null 2>&1 || true; done
+FAULTS_DONE=$(grep -c "FAULT " "$CHAOS_LOG" 2>/dev/null || echo 0)
+say "chaos stopped: $FAULTS_DONE faults injected (log: $CHAOS_LOG)"
+# shellcheck disable=SC1090
+[[ -f "$GARBO_SUMMARY" ]] && source "$GARBO_SUMMARY" || true
+say "garbo fired: private=${GARBO_PRIVATE_FIRED:-0} foreign=${GARBO_FOREIGN_FIRED:-0} gis='${GARBO_FOREIGN_GIS:-}'"
+
+# ── 4. post-chaos heal ───────────────────────────────────────────────────────
+say "=== post-chaos settle (${POST_CHAOS_SETTLE}s heal window) ==="
+for _ in $(seq 1 30); do
+    docker inspect "$AGGLAYER_CONTAINER" --format '{{.State.Health.Status}}' 2>/dev/null | grep -q healthy && break
+    sleep 5
+done
+sleep "$POST_CHAOS_SETTLE"
+
+# ── 5a. LEGITIMATE completeness (the primary verdict) ────────────────────────
+say "=== (a) verify-event-completeness (legit traffic) ==="
+VC_RC=2
+if [[ -x "$TOOL_BIN" ]]; then
+    ALLOW_LATE="${ALLOW_LATE:-1}" TOOL_BIN="$TOOL_BIN" \
+        NODE_CONTAINER="${PROJECT}-miden-node-1" AGGLAYER_CONTAINER="$AGGLAYER_CONTAINER" \
+        "$SCRIPT_DIR/verify-event-completeness.sh" > /tmp/chaos-verify.out 2>&1
+    VC_RC=$?
+    grep -aE "TYPE|B2AGG->|CLAIM->|GER->|VERDICT|SANITY|MISSING" /tmp/chaos-verify.out | tail -10
+else
+    say "WARN: $TOOL_BIN not found — completeness cannot run"
+fi
+LOCKS=$(docker logs "$AGGLAYER_CONTAINER" 2>&1 | grep -c "database is locked" || true)
+
+# ── 5b. GARBO containment (the second verdict) ───────────────────────────────
+say "=== (b) garbo containment ==="
+GARBO_OK=1
+# Foreign-claim class: each fabricated global index must have ZERO ClaimEvent rows.
+FOREIGN_LEAK=0
+for gi_hex in ${GARBO_FOREIGN_GIS:-}; do
+    gi_pad=$(python3 -c "print(format(int('$gi_hex',16),'064x'))" 2>/dev/null || echo "")
+    [[ -z "$gi_pad" ]] && continue
+    rows=$(pgq "SELECT COUNT(*) FROM synthetic_logs WHERE topics[1] = '${CLAIM_EVENT_TOPIC}' AND lower(data) LIKE '0x${gi_pad}%';")
+    if [[ "${rows:-0}" != "0" ]]; then
+        say "  GARBO LEAK: foreign gi 0x$gi_hex has $rows ClaimEvent row(s) — CONTAINMENT BREACH"
+        FOREIGN_LEAK=$((FOREIGN_LEAK + rows)); GARBO_OK=0
+    else
+        say "  foreign gi 0x$gi_hex: 0 ClaimEvent rows (contained)"
+    fi
+done
+[[ "${GARBO_FOREIGN_FIRED:-0}" -gt 0 && -z "${GARBO_FOREIGN_GIS:-}" ]] && { say "  WARN: foreign fired but no gi recorded"; }
+# Skip counters (best-effort — in-memory, may have reset on a chaos proxy restart).
+NOW_PRIV_SKIP=$(counter synthetic_reconciler_private_skipped_total)
+NOW_FOREIGN_SKIP=$(counter claim_event_foreign_skipped_total)
+say "  private_skipped_total: $BASE_PRIV_SKIP -> $NOW_PRIV_SKIP (garbo private fired=${GARBO_PRIVATE_FIRED:-0})"
+say "  foreign_skipped_total: $BASE_FOREIGN_SKIP -> $NOW_FOREIGN_SKIP (garbo foreign fired=${GARBO_FOREIGN_FIRED:-0})"
+# The verify's extra==0 (checked below via VC_RC) is the restart-robust proof
+# that NO private/tag-0/garbo note leaked as a real BridgeEvent/ClaimEvent.
+
+# ── 6. two-sided verdict ─────────────────────────────────────────────────────
+say "======================================================================"
+say "  UNIFIED CHAOS SOAK RESULT"
+say "    N=$N  faults=$FAULTS_DONE  garbo(private=${GARBO_PRIVATE_FIRED:-0} foreign=${GARBO_FOREIGN_FIRED:-0})"
+say "    loadtest_rc=$LT_RC  verify_rc=$VC_RC  store_locks=$LOCKS  foreign_leak=$FOREIGN_LEAK"
+# The mixed loadtest (MIX_VERIFY=0) exits 0 on a clean completion and non-zero
+# ONLY if its driver ABORTED (a fail() — e.g. a wedge or a harness bug). A
+# crashed driver means the full mixed load never ran, so it must NOT green even
+# if the (reduced) traffic verifies — else a dead driver false-passes.
+LEGIT_OK=0; [[ "$VC_RC" == "0" && "${LOCKS:-1}" == "0" && "$LT_RC" == "0" ]] && LEGIT_OK=1
+say "    (a) LEGIT completeness: $([[ $LEGIT_OK == 1 ]] && echo PASS || echo FAIL)  (verify_rc=$VC_RC locks=$LOCKS loadtest_rc=$LT_RC)"
+say "    (b) GARBO containment:  $([[ $GARBO_OK == 1 ]] && echo PASS || echo FAIL)  (foreign_leak=$FOREIGN_LEAK)"
+if [[ "$LEGIT_OK" == "1" && "$GARBO_OK" == "1" ]]; then
+    say "  >>> CHAOS SOAK PASS — every legit event survived exact-block; every garbo input contained <<<"
+    say "======================================================================"
+    exit 0
+else
+    say "  >>> CHAOS SOAK NOT-GREEN — inspect /tmp/chaos-verify.out, $CHAOS_LOG, $GARBO_LOG, /tmp/chaos-lt.out <<<"
+    say "  (stack left UP for forensics)"
+    say "======================================================================"
+    exit 1
+fi


### PR DESCRIPTION
## Purpose

Adds a manual resilience and containment gate on top of #124's certified four-direction bridge harness.

The happy-path suite in #124 proves that L1, Miden, and L2B can bridge in both directions. This PR asks the harder operational question:

> While legitimate bridge traffic is active, can the Miden-AggLayer proxy survive transient dependency failures, recover to a complete synthetic Ethereum view, and refuse Miden inputs that do not belong to its deployment?

The answer is exercised by three scripts:

- <code>scripts/chaos-seeder.sh</code> — randomized external infrastructure faults;
- <code>scripts/chaos-garbo.sh</code> — private/tag-0 notes and a claim from an independent foreign bridge deployment; and
- <code>scripts/e2e-chaos-soak.sh</code> — concurrent storm orchestration, restoration, healing, and the final three-gate verdict.

This is deliberately a test-only delta: no Rust product code, contracts, fixtures, or Compose topology are changed.

## Chaos overlay

The PR reuses #124's complete per-rollup topology rather than duplicating it. This diagram is the fault overlay: red is the harness, blue is the Miden proxy boundary being stressed, and green is the independent post-heal check.

~~~mermaid
flowchart LR
  subgraph HarnessZone["CHAOS HARNESS"]
    Orchestrator["e2e-chaos-soak.sh"]
    Load["mixed four-direction load<br/>from #124"]
    Seeder["infrastructure fault seeder"]
    Garbo["adversarial input injector"]
    Orchestrator --> Load
    Orchestrator --> Seeder
    Orchestrator --> Garbo
  end

  subgraph BaseZone["LIVE BRIDGE STACK INHERITED FROM #124"]
    Routes["L1 · Miden · L2B<br/>per-rollup AggKit + bridge services<br/>AggLayer settlement"]

    subgraph MidenZone["MIDEN PROXY BOUNDARY"]
      Proxy["miden-agglayer proxy<br/>EVM RPC + synthetic projector"]
      Pg[("proxy PostgreSQL")]
      Prover["Miden transaction prover"]
      Node["Miden node"]
      Foreign["independent foreign bridge<br/>network 3"]
      Synthetic[("synthetic Ethereum logs")]
      Truth[("Miden node DB snapshot")]

      Proxy --> Pg
      Proxy --> Prover
      Proxy --> Node
      Proxy --> Synthetic
      Node --> Truth
    end

    Routes <--> Proxy
  end

  subgraph VerdictZone["POST-HEAL VERDICT"]
    Verify["event-completeness verifier"]
    Contain["garbo containment checks"]
  end

  Load --> Routes
  Seeder -. "pause 4–11s" .-> Pg
  Seeder -. "restart" .-> Prover
  Seeder -. "restart" .-> Proxy
  Seeder -. "disconnect 5–14s" .-> Node
  Garbo -->|"private tag-0 note"| Node
  Garbo -->|"foreign-deployment claim"| Foreign
  Foreign -. "must not project through" .-> Proxy
  Synthetic --> Verify
  Truth --> Verify
  Synthetic --> Contain

  classDef harness fill:#fee2e2,stroke:#dc2626,color:#450a0a,stroke-width:2px
  classDef base fill:#f3e8ff,stroke:#7e22ce,color:#3b0764,stroke-width:2px
  classDef miden fill:#dbeafe,stroke:#2563eb,color:#172554,stroke-width:2px
  classDef verdict fill:#dcfce7,stroke:#059669,color:#064e3b,stroke-width:2px
  class Orchestrator,Load,Seeder,Garbo harness
  class Routes base
  class Proxy,Pg,Prover,Node,Foreign,Synthetic,Truth miden
  class Verify,Contain verdict
  style HarnessZone fill:#fff7f7,stroke:#dc2626,stroke-width:4px,color:#450a0a
  style BaseZone fill:#faf5ff,stroke:#7e22ce,stroke-width:4px,color:#3b0764
  style MidenZone fill:#eff6ff,stroke:#2563eb,stroke-width:4px,color:#172554
  style VerdictZone fill:#f0fdf4,stroke:#059669,stroke-width:4px,color:#064e3b
~~~

The seeder faults the shipped proxy and its dependencies from outside the process. It deliberately does not add in-binary failpoints or destructively fault the L1, L2B, AggKit, or Miden chain of record.

## Legitimate workload during the storm

<code>e2e-chaos-soak.sh</code> invokes the mixed load generator from #124 with its internal verifier disabled. This keeps faults active during submission and draining, then runs one authoritative comparison after restoration and healing.

With the chaos wrapper's defaults, the storm contains:

| Route | Default volume | Claim mode | What it exercises |
|---|---:|---|---|
| L1 → Miden | 30 | Automatic | L1 deposits, GER propagation, Miden claim publication, and synthetic <code>ClaimEvent</code> recovery |
| Miden → L1 | 30 | Automatic | Miden bridge-out notes, certificate/settlement progress, and L1 release |
| L2B → Miden | 2 | Client-submitted | Proof from L2B's isolated bridge service followed by <code>claimAsset</code> on the Miden proxy |
| Miden → L2B | 2 | Client-submitted | Proof from Miden's isolated bridge service followed by <code>claimAsset</code> on L2B |
| Same-address origin clash | 1 L1 token + 1 L2B token at the same CREATE address | Mixed | Exercises the <code>(origin_address, origin_network)</code> isolation path while the other traffic is running |

<code>N=60</code> controls only the L1 legs and is split exactly as <code>30/30</code>. The L2↔L2 counts are controlled independently by <code>L2L2_FWD</code> and <code>L2L2_BACK</code>.

> [!IMPORTANT]
> **Current expected-count limitation:** the soak invokes the inherited driver with <code>MIX_VERIFY=0</code> so verification happens once, after healing. At the current base head, that mode exits before the driver's submitted/claimed-count and address-clash assertions. The post-heal verifier proves that every consumed bridge note at its consistency cut has one corresponding synthetic event, but it does not prove that every requested operation was submitted or settled. #124 remains the functional-volume authority until no-internal-verify mode preserves those workload assertions.

## Infrastructure fault model

The seeder chooses one fault at a time from a randomized menu. The default gap is 25–55 seconds and the default chaos window is 300 seconds.

| Fault | Injection | Recovery behavior under test |
|---|---|---|
| <code>pause-pg</code> | Pause the proxy's PostgreSQL container for 4–11 seconds | Store retry/atomicity and recovery after a temporary write stall |
| <code>kill-prover</code> | Docker-restart the transaction prover | Recovery when proof service availability is interrupted |
| <code>restart-proxy</code> | Docker-restart the proxy mid-run | Durable cursors, restart recovery, late-consumption sweep, and reconciliation |
| <code>partition-node</code> | Disconnect the Miden node from the Compose network for 5–14 seconds | Sync retry and recovery after loss of node connectivity; reconnect preserves Compose aliases |

A fault counts only after the Docker operation that injects it succeeds. Failed operations emit <code>SKIP … not injected</code> and cannot satisfy the coverage gate. Every individual fault is bounded and self-restoring, an EXIT trap restores anything left behind, and the orchestrator performs a second belt-and-suspenders restoration before verification.

The random order can be reproduced with <code>CHAOS_SEED</code>. A green run guarantees at least one successful infrastructure fault, not that all four fault classes happened in that particular run.

## Adversarial input model

| Class | Input | Expected containment | Hard verdict evidence |
|---|---|---|---|
| Private/tag-0 | Repeated private P2ID notes produced with the shipped bridge tool | The visibility reconciler skips them without wedging; they never become a synthetic bridge/claim event | The completeness comparison must have zero extra events. The skip metric delta is printed but is informational because a proxy restart can reset it |
| Foreign deployment | A separate network-3 service, GER manager, and bridge on the same Miden chain submits a valid claim through its own bridge | This proxy rejects the Claim-shaped note because its consumer/provenance belongs to another deployment | Every recorded foreign global index must have exactly zero synthetic <code>ClaimEvent</code> rows |

The heavy foreign class fires once near the start and can be disabled with <code>GARBO_FOREIGN=0</code>. Private-note timing is randomized and reproducible with <code>GARBO_SEED</code>.

Unknown-faucet quarantine is intentionally not manufactured here. Deleting a registry row is not a faithful test because metadata recovery can reconstruct it from the bridge's authoritative map; the current shipped tool cannot create a genuinely unknown faucet.

## Lifecycle and pass contract

~~~mermaid
flowchart TD
  Ready["reuse live stack<br/>or recreate with FRESH=1"] --> Load["mixed legitimate traffic"]
  Ready --> Seeder["random infrastructure faults"]
  Ready --> Garbo["private + foreign inputs"]

  Load --> Restore["stop injectors<br/>unpause · reconnect · restart"]
  Seeder --> Restore
  Garbo --> Restore
  Restore --> Healthy["wait for proxy health"]
  Healthy --> Settle["post-chaos heal window<br/>default 150s"]
  Settle --> Snapshot["snapshot Miden truth<br/>read synthetic logs"]

  Snapshot --> A["LEGIT_OK<br/>driver did not abort<br/>0 missing / 0 extra<br/>0 store-lock lines"]
  Snapshot --> B["GARBO_OK<br/>0 foreign ClaimEvent leaks"]
  Snapshot --> C["CHAOS_OK<br/>≥1 injected fault<br/>private fired<br/>foreign fired if enabled"]

  A --> All{"all three pass?"}
  B --> All
  C --> All
  All -->|"yes"| Pass["CHAOS SOAK PASS"]
  All -->|"no"| Fail["NOT GREEN<br/>retain stack for forensics"]

  classDef phase fill:#dbeafe,stroke:#2563eb,color:#172554,stroke-width:2px
  classDef gate fill:#fef3c7,stroke:#d97706,color:#451a03,stroke-width:2px
  classDef pass fill:#dcfce7,stroke:#059669,color:#064e3b,stroke-width:2px
  classDef fail fill:#fee2e2,stroke:#dc2626,color:#450a0a,stroke-width:2px
  class Ready,Load,Seeder,Garbo,Restore,Healthy,Settle,Snapshot phase
  class A,B,C,All gate
  class Pass pass
  class Fail fail
~~~

### Gate A — legitimate event durability

The independent verifier compares two sources:

1. **Truth:** a snapshot of the Miden node database, containing bridge-consumed B2AGG, CLAIM, and UpdateGER notes classified by canonical script root and bridge consumer.
2. **View:** the proxy's synthetic <code>BridgeEvent</code>, <code>ClaimEvent</code>, and <code>UpdateHashChainValue</code> logs up to the same consistency cut.

For each event type it requires one log per consumed note, zero missing logs, and zero extra logs. Exact-block and later-block recovery are reported separately. The chaos wrapper uses <code>ALLOW_LATE=1</code>, so a log recovered at a later synthetic block is accepted after a fault; it must still exist exactly once.

The gate also requires the mixed driver not to abort and requires zero <code>database is locked</code> lines in the proxy logs.

### Gate B — adversarial containment

Every recorded foreign global index must have zero synthetic <code>ClaimEvent</code> rows. Private/tag-0 leakage would appear as an extra event in Gate A. Skip counters remain useful diagnostics but are not authoritative because restarting the proxy resets in-memory metrics.

### Gate C — non-empty chaos coverage

The run cannot pass as an empty happy-path test. It requires:

- at least one successfully injected infrastructure fault;
- at least one private/tag-0 input; and
- at least one foreign claim when <code>GARBO_FOREIGN=1</code>.

The final verdict is:

~~~text
LEGIT_OK && GARBO_OK && CHAOS_OK
~~~

## What a green run does—and does not—prove

A green run proves that, after transient faults and a healing window:

- every bridge note consumed in the verifier's consistency cut has exactly one corresponding synthetic event;
- no unrelated synthetic events appeared;
- the tested foreign claim did not leak into this deployment's event view;
- the private and enabled foreign garbo classes actually fired;
- at least one external infrastructure fault was successfully injected; and
- no <code>database is locked</code> line appears in the proxy logs.

It does **not** currently prove:

- that every configured <code>30/30/2/2</code> submission or the same-address clash completed successfully—the chaos wrapper uses <code>MIX_VERIFY=0</code>, so #124 remains the authority for those functional assertions;
- strict exact-block projection under faults—late-but-recovered events are explicitly allowed and reported;
- that all four infrastructure fault classes were covered in one randomized run;
- a run-scoped nonzero legitimate workload when reusing historical state—the verifier reads full history, so <code>FRESH=1</code> is recommended for release evidence;
- resilience to destructive node loss, reorgs, disk corruption, CPU/memory exhaustion, or faults in L1, L2B, AggKit, and bridge-service; or
- the unknown-faucet quarantine path.

These boundaries are intentional in the description so the soak is used as a recovery/containment gate, not mistaken for the functional certification supplied by #124.

## Running the soak

Build the verifier tool, ensure no other E2E stack is using the shared ports/network, then run:

~~~sh
cargo build --bin bridge-out-tool
FRESH=1 ./scripts/e2e-chaos-soak.sh
~~~

The explicit default-equivalent form is:

~~~sh
FRESH=1 \
N=60 \
L2L2_FWD=2 \
L2L2_BACK=2 \
CHAOS_DURATION=300 \
GARBO_DURATION=300 \
POST_CHAOS_SETTLE=150 \
./scripts/e2e-chaos-soak.sh
~~~

For a reproducible schedule:

~~~sh
FRESH=1 \
CHAOS_SEED=133 \
GARBO_SEED=133 \
MIX_SEED=133 \
./scripts/e2e-chaos-soak.sh
~~~

On failure the stack stays up for inspection.

## Evidence and artifacts

| Artifact | Contents |
|---|---|
| <code>/tmp/chaos-events.log</code> | Successfully injected and skipped infrastructure faults |
| <code>/tmp/chaos-seeder.out</code> | Seeder stdout/stderr and restoration timeline |
| <code>/tmp/chaos-garbo.log</code> / <code>/tmp/chaos-garbo.out</code> | Adversarial-input timeline and tool output |
| <code>/tmp/chaos-garbo-summary.env</code> | Fired counts and foreign global indexes consumed by the verdict |
| <code>/tmp/chaos-lt.out</code> / <code>/tmp/mixed-l2l2.log</code> | Mixed traffic driver and per-operation output |
| <code>/tmp/chaos-verify.out</code> | Per-type node-truth versus synthetic-log completeness table |
| <code>/tmp/mixed-l1-loadtest.out</code> and <code>.loadtest-results/</code> | Underlying L1↔Miden load details |

These files are overwritten by later runs and are not uploaded automatically.

## Scope, validation, and stack

The complete delta is:

~~~text
scripts/chaos-seeder.sh
scripts/chaos-garbo.sh
scripts/e2e-chaos-soak.sh
~~~

- Current head: <code>10c7213</code> — two commits, three added scripts, 514 lines.
- Standard <code>check</code> and Aikido security checks are green.
- The opt-in <code>e2e-l2l2</code> job is skipped in ordinary PR CI; CI does not execute this soak.
- No full manual soak evidence is attached to the current head.
- #131 is closed and superseded by this clean restack.

Release stack:

~~~text
main
└── #124  feat/l2-to-l2-e2e
    └── #133  feat/chaos-soak  ← this PR
        └── #134  feat/vb-soak
            └── #135  feat/miden-origin  (draft)
~~~

Review focus:

- no false-green path when fault or garbo setup fails;
- correct restoration of PostgreSQL, prover, proxy, node connectivity, and Compose aliases;
- correctness of the Miden-node truth versus synthetic-log consistency cut;
- provenance containment for the foreign deployment; and
- the explicit guarantee boundaries above.
