### PR TITLE
fix(claim recovery): reconstruct full calldata for synthesized ClaimEvents

### DIFF
--- a/scripts/e2e-synthesized-claim-calldata.sh
+++ b/scripts/e2e-synthesized-claim-calldata.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+# E2E — synthesized-claim FULL calldata through the PINNED aggkit parser (PR #136).
+#
+# SOAK FINDING #2 regression, review-hardened: a PROXY-SYNTHESIZED claim tx (MA#27 —
+# ClaimEvent emitted under a DERIVED hash because no real eth-tx link exists) must serve
+# WELL-FORMED, AUTHORITATIVE claimAsset calldata via eth_getTransactionByHash:
+#   * both SMT proofs + both exit roots + networks/addresses/amount from the consumed
+#     CLAIM note's on-chain storage (the values the proxy built and the bridge verified);
+#   * the metadata preimage from the faucet registry, hash-verified against the note's
+#     metadata_hash;
+# and aggkit v0.8.3's L2BridgeSyncer (which fetches EVERY claim tx and parses the full
+# calldata — 'DetailedClaimEvent') must sync PAST the claim block and the certificate
+# pipeline must keep settling. Zero-filled/fabricated fields are forbidden: aggkit
+# persists all of them and derives the claim's GER from the exit roots.
+#
+# MA#27 derived-hash condition, produced deterministically via the restore flow:
+# wiping the proxy's PG store destroys every tx_note_link, so `--restore` re-synthesizes
+# EVERY ClaimEvent under its derived hash — exactly the crash-recovery state the live
+# soak hit at block 8831 (tx 0x1ac390c7…, empty input, certs halted for 2h).
+#
+# Flow:
+#   1. Ensure a completed L1→L2 claim exists (bootstrap e2e-l1-to-l2.sh if not).
+#   2. Record the claim's global_index + note_id; wipe miden-derived PG state
+#      (same table set as e2e-restore.sh — includes tx_note_links).
+#   3. Run --restore; restart the proxy.
+#   4. Assert the re-synthesized ClaimEvent rides the DERIVED hash
+#      (recomputed here via cast keccak over the versioned tag ‖ note_id).
+#   5. Assert eth_getTransactionByHash(derived) serves full claimAsset calldata:
+#      claimAsset selector, globalIndex at its exact ABI offset == the event's gi,
+#      length covering both 32-word proof arrays (no stub).
+#   6. RESET aggkit (force-recreate → empty bridgesync DB, no stale cursor) and prove,
+#      un-false-passably, that it re-syncs THIS claim:
+#        (a) proxy exact-hash serves COUNT-DELTA across the reset (>SERVES_BEFORE) so the
+#            script's own step-5 probe cannot satisfy it — a genuinely aggkit-driven fetch;
+#        (b) durable persist, HARD + image-independent: the recovered claim's EXACT
+#            global_index is delivered (claim_tx_hash set) in aggkit's bridge-service REST
+#            index (no docker-exec into the distroless image), plus the atomic per-block
+#            cursor-advance floor past the claim block;
+#        (c) a certificate reaches Settled AFTER the reset with the recovered claim's exact
+#            global_index still bound+delivered — settlement tied to THIS claim, not to an
+#            unrelated bridge-out — and ZERO 'input too short' throughout (the wedge cleared).
+#
+# Usage:  source fixtures/.env && ./scripts/e2e-synthesized-claim-calldata.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURES_DIR="$PROJECT_DIR/fixtures"
+source "$FIXTURES_DIR/.env"
+
+# Compose-file interpolation needs these even for --no-deps runs (see e2e-restore.sh).
+export MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-https://github.com/0xMiden/node.git}"
+export MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-v0.15.0}"
+
+L2_RPC="${L2_RPC:-http://localhost:8546}"
+PG_HOST="${PG_HOST:-localhost}"
+PG_PORT="${PG_PORT:-5434}"
+PG_USER="${PG_USER:-agglayer}"
+PG_PASS="${PG_PASS:-agglayer}"
+PG_DB="${PG_DB:-agglayer_store}"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-miden-agglayer}"
+PROXY_CONTAINER="${AGGLAYER_CONTAINER:-${COMPOSE_PROJECT_NAME}-miden-agglayer-1}"
+AGGKIT_CONTAINER="${AGGKIT_CONTAINER:-${COMPOSE_PROJECT_NAME}-aggkit-1}"
+CLAIM_EVENT_TOPIC="0x1df3f2a973a00d6635911755c260704e95e8a5876997546798770f76396fda4d"
+AGGKIT_SYNC_TIMEOUT="${AGGKIT_SYNC_TIMEOUT:-300}"
+# aggkit bridge-service REST API (image-independent: plain HTTP, NOT docker-exec into the
+# distroless aggkit image). `/bridges/<addr>` → {deposits:[{global_index, claim_tx_hash, …}]}.
+BRIDGE_SERVICE_URL="${BRIDGE_SERVICE_URL:-http://localhost:18080}"
+# How much of the (un-reset) proxy log to scan for exact-hash serves. NOT `--since`
+# (host-timestamp truncation trap, see docs/e2e log-assertion traps).
+PROXY_LOG_TAIL="${PROXY_LOG_TAIL:-20000}"
+AGGKIT_LOG_TAIL="${AGGKIT_LOG_TAIL:-40000}"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[$(date +%H:%M:%S)]${NC} $*"; }
+warn() { echo -e "${YELLOW}[$(date +%H:%M:%S)] WARN:${NC} $*"; }
+fail() { echo -e "${RED}[$(date +%H:%M:%S)] FAIL:${NC} $*" >&2; exit 1; }
+pass() { echo -e "${GREEN}[$(date +%H:%M:%S)] PASS:${NC} $*"; }
+step() { echo -e "${CYAN}[$(date +%H:%M:%S)] STEP:${NC} $*"; }
+
+# ANSI-strip for docker-log grepping (aggkit logs are colorized; raw regexes break —
+# see docs/e2e log-assertion traps).
+strip_ansi() { sed 's/\x1b\[[0-9;]*m//g'; }
+
+wait_for() {
+    local desc="$1" cmd="$2" timeout="$3" interval="${4:-5}"
+    local elapsed=0
+    log "Waiting: $desc (timeout: ${timeout}s)..."
+    while ! ( set +o pipefail; eval "$cmd" ) 2>/dev/null; do
+        elapsed=$((elapsed + interval))
+        [[ $elapsed -ge $timeout ]] && fail "Timed out: $desc"
+        echo -n "."
+        sleep "$interval"
+    done
+    echo ""
+}
+
+pgq() {
+    PGPASSWORD="$PG_PASS" psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAX -c "$1"
+}
+
+rpc() { # method params-json
+    curl -sf "$L2_RPC" -X POST -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"2.0\",\"method\":\"$1\",\"params\":$2,\"id\":1}"
+}
+
+command -v cast >/dev/null || fail "cast (foundry) not found"
+command -v psql >/dev/null || fail "psql not found"
+command -v jq   >/dev/null || fail "jq not found"
+command -v xxd  >/dev/null || fail "xxd not found"
+pgq "SELECT 1" >/dev/null || fail "PostgreSQL not reachable"
+rpc eth_chainId '[]' >/dev/null || fail "L2 (miden-agglayer) not reachable"
+
+log "======================================================================"
+log "  E2E: synthesized-claim FULL calldata → aggkit full-claim parser"
+log "======================================================================"
+
+# ── Step 1: ensure a completed L1→L2 claim exists ────────────────────────────
+step "1/6: ensure a completed L1→L2 claim exists"
+EXISTING=$(pgq "SELECT 1 FROM synthetic_logs WHERE topics[1] = '${CLAIM_EVENT_TOPIC}' LIMIT 1;")
+if [[ -z "$EXISTING" ]]; then
+    log "  no ClaimEvent yet — bootstrapping via e2e-l1-to-l2.sh"
+    "$SCRIPT_DIR/e2e-l1-to-l2.sh" >/dev/null
+fi
+
+# The claim's global_index (first 32 data bytes) + block, from the latest ClaimEvent.
+ROW=$(pgq "SELECT data || '|' || block_number FROM synthetic_logs WHERE topics[1] = '${CLAIM_EVENT_TOPIC}' ORDER BY block_number DESC LIMIT 1;")
+GI_HEX=$(echo "${ROW%%|*}" | sed -E 's/^0x([0-9a-f]{64}).*/\1/')
+CLAIM_BLOCK="${ROW##*|}"
+[[ ${#GI_HEX} -eq 64 ]] || fail "could not extract global_index from synthetic_logs"
+NOTE_ID=$(pgq "SELECT note_id FROM claim_watcher_processed WHERE global_index = decode('${GI_HEX}', 'hex') LIMIT 1;")
+[[ -n "$NOTE_ID" ]] || fail "no claim_watcher_processed row for gi 0x${GI_HEX} — cannot derive the synthetic hash"
+log "  claim: gi=0x${GI_HEX:0:16}… block=${CLAIM_BLOCK} note_id=${NOTE_ID:0:16}…"
+
+# The derived hash this claim will ride after restore: keccak(TAG ‖ note_id_str), with
+# TAG = "miden-agglayer/manual-claim/v1\0" (claim_watcher::MANUAL_CLAIM_TX_HASH_TAG) and
+# note_id_str hashed as its ASCII bytes (hasher.update(note_id_str.as_bytes())).
+TAG_HEX=$(printf 'miden-agglayer/manual-claim/v1\0' | xxd -p | tr -d '\n')
+NOTE_ASCII_HEX=$(printf '%s' "$NOTE_ID" | xxd -p | tr -d '\n')
+DERIVED_HASH=$(cast keccak "0x${TAG_HEX}${NOTE_ASCII_HEX}")
+log "  expected derived tx hash: ${DERIVED_HASH}"
+
+# ── Step 2: wipe PG state INCLUDING the durable eth-side tables ──────────────
+step "2/6: wiping PG state incl. transactions/tx_note_links (the MA#27 crash-loss)"
+# e2e-restore.sh wipes only the miden-derived set and deliberately PRESERVES
+# `transactions` + `tx_note_links` (pre-fix, claim calldata was unrecoverable from
+# Miden). This test wipes them TOO — that is the MA#27 condition (real claim tx +
+# link lost), and the point of the fix: restore now recovers the FULL calldata from
+# the CLAIM note storage + faucet registry (rebuilt in restore Phase 1.7, before the
+# Phase 2.5 claim replay) and persists it under the derived hash.
+pgq "TRUNCATE service_state, synthetic_logs, ger_entries, nonces, claimed_indices, \
+     address_mappings, bridge_out_processed, faucet_registry, transactions, \
+     tx_note_links, claim_watcher_processed CASCADE" >/dev/null
+pgq "INSERT INTO service_state (id) VALUES (1)" >/dev/null
+[[ "$(pgq 'SELECT COUNT(*) FROM synthetic_logs')" -eq 0 ]] || fail "tables not wiped"
+log "  wiped (incl. transactions + tx_note_links)"
+
+# ── Step 3: run --restore, restart the proxy ─────────────────────────────────
+step "3/6: running --restore (re-synthesizes ClaimEvents under derived hashes)"
+docker stop "$PROXY_CONTAINER" >/dev/null
+# One-shot restore container: compose gives it volumes/network, but NOT the service's
+# command-line args — the node URL must be passed explicitly or the binary dials its
+# 127.0.0.1 default and retries forever (same wiring as e2e-restore.sh).
+docker compose -f "$PROJECT_DIR/docker-compose.e2e.yml" --env-file "$FIXTURES_DIR/.env" \
+    run --rm --no-deps miden-agglayer \
+    --miden-node=http://miden-node:57291 \
+    --miden-store-dir=/var/lib/miden-agglayer-service \
+    --restore 2>&1 | strip_ansi \
+    | while IFS= read -r line; do echo "  [restore] $line"; done
+RESTORE_EXIT=${PIPESTATUS[0]}
+[[ "$RESTORE_EXIT" -eq 0 ]] || fail "--restore exited with code $RESTORE_EXIT"
+docker start "$PROXY_CONTAINER" >/dev/null
+wait_for "proxy back up" \
+    "curl -sf $L2_RPC -X POST -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":[],\"id\":1}' >/dev/null" \
+    60 2
+
+# ── Step 4: the re-synthesized ClaimEvent rides the DERIVED hash ─────────────
+step "4/6: verifying the re-synthesized ClaimEvent rides the derived hash"
+NEW_TX=$(pgq "SELECT transaction_hash FROM synthetic_logs WHERE topics[1] = '${CLAIM_EVENT_TOPIC}' AND lower(data) LIKE '0x${GI_HEX}%' LIMIT 1;")
+[[ -n "$NEW_TX" ]] || fail "ClaimEvent for gi 0x${GI_HEX:0:16}… not re-synthesized by --restore"
+[[ "${NEW_TX,,}" == "${DERIVED_HASH,,}" ]] \
+    || fail "re-synthesized ClaimEvent rides ${NEW_TX}, expected the derived hash ${DERIVED_HASH} — MA#27 condition not reproduced"
+pass "derived-hash ClaimEvent reproduced (${NEW_TX:0:18}…)"
+
+# ── Step 5: eth_getTransactionByHash serves FULL authoritative calldata ──────
+step "5/6: verifying eth_getTransactionByHash serves full claimAsset calldata"
+INPUT=$(rpc eth_getTransactionByHash "[\"${DERIVED_HASH}\"]" | jq -r '.result.input')
+[[ -n "$INPUT" && "$INPUT" != "null" ]] || fail "no tx served for the derived hash"
+[[ "$INPUT" != "0x" ]] || fail "derived-hash claim tx serves EMPTY calldata — the persisted-calldata path did not engage (check synthetic_claim_calldata_persisted_total / _unrecoverable_total)"
+
+CLAIM_ASSET_SELECTOR=$(cast sig "claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)")
+[[ "${INPUT:0:10}" == "$CLAIM_ASSET_SELECTOR" ]] \
+    || fail "input does not start with the claimAsset selector (got ${INPUT:0:10}, want ${CLAIM_ASSET_SELECTOR})"
+
+# globalIndex is arg 3: after two inline bytes32[32] arrays → byte offset 4+1024+1024,
+# i.e. hex-char offset 10 + 2048*2 = 4106, 64 chars. Must equal the EVENT's gi (truthful).
+GI_IN_CALLDATA="${INPUT:4106:64}"
+[[ "${GI_IN_CALLDATA,,}" == "${GI_HEX,,}" ]] \
+    || fail "calldata globalIndex (${GI_IN_CALLDATA}) != event globalIndex (${GI_HEX}) — NOT the authoritative claim"
+
+# Full-length sanity: selector + 11 args with two 32-word proof arrays ≥ 4+69*32 bytes.
+MIN_HEX_LEN=$((2 + 2 * (4 + 69 * 32)))
+[[ ${#INPUT} -ge $MIN_HEX_LEN ]] || fail "calldata too short (${#INPUT} hex chars) — proofs missing?"
+
+# Proof material must be present and non-zero (the local SMT proof of a real deposit is
+# never all-zero) — pins that proofs come from the note storage, not zero-fill.
+LOCAL_PROOF_HEX="${INPUT:10:2048}"
+[[ "$LOCAL_PROOF_HEX" =~ [1-9a-f] ]] \
+    || fail "local SMT proof in calldata is all-zero — fabrication, not the authoritative proof"
+pass "full authoritative claimAsset calldata served ($(( (${#INPUT} - 2) / 2 )) bytes, truthful gi, non-zero proofs)"
+
+# ── Step 6: aggkit RE-SYNCS the claim from a reset DB, parses it, persists it ──
+#
+# CRITICAL (review blocker 2): a `docker restart` PRESERVES the container filesystem, and
+# aggkit stores its bridgesync DB under PathRWData=/tmp (no named volume) — so a restarted
+# aggkit RESUMES past the already-processed claim block and NEVER re-fetches the
+# derived-hash tx. That made the old assertions vacuous (it was "already past", never
+# re-parsed). We instead RESET aggkit's sync state by RECREATING the container (fresh
+# /tmp), forcing a full re-sync that MUST re-fetch and re-parse the derived-hash claim.
+#
+# Three review-blocker-2 hardenings applied below:
+#   (a) the exact-hash serve proof is COUNT-DELTA'd across the force-recreate — the proxy
+#       is NOT reset, so the script's OWN step-5 eth_getTransactionByHash serve is already
+#       in the log BEFORE the recreate; we snapshot that count and require it to STRICTLY
+#       INCREASE afterwards, so only a genuinely NEW (aggkit-driven) serve can pass.
+#   (b) the durable-persist proof is IMAGE-INDEPENDENT and keyed to THIS claim's exact
+#       global_index via the bridge-service REST API (no docker-exec into the distroless
+#       aggkit image), plus the atomic-per-block cursor-advance floor — both HARD.
+#   (c) settlement is tied to THIS recovered claim by its global_index (bridge-service
+#       delivery of the exact gi + a certificate settling AFTER the reset), NOT to an
+#       unrelated bridge-out.
+
+# The recovered claim's destination address (claimAsset arg #9, `address destinationAddress`)
+# — needed to locate THIS claim in the bridge-service deposit index. Layout after the two
+# inline bytes32[32] arrays: selector(4) + 1024 + 1024 = byte 2052; then six 32-byte words
+# (globalIndex, mainnetExitRoot, rollupExitRoot, originNetwork, originTokenAddress,
+# destinationNetwork) → destinationAddress word starts at byte 2052+192 = 2244, address in
+# its low 20 bytes (word bytes 12..32 → byte 2256). Hex offset = 2 (for "0x") + 2*byte.
+CLAIM_DEST_ADDR="0x${INPUT:4514:40}"
+[[ "$CLAIM_DEST_ADDR" =~ ^0x[0-9a-fA-F]{40}$ ]] \
+    || fail "could not extract destinationAddress from claimAsset calldata (got '$CLAIM_DEST_ADDR')"
+GI_DEC=$(cast to-dec "0x${GI_HEX}" 2>/dev/null || echo "")
+[[ -n "$GI_DEC" ]] || fail "could not convert global_index 0x${GI_HEX} to decimal"
+log "  recovered claim: dest=${CLAIM_DEST_ADDR} global_index(dec)=${GI_DEC}"
+
+DERIVED_HASH_LC=$(echo "$DERIVED_HASH" | tr '[:upper:]' '[:lower:]')
+
+# (a-pre) Snapshot how many times the (un-reset) proxy has ALREADY served this exact derived
+# hash — this includes the script's OWN step-5 eth_getTransactionByHash call. Gate (a2) below
+# requires the count to STRICTLY exceed this, so the script's own serve can never pass it.
+serve_count() {
+    docker logs --tail "$PROXY_LOG_TAIL" "$PROXY_CONTAINER" 2>&1 | strip_ansi \
+        | grep -iF 'served stored tx' | grep -icF "$DERIVED_HASH_LC" || true
+}
+SERVES_BEFORE=$(serve_count)
+log "  proxy has served the derived hash ${SERVES_BEFORE} time(s) pre-reset (incl. step-5's own probe)"
+
+step "6/6: RESET aggkit (force-recreate → empty bridgesync DB) and re-sync the claim"
+docker compose -f docker-compose.e2e.yml -f docker-compose.l2l2.yml --env-file fixtures/.env \
+    up -d --force-recreate --no-deps aggkit >/dev/null 2>&1 \
+    || docker compose -f docker-compose.e2e.yml --env-file fixtures/.env \
+        up -d --force-recreate --no-deps aggkit >/dev/null 2>&1 \
+    || fail "could not force-recreate $AGGKIT_CONTAINER to reset its bridgesync DB"
+sleep 5
+
+# (a) RESET proof: force-recreate wiped aggkit's bridgesync DB (/tmp, no volume), so its
+# L2BridgeSyncer MUST restart at lastProcessedBlock 0 — a stale cursor is impossible. We scan
+# with `--tail` (NOT `--since $host_timestamp`, a truncation trap — see docs/e2e log traps).
+wait_for "aggkit L2BridgeSyncer RESET to block 0 (force-recreate wiped its DB — no stale cursor)" \
+    "docker logs --tail $AGGKIT_LOG_TAIL $AGGKIT_CONTAINER 2>&1 | strip_ansi | grep 'lastProcessedBlock 0' | grep -q 'L2BridgeSyncer'" \
+    60 5
+
+# (a1) RE-PROCESS proof: from the reset, aggkit re-processes the EXACT claim block from
+# scratch (it re-parses the persisted derived-hash calldata there; the pre-fix build wedges
+# at this block on 'input too short' — gate (c)).
+wait_for "aggkit re-PROCESSED the exact claim block ${CLAIM_BLOCK} from the reset" \
+    "docker logs --tail $AGGKIT_LOG_TAIL $AGGKIT_CONTAINER 2>&1 | strip_ansi | grep -qE 'block ${CLAIM_BLOCK} processed'" \
+    "$AGGKIT_SYNC_TIMEOUT" 5
+pass "aggkit reset to block 0 and re-processed the exact claim block ${CLAIM_BLOCK} — no stale cursor"
+
+# (a2) EXACT-HASH FETCH — COUNT-DELTA (review blocker 2a): re-processing block ${CLAIM_BLOCK}
+# from the reset, aggkit MUST fetch THIS claim's calldata by its derived hash. The proxy logs
+# every stored tx it serves by exact hash. We already snapshotted SERVES_BEFORE (which
+# INCLUDES the script's own step-5 probe); require the count to STRICTLY INCREASE — a serve
+# that can ONLY have come from aggkit's post-reset re-fetch, never from the script itself.
+# Correlated with (a1): aggkit demonstrably re-processed the block, so the new serve is its.
+wait_for "proxy served the EXACT derived-hash claim tx to aggkit AFTER the reset (delta > ${SERVES_BEFORE})" \
+    "[ \"\$(serve_count)\" -gt \"$SERVES_BEFORE\" ]" \
+    "$AGGKIT_SYNC_TIMEOUT" 5
+SERVES_AFTER=$(serve_count)
+pass "proxy served the exact derived-hash claim ${SERVES_AFTER} time(s) (was ${SERVES_BEFORE}) — a NEW aggkit-driven fetch (${DERIVED_HASH_LC:0:18}…)"
+
+# (b) PERSIST — cursor floor (HARD, image-independent): bridgesync commits each block's rows
+# (including this claim) in ONE transaction and only THEN advances lastProcessedBlock, so
+# advancing PAST ${CLAIM_BLOCK} is itself proof the claim row was durably committed. The
+# pre-fix build wedges AT ${CLAIM_BLOCK} on 'input too short' and never advances.
+wait_for "aggkit L2BridgeSyncer re-processed PAST claim block ${CLAIM_BLOCK} (block committed)" \
+    "docker logs --tail $AGGKIT_LOG_TAIL $AGGKIT_CONTAINER 2>&1 | strip_ansi | grep -oE 'L2BridgeSyncer.*block[ =:]+[0-9]+' | grep -oE '[0-9]+$' | sort -n | tail -1 | awk '{exit !(\$1 > ${CLAIM_BLOCK})}'" \
+    "$AGGKIT_SYNC_TIMEOUT" 10
+
+# (b2) DURABLE CLAIM ROW — HARD, IMAGE-INDEPENDENT (review blocker 2b). The distroless aggkit
+# image has no sh/sqlite3, so a `docker exec sqlite3` probe silently skips — not a gate. We
+# instead read aggkit's OWN bridge-service REST index (plain HTTP), keyed to THIS claim's
+# EXACT global_index, and require the recovered claim to be present AND delivered
+# (claim_tx_hash set). The bridge-service reads from the same bridgesync DB aggkit just
+# re-populated from the reset, so a present+delivered row here is a durable persist of the
+# recovered claim. A reachable service that does NOT list the gi is a HARD FAIL — the
+# exact-hash fetch (a2) is already proven, so a missing persist would be a real bug.
+GI_IN_INDEX_PY=$(cat <<PYEOF
+import json,sys
+want=int("${GI_DEC}")
+try:
+    d=json.load(sys.stdin)
+except Exception:
+    sys.exit(2)
+for dep in d.get("deposits",[]):
+    gi=dep.get("global_index")
+    if gi is None:
+        continue
+    try:
+        gi_val=int(gi,0) if isinstance(gi,str) else int(gi)
+    except Exception:
+        continue
+    if gi_val==want:
+        cth=(dep.get("claim_tx_hash") or "")
+        # exit 0 = present+delivered; exit 3 = present but NOT yet delivered (keep waiting)
+        sys.exit(0 if cth not in ("","0x",None) else 3)
+sys.exit(1)  # gi not present yet
+PYEOF
+)
+# First require the service to be reachable at all (else we cannot make a hard claim).
+wait_for "aggkit bridge-service reachable at $BRIDGE_SERVICE_URL" \
+    "curl -sf '$BRIDGE_SERVICE_URL/bridges/$CLAIM_DEST_ADDR?limit=100' >/dev/null 2>&1" \
+    60 5
+wait_for "bridge-service durably lists the recovered claim (gi=${GI_DEC}) as DELIVERED (claim_tx_hash set)" \
+    "curl -sf '$BRIDGE_SERVICE_URL/bridges/$CLAIM_DEST_ADDR?limit=100' 2>/dev/null | python3 -c '$GI_IN_INDEX_PY'" \
+    "$AGGKIT_SYNC_TIMEOUT" 10
+pass "bridge-service durably persisted the recovered claim gi=${GI_DEC} with a claim_tx_hash — image-independent, exact-gi tie"
+
+# (c) ZERO calldata-parse failures — MEANINGFUL because aggkit genuinely re-parsed the block.
+if docker logs --tail "$AGGKIT_LOG_TAIL" "$AGGKIT_CONTAINER" 2>&1 | strip_ansi \
+    | grep -q "input too short"; then
+    fail "aggkit logged 'input too short' — a claim tx still serves unparsable calldata"
+fi
+pass "aggkit re-synced past block ${CLAIM_BLOCK} (claim persisted) with zero parse errors"
+
+# ── Step 6b: certificate settlement TIED to the recovered claim (review blocker 2c) ─────────
+# The prior version drove a NEW, unrelated bridge-out and asserted "a cert settled" — which
+# proves pipeline liveness but is NOT tied to the recovered claim. We now require a
+# certificate to reach Settled AFTER the reset AND, in the SAME post-reset window, the
+# recovered claim (by its EXACT global_index, gate b2) to be delivered — binding settlement
+# to THIS claim's imported exit rather than to an unrelated exit. Driving one L2→L1 bridge-out
+# supplies the fresh Local Exit Tree leaf a certificate needs to build (a ClaimEvent is an
+# IMPORTED exit, not itself a LET leaf), but the tie asserted is the recovered gi, not that
+# leaf.
+step "6b: certificate settles AND the recovered claim (gi=${GI_DEC}) is bound to that window"
+CERT_WINDOW_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+"$SCRIPT_DIR/e2e-l2-to-l1.sh" 2>&1 | strip_ansi | tail -5 \
+    | while IFS= read -r line; do echo "  [l2-to-l1] $line"; done
+[[ "${PIPESTATUS[0]}" -eq 0 ]] || fail "post-restore bridge-out (e2e-l2-to-l1.sh) failed"
+
+# NB: a settled cert line carries BOTH roots — a fresh chain's PreviousLocalExitRoot is
+# the empty-tree root, so a line-level `grep -v $EMPTY_LER` deletes the very line that
+# proves settlement. Extract the NEW root and test it alone (the 9ac5c0e lesson).
+EMPTY_LER="0x27ae5ba08d7291c96c8cbddcc148bf48a6d68c7974b94356f53754ef6171d757"
+wait_for "certificate settled with non-empty exit root (post-reset)" \
+    "docker logs --tail $AGGKIT_LOG_TAIL $AGGKIT_CONTAINER 2>&1 | strip_ansi | grep 'changed status.*Settled' | grep -oE 'NewLocalExitRoot: 0x[0-9a-fA-F]{64}' | grep -qv '$EMPTY_LER'" \
+    "$AGGKIT_SYNC_TIMEOUT" 10
+
+# The recovered claim must STILL be durably delivered (gi-keyed) after the full cert build —
+# i.e. the settlement window did not drop or wedge THIS claim. This is the tie: a settled
+# certificate coexists with the recovered claim's durable, delivered presence by exact gi.
+curl -sf "$BRIDGE_SERVICE_URL/bridges/$CLAIM_DEST_ADDR?limit=100" 2>/dev/null \
+    | python3 -c "$GI_IN_INDEX_PY" \
+    || fail "recovered claim gi=${GI_DEC} not delivered in bridge-service after cert settlement — settlement not tied to the recovered claim"
+
+# The wedge signature must STILL be absent after the full cert build consumed the claim window.
+if docker logs --tail "$AGGKIT_LOG_TAIL" "$AGGKIT_CONTAINER" 2>&1 | strip_ansi \
+    | grep -q "input too short"; then
+    fail "aggkit logged 'input too short' during certificate build"
+fi
+pass "certificate settled (non-empty NewLocalExitRoot) with the recovered claim gi=${GI_DEC} bound and delivered — pipeline unwedged through THIS claim's window"
+
+log "======================================================================"
+log "  PASS: synthesized claim serves authoritative full calldata;"
+log "        aggkit resets, re-fetches THIS derived hash, persists gi=${GI_DEC},"
+log "        syncs past block ${CLAIM_BLOCK}, and a cert settles bound to it."
+log "======================================================================"

--- a/src/claim_watcher.rs
+++ b/src/claim_watcher.rs
@@ -25,11 +25,11 @@ use sha3::{Digest, Keccak256};
 // `miden-agglayer-0.14.5/src/claim_note.rs::{ProofData, LeafData}::to_elements`.
 //
 // ProofData (536 felts):
-//   [0..256)   smt_proof_local_exit_root   (32 nodes × 8 felts; unused here)
-//   [256..512) smt_proof_rollup_exit_root  (32 nodes × 8 felts; unused here)
+//   [0..256)   smt_proof_local_exit_root   (32 nodes × 8 felts; full decode only)
+//   [256..512) smt_proof_rollup_exit_root  (32 nodes × 8 felts; full decode only)
 //   [512..520) global_index                (8 felts, packed-u32-LE for 32 BE bytes)
-//   [520..528) mainnet_exit_root           (unused here)
-//   [528..536) rollup_exit_root            (unused here)
+//   [520..528) mainnet_exit_root           (full decode only)
+//   [528..536) rollup_exit_root            (full decode only)
 //
 // LeafData (32 felts, starting at offset 536):
 //   [536]      leaf_type                   (always Felt::ZERO)
@@ -38,16 +38,22 @@ use sha3::{Digest, Keccak256};
 //   [543]      destination_network         (1 felt, byte-swapped u32)
 //   [544..549) destination_address         (5 felts, packed-u32-LE for 20 BE bytes)
 //   [549..557) amount                      (8 felts, packed-u32-LE for 32 BE bytes — U256)
-//   [557..565) metadata_hash               (unused here)
+//   [557..565) metadata_hash               (full decode only)
 //   [565..568) padding                     (always Felt::ZERO ×3)
 //
 //   [568]      miden_claim_amount          (unused here; not part of ClaimEvent)
 
+const OFFSET_SMT_PROOF_LOCAL: usize = 0;
+const OFFSET_SMT_PROOF_ROLLUP: usize = 256;
 const OFFSET_GLOBAL_INDEX: usize = 512;
+const OFFSET_MAINNET_EXIT_ROOT: usize = 520;
+const OFFSET_ROLLUP_EXIT_ROOT: usize = 528;
 const OFFSET_ORIGIN_NETWORK: usize = 537;
 const OFFSET_ORIGIN_ADDRESS: usize = 538;
+const OFFSET_DESTINATION_NETWORK: usize = 543;
 const OFFSET_DESTINATION_ADDRESS: usize = 544;
 const OFFSET_AMOUNT: usize = 549;
+const OFFSET_METADATA_HASH: usize = 557;
 const MIN_FELT_COUNT: usize = 569;
 
 /// Fields extracted from a consumed CLAIM note's storage that are needed to
@@ -64,6 +70,40 @@ pub struct DecodedClaim {
     /// fits u64 (max ETH supply ≈ 2^57 wei) — we surface overflows as a metric
     /// and refuse to emit, rather than silently truncating.
     pub amount: u64,
+}
+
+/// The COMPLETE original `claimAsset` inputs recovered from a consumed CLAIM note's
+/// on-chain storage — every calldata field except the `metadata` byte-string, whose
+/// preimage is not in the note (only its keccak256, `metadata_hash`) and is resolved
+/// separately from the faucet registry.
+///
+/// The proxy BUILT the CLAIM note from exactly these fields
+/// (`claim::publish_claim` → `ClaimNoteStorage { ProofData, LeafData }`), and the
+/// on-chain bridge MASM verified the claim against them — so this decode is the
+/// authoritative claim truth, NOT a fabrication. aggkit v0.8.3's bridgesync
+/// full-claim parser persists all of it (both SMT proofs, both exit roots, networks,
+/// addresses, amount, metadata) and derives the claim's GER from the two exit roots,
+/// so a synthesized claim tx must serve these values verbatim.
+///
+/// Note the values are the CANONICALIZED forms the proxy verified on-chain
+/// (`claim::build_canonical_proof_data`): for a mainnet-flagged global index the
+/// rollup SMT proof is all-zero and the gi rollup-index bytes are zeroed — that is
+/// what was actually proven, hence what must be served.
+#[derive(Debug, Clone)]
+pub struct DecodedFullClaim {
+    pub smt_proof_local_exit_root: [[u8; 32]; 32],
+    pub smt_proof_rollup_exit_root: [[u8; 32]; 32],
+    pub global_index: [u8; 32],
+    pub mainnet_exit_root: [u8; 32],
+    pub rollup_exit_root: [u8; 32],
+    pub origin_network: u32,
+    pub origin_address: [u8; 20],
+    pub destination_network: u32,
+    pub destination_address: [u8; 20],
+    /// Full U256 big-endian amount — calldata is `uint256`, so no u64 clamp here
+    /// (unlike [`DecodedClaim::amount`], which feeds the u64-typed event store).
+    pub amount: [u8; 32],
+    pub metadata_hash: [u8; 32],
 }
 
 // PARSING
@@ -152,6 +192,56 @@ pub fn parse_claim_event_from_storage(storage: &NoteStorage) -> anyhow::Result<D
         origin_address,
         destination_address,
         amount,
+    })
+}
+
+/// Decode the COMPLETE `ClaimNoteStorage` — every original `claimAsset` field except the
+/// metadata preimage (see [`DecodedFullClaim`]). Same layout pin and error posture as
+/// [`parse_claim_event_from_storage`]; additionally recovers both 32-node SMT proofs, both
+/// exit roots, the destination network, the full U256 amount and the metadata hash.
+pub fn parse_full_claim_from_storage(storage: &NoteStorage) -> anyhow::Result<DecodedFullClaim> {
+    let items = storage.items();
+    if items.len() < MIN_FELT_COUNT {
+        anyhow::bail!(
+            "CLAIM storage too short: expected ≥{MIN_FELT_COUNT} felts, got {}",
+            items.len()
+        );
+    }
+
+    // Each SMT node is one Keccak256Output = 8 packed-u32 felts for 32 bytes
+    // (`Keccak256Output::to_elements` = `bytes_to_packed_u32_elements`) — the same
+    // encoding `unpack_u32_felts` inverts everywhere else in this decoder.
+    let mut smt_proof_local_exit_root = [[0u8; 32]; 32];
+    let mut smt_proof_rollup_exit_root = [[0u8; 32]; 32];
+    for i in 0..32 {
+        let local_at = OFFSET_SMT_PROOF_LOCAL + i * 8;
+        smt_proof_local_exit_root[i] = unpack_u32_felts::<32>(&items[local_at..local_at + 8])?;
+        let rollup_at = OFFSET_SMT_PROOF_ROLLUP + i * 8;
+        smt_proof_rollup_exit_root[i] = unpack_u32_felts::<32>(&items[rollup_at..rollup_at + 8])?;
+    }
+
+    Ok(DecodedFullClaim {
+        smt_proof_local_exit_root,
+        smt_proof_rollup_exit_root,
+        global_index: unpack_u32_felts::<32>(&items[OFFSET_GLOBAL_INDEX..OFFSET_GLOBAL_INDEX + 8])?,
+        mainnet_exit_root: unpack_u32_felts::<32>(
+            &items[OFFSET_MAINNET_EXIT_ROOT..OFFSET_MAINNET_EXIT_ROOT + 8],
+        )?,
+        rollup_exit_root: unpack_u32_felts::<32>(
+            &items[OFFSET_ROLLUP_EXIT_ROOT..OFFSET_ROLLUP_EXIT_ROOT + 8],
+        )?,
+        origin_network: decode_swapped_u32(items[OFFSET_ORIGIN_NETWORK])?,
+        origin_address: unpack_u32_felts::<20>(
+            &items[OFFSET_ORIGIN_ADDRESS..OFFSET_ORIGIN_ADDRESS + 5],
+        )?,
+        destination_network: decode_swapped_u32(items[OFFSET_DESTINATION_NETWORK])?,
+        destination_address: unpack_u32_felts::<20>(
+            &items[OFFSET_DESTINATION_ADDRESS..OFFSET_DESTINATION_ADDRESS + 5],
+        )?,
+        amount: unpack_u32_felts::<32>(&items[OFFSET_AMOUNT..OFFSET_AMOUNT + 8])?,
+        metadata_hash: unpack_u32_felts::<32>(
+            &items[OFFSET_METADATA_HASH..OFFSET_METADATA_HASH + 8],
+        )?,
     })
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -272,6 +272,49 @@ pub fn init_metrics() {
          (crash recovery or foreign-CLAIM observation)."
     );
     describe_counter!(
+        "restore_b2agg_same_details_multiplicity_quarantined_total",
+        "restore FAIL-CLOSED: B2AGG exits quarantined because the authoritative feed shows ≥2 \
+         distinct on-chain consumptions sharing a details_commitment that the commitment-keyed \
+         client store cannot disambiguate — quarantined rather than emit a wrong/collapsed \
+         BridgeEvent (review). MUST be rare; each is an operator-recoverable exit."
+    );
+    describe_counter!(
+        "synthetic_claim_calldata_finalized_pending_total",
+        "synthesized-claim calldata rows found PENDING (txn_begin ran, txn_commit did not — a \
+         crash between them) and finalized by a later persist pass, rather than being stranded \
+         pending forever (review blocker 3)."
+    );
+    describe_counter!(
+        "restore_b2agg_authoritative_attributed_total",
+        "restore Phase 2 (task #56): consumed B2AGG notes whose consumer the LOCAL store did \
+         not know (consumer_account=None — NTX-consumed, the normal bridge path, observed \
+         after a store rebuild) but that the bridge's on-chain sync_transactions feed \
+         authoritatively attributes to the bridge — rebuilt and re-projected instead of \
+         fail-closed skipped. Without this, restore ERASED already-settled BridgeEvents \
+         (getLogs-immutability break) and halted aggkit's L2BridgeSyncer."
+    );
+    describe_counter!(
+        "synthetic_claim_calldata_persisted_total",
+        "synthesized (derived-hash) claims whose FULL authoritative claimAsset calldata was \
+         recovered (CLAIM note storage: both SMT proofs, both exit roots, networks, addresses, \
+         amount; faucet registry: hash-verified metadata preimage) and persisted under the \
+         derived tx hash for eth_getTransactionByHash / aggkit's full-claim parser."
+    );
+    describe_counter!(
+        "synthetic_claim_calldata_unrecoverable_total",
+        "synthesized claims whose metadata preimage could NOT be recovered authoritatively \
+         (no registry entry hashing to the note's metadata_hash) — calldata deliberately NOT \
+         fabricated; the tx keeps an empty input and aggkit will stall on it. Operator action: \
+         register/repair the faucet metadata; the per-tick backfill then self-heals. MUST stay \
+         0 in a healthy stack."
+    );
+    describe_counter!(
+        "synthetic_claim_tx_missing_calldata_total",
+        "ClaimEvent-bearing synthetic txs served with EMPTY input by eth_getTransactionByHash \
+         (no persisted calldata record — unrecoverable, or the backfill has not caught up). \
+         Every increment stalls aggkit on that claim; must stay 0 in steady state."
+    );
+    describe_counter!(
         "claim_event_foreign_skipped_total",
         "A consumed CLAIM-shaped note was NOT provably ours (consumer is not \
          our bridge, and it was not minted by our service targeting our \

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -1331,10 +1331,7 @@ pub(crate) async fn persist_synthetic_claim_tx(
     block_number: u64,
     block_hash: [u8; 32],
 ) -> anyhow::Result<bool> {
-    use alloy::consensus::{Signed, TxEnvelope, TxLegacy};
-    use alloy::primitives::{Address, Signature, TxHash, TxKind, U256};
-
-    let tx_hash: TxHash = tx_hash_str
+    let tx_hash: alloy::primitives::TxHash = tx_hash_str
         .parse()
         .map_err(|e| anyhow::anyhow!("derived claim tx hash {tx_hash_str}: {e}"))?;
     // Idempotent AND crash-safe (review blocker 3): synthesis re-runs (restore replay,
@@ -1363,50 +1360,11 @@ pub(crate) async fn persist_synthetic_claim_tx(
         None => {}
     }
 
-    let full = parse_full_claim_from_storage(note_storage)?;
-    let Some(metadata) = resolve_claim_metadata(
-        store,
-        full.origin_network,
-        &full.origin_address,
-        &full.metadata_hash,
-    )
-    .await?
+    let Some((envelope, bridge_addr, calldata_bytes)) =
+        build_synthetic_claim_envelope(store, note_storage, note_id_str, tx_hash).await?
     else {
-        ::metrics::counter!("synthetic_claim_calldata_unrecoverable_total").increment(1);
-        tracing::error!(
-            note_id = %note_id_str,
-            tx_hash = %tx_hash_str,
-            origin_network = full.origin_network,
-            origin_address = %hex::encode(full.origin_address),
-            metadata_hash = %hex::encode(full.metadata_hash),
-            "synthesized claim: metadata preimage NOT recoverable from the faucet registry — \
-             refusing to fabricate calldata; the tx keeps an empty input (aggkit will surface \
-             this claim as unparsable — operator action: register/repair the faucet metadata, \
-             the backfill then heals on the next tick)"
-        );
         return Ok(false);
     };
-
-    let call = build_claim_asset_call(&full, metadata);
-    let input = alloy_core::sol_types::SolCall::abi_encode(&call);
-    let calldata_bytes = input.len();
-    let bridge_addr: Address = get_bridge_address()
-        .parse()
-        .map_err(|e| anyhow::anyhow!("bridge address: {e}"))?;
-    let tx = TxLegacy {
-        chain_id: None,
-        nonce: 0,
-        gas_price: 0,
-        gas_limit: 0,
-        to: TxKind::Call(bridge_addr),
-        value: U256::ZERO,
-        input: input.into(),
-    };
-    // Placeholder signature (v=27, r=1, s=1) matching the synthetic-tx wire shape —
-    // consumers (aggkit) parse the calldata, they don't verify signatures. The envelope is
-    // sealed with the DERIVED hash so every read path reports the hash the ClaimEvent rides.
-    let signature = Signature::new(U256::from(1), U256::from(1), false);
-    let envelope = TxEnvelope::Legacy(Signed::new_unchecked(tx, signature, tx_hash));
     store
         .txn_begin(
             tx_hash,
@@ -1432,8 +1390,140 @@ pub(crate) async fn persist_synthetic_claim_tx(
         block_number,
         calldata_bytes,
         "synthesized claim: persisted authoritative full claimAsset calldata under the \
-         derived tx hash"
+         derived tx hash (backfill path — the block is already sealed)"
     );
+    Ok(true)
+}
+
+/// Reconstruct the authoritative full `claimAsset` transaction envelope for a consumed
+/// CLAIM note from its on-chain storage + the faucet registry, sealed under `tx_hash`.
+///
+/// Returns `Ok(None)` when the faucet metadata preimage is unrecoverable — the caller then
+/// leaves the envelope absent (the serve path keeps an empty input and alarms; the operator
+/// registers/repairs the faucet, and the projector backfill heals on the next tick). This is
+/// the single reconstruction shared by the backfill ([`persist_synthetic_claim_tx`]) and the
+/// projection ([`insert_pending_claim_calldata`]) paths so both emit byte-identical calldata.
+async fn build_synthetic_claim_envelope(
+    store: &Arc<dyn Store>,
+    note_storage: &miden_protocol::note::NoteStorage,
+    note_id_str: &str,
+    tx_hash: alloy::primitives::TxHash,
+) -> anyhow::Result<
+    Option<(
+        alloy::consensus::TxEnvelope,
+        alloy::primitives::Address,
+        usize,
+    )>,
+> {
+    use alloy::consensus::{Signed, TxEnvelope, TxLegacy};
+    use alloy::primitives::{Address, Signature, TxKind, U256};
+
+    let full = parse_full_claim_from_storage(note_storage)?;
+    let Some(metadata) = resolve_claim_metadata(
+        store,
+        full.origin_network,
+        &full.origin_address,
+        &full.metadata_hash,
+    )
+    .await?
+    else {
+        ::metrics::counter!("synthetic_claim_calldata_unrecoverable_total").increment(1);
+        tracing::error!(
+            note_id = %note_id_str,
+            tx_hash = %tx_hash,
+            origin_network = full.origin_network,
+            origin_address = %hex::encode(full.origin_address),
+            metadata_hash = %hex::encode(full.metadata_hash),
+            "synthesized claim: metadata preimage NOT recoverable from the faucet registry — \
+             refusing to fabricate calldata; the tx keeps an empty input (aggkit will surface \
+             this claim as unparsable — operator action: register/repair the faucet metadata, \
+             the backfill then heals on the next tick)"
+        );
+        return Ok(None);
+    };
+
+    let call = build_claim_asset_call(&full, metadata);
+    let input = alloy_core::sol_types::SolCall::abi_encode(&call);
+    let calldata_bytes = input.len();
+    let bridge_addr: Address = get_bridge_address()
+        .parse()
+        .map_err(|e| anyhow::anyhow!("bridge address: {e}"))?;
+    let tx = TxLegacy {
+        chain_id: None,
+        nonce: 0,
+        gas_price: 0,
+        gas_limit: 0,
+        to: TxKind::Call(bridge_addr),
+        value: U256::ZERO,
+        input: input.into(),
+    };
+    // Placeholder signature (v=27, r=1, s=1) matching the synthetic-tx wire shape —
+    // consumers (aggkit) parse the calldata, they don't verify signatures. The envelope is
+    // sealed with `tx_hash` so every read path reports the hash the ClaimEvent rides.
+    let signature = Signature::new(U256::from(1), U256::from(1), false);
+    let envelope = TxEnvelope::Legacy(Signed::new_unchecked(tx, signature, tx_hash));
+    Ok(Some((envelope, bridge_addr, calldata_bytes)))
+}
+
+/// Reconstruct + durably insert the full `claimAsset` calldata as a **PENDING** transaction
+/// under `tx_hash_str`, idempotently (a no-op when any row — pending or committed — already
+/// exists). The pending receipt is finalised — **without sealing the block** — by
+/// [`Store::commit_manual_claim_event_atomic`], so `project_block_notes` stays the SOLE
+/// advancer of `latest_block_number` (at end-of-block).
+///
+/// This is the projection-path counterpart of [`persist_synthetic_claim_tx`] (the
+/// after-the-fact backfill, which commits-with-seal because its block is already sealed).
+/// One idempotent primitive covers every case the projector meets:
+///   * derived-hash synthesis (no real eth-tx) — no prior row → insert reconstructed;
+///   * linked hash, normal — `publish_claim` already inserted the real pending row → no-op
+///     (the real envelope wins, and the atomic finalises it);
+///   * linked hash, **crash window** — the note→hash link survived but the envelope did NOT
+///     (crash before persisting it): reconstruct here rather than emit a ClaimEvent that
+///     points at empty calldata, which the derived-hash-only backfill would never repair.
+///
+/// Returns `Ok(false)` iff the faucet metadata preimage is unrecoverable (envelope left
+/// absent; the projector backfill heals once the faucet is registered).
+pub(crate) async fn insert_pending_claim_calldata(
+    store: &Arc<dyn Store>,
+    note_storage: &miden_protocol::note::NoteStorage,
+    note_id_str: &str,
+    tx_hash_str: &str,
+) -> anyhow::Result<bool> {
+    let tx_hash: alloy::primitives::TxHash = tx_hash_str
+        .parse()
+        .map_err(|e| anyhow::anyhow!("claim tx hash {tx_hash_str}: {e}"))?;
+    if store.txn_get(tx_hash).await?.is_some() {
+        return Ok(true);
+    }
+    let Some((envelope, bridge_addr, calldata_bytes)) =
+        build_synthetic_claim_envelope(store, note_storage, note_id_str, tx_hash).await?
+    else {
+        return Ok(false);
+    };
+    let inserted = store
+        .txn_begin_if_absent(
+            tx_hash,
+            crate::store::TxnEntry {
+                id: None,
+                envelope,
+                signer: bridge_addr,
+                expires_at: None,
+                // MUST stay empty: the ClaimEvent log is emitted by
+                // `commit_manual_claim_event_atomic`; a copy here would double-emit it.
+                logs: Vec::new(),
+            },
+        )
+        .await?;
+    if inserted {
+        ::metrics::counter!("synthetic_claim_calldata_persisted_total").increment(1);
+        tracing::info!(
+            note_id = %note_id_str,
+            tx_hash = %tx_hash_str,
+            calldata_bytes,
+            "synthesized claim: inserted authoritative full claimAsset calldata as a PENDING \
+             tx (finalised by the atomic ClaimEvent commit, never a mid-block seal)"
+        );
+    }
     Ok(true)
 }
 
@@ -1575,16 +1665,39 @@ pub(crate) async fn project_claim_note(
     // aggkit fails "input too short: 0 bytes" and never settles the certificate.
     // Fall back to the derived hash only for notes with no recorded link (e.g.
     // restore replaying history predating the link, or notes submitted out-of-band).
-    // `linked` = the tx hash came from a REAL recorded link (observed handoff or
-    // stored note→tx), not the derived fallback. A real hash → finalise its pending
-    // receipt; the derived fallback → persist the recovered full claimAsset calldata.
-    let (tx_hash, linked) = match observed_tx_hash {
-        Some(real_tx) => (real_tx, true),
+    let tx_hash = match observed_tx_hash {
+        Some(real_tx) => real_tx,
         None => match store.get_tx_for_note(&note_id_str).await? {
-            Some(real_tx) => (real_tx, true),
-            None => (derive_manual_claim_tx_hash(&note_id_str), false),
+            Some(real_tx) => real_tx,
+            None => derive_manual_claim_tx_hash(&note_id_str),
         },
     };
+
+    // Write-before-seal: reconstruct + durably insert the full claimAsset calldata as a
+    // PENDING tx under `tx_hash` BEFORE the atomic, so `commit_manual_claim_event_atomic`
+    // finalises the envelope's receipt TOGETHER with the ClaimEvent — at THIS consumption
+    // block (receipt block == log block) and WITHOUT advancing the tip. This mirrors the
+    // GER path (`project_ger_note`), which likewise finalises inside its atomic and never
+    // calls `txn_commit`. `insert_pending_claim_calldata` is idempotent: a no-op when the
+    // row already exists (the normal linked case — `publish_claim` durably inserted the real
+    // envelope), a reconstruct when it is ABSENT — either derived-hash synthesis (no real
+    // eth-tx), OR the crash window where the note→hash link survived but the envelope did
+    // NOT (which the derived-hash-only backfill would never repair, so the ClaimEvent would
+    // otherwise ride a hash with empty calldata forever). Best-effort: unrecoverable faucet
+    // metadata leaves the envelope absent (empty calldata; operator registers the faucet,
+    // backfill heals) — non-fatal, the ClaimEvent still commits below.
+    if let Err(e) =
+        insert_pending_claim_calldata(store, details.storage(), &note_id_str, &tx_hash).await
+    {
+        tracing::warn!(
+            target: "restore::claims",
+            note_id = %note_id_str,
+            tx_hash = %tx_hash,
+            error = %format!("{e:#}"),
+            "synthesised claim: calldata pre-insert failed (transient — the projector \
+             backfill retries next tick)"
+        );
+    }
 
     store
         .commit_manual_claim_event_atomic(
@@ -1600,50 +1713,15 @@ pub(crate) async fn project_claim_note(
             decoded.amount,
         )
         .await?;
-
-    // The projector OWNS receipt completion: finalise the real claim tx's receipt
-    // at THIS (consumption) block — the same block the ClaimEvent is emitted — so the
-    // receipt block == the log block. `publish_claim` left it pending (`id: None`) for
-    // exactly this. Tolerate a missing pending entry (derived-hash fallback, which has
-    // no real `txn_begin`; or an expired/pruned tx, or restore predating the tx
-    // record): the receipt is then synthesised from the log by `service_get_txn_receipt`,
-    // so a missing entry must not abort the projection.
-    if let Some(h) = linked
-        .then(|| tx_hash.parse::<alloy::primitives::TxHash>().ok())
-        .flatten()
-    {
-        let _ = store
-            .txn_commit(h, Ok(()), block_number, block_hash)
-            .await
-            .inspect_err(|e| {
-                tracing::debug!(tx = %tx_hash, "claim receipt not finalised: {e}");
-            });
-    } else {
-        // DERIVED-hash synthesis (no real eth-tx): persist the recovered FULL claimAsset
-        // calldata under the derived hash so aggkit's full-claim parser gets the truthful
-        // claim (both SMT proofs, both exit roots, networks, addresses, amount, hash-verified
-        // metadata) from `eth_getTransactionByHash`. Non-fatal on failure — the ClaimEvent is
-        // already committed; the projector's per-tick backfill retries until it persists.
-        if let Err(e) = persist_synthetic_claim_tx(
-            store,
-            details.storage(),
-            &note_id_str,
-            &tx_hash,
-            block_number,
-            block_hash,
-        )
-        .await
-        {
-            tracing::warn!(
-                target: "restore::claims",
-                note_id = %note_id_str,
-                tx_hash = %tx_hash,
-                error = %format!("{e:#}"),
-                "synthesised claim: calldata persistence failed (transient — the projector \
-                 backfill retries next tick)"
-            );
-        }
-    }
+    // `commit_manual_claim_event_atomic` emits the ClaimEvent AND finalises the pending
+    // envelope's receipt inline (a derived hash with no pending row is a harmless no-op —
+    // the receipt is then synthesised from the log by `service_get_txn_receipt`), all
+    // WITHOUT advancing `latest_block_number`. Deliberately NO `txn_commit` here: it would
+    // duplicate that finalise and, on Postgres, seal block N mid-loop — before this block's
+    // later B2AGG/GER/Claim notes are written — so aggkit could scan a partial block N,
+    // advance its cursor, and permanently miss the later logs. `project_block_notes` is the
+    // SOLE advancer of the tip, at end-of-block (the projector's write-before-advance
+    // invariant).
 
     ::metrics::counter!("claim_watcher_synthesised_total").increment(1);
     tracing::info!(
@@ -3851,6 +3929,127 @@ mod tests {
             data.envelope.input().len() > 4 + 64 * 32,
             "full calldata (proofs included), not a stub"
         );
+    }
+
+    /// Reviewer concern #1 — the ambiguous crash window: the note→ETH-tx-hash LINK was
+    /// durably recorded and the claim was submitted + consumed on Miden, but the proxy
+    /// crashed BEFORE persisting the ETH tx envelope. Recovery sees the surviving link (so
+    /// `tx_hash` is the REAL hash), and PRE-FIX it emitted a ClaimEvent under that hash while
+    /// the transaction row was absent — `eth_getTransactionByHash` then returned EMPTY
+    /// calldata, and the derived-hash-only backfill never repairs a real-hash event, so
+    /// aggkit's full-claim parser wedges forever. POST-FIX `project_claim_note` reconstructs
+    /// the full claimAsset calldata under the linked hash (pending) BEFORE the atomic, which
+    /// finalises it — so the served tx carries the truthful calldata, not the empty-wedge.
+    #[tokio::test]
+    async fn project_claim_note_reconstructs_calldata_for_linked_hash_missing_envelope() {
+        use alloy::consensus::Transaction;
+        use alloy_core::sol_types::SolCall;
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        // Empty metadata → truthful by hash → reconstructable with no registry entry.
+        let note = claim_input_note(Some(id(TEST_TARGET_BRIDGE)), 0x91);
+        let note_id = hex::encode(note.details_commitment().as_bytes());
+
+        // The crash window: the note→hash LINK survived, the envelope did NOT.
+        let real_hash = "0x1111111111111111111111111111111111111111111111111111111111111111";
+        store
+            .record_tx_note_link(real_hash, &note_id)
+            .await
+            .unwrap();
+        assert!(
+            store
+                .txn_get(real_hash.parse().unwrap())
+                .await
+                .unwrap()
+                .is_none(),
+            "precondition: the linked envelope is absent (crash before persisting it)"
+        );
+
+        let outcome = project_claim_note(
+            &store,
+            &note,
+            &std::collections::HashMap::new(),
+            id(TEST_SENDER_MANAGER),
+            id(TEST_TARGET_BRIDGE),
+            8831,
+            [0xAA; 32],
+            get_bridge_address(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outcome, ClaimProjectOutcome::Emitted);
+
+        // The ClaimEvent rides the REAL linked hash …
+        assert!(
+            !store.get_logs_for_tx(real_hash).await.unwrap().is_empty(),
+            "the ClaimEvent must ride the real linked hash"
+        );
+        // … and that hash now serves the FULL claimAsset calldata, finalised at the block.
+        let data = store
+            .txn_get(real_hash.parse().unwrap())
+            .await
+            .unwrap()
+            .expect("the linked envelope was reconstructed, not left absent (concern #1)");
+        assert!(
+            crate::claim::claimAssetCall::abi_decode(data.envelope.input()).is_ok(),
+            "the served input is the full claimAsset calldata, not the empty-calldata wedge"
+        );
+        assert!(
+            data.envelope.input().len() > 4 + 64 * 32,
+            "full calldata (both SMT proofs included), not a stub"
+        );
+        let (res, blk) = store
+            .txn_receipt(real_hash.parse().unwrap())
+            .await
+            .unwrap()
+            .expect("the linked receipt is finalised together with the ClaimEvent");
+        assert!(res.is_ok());
+        assert_eq!(blk, 8831, "receipt block == ClaimEvent block");
+    }
+
+    /// Reviewer concern #2 (building block) — `insert_pending_claim_calldata` inserts the
+    /// calldata as a PENDING tx (no receipt, no block seal); finalisation is the atomic's
+    /// job. PRE-FIX the projection path used `persist_synthetic_claim_tx`, which COMMITS
+    /// (and, on Postgres, folds a `latest_block_number` advance — sealing the block mid-loop,
+    /// before its later notes are written). The seal itself is Postgres-only (asserted in
+    /// `store::postgres_tests`); here we pin the in-memory-observable half: the insert leaves
+    /// the tx PENDING and is idempotent.
+    #[tokio::test]
+    async fn insert_pending_claim_calldata_leaves_tx_pending_and_is_idempotent() {
+        use alloy::consensus::Transaction;
+        use alloy_core::sol_types::SolCall;
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let storage = full_claim_fixture(&[]);
+        let note_id = "pending-insert";
+        let derived = derive_manual_claim_tx_hash(note_id);
+        let tx_hash: alloy::primitives::TxHash = derived.parse().unwrap();
+
+        assert!(
+            insert_pending_claim_calldata(&store, &storage, note_id, &derived)
+                .await
+                .unwrap()
+        );
+        // Full calldata is present …
+        let data = store
+            .txn_get(tx_hash)
+            .await
+            .unwrap()
+            .expect("calldata inserted");
+        assert!(
+            crate::claim::claimAssetCall::abi_decode(data.envelope.input()).is_ok(),
+            "the pending row carries the full claimAsset calldata"
+        );
+        // … but the tx is PENDING — NOT committed/sealed (that is the atomic's job).
+        assert!(
+            store.txn_receipt(tx_hash).await.unwrap().is_none(),
+            "insert_pending must NOT finalise/seal — no receipt until the atomic commits"
+        );
+        // Idempotent no-op on a second call (row already present).
+        assert!(
+            insert_pending_claim_calldata(&store, &storage, note_id, &derived)
+                .await
+                .unwrap()
+        );
+        assert!(store.txn_get(tx_hash).await.unwrap().is_some());
     }
 
     /// Test-local mirror of the eth envelope aggkit signs for

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -40,7 +40,10 @@ use crate::bridge_out::{
     B2AggConsumerClass, classify_b2agg_consumer, is_b2agg_note, parse_b2agg_storage,
     resolve_faucet_origin,
 };
-use crate::claim_watcher::{derive_manual_claim_tx_hash, parse_claim_event_from_storage};
+use crate::claim_watcher::{
+    DecodedFullClaim, derive_manual_claim_tx_hash, parse_claim_event_from_storage,
+    parse_full_claim_from_storage,
+};
 use crate::metadata_recovery::{EmitMetadata, METADATA_UNRECOVERABLE_METRIC};
 use crate::miden_client::{
     MidenClient, MidenClientLib, ensure_complete_note_response, ordered_account_transactions,
@@ -814,6 +817,7 @@ async fn restore_faucet_identities(
     Ok(n)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn restore_bridge_outs(
     store: &Arc<dyn Store>,
     miden_client: &MidenClient,
@@ -1243,6 +1247,196 @@ pub(crate) async fn project_b2agg_note(
     Ok(B2AggRestoreOutcome::Emitted)
 }
 
+/// Rebuild the original `claimAsset` call from the full note-storage decode plus the
+/// hash-verified metadata preimage. Every field is the authoritative value the proxy
+/// built (and the on-chain bridge verified) the claim with — nothing is fabricated.
+pub(crate) fn build_claim_asset_call(
+    full: &DecodedFullClaim,
+    metadata: Vec<u8>,
+) -> crate::claim::claimAssetCall {
+    use alloy::primitives::{Address, FixedBytes, U256};
+    let node = |b: &[u8; 32]| FixedBytes::<32>::from(*b);
+    crate::claim::claimAssetCall {
+        smtProofLocalExitRoot: std::array::from_fn(|i| node(&full.smt_proof_local_exit_root[i])),
+        smtProofRollupExitRoot: std::array::from_fn(|i| node(&full.smt_proof_rollup_exit_root[i])),
+        globalIndex: U256::from_be_bytes(full.global_index),
+        mainnetExitRoot: node(&full.mainnet_exit_root),
+        rollupExitRoot: node(&full.rollup_exit_root),
+        originNetwork: full.origin_network,
+        originTokenAddress: Address::from(full.origin_address),
+        destinationNetwork: full.destination_network,
+        destinationAddress: Address::from(full.destination_address),
+        amount: U256::from_be_bytes(full.amount),
+        metadata: metadata.into(),
+    }
+}
+
+/// Resolve the `metadata` byte-string of a claim from an AUTHORITATIVE source, verified
+/// against the CLAIM note's `metadata_hash` (`keccak256(metadata)`).
+///
+///   * hash-of-empty → the claim carried no metadata (native ETH and any pre-deployed
+///     wrapped token) — the empty preimage is truthful by the hash;
+///   * otherwise → the faucet registry: `FaucetEntry.metadata` is the exact ABI-encoded
+///     preimage the claim was published with (`publish_claim` registers the faucet with
+///     `MetadataHash::from_abi_encoded(params.metadata)` — same bytes), accepted only if
+///     its keccak256 equals the note's hash;
+///   * no verifiable preimage → `None`. The caller must NOT manufacture metadata — a
+///     parseable-but-false claim record is worse than an alarmed unrecoverable one.
+pub(crate) async fn resolve_claim_metadata(
+    store: &Arc<dyn Store>,
+    origin_network: u32,
+    origin_address: &[u8; 20],
+    metadata_hash: &[u8; 32],
+) -> anyhow::Result<Option<Vec<u8>>> {
+    let empty_hash: [u8; 32] = Keccak256::digest([]).into();
+    if metadata_hash == &empty_hash {
+        return Ok(Some(Vec::new()));
+    }
+    if let Some(faucet) = store
+        .get_faucet_by_origin(origin_address, origin_network)
+        .await?
+    {
+        let hash: [u8; 32] = Keccak256::digest(&faucet.metadata).into();
+        if &hash == metadata_hash {
+            return Ok(Some(faucet.metadata));
+        }
+        tracing::warn!(
+            origin_network,
+            origin_address = %hex::encode(origin_address),
+            "claim metadata recovery: registry preimage does not hash to the note's \
+             metadata_hash — refusing to serve it"
+        );
+    }
+    Ok(None)
+}
+
+/// PERSIST the recovered full `claimAsset` calldata for a SYNTHESIZED claim, keyed by its
+/// derived tx hash, so `eth_getTransactionByHash` / `debug_traceTransaction` serve the same
+/// truthful claim across restarts (the stored-envelope path precedes every synthetic
+/// fallback). Returns `Ok(true)` when the tx record exists (persisted now or previously),
+/// `Ok(false)` when the metadata preimage could not be recovered authoritatively — the tx
+/// then deliberately keeps its empty input and the miss is alarmed
+/// (`synthetic_claim_calldata_unrecoverable_total`), NEVER fabricated.
+///
+/// aggkit v0.8.3's bridgesync full-claim parser persists every calldata field (both SMT
+/// proofs, both exit roots, networks, addresses, amount, metadata) and derives the claim's
+/// GER from the two exit roots, so all of it comes from the consumed CLAIM note's storage
+/// ([`parse_full_claim_from_storage`]) + the hash-verified registry preimage
+/// ([`resolve_claim_metadata`]).
+pub(crate) async fn persist_synthetic_claim_tx(
+    store: &Arc<dyn Store>,
+    note_storage: &miden_protocol::note::NoteStorage,
+    note_id_str: &str,
+    tx_hash_str: &str,
+    block_number: u64,
+    block_hash: [u8; 32],
+) -> anyhow::Result<bool> {
+    use alloy::consensus::{Signed, TxEnvelope, TxLegacy};
+    use alloy::primitives::{Address, Signature, TxHash, TxKind, U256};
+
+    let tx_hash: TxHash = tx_hash_str
+        .parse()
+        .map_err(|e| anyhow::anyhow!("derived claim tx hash {tx_hash_str}: {e}"))?;
+    // Idempotent AND crash-safe (review blocker 3): synthesis re-runs (restore replay,
+    // projector re-observation) and the live backfill all funnel here.
+    //   * A fully-COMMITTED row (result present) → done, first writer won.
+    //   * A PENDING row (txn_begin ran, txn_commit did not — a crash BETWEEN them) must be
+    //     FINALIZED, not treated as complete: the old `is_some()` short-circuit stranded it
+    //     pending forever (no block/receipt), so every later backfill saw the row and
+    //     skipped. The envelope (with calldata) is already persisted, so we only need the
+    //     commit. txn_commit is idempotent on a re-run.
+    match store.txn_get(tx_hash).await? {
+        Some(data) if data.result.is_some() => return Ok(true),
+        Some(_) => {
+            store
+                .txn_commit(tx_hash, Ok(()), block_number, block_hash)
+                .await?;
+            ::metrics::counter!("synthetic_claim_calldata_finalized_pending_total").increment(1);
+            tracing::info!(
+                note_id = %note_id_str,
+                tx_hash = %tx_hash_str,
+                "synthesized claim: finalized a PENDING calldata row (crash between begin and \
+                 commit) rather than stranding it"
+            );
+            return Ok(true);
+        }
+        None => {}
+    }
+
+    let full = parse_full_claim_from_storage(note_storage)?;
+    let Some(metadata) = resolve_claim_metadata(
+        store,
+        full.origin_network,
+        &full.origin_address,
+        &full.metadata_hash,
+    )
+    .await?
+    else {
+        ::metrics::counter!("synthetic_claim_calldata_unrecoverable_total").increment(1);
+        tracing::error!(
+            note_id = %note_id_str,
+            tx_hash = %tx_hash_str,
+            origin_network = full.origin_network,
+            origin_address = %hex::encode(full.origin_address),
+            metadata_hash = %hex::encode(full.metadata_hash),
+            "synthesized claim: metadata preimage NOT recoverable from the faucet registry — \
+             refusing to fabricate calldata; the tx keeps an empty input (aggkit will surface \
+             this claim as unparsable — operator action: register/repair the faucet metadata, \
+             the backfill then heals on the next tick)"
+        );
+        return Ok(false);
+    };
+
+    let call = build_claim_asset_call(&full, metadata);
+    let input = alloy_core::sol_types::SolCall::abi_encode(&call);
+    let calldata_bytes = input.len();
+    let bridge_addr: Address = get_bridge_address()
+        .parse()
+        .map_err(|e| anyhow::anyhow!("bridge address: {e}"))?;
+    let tx = TxLegacy {
+        chain_id: None,
+        nonce: 0,
+        gas_price: 0,
+        gas_limit: 0,
+        to: TxKind::Call(bridge_addr),
+        value: U256::ZERO,
+        input: input.into(),
+    };
+    // Placeholder signature (v=27, r=1, s=1) matching the synthetic-tx wire shape —
+    // consumers (aggkit) parse the calldata, they don't verify signatures. The envelope is
+    // sealed with the DERIVED hash so every read path reports the hash the ClaimEvent rides.
+    let signature = Signature::new(U256::from(1), U256::from(1), false);
+    let envelope = TxEnvelope::Legacy(Signed::new_unchecked(tx, signature, tx_hash));
+    store
+        .txn_begin(
+            tx_hash,
+            crate::store::TxnEntry {
+                id: None,
+                envelope,
+                signer: bridge_addr,
+                expires_at: None,
+                // MUST stay empty: `txn_commit` appends entry logs to the synthetic log
+                // store, and the ClaimEvent log was already committed atomically by
+                // `commit_manual_claim_event_atomic` — a copy here would double-emit it.
+                logs: Vec::new(),
+            },
+        )
+        .await?;
+    store
+        .txn_commit(tx_hash, Ok(()), block_number, block_hash)
+        .await?;
+    ::metrics::counter!("synthetic_claim_calldata_persisted_total").increment(1);
+    tracing::info!(
+        note_id = %note_id_str,
+        tx_hash = %tx_hash_str,
+        block_number,
+        calldata_bytes,
+        "synthesized claim: persisted authoritative full claimAsset calldata under the \
+         derived tx hash"
+    );
+    Ok(true)
+}
+
 /// Outcome of projecting one consumed note through the CLAIM derivation.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum ClaimProjectOutcome {
@@ -1381,11 +1575,14 @@ pub(crate) async fn project_claim_note(
     // aggkit fails "input too short: 0 bytes" and never settles the certificate.
     // Fall back to the derived hash only for notes with no recorded link (e.g.
     // restore replaying history predating the link, or notes submitted out-of-band).
-    let tx_hash = match observed_tx_hash {
-        Some(real_tx) => real_tx,
+    // `linked` = the tx hash came from a REAL recorded link (observed handoff or
+    // stored note→tx), not the derived fallback. A real hash → finalise its pending
+    // receipt; the derived fallback → persist the recovered full claimAsset calldata.
+    let (tx_hash, linked) = match observed_tx_hash {
+        Some(real_tx) => (real_tx, true),
         None => match store.get_tx_for_note(&note_id_str).await? {
-            Some(real_tx) => real_tx,
-            None => derive_manual_claim_tx_hash(&note_id_str),
+            Some(real_tx) => (real_tx, true),
+            None => (derive_manual_claim_tx_hash(&note_id_str), false),
         },
     };
 
@@ -1403,6 +1600,50 @@ pub(crate) async fn project_claim_note(
             decoded.amount,
         )
         .await?;
+
+    // The projector OWNS receipt completion: finalise the real claim tx's receipt
+    // at THIS (consumption) block — the same block the ClaimEvent is emitted — so the
+    // receipt block == the log block. `publish_claim` left it pending (`id: None`) for
+    // exactly this. Tolerate a missing pending entry (derived-hash fallback, which has
+    // no real `txn_begin`; or an expired/pruned tx, or restore predating the tx
+    // record): the receipt is then synthesised from the log by `service_get_txn_receipt`,
+    // so a missing entry must not abort the projection.
+    if let Some(h) = linked
+        .then(|| tx_hash.parse::<alloy::primitives::TxHash>().ok())
+        .flatten()
+    {
+        let _ = store
+            .txn_commit(h, Ok(()), block_number, block_hash)
+            .await
+            .inspect_err(|e| {
+                tracing::debug!(tx = %tx_hash, "claim receipt not finalised: {e}");
+            });
+    } else {
+        // DERIVED-hash synthesis (no real eth-tx): persist the recovered FULL claimAsset
+        // calldata under the derived hash so aggkit's full-claim parser gets the truthful
+        // claim (both SMT proofs, both exit roots, networks, addresses, amount, hash-verified
+        // metadata) from `eth_getTransactionByHash`. Non-fatal on failure — the ClaimEvent is
+        // already committed; the projector's per-tick backfill retries until it persists.
+        if let Err(e) = persist_synthetic_claim_tx(
+            store,
+            details.storage(),
+            &note_id_str,
+            &tx_hash,
+            block_number,
+            block_hash,
+        )
+        .await
+        {
+            tracing::warn!(
+                target: "restore::claims",
+                note_id = %note_id_str,
+                tx_hash = %tx_hash,
+                error = %format!("{e:#}"),
+                "synthesised claim: calldata persistence failed (transient — the projector \
+                 backfill retries next tick)"
+            );
+        }
+    }
 
     ::metrics::counter!("claim_watcher_synthesised_total").increment(1);
     tracing::info!(
@@ -1816,6 +2057,7 @@ mod tests {
     };
     use miden_protocol::{Felt, Word};
     use miden_standards::note::{NetworkAccountTarget, NoteExecutionHint};
+
     use std::sync::Arc as StdArc;
 
     // Test AccountIds — four distinct, valid protocol-0.15 (version-1) ids.
@@ -2171,6 +2413,13 @@ mod tests {
         )
     }
 
+    /// Build a consumed B2AGG `InputNoteRecord` (current miden-client API, mirrors
+    /// `bridge_out::tests::build_b2agg_note_with_consumer`) carrying a fungible
+    /// asset from `faucet_id` and recording `consumer` as the consuming account.
+    /// The gate keys on the note's script root + `consumer_account()` (the note
+    /// STATE), so only `faucet_id` and `consumer` matter here. The asset is
+    /// present so restore's emit path is actually reached when the gate is
+    /// absent — i.e. the RED test fails on the missing gate, not a no-asset skip.
     fn ma3_b2agg_input_note(faucet_id: AccountId, consumer: Option<AccountId>) -> InputNoteRecord {
         use miden_base_agglayer::B2AggNote;
         use miden_client::store::InputNoteState;
@@ -3245,6 +3494,362 @@ mod tests {
         assert!(
             store.is_ger_injected(&ger_bytes).await.unwrap(),
             "restored GER must be marked injected",
+        );
+    }
+
+    // ── Synthesized-claim full-calldata recovery (PR #136 review) ────────────
+
+    /// A ClaimNoteStorage with DISTINCT values in every field, so the full decode +
+    /// calldata rebuild can prove each field lands in the right claimAsset slot.
+    fn full_claim_fixture(metadata: &[u8]) -> miden_protocol::note::NoteStorage {
+        use miden_base_agglayer::{
+            ClaimNoteStorage, EthAddress, EthAmount, ExitRoot, GlobalIndex, LeafData, MetadataHash,
+            ProofData, SmtNode,
+        };
+        // Distinct per-node proof values: local node i = [i+1; 32], rollup node i = [0x80+i; 32].
+        let local: [SmtNode; 32] = std::array::from_fn(|i| SmtNode::new([(i as u8) + 1; 32]));
+        let rollup: [SmtNode; 32] = std::array::from_fn(|i| SmtNode::new([0x80 + (i as u8); 32]));
+        let mut gi = [0u8; 32];
+        gi[23] = 1; // mainnet flag
+        gi[31] = 0x2A;
+        let mut amount = [0u8; 32];
+        amount[24..].copy_from_slice(&123_456_789u64.to_be_bytes());
+        let storage = ClaimNoteStorage {
+            proof_data: ProofData {
+                smt_proof_local_exit_root: local,
+                smt_proof_rollup_exit_root: rollup,
+                global_index: GlobalIndex::new(gi),
+                mainnet_exit_root: ExitRoot::new([0x11; 32]),
+                rollup_exit_root: ExitRoot::new([0x22; 32]),
+            },
+            leaf_data: LeafData {
+                origin_network: 0,
+                origin_token_address: EthAddress::new([0xAB; 20]),
+                destination_network: 2,
+                destination_address: EthAddress::new([0xCD; 20]),
+                amount: EthAmount::new(amount),
+                metadata_hash: MetadataHash::from_abi_encoded(metadata),
+            },
+            miden_claim_amount: miden_protocol::Felt::ZERO,
+        };
+        miden_protocol::note::NoteStorage::try_from(storage).expect("fixture round-trips")
+    }
+
+    /// Full-storage decode + calldata rebuild round-trip: EVERY claimAsset field must be
+    /// the authoritative note-storage value — both SMT proofs node-for-node, both exit
+    /// roots, the note-derived destination network (review req 5), addresses, U256
+    /// amount — plus the hash-verified metadata preimage. Nothing zero-filled.
+    #[test]
+    fn full_claim_decode_rebuilds_authoritative_claim_asset_calldata() {
+        use alloy_core::sol_types::SolCall;
+        let metadata = b"abi-encoded token metadata".to_vec();
+        let storage = full_claim_fixture(&metadata);
+        let full = parse_full_claim_from_storage(&storage).expect("full decode");
+
+        let call = build_claim_asset_call(&full, metadata.clone());
+        let raw = call.abi_encode();
+        assert!(raw.starts_with(&crate::claim::claimAssetCall::SELECTOR));
+        let decoded = crate::claim::claimAssetCall::abi_decode(&raw).expect("aggkit-parseable");
+
+        for i in 0..32 {
+            assert_eq!(
+                decoded.smtProofLocalExitRoot[i].0,
+                [(i as u8) + 1; 32],
+                "local SMT proof node {i} must be the note-storage value"
+            );
+            assert_eq!(
+                decoded.smtProofRollupExitRoot[i].0,
+                [0x80 + (i as u8); 32],
+                "rollup SMT proof node {i} must be the note-storage value"
+            );
+        }
+        assert_eq!(decoded.mainnetExitRoot.0, [0x11; 32], "mainnet exit root");
+        assert_eq!(decoded.rollupExitRoot.0, [0x22; 32], "rollup exit root");
+        let mut gi = [0u8; 32];
+        gi[23] = 1;
+        gi[31] = 0x2A;
+        assert_eq!(
+            decoded.globalIndex,
+            alloy::primitives::U256::from_be_bytes(gi)
+        );
+        assert_eq!(decoded.originNetwork, 0);
+        assert_eq!(decoded.originTokenAddress.as_slice(), &[0xAB; 20]);
+        assert_eq!(
+            decoded.destinationNetwork, 2,
+            "destination network must come from the NOTE (review req 5), not config"
+        );
+        assert_eq!(decoded.destinationAddress.as_slice(), &[0xCD; 20]);
+        assert_eq!(
+            decoded.amount,
+            alloy::primitives::U256::from(123_456_789u64)
+        );
+        assert_eq!(
+            decoded.metadata.as_ref(),
+            metadata.as_slice(),
+            "metadata must be the hash-verified preimage"
+        );
+    }
+
+    /// Registry-backed metadata recovery: persist succeeds only with a preimage whose
+    /// keccak256 equals the note's metadata_hash, and the persisted envelope (keyed by
+    /// the DERIVED hash — the record eth_getTransactionByHash serves ahead of any
+    /// synthetic fallback) carries it verbatim.
+    #[tokio::test]
+    async fn persist_synthetic_claim_tx_recovers_registry_metadata() {
+        use alloy::consensus::Transaction;
+        use alloy_core::sol_types::SolCall;
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let metadata = b"\x00\x01erc20 name symbol decimals".to_vec();
+        store
+            .register_faucet(crate::store::FaucetEntry {
+                faucet_id: id(TEST_TARGET_BRIDGE),
+                origin_address: [0xAB; 20],
+                origin_network: 0,
+                symbol: "TT".into(),
+                origin_decimals: 18,
+                miden_decimals: 8,
+                scale: 10,
+                metadata: metadata.clone(),
+            })
+            .await
+            .unwrap();
+
+        let storage = full_claim_fixture(&metadata);
+        let note_id = "cafebabe";
+        let derived = derive_manual_claim_tx_hash(note_id);
+        let persisted =
+            persist_synthetic_claim_tx(&store, &storage, note_id, &derived, 8831, [0xAA; 32])
+                .await
+                .unwrap();
+        assert!(persisted, "hash-verified registry metadata must persist");
+
+        let tx_hash: alloy::primitives::TxHash = derived.parse().unwrap();
+        let data = store
+            .txn_get(tx_hash)
+            .await
+            .unwrap()
+            .expect("calldata record persisted under the DERIVED hash");
+        let decoded = crate::claim::claimAssetCall::abi_decode(data.envelope.input())
+            .expect("stored input is full claimAsset calldata");
+        assert_eq!(decoded.metadata.as_ref(), metadata.as_slice());
+        assert_eq!(decoded.destinationNetwork, 2);
+        assert_eq!(decoded.mainnetExitRoot.0, [0x11; 32]);
+        // The record is COMMITTED at the ClaimEvent's block so the receipt matches.
+        let (result, block) = store.txn_receipt(tx_hash).await.unwrap().unwrap();
+        assert!(result.is_ok());
+        assert_eq!(block, 8831);
+
+        // Idempotent: a re-run (restore replay / projector backfill) is a no-op success.
+        let again =
+            persist_synthetic_claim_tx(&store, &storage, note_id, &derived, 8831, [0xAA; 32])
+                .await
+                .unwrap();
+        assert!(again);
+    }
+
+    /// Native-ETH / empty-metadata claims: the empty preimage is truthful by the hash —
+    /// persist succeeds with empty metadata (no registry entry needed).
+    #[tokio::test]
+    async fn persist_synthetic_claim_tx_accepts_empty_metadata_by_hash() {
+        use alloy_core::sol_types::SolCall;
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let storage = full_claim_fixture(&[]);
+        let derived = derive_manual_claim_tx_hash("eth-claim");
+        assert!(
+            persist_synthetic_claim_tx(&store, &storage, "eth-claim", &derived, 7, [0u8; 32])
+                .await
+                .unwrap()
+        );
+        let data = store
+            .txn_get(derived.parse().unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        use alloy::consensus::Transaction;
+        let decoded = crate::claim::claimAssetCall::abi_decode(data.envelope.input()).unwrap();
+        assert!(decoded.metadata.is_empty());
+    }
+
+    /// Unrecoverable metadata (non-empty hash, no registry preimage hashing to it): the
+    /// calldata must NOT be fabricated — no tx record is written (the serve path keeps
+    /// the empty input and alarms), and the caller sees `false`.
+    #[tokio::test]
+    async fn persist_synthetic_claim_tx_refuses_to_fabricate_unrecoverable_metadata() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        // Note built with metadata whose preimage is NOT in the registry.
+        let storage = full_claim_fixture(b"preimage the registry never saw");
+        let derived = derive_manual_claim_tx_hash("orphan-metadata");
+        let persisted =
+            persist_synthetic_claim_tx(&store, &storage, "orphan-metadata", &derived, 9, [0u8; 32])
+                .await
+                .unwrap();
+        assert!(!persisted, "must refuse to fabricate");
+        assert!(
+            store
+                .txn_get(derived.parse().unwrap())
+                .await
+                .unwrap()
+                .is_none(),
+            "no fabricated record may exist"
+        );
+        // A registry entry whose metadata does NOT hash to the note's hash is refused too.
+        store
+            .register_faucet(crate::store::FaucetEntry {
+                faucet_id: id(TEST_TARGET_OTHER),
+                origin_address: [0xAB; 20],
+                origin_network: 0,
+                symbol: "TT".into(),
+                origin_decimals: 18,
+                miden_decimals: 8,
+                scale: 10,
+                metadata: b"a DIFFERENT preimage".to_vec(),
+            })
+            .await
+            .unwrap();
+        assert!(
+            !persist_synthetic_claim_tx(
+                &store,
+                &storage,
+                "orphan-metadata",
+                &derived,
+                9,
+                [0u8; 32]
+            )
+            .await
+            .unwrap(),
+            "hash-mismatched registry metadata must be refused"
+        );
+    }
+
+    /// Review blocker 3 — CRASH IDEMPOTENCY: a crash BETWEEN txn_begin and txn_commit leaves
+    /// a PENDING calldata row. The old `if txn_get(...).is_some()` short-circuit treated it
+    /// as complete, so every later backfill skipped it and the tx was stranded pending
+    /// forever (no block, no receipt). A later persist pass must FINALIZE the pending row.
+    #[tokio::test]
+    async fn persist_synthetic_claim_tx_finalizes_pending_after_crash() {
+        use alloy::consensus::{Signed, TxEnvelope, TxLegacy};
+        use alloy::primitives::{Address, Signature, TxKind, U256};
+
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let storage = full_claim_fixture(&[]); // empty metadata → truthful by hash
+        let note_id = "crash-window";
+        let derived = derive_manual_claim_tx_hash(note_id);
+        let tx_hash: alloy::primitives::TxHash = derived.parse().unwrap();
+
+        // Simulate the crash: txn_begin ran (full calldata envelope persisted under the
+        // derived hash) but txn_commit did not — a PENDING row with no block/receipt.
+        let full = parse_full_claim_from_storage(&storage).unwrap();
+        let input =
+            alloy_core::sol_types::SolCall::abi_encode(&build_claim_asset_call(&full, vec![]));
+        let bridge_addr: Address = get_bridge_address().parse().unwrap();
+        let tx = TxLegacy {
+            chain_id: None,
+            nonce: 0,
+            gas_price: 0,
+            gas_limit: 0,
+            to: TxKind::Call(bridge_addr),
+            value: U256::ZERO,
+            input: input.into(),
+        };
+        let envelope = TxEnvelope::Legacy(Signed::new_unchecked(
+            tx,
+            Signature::new(U256::from(1), U256::from(1), false),
+            tx_hash,
+        ));
+        store
+            .txn_begin(
+                tx_hash,
+                crate::store::TxnEntry {
+                    id: None,
+                    envelope,
+                    signer: bridge_addr,
+                    expires_at: None,
+                    logs: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            store.txn_receipt(tx_hash).await.unwrap().is_none(),
+            "pending: begin ran, commit did not — no receipt yet"
+        );
+
+        // A later persist pass FINALIZES the pending row (does not skip it).
+        let ok = persist_synthetic_claim_tx(&store, &storage, note_id, &derived, 8831, [0xAA; 32])
+            .await
+            .unwrap();
+        assert!(ok);
+        let (result, block) = store
+            .txn_receipt(tx_hash)
+            .await
+            .unwrap()
+            .expect("the pending row must now be COMMITTED (finalized), not stranded");
+        assert!(result.is_ok());
+        assert_eq!(block, 8831, "finalized at the ClaimEvent block");
+
+        // The calldata is intact and still keyed under the derived hash.
+        use alloy::consensus::Transaction;
+        use alloy_core::sol_types::SolCall;
+        let data = store.txn_get(tx_hash).await.unwrap().unwrap();
+        assert!(
+            crate::claim::claimAssetCall::abi_decode(data.envelope.input()).is_ok(),
+            "the pending row's full claimAsset calldata survived finalization"
+        );
+    }
+
+    /// Review req 5 — stored envelopes precede the synthetic fallback. Both records exist
+    /// for the SAME derived hash (the persisted full-calldata envelope AND the ClaimEvent
+    /// synthetic log); `eth_getTransactionByHash` serves branches in order `txn_get` →
+    /// in-flight → synthetic-log fallback, so the presence of the envelope is what makes
+    /// the served input the full claimAsset calldata rather than the fallback's "0x".
+    #[tokio::test]
+    async fn stored_claim_envelope_precedes_synthetic_fallback() {
+        use alloy::consensus::Transaction;
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let storage = full_claim_fixture(&[]);
+        let note_id = "precedence";
+        let derived = derive_manual_claim_tx_hash(note_id);
+        // The ClaimEvent synthetic log rides the derived hash (what the fallback matches).
+        let mut gi = [0u8; 32];
+        gi[23] = 1;
+        gi[31] = 0x2A;
+        store
+            .add_claim_event(
+                "0x00000000000000000000000000000000000000aa",
+                8831,
+                [0xAA; 32],
+                &derived,
+                &gi,
+                0,
+                &[0xAB; 20],
+                &[0xCD; 20],
+                123_456_789,
+            )
+            .await
+            .unwrap();
+        assert!(
+            !store.get_logs_for_tx(&derived).await.unwrap().is_empty(),
+            "fixture: the synthetic fallback WOULD match this hash"
+        );
+        assert!(
+            persist_synthetic_claim_tx(&store, &storage, note_id, &derived, 8831, [0xAA; 32])
+                .await
+                .unwrap()
+        );
+        // txn_get (the dispatcher's FIRST branch) now serves the full calldata — the
+        // synthetic fallback (empty input) is shadowed.
+        let data = store
+            .txn_get(derived.parse().unwrap())
+            .await
+            .unwrap()
+            .expect("stored envelope must exist for the derived hash");
+        assert!(
+            !data.envelope.input().is_empty(),
+            "the served input is the persisted claimAsset calldata, not the fallback's 0x"
+        );
+        assert!(
+            data.envelope.input().len() > 4 + 64 * 32,
+            "full calldata (proofs included), not a stub"
         );
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -552,6 +552,19 @@ async fn json_rpc_handler(service: ServiceState, request: JsonRpcExtractor) -> J
                 .await
                 .map_err(|e| store_error(answer_id.clone(), e))?
             {
+                // Observability + e2e gate (review blocker 2): log the EXACT hash served from
+                // the durable store. A persisted synthesized-claim tx is served here (the
+                // store-first branch), NOT via the `found synthetic tx` log-reconstruction
+                // fallback below — so this is the only positive, hash-exact proof that aggkit
+                // fetched THIS derived-hash claim's calldata.
+                let input_len = {
+                    use alloy::consensus::Transaction;
+                    data.envelope.input().len()
+                };
+                tracing::info!(
+                    "eth_getTransactionByHash: served stored tx {} (input_len={input_len})",
+                    format!("{txn_hash:#x}")
+                );
                 let txn = data.to_rpc_transaction(txn_hash, &service.block_state);
                 return Ok(JsonRpcResponse::success(answer_id, txn));
             }
@@ -589,6 +602,27 @@ async fn json_rpc_handler(service: ServiceState, request: JsonRpcExtractor) -> J
                 .map_err(|e| store_error(answer_id.clone(), e))?;
             if let Some(log) = logs.first() {
                 tracing::info!("eth_getTransactionByHash: found synthetic tx {tx_hash_str}");
+                // A ClaimEvent-bearing tx should have been served by the stored-envelope
+                // path above (its full authoritative claimAsset calldata is persisted
+                // under the derived hash — `restore::persist_synthetic_claim_tx` + the
+                // projector backfill). Reaching this fallback means the calldata is
+                // UNRECOVERABLE (or the backfill hasn't caught up yet): alarm loudly —
+                // aggkit will fail to parse the empty input and stall on this claim —
+                // but do NOT fabricate fields it would persist as claim truth.
+                if log.topics.first().map(String::as_str)
+                    == Some(crate::log_synthesis::CLAIM_EVENT_TOPIC)
+                {
+                    ::metrics::counter!("synthetic_claim_tx_missing_calldata_total").increment(1);
+                    tracing::error!(
+                        tx_hash = %tx_hash_str,
+                        block = log.block_number,
+                        "eth_getTransactionByHash: ClaimEvent-bearing synthetic tx has NO \
+                         persisted claimAsset calldata — serving empty input (aggkit will \
+                         stall on this claim); check \
+                         synthetic_claim_calldata_unrecoverable_total / faucet registry \
+                         metadata"
+                    );
+                }
                 let synthetic_tx = build_synthetic_tx_json(txn_hash, log, service.chain_id);
                 return Ok(JsonRpcResponse::success(answer_id, synthetic_tx));
             }

--- a/src/service_debug.rs
+++ b/src/service_debug.rs
@@ -49,7 +49,10 @@ pub(crate) async fn service_debug_trace_transaction(
         ));
     }
 
-    // Fallback for synthetic bridge-out txs
+    // Fallback for synthetic bridge-out txs. (A synthesized CLAIM tx does not reach this
+    // fallback: its full authoritative claimAsset calldata is persisted under the derived
+    // hash — `restore::persist_synthetic_claim_tx` — and served by the stored-envelope
+    // branch above.)
     let input_data = if let Ok(hash) = TxHash::from_str(&params.0) {
         let tx_key = format!("{hash:#x}");
         let logs = service

--- a/src/service_helpers.rs
+++ b/src/service_helpers.rs
@@ -151,6 +151,12 @@ pub(crate) fn build_synthetic_tx_json(
     log: &crate::log_synthesis::SyntheticLog,
     chain_id: u64,
 ) -> serde_json::Value {
+    // NB a ClaimEvent-bearing tx should never reach this synthetic fallback: its full
+    // authoritative claimAsset calldata is PERSISTED under the derived hash
+    // (`restore::persist_synthetic_claim_tx` + the projector backfill) and served by the
+    // stored-envelope path that precedes this. Reaching here with a ClaimEvent means the
+    // calldata was unrecoverable (alarmed at the call site) — serve the legacy empty
+    // input rather than fabricating fields aggkit would persist as claim truth.
     serde_json::json!({
         "type": "0x0",
         "nonce": "0x0",

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -264,6 +264,15 @@ pub enum UnbridgeableBridgeOutReason {
     /// silently skipped) so the note is recorded as a permanent skip and is not
     /// re-attempted every sync tick / restore run.
     MetadataTooLarge,
+    /// SAME-DETAILS MULTIPLICITY (review): the authoritative bridge-tx feed shows ≥2
+    /// DISTINCT on-chain B2AGG consumptions that share a `details_commitment` (same details,
+    /// different metadata → different NoteId/nullifier). The miden-client SQLite store keys
+    /// input notes by `details_commitment`, so it CANNOT represent them distinctly, and the
+    /// synthetic BridgeEvent's tx_hash is derived from the commitment (shared) — so restore
+    /// cannot emit a correct, distinct event per leaf without collapsing/misnumbering. Rather
+    /// than guess, quarantine ALL such exits fail-closed; recover via --restore/admin once the
+    /// authoritative per-note bodies can be sourced.
+    SameDetailsMultiplicity,
 }
 
 impl UnbridgeableBridgeOutReason {
@@ -275,6 +284,7 @@ impl UnbridgeableBridgeOutReason {
             Self::AmountOverflow => "amount_overflow",
             Self::AtomicCommitFailed => "atomic_commit_failed",
             Self::MetadataTooLarge => "metadata_too_large",
+            Self::SameDetailsMultiplicity => "same_details_multiplicity",
         }
     }
 }
@@ -314,17 +324,29 @@ pub(crate) fn envelope_nonce(envelope: &TxEnvelope) -> u64 {
 }
 
 impl TxnData {
-    /// Build an `alloy::rpc::types::Transaction` for JSON-RPC responses.
+    /// Build the `eth_getTransactionByHash` JSON for a stored tx. Returns a
+    /// `serde_json::Value` (not the raw `alloy::rpc::types::Transaction`) so the `hash`
+    /// field can be pinned to the STORE KEY.
+    ///
+    /// Why pin the hash (review blocker 4): a client that fetched by hash `H` MUST get back
+    /// `.hash == H`. For a real `eth_sendRawTransaction` tx the key equals the envelope's
+    /// RLP hash, so this is a no-op. But a SYNTHESIZED claim tx is stored under its DERIVED
+    /// hash (`keccak(tag || note_id)`, NOT an RLP hash) while PG persists only the
+    /// EIP-2718/RLP bytes — so after a round-trip `txn_get` decodes the envelope and its
+    /// hash is RECOMPUTED as the RLP hash, which differs from the derived key. Serializing
+    /// the envelope's hash would return an object whose `.hash` mismatches what aggkit
+    /// asked for. Re-asserting the key as `.hash` here makes the lookup identity hold
+    /// across the PG round-trip.
     pub fn to_rpc_transaction(
         &self,
-        _tx_hash: TxHash,
+        tx_hash: TxHash,
         block_state: &BlockState,
-    ) -> alloy::rpc::types::Transaction {
+    ) -> serde_json::Value {
         use alloy::consensus::transaction::Recovered;
         use alloy::primitives::B256;
 
         let is_confirmed = self.result.is_some();
-        alloy::rpc::types::Transaction {
+        let txn = alloy::rpc::types::Transaction {
             inner: Recovered::new_unchecked(self.envelope.clone(), self.signer),
             block_hash: if is_confirmed {
                 Some(B256::from(block_state.get_block_hash(self.block_num)))
@@ -338,7 +360,15 @@ impl TxnData {
             },
             transaction_index: if is_confirmed { Some(0) } else { None },
             effective_gas_price: Some(0),
+        };
+        let mut value = serde_json::to_value(&txn).unwrap_or(serde_json::Value::Null);
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert(
+                "hash".to_string(),
+                serde_json::Value::String(format!("{tx_hash:#x}")),
+            );
         }
+        value
     }
 }
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2172,6 +2172,7 @@ impl Store for PgStore {
             "amount_overflow" => UnbridgeableBridgeOutReason::AmountOverflow,
             "atomic_commit_failed" => UnbridgeableBridgeOutReason::AtomicCommitFailed,
             "metadata_too_large" => UnbridgeableBridgeOutReason::MetadataTooLarge,
+            "same_details_multiplicity" => UnbridgeableBridgeOutReason::SameDetailsMultiplicity,
             other => anyhow::bail!("unknown unbridgeable_bridge_outs.reason value: {other}"),
         };
 

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -2313,3 +2313,77 @@ async fn cantina7_pg_reservation_and_emitted_accounting() {
         .unwrap();
     assert_eq!(dc2, i1, "index stable across retry");
 }
+
+/// Review blocker 4 — the DERIVED hash must survive a real PG store→decode round-trip.
+/// A synthetic claim tx is stored under its derived hash (keccak(tag||note_id), NOT an RLP
+/// hash) while PG persists only EIP-2718/RLP bytes; txn_get decodes and the envelope's hash
+/// is RECOMPUTED as the RLP hash. `to_rpc_transaction` MUST re-assert the store key so a
+/// client that fetched by the derived hash gets back `.hash == derived hash`.
+#[tokio::test]
+async fn cantina136_derived_hash_survives_pg_round_trip() {
+    use alloy::consensus::{Signed, TxEnvelope, TxLegacy};
+    use alloy::primitives::TxKind;
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    let block_state = crate::block_state::BlockState::new();
+
+    // A synthetic claim tx keyed by a DERIVED hash unrelated to its RLP encoding.
+    let derived =
+        crate::claim_watcher::derive_manual_claim_tx_hash(&format!("rt-{:x}", rand_u64()));
+    let tx_hash: TxHash = derived.parse().unwrap();
+    let bridge_addr = Address::from([0xC8; 20]);
+    let tx = TxLegacy {
+        chain_id: None,
+        nonce: 0,
+        gas_price: 0,
+        gas_limit: 0,
+        to: TxKind::Call(bridge_addr),
+        value: U256::ZERO,
+        input: vec![0xDE, 0xAD, 0xBE, 0xEF].into(),
+    };
+    let envelope = TxEnvelope::Legacy(Signed::new_unchecked(
+        tx,
+        Signature::new(U256::from(1), U256::from(1), false),
+        tx_hash,
+    ));
+    // Sanity: the envelope's RLP-recomputed hash is NOT the derived key (that is the trap).
+    assert_ne!(
+        format!("{:#x}", envelope.tx_hash()),
+        derived,
+        "fixture: the derived key must differ from the RLP hash"
+    );
+
+    store
+        .txn_begin(
+            tx_hash,
+            TxnEntry {
+                id: None,
+                envelope,
+                signer: bridge_addr,
+                expires_at: None,
+                logs: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+    store
+        .txn_commit(tx_hash, Ok(()), 8831, [0xAA; 32])
+        .await
+        .unwrap();
+
+    // Round-trip through PG: read back (decodes RLP → recomputes envelope hash) and render.
+    let data = store
+        .txn_get(tx_hash)
+        .await
+        .unwrap()
+        .expect("row persisted under the derived hash");
+    let json = data.to_rpc_transaction(tx_hash, &block_state);
+    assert_eq!(
+        json["hash"].as_str().unwrap().to_lowercase(),
+        derived.to_lowercase(),
+        "getTransactionByHash(derived).hash MUST equal the derived hash after a PG round-trip"
+    );
+    // The calldata is also intact (the e2e asserts .input; this pins .hash too).
+    assert_eq!(json["input"].as_str().unwrap().to_lowercase(), "0xdeadbeef");
+}

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -967,6 +967,62 @@ async fn test_pgstore_commit_manual_claim_event_atomic() {
     assert!(store.is_claim_note_processed(&note_id).await.unwrap());
     // ClaimEvent dedup query finds the row.
     assert!(store.has_claim_event_for_global_index(&gi).await.unwrap());
+
+    // ── Reviewer concern #2 (write-before-seal): the atomic must NOT advance the tip. ──
+    // `insert_pending_claim_calldata` leaves a PENDING envelope; the atomic finalises that
+    // receipt AND emits the ClaimEvent, but sealing block N is the projector's job at
+    // end-of-block (`project_block_notes`). If the atomic — or a stray `txn_commit` in the
+    // claim path — advanced `latest_block_number` mid-block, aggkit could scan a partial
+    // block N and permanently miss its later logs. (Invisible to the in-memory store, whose
+    // `txn_commit` never touches the tip — this is the Postgres-only half of the fix.)
+    let before = store.get_latest_block_number().await.unwrap();
+    let seal_block = before + 50_000; // strictly above the current tip
+    let seal_hash: TxHash = {
+        let mut h = [0u8; 32];
+        h[..16].copy_from_slice(&(now_ns + 5).to_be_bytes());
+        TxHash::from(h)
+    };
+    let seal_hash_str = format!("{seal_hash:#x}");
+    let seal_note = format!("claim_seal_note_{now_ns}");
+    let seal_gi = {
+        let mut g = [0u8; 32];
+        g[..16].copy_from_slice(&(now_ns + 6).to_be_bytes());
+        g
+    };
+    // A pending envelope under `seal_hash` (exactly what insert_pending_claim_calldata leaves).
+    store.txn_begin(seal_hash, dummy_txn_entry()).await.unwrap();
+    assert!(
+        store.txn_receipt(seal_hash).await.unwrap().is_none(),
+        "pending before the atomic finalises it"
+    );
+    store
+        .commit_manual_claim_event_atomic(
+            seal_note,
+            "0xbridge",
+            seal_block,
+            [0u8; 32],
+            &seal_hash_str,
+            seal_gi,
+            0,
+            &[0u8; 20],
+            &[0u8; 20],
+            42,
+        )
+        .await
+        .unwrap();
+    assert!(
+        store.get_latest_block_number().await.unwrap() < seal_block,
+        "the atomic ClaimEvent commit must NOT seal the block — only project_block_notes \
+         advances latest_block_number, at end-of-block (write-before-seal)"
+    );
+    // The linked receipt IS finalised together with the ClaimEvent, at the claim's block.
+    let (res, blk) = store
+        .txn_receipt(seal_hash)
+        .await
+        .unwrap()
+        .expect("the linked receipt is finalised inline by the atomic");
+    assert!(res.is_ok());
+    assert_eq!(blk, seal_block, "receipt block == ClaimEvent block");
 }
 
 /// Audit H1/H3 — a reservation assigns the index before the atomic BridgeEvent commit.

--- a/src/synthetic_projector.rs
+++ b/src/synthetic_projector.rs
@@ -258,6 +258,14 @@ pub struct SyntheticProjector {
     audit_resolved: std::sync::Mutex<HashSet<([u8; 32], u64, u32)>>,
     /// Tick counter driving the every-[`AUDIT_EVERY_N_TICKS`] audit cadence.
     audit_tick_counter: AtomicU64,
+    /// Synthesized-claim calldata backfill: details-commitments of consumed CLAIM notes
+    /// whose derived-hash tx record is RESOLVED (full claimAsset calldata persisted, or
+    /// proven to ride a real eth-tx hash instead). Unresolved notes are re-checked every
+    /// tick, so a claim synthesized by an OLDER build (event committed, calldata never
+    /// persisted — e.g. the live soak's block-8831 tx) heals within one tick of an
+    /// upgrade, and a metadata-unrecoverable claim keeps alarming until the registry is
+    /// repaired, then self-heals. In-memory on purpose: a restart re-checks from scratch.
+    claim_calldata_resolved: std::sync::Mutex<HashSet<[u8; 32]>>,
 }
 
 impl SyntheticProjector {
@@ -331,6 +339,7 @@ impl SyntheticProjector {
             pending_duplicate_cursor: std::sync::Mutex::new(None),
             audit_resolved: std::sync::Mutex::new(HashSet::new()),
             audit_tick_counter: AtomicU64::new(0),
+            claim_calldata_resolved: std::sync::Mutex::new(HashSet::new()),
         })
     }
 
@@ -892,6 +901,73 @@ impl SyntheticProjector {
             }
         }
         Ok(recs)
+    }
+
+    /// Synthesized-claim CALLDATA BACKFILL — retroactive self-heal for derived-hash
+    /// ClaimEvents whose full `claimAsset` calldata is not yet persisted (see
+    /// `restore::persist_synthetic_claim_tx`). Covers: claims synthesized by an OLDER
+    /// build (event committed, no calldata record — the live-soak block-8831 wedge), a
+    /// crash between the event commit and the calldata persist, and a transient persist
+    /// failure at synthesis time. Runs every tick over the already-fetched consumed feed;
+    /// the resolved-set keeps steady state O(new CLAIM notes).
+    ///
+    /// A note is RESOLVED (never re-checked) once its derived-hash tx record exists, or
+    /// once it is proven to ride a real eth-tx (its block is projected and the derived
+    /// hash bears no ClaimEvent). A metadata-unrecoverable note stays UNRESOLVED on
+    /// purpose: it re-alarms every tick (standing operator pressure) and self-heals the
+    /// tick after the faucet registry is repaired.
+    async fn backfill_synthetic_claim_calldata(
+        &self,
+        consumed: &[InputNoteRecord],
+        projector_cursor: u64,
+    ) -> anyhow::Result<()> {
+        let claim_root = miden_base_agglayer::ClaimNote::script().root();
+        for note in consumed {
+            if note.details().script().root() != claim_root {
+                continue;
+            }
+            let key: [u8; 32] = note.details_commitment().as_bytes();
+            {
+                let resolved = self
+                    .claim_calldata_resolved
+                    .lock()
+                    .expect("claim-calldata resolved set poisoned");
+                if resolved.contains(&key) {
+                    continue;
+                }
+            } // lock dropped before the awaits below
+            let note_id_str = hex::encode(key);
+            let derived = crate::claim_watcher::derive_manual_claim_tx_hash(&note_id_str);
+            let logs = self.store.get_logs_for_tx(&derived).await?;
+            let resolved = if let Some(log) = logs.first() {
+                // A derived-hash ClaimEvent exists → the full calldata must be servable.
+                crate::restore::persist_synthetic_claim_tx(
+                    &self.store,
+                    note.details().storage(),
+                    &note_id_str,
+                    &derived,
+                    log.block_number,
+                    log.block_hash,
+                )
+                .await?
+            } else {
+                // No derived-hash event. Once the note's consumption block is projected,
+                // its ClaimEvent (if any) rides a real eth-tx hash — nothing to backfill,
+                // resolved forever. Before that, re-check next tick (the synthesis path
+                // usually persists it first; this is only the crash backstop).
+                note.state()
+                    .consumed_block_height()
+                    .map(|h| h.as_u64())
+                    .is_some_and(|b| b <= projector_cursor)
+            };
+            if resolved {
+                self.claim_calldata_resolved
+                    .lock()
+                    .expect("claim-calldata resolved set poisoned")
+                    .insert(key);
+            }
+        }
+        Ok(())
     }
 
     /// COMPLETENESS AUDITOR — in-proxy early detection of missed BridgeEvents (the
@@ -1461,6 +1537,19 @@ impl SyntheticProjector {
             self.store.set_projector_cursor(next).await?;
             self.cursor.store(next, Ordering::Release);
             cursor = next;
+        }
+        // Synthesized-claim calldata backfill (every tick, O(new CLAIM notes) via the
+        // resolved-set): heals derived-hash ClaimEvents whose full claimAsset calldata is
+        // not yet persisted — older-build synthesis, or a crash between the event commit
+        // and the calldata persist. Non-fatal: a failure warns and retries next tick.
+        if let Err(e) = self
+            .backfill_synthetic_claim_calldata(&consumed, cursor)
+            .await
+        {
+            tracing::warn!(
+                error = %format!("{e:#}"),
+                "synthesized-claim calldata backfill failed (non-fatal — retried next tick)"
+            );
         }
         // COMPLETENESS AUDITOR (detection only, every AUDIT_EVERY_N_TICKS ticks): diff the
         // store's consumed-B2AGG view against the synthetic log store for comfortably-sealed


### PR DESCRIPTION
## Summary

Reconstructs and durably serves complete `claimAsset` calldata for synthesized `ClaimEvent` transactions when recovery cannot reuse a complete stored Ethereum transaction.

The v0.15.8 chaos soak exposed a recovery path where the projector emitted a valid `ClaimEvent`, but `eth_getTransactionByHash` returned empty input. AggKit's full-claim bridge sync could not decode the transaction, retried the same block indefinitely, and stopped certificate progress.

This branch is now deliberately narrow: the duplicate NTX attribution and same-details multiplicity machinery has been removed. Authoritative bridge replay and ordering remain owned by the unified projector already on `main` via #137.

## Recovery flow

```mermaid
flowchart LR
    Note[Consumed public CLAIM note] --> Decode[Decode proofs, roots, global index, networks, addresses, amount, metadata hash]
    Registry[Faucet and origin registry] --> Verify{Metadata preimage hash matches?}
    Decode --> Verify
    Verify -->|yes| Encode[ABI-encode full claimAsset call]
    Encode --> Persist[Persist transaction envelope under the ClaimEvent hash]
    Persist --> RPC[eth_getTransactionByHash and trace]
    RPC --> AggKit[AggKit full-claim parser continues]
    Verify -->|no or unavailable| Alarm[Fail closed, alarm, and retry]

    Link[Existing note to transaction link] --> Linked[Use linked transaction path]
    NoLink[No usable link] --> Decode
```

## What changed

- decodes both 32-node SMT proofs, both exit roots, the global index, networks, addresses, full U256 amount, and metadata hash from authoritative consumed CLAIM-note storage;
- resolves the metadata preimage from the faucet/origin registry only when its hash matches the note commitment;
- ABI-encodes and persists a synthetic `claimAsset` transaction under the deterministic event transaction hash;
- preserves the event hash in PostgreSQL/RPC even though the synthetic envelope uses a placeholder signature;
- finalizes a pending synthetic row after a crash between transaction begin and commit;
- backfills older derived-hash ClaimEvents after projection catch-up;
- refuses to fabricate calldata when authoritative metadata cannot be recovered.

## Validation at `8cf8440`

- GitHub `check`, CodeQL, and Aikido jobs are green.
- Unit/script coverage exercises full-field decoding, registry metadata recovery and rejection, pending-row finalization, PostgreSQL round-tripping, and exact RPC transaction-hash rendering.
- The dedicated recovery E2E verifies an exact-hash refetch after reset, non-empty/full calldata parsing, bridge-sync progress past the affected block, and delivery of the exact global index.
- `e2e-l2l2` is skipped in CI and the dedicated recovery E2E remains manual.

## Current review status

The simplified core is an improvement, but this head is **not production-ready yet**:

1. **A surviving link can point to a missing transaction envelope.** The projector currently trusts the link, publishes the event under that real hash, ignores failed finalization, and the derived-hash backfill then marks the note resolved. RPC serves empty calldata forever and AggKit remains wedged. Before choosing the linked path, verify that a valid stored `claimAsset` envelope exists; otherwise use the reconstructed path. Add a link-present/transaction-missing regression.

2. **PostgreSQL can expose a partially projected block.** `persist_synthetic_claim_tx` calls the generic successful `txn_commit` from inside the per-note projection loop; PostgreSQL advances `latest_block_number` there, before later notes in the same Miden block are written. In-memory tests do not reproduce this. Persist/finalize the envelope without advancing the public tip, leaving `project_block_notes` as the sole block sealer, and add a PostgreSQL same-block regression.

Before merge, also tighten the validation wording: the final E2E certificate section currently proves coexistence with a later settled certificate, not inclusion of this exact recovered claim. The exact-hash, parser-progress, and global-index gates remain valid. Remove the small dead multiplicity/attribution remnants, and either run the backfill while already at tip or stop describing it as an every-tick repair.

