### PR TITLE
test(claim): certify manual user claims and signer-agnostic dedup

### DIFF
--- a/scripts/e2e-manual-user-claim.sh
+++ b/scripts/e2e-manual-user-claim.sh
@@ -62,7 +62,7 @@ WEI_PER_MIDEN_UNIT=10000000000
 EXPECTED_UNITS_PER_DEPOSIT=$((DEPOSIT_AMOUNT / WEI_PER_MIDEN_UNIT))
 
 CLAIM_EVENT_TOPIC="0x1df3f2a973a00d6635911755c260704e95e8a5876997546798770f76396fda4d"
-MAX_LEG1_ATTEMPTS="${MAX_LEG1_ATTEMPTS:-3}"
+MAX_LEG1_ATTEMPTS="${MAX_LEG1_ATTEMPTS:-5}"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'; NC='\033[0m'
 log()  { echo -e "${GREEN}[$(date +%H:%M:%S)]${NC} $*"; }
@@ -192,67 +192,107 @@ do_l1_deposit() {
     [[ "$status" == "1" ]] || fail "L1 deposit tx failed (status=$status): $tx"
 }
 
+# dep_static_vars <deposit-json> → emits shell assignments for the deposit's
+# static claim fields (one python invocation; values are bridge-service hex
+# strings / integers). eval'd by the callers.
+dep_static_vars() {
+    python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+m = d.get('metadata') or '0x'
+if m in ('None', 'null', ''): m = '0x'
+print(f\"DEP_CNT={d['deposit_cnt']};DEP_GI={d['global_index']};\"
+      f\"DEP_ORIG_NET={d['orig_net']};DEP_ORIG_ADDR={d['orig_addr']};\"
+      f\"DEP_DEST_NET={d['dest_net']};DEP_DEST_ADDR={d['dest_addr']};\"
+      f\"DEP_AMOUNT={d['amount']};DEP_METADATA={m}\")
+"
+}
+
 # build_user_claim_raw <deposit-json> → prints the pre-signed raw claimAsset tx
-# for the USER key (empty on proof-not-ready). Nonce is re-read per call.
+# for the USER key (empty on proof-not-ready). One-shot convenience wrapper
+# (the race loop in submit_user_claim inlines a faster variant).
 build_user_claim_raw() {
-    local dep="$1" cnt gi orig_net orig_addr dest_net dest_addr amount metadata
-    local proof mer rer smt_local smt_rollup calldata nonce_hex nonce
-    cnt=$(echo "$dep" | dep_field deposit_cnt)
-    gi=$(echo "$dep" | dep_field global_index)
-    orig_net=$(echo "$dep" | dep_field orig_net)
-    orig_addr=$(echo "$dep" | dep_field orig_addr)
-    dest_net=$(echo "$dep" | dep_field dest_net)
-    dest_addr=$(echo "$dep" | dep_field dest_addr)
-    amount=$(echo "$dep" | dep_field amount)
-    metadata=$(echo "$dep" | dep_field metadata)
-    [[ -z "$metadata" || "$metadata" == "None" ]] && metadata="0x"
-
-    proof=$(curl -sf "$BRIDGE_SERVICE_URL/merkle-proof?deposit_cnt=$cnt&net_id=0" 2>/dev/null) || return 0
+    local dep="$1" proof calldata nonce_hex
+    local DEP_CNT DEP_GI DEP_ORIG_NET DEP_ORIG_ADDR DEP_DEST_NET DEP_DEST_ADDR DEP_AMOUNT DEP_METADATA
+    local MER RER SMT_LOCAL SMT_ROLLUP
+    eval "$(echo "$dep" | dep_static_vars)" || return 0
+    proof=$(curl -sf "$BRIDGE_SERVICE_URL/merkle-proof?deposit_cnt=$DEP_CNT&net_id=0" 2>/dev/null) || return 0
     [[ -z "$proof" ]] && return 0
-    mer=$(echo "$proof" | python3 -c "import json,sys; print(json.load(sys.stdin)['proof']['main_exit_root'])") || return 0
-    rer=$(echo "$proof" | python3 -c "import json,sys; print(json.load(sys.stdin)['proof']['rollup_exit_root'])") || return 0
-    smt_local=$(echo "$proof" | python3 -c "
-import json, sys
-p = json.load(sys.stdin)['proof']['merkle_proof']
-while len(p) < 32: p.append('0x' + '00' * 32)
-print('[' + ','.join(p[:32]) + ']')
-") || return 0
-    smt_rollup=$(echo "$proof" | python3 -c "
-import json, sys
-p = json.load(sys.stdin)['proof']['rollup_merkle_proof']
-while len(p) < 32: p.append('0x' + '00' * 32)
-print('[' + ','.join(p[:32]) + ']')
-") || return 0
-
-    calldata=$(cast calldata \
-        'claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)' \
-        "$smt_local" "$smt_rollup" "$gi" "$mer" "$rer" \
-        "$orig_net" "$orig_addr" "$dest_net" "$dest_addr" "$amount" "$metadata") || return 0
-
+    eval "$(echo "$proof" | proof_vars)" || return 0
+    [[ -z "${MER:-}" ]] && return 0
+    calldata=$(claim_calldata_for) || return 0
     nonce_hex=$(rpc eth_getTransactionCount "[\"$USER_ADDR\",\"latest\"]" \
         | python3 -c "import json,sys; print(json.load(sys.stdin)['result'])") || return 0
-    nonce=$((nonce_hex))
-
-    cast mktx --private-key "$USER_KEY" --chain "$CHAIN_ID" --nonce "$nonce" \
+    cast mktx --private-key "$USER_KEY" --chain "$CHAIN_ID" --nonce "$((nonce_hex))" \
         --legacy --gas-price 1000000000 --gas-limit 5000000 \
         "$BRIDGE_ADDRESS" "$calldata" 2>/dev/null || return 0
 }
 
+# proof_vars: stdin = merkle-proof JSON → shell assignments MER/RER/SMT_LOCAL/
+# SMT_ROLLUP (single python invocation — the race loop is latency-sensitive).
+proof_vars() {
+    python3 -c "
+import json, sys
+try:
+    p = json.load(sys.stdin)['proof']
+except Exception:
+    sys.exit(0)
+def pad(a):
+    a = list(a)
+    while len(a) < 32: a.append('0x' + '00' * 32)
+    return '[' + ','.join(a[:32]) + ']'
+print(f\"MER={p['main_exit_root']};RER={p['rollup_exit_root']};\"
+      f\"SMT_LOCAL={pad(p['merkle_proof'])};SMT_ROLLUP={pad(p['rollup_merkle_proof'])}\")
+"
+}
+
+# claim_calldata_for: uses the DEP_*/MER/RER/SMT_* vars in scope.
+claim_calldata_for() {
+    cast calldata \
+        'claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)' \
+        "$SMT_LOCAL" "$SMT_ROLLUP" "$DEP_GI" "$MER" "$RER" \
+        "$DEP_ORIG_NET" "$DEP_ORIG_ADDR" "$DEP_DEST_NET" "$DEP_DEST_ADDR" \
+        "$DEP_AMOUNT" "$DEP_METADATA"
+}
+
 # submit_user_claim <deposit-json> <timeout-secs>
-# Tight retry loop: rebuild + submit the user's claim until accepted or the
-# dedup rejection fires. Sets:
+# Tight retry loop racing the sponsor's 2s ClaimTxManager monitor: re-fetch the
+# proof each round (the exit-root pair must coincide with an injected GER —
+# C6), but only re-sign when the pair CHANGES, and fetch the nonce once — the
+# loop period stays well under the sponsor's poll. Sets:
 #   SUBMIT_OUTCOME = user_won | dedup_rejected | timeout
 #   USER_TX        = the user's accepted tx hash (user_won only)
 #   LAST_ERR       = last JSON-RPC error message
 submit_user_claim() {
-    local dep="$1" timeout="$2" started raw resp result errmsg
+    local dep="$1" timeout="$2" started proof raw resp result errmsg
+    local calldata nonce_hex nonce last_pair=""
+    local DEP_CNT DEP_GI DEP_ORIG_NET DEP_ORIG_ADDR DEP_DEST_NET DEP_DEST_ADDR DEP_AMOUNT DEP_METADATA
+    local MER RER SMT_LOCAL SMT_ROLLUP
     SUBMIT_OUTCOME="timeout"; USER_TX=""; LAST_ERR=""
+
+    eval "$(echo "$dep" | dep_static_vars)"
+    # The user's proxy nonce only advances when a tx is ACCEPTED — which ends
+    # this loop — so one fetch up front is safe.
+    nonce_hex=$(rpc eth_getTransactionCount "[\"$USER_ADDR\",\"latest\"]" \
+        | python3 -c "import json,sys; print(json.load(sys.stdin)['result'])") || nonce_hex=0x0
+    nonce=$((nonce_hex))
+
     started=$(date +%s)
+    raw=""
     while (( $(date +%s) - started < timeout )); do
-        raw=$(build_user_claim_raw "$dep")
-        if [[ -z "$raw" ]]; then
-            sleep 1; continue    # proof not available yet
+        proof=$(curl -sf -m 5 "$BRIDGE_SERVICE_URL/merkle-proof?deposit_cnt=$DEP_CNT&net_id=0" 2>/dev/null) || { sleep 0.5; continue; }
+        [[ -z "$proof" ]] && { sleep 0.5; continue; }
+        MER=""
+        eval "$(echo "$proof" | proof_vars)"
+        [[ -z "$MER" ]] && { sleep 0.5; continue; }
+        if [[ "$MER|$RER" != "$last_pair" ]]; then
+            calldata=$(claim_calldata_for) || { sleep 0.5; continue; }
+            raw=$(cast mktx --private-key "$USER_KEY" --chain "$CHAIN_ID" --nonce "$nonce" \
+                --legacy --gas-price 1000000000 --gas-limit 5000000 \
+                "$BRIDGE_ADDRESS" "$calldata" 2>/dev/null) || { sleep 0.5; continue; }
+            last_pair="$MER|$RER"
         fi
+        [[ -z "$raw" ]] && { sleep 0.5; continue; }
         resp=$(rpc eth_sendRawTransaction "[\"$raw\"]")
         result=$(echo "$resp" | python3 -c "import json,sys; print(json.load(sys.stdin).get('result') or '')" 2>/dev/null || true)
         errmsg=$(echo "$resp" | python3 -c "import json,sys; print(json.load(sys.stdin).get('error',{}).get('message') or '')" 2>/dev/null || true)
@@ -263,8 +303,8 @@ submit_user_claim() {
         if [[ "$errmsg" == *"already submitted"* ]]; then
             SUBMIT_OUTCOME="dedup_rejected"; return 0
         fi
-        # C6 GER-not-seen and transient rejections: retry.
-        sleep 1
+        # C6 GER-not-seen and transient rejections: retry quickly.
+        sleep 0.3
     done
     return 0
 }
@@ -393,7 +433,12 @@ wait_for "race deposit ready_for_claim" \
 pass "race deposit is ready_for_claim — sponsor is live on it now"
 
 # Anchor the proxy log BEFORE the race so the dedup-rejection grep is scoped.
-LOGS_BEFORE=$(docker logs "$AGGLAYER_CONTAINER" 2>&1 | wc -l)
+# Timestamp anchor + `--tail` window, NOT a line-count over a full read:
+# docker's sequential log readers (plain read, --since) can die at a corrupt
+# entry mid-file on long-lived stacks (observed live: full read stopped hours
+# behind the tip), silently returning nothing past it. `--tail` seeks from the
+# END and stays reliable; ISO-8601 timestamps compare lexicographically.
+RACE_START_TS=$(date -u +%Y-%m-%dT%H:%M:%S)
 
 submit_user_claim "$DEP_JSON" 420
 WINNER=""; WINNER_TX=""
@@ -450,11 +495,12 @@ else
     warn "could not rebuild the user claim for the deterministic dedup check"
 fi
 
-# Best-effort: the proxy-side view of the loser (ANSI stripped, anchored on
-# the exact dedup message + this gi — never a bare FAIL/error grep).
-DEDUP_LOG_HITS=$(docker logs "$AGGLAYER_CONTAINER" 2>&1 \
-    | tail -n +$((LOGS_BEFORE + 1)) \
+# The proxy-side view of the loser (ANSI stripped, anchored on the exact
+# dedup message + this gi — never a bare FAIL/error grep). The deterministic
+# resubmission above guarantees at least one hit exists.
+DEDUP_LOG_HITS=$(docker logs --tail 6000 "$AGGLAYER_CONTAINER" 2>&1 \
     | strip_ansi \
+    | awk -v ts="$RACE_START_TS" '$1 >= ts' \
     | grep -c "already submitted for global_index ${GI2}" || true)
 log "proxy log dedup rejections for gi=$GI2 since race start: $DEDUP_LOG_HITS"
 [[ "$DEDUP_LOG_HITS" -ge 1 ]] \
@@ -474,6 +520,36 @@ done
 [[ "$BALANCE" -ge $((BAL_AFTER_LEG1 + EXPECTED_UNITS_PER_DEPOSIT)) ]] \
     || fail "raced deposit never minted (balance $BALANCE, expected ≥ $((BAL_AFTER_LEG1 + EXPECTED_UNITS_PER_DEPOSIT)))"
 pass "raced deposit minted exactly once: balance $BAL_AFTER_LEG1 → $BALANCE"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Epilogue — DETECT (report-only) the sponsor ethtxmanager wedge
+# ══════════════════════════════════════════════════════════════════════════════
+# FINDING (observed live, 2026-07-13 rel-v0158): when the user front-runs the
+# sponsor, aggkit's ClaimTxManager wedges. It has already signed its own claim
+# tx for the raced gi at its next nonce; the proxy rejects that tx FOREVER
+# ("claim already submitted" — the gi landed under the user's tx, hard dedup),
+# the R4 nonce gate never advances, and every later sponsor claim queues
+# behind it at nonce+1 ("nonce mismatch", observed live as tx.nonce=35 vs
+# expected=34 every 2s). On a real EVM chain the sponsor's claimAsset would
+# MINE as an AlreadyClaimed revert and consume the nonce; the proxy instead
+# rejects at RPC submission, so the nonce never burns — sponsor autoclaim is
+# dead for ALL later deposits from that point on. This epilogue only DETECTS
+# and reports the wedge; the operator remedy (verified live) is to consume the
+# sponsor's expected nonce with a benign accepted tx, e.g. a zero-amount
+# claimAsset signed by the fixture sponsor key, once per head-blocked tx.
+step "Epilogue — check whether this run wedged the sponsor autoclaimer"
+sleep 8
+RECENT=$(docker logs --tail 400 "$AGGLAYER_CONTAINER" 2>&1 \
+    | strip_ansi \
+    | awk -v ts="$(date -u -d '-9 seconds' +%Y-%m-%dT%H:%M:%S)" '$1 >= ts')
+if echo "$RECENT" | grep -qE "ERR claim already submitted for global_index (${LEG1_GI}|${GI2})\b"; then
+    warn "SPONSOR WEDGED: the proxy is still rejecting the sponsor's head tx for a"
+    warn "user-won gi every ~2s (hard dedup + R4 strict nonce = permanent block)."
+    warn "Sponsor autoclaim will NOT work for later deposits until an operator"
+    warn "consumes the sponsor's expected nonce (see comment above this check)."
+else
+    pass "no head-blocked dedup spam from the sponsor in the last 8s"
+fi
 
 echo ""
 log "======================================================================"

--- a/scripts/e2e-manual-user-claim.sh
+++ b/scripts/e2e-manual-user-claim.sh
@@ -196,7 +196,10 @@ source "$SCRIPT_DIR/lib-isolated-wallet.sh"
 
 SPONSOR_VERIFIED_AT_EXIT=0
 cleanup() {
-    local rc=$?
+    # rc from the first arg when a re-installed trap passes it explicitly (a bare
+    # `(exit "$rc")` before cleanup aborts the trap under `set -e` on failure —
+    # skipping cleanup exactly when it matters); otherwise fall back to $?.
+    local rc=${1:-$?}
     # Best-effort: never leave the shared stack with a wedged sponsor if the
     # script died before the epilogue heal (subshell so any `fail` inside the
     # heal cannot mask the original exit code).
@@ -905,9 +908,14 @@ print('\n'.join(out))
     read -r -a compose <<<"$ALLOWLIST_COMPOSE_CMD"
 
     ALLOWLIST_ACTIVE=1
-    # Preserve the failing command's exit code across the best-effort restore
-    # so cleanup() still sees it.
-    trap 'rc=$?; if [[ "$ALLOWLIST_ACTIVE" == "1" ]]; then ( restore_proxy_config ) || true; fi; (exit "$rc"); cleanup' EXIT
+    # This optional phase can itself re-wedge the sponsor; clear the "verified at
+    # exit" flag so cleanup's best-effort heal runs again if this phase fails.
+    SPONSOR_VERIFIED_AT_EXIT=0
+    # Preserve the failing command's exit code and pass it to cleanup EXPLICITLY.
+    # A bare `(exit "$rc")` before cleanup aborts the trap under `set -e` on a
+    # nonzero status, so cleanup (wallet wipe + sponsor heal) would be skipped
+    # exactly on failure. Passing $rc as an arg avoids that.
+    trap 'rc=$?; if [[ "$ALLOWLIST_ACTIVE" == "1" ]]; then ( restore_proxy_config ) || true; fi; cleanup "$rc"' EXIT
     "${compose[@]}" -f "$ALLOWLIST_OVERRIDE" up -d --no-deps --force-recreate miden-agglayer \
         || fail "could not recreate the proxy with the allow-list override"
     wait_for "proxy healthy with allow-list config" "rpc eth_chainId '[]' | grep -q '\"result\"'" 300 5

--- a/scripts/e2e-manual-user-claim.sh
+++ b/scripts/e2e-manual-user-claim.sh
@@ -8,32 +8,67 @@
 # only (signer-agnostic). This script drives that end-to-end:
 #
 #   Leg 1 — manual user claim wins:
-#     1. Bridge L1→L2 (bridgeAsset on Anvil) to an isolated Miden wallet.
+#     1. Bridge L1→L2 (bridgeAsset on Anvil) to a FRESH isolated Miden wallet
+#        (provisioned per run — nothing else ever deposits to it, so balance
+#        accounting is exact and causal, not >=).
 #     2. A USER key — the anvil dev key, NOT the claimsponsor keystore —
 #        pre-signs claimAsset (proof fetched from bridge-service) and submits
 #        it via raw eth_sendRawTransaction in a tight retry loop (retrying the
 #        C6 "GER not observed yet" rejections), racing the sponsor's 2s
-#        monitor. The user's 1s loop should land first; if the sponsor wins a
-#        round anyway, a fresh deposit is tried (up to MAX_LEG1_ATTEMPTS).
+#        monitor. The user's sub-second loop should land first; if the sponsor
+#        wins a round anyway, a fresh deposit is tried (MAX_LEG1_ATTEMPTS).
 #     3. Assert: user tx receipt (status 1), exactly ONE ClaimEvent for the
-#        globalIndex, the event under the USER's tx hash, and the wrapped
-#        balance delta on the Miden wallet.
+#        globalIndex, the event under the USER's tx hash, receipt.from == the
+#        USER (hard), and the wallet balance == EXACTLY the deposits sent so
+#        far × the per-deposit mint (deposit-linked accounting).
 #
-#   Leg 2 — dedup race on the same globalIndex:
-#     4. Second deposit; wait until it is ready_for_claim (sponsor is now
-#        actively trying), then fire the user's manual claim on the SAME
-#        globalIndex. Whoever wins, assert: exactly ONE ClaimEvent for the gi;
-#        the loser observed the "claim already submitted" dedup rejection
-#        (the user's own rejected submission if the sponsor won; a
-#        deterministic extra user submission — plus a best-effort proxy-log
-#        grep for the sponsor's rejection — if the user won); and the winner's
-#        tx hash is the one carrying the ClaimEvent + receipt.
+#   Sponsor heal + functional verification (between the legs AND as the
+#   epilogue — both HARD):
+#     Front-running the sponsor wedges aggkit/bridge-service's ClaimTxManager:
+#     it has signed its own claim tx for the raced gi at its next nonce; the
+#     proxy rejects that tx FOREVER ("claim already submitted" — hard dedup),
+#     the R4 nonce gate never advances, and every later sponsor claim queues
+#     behind it ("nonce mismatch" spam every ~2s). On a real EVM chain the
+#     sponsor's claimAsset would MINE as an AlreadyClaimed revert and consume
+#     the nonce; the proxy rejects at RPC submission, so the nonce never burns.
+#     THE HEAL (validated live, 2026-07-13 rel-v0158): consume each wedged
+#     head nonce with a benign zero-amount claimAsset no-op signed by the
+#     sponsor key (the proxy accepts zero-amount claims immediately, RPC-only:
+#     no Miden publish, no ClaimEvent, no claim lock — src/service_send_raw_txn.rs
+#     "skipping zero-amount claim"), until the sponsor's submissions stop being
+#     nonce-frozen. Then HARD-assert the sponsor is functional: a fresh deposit
+#     must autoclaim with receipt.from == the sponsor. The test FAILS if the
+#     sponsor cannot be healed — never a warning.
+#
+#   Leg 2 — dedup race on the same globalIndex (sponsor participation PROVEN):
+#     Second deposit; wait until it is ready_for_claim, then fire the user's
+#     manual claim on the SAME globalIndex against the (verified-live) sponsor.
+#     Whoever wins, assert: exactly ONE ClaimEvent for the gi; and POSITIVE
+#     sponsor participation —
+#       · sponsor won → the winning receipt's from == the SPONSOR address;
+#       · user won   → after the user's last (deterministic, dedup-rejected)
+#         submission, NEW "claim already submitted" rejections for this gi
+#         keep appearing in the proxy log (only the sponsor submits it by
+#         then), AND the sponsor signer's eth_sendRawTransaction submissions
+#         are visible in the proxy's nonce_snoop log.
+#     The test FAILS if the sponsor never raced gi2.
+#
+#   Optional ALLOWLIST_LEG=1 phase (DISPOSABLE STACKS ONLY — restarts the
+#   proxy): recreates the proxy container with --insecure-allow-any-signer
+#   REMOVED and ALLOWED_SIGNERS={user,sponsor,aggoracle,sequencer}; proves a
+#   manual user claim passes on allow-list membership alone and that a
+#   non-listed signer is rejected on the allow-list gate; then restores the
+#   original configuration. NEVER run this mid-suite: it recreates the proxy
+#   container twice.
 #
 # USER key: anvil dev key #0 — a TEST-ONLY kurtosis credential already used by
 # e2e-security.sh and scripts/claim.sh. Fine in fixtures/scripts; never prod.
 #
-# Stack-reuse-safe: baselines deposit counts and balances; never restarts
-# containers. Run with COMPOSE_PROJECT_NAME=<project> to target a named stack.
+# Stack-reuse-safe: destination wallet + baselines are per-run; eth_getLogs is
+# windowed from the script-start block and chunk-paginated (5000 blocks) under
+# the proxy's MAX_GETLOGS_BLOCK_RANGE cap; the sponsor is healed (hard-verified)
+# before exit. Never restarts containers (except the opt-in ALLOWLIST_LEG).
+# Run with COMPOSE_PROJECT_NAME=<project> to target a named stack.
 # ══════════════════════════════════════════════════════════════════════════════
 set -euo pipefail
 
@@ -63,6 +98,7 @@ EXPECTED_UNITS_PER_DEPOSIT=$((DEPOSIT_AMOUNT / WEI_PER_MIDEN_UNIT))
 
 CLAIM_EVENT_TOPIC="0x1df3f2a973a00d6635911755c260704e95e8a5876997546798770f76396fda4d"
 MAX_LEG1_ATTEMPTS="${MAX_LEG1_ATTEMPTS:-5}"
+MAX_SPONSOR_NOOPS="${MAX_SPONSOR_NOOPS:-8}"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'; NC='\033[0m'
 log()  { echo -e "${GREEN}[$(date +%H:%M:%S)]${NC} $*"; }
@@ -113,84 +149,165 @@ done
 CHAIN_ID_HEX=$(rpc eth_chainId '[]' | python3 -c "import json,sys; print(json.load(sys.stdin)['result'])")
 CHAIN_ID=$((CHAIN_ID_HEX))
 USER_ADDR=$(cast wallet address --private-key "$USER_KEY")
-log "proxy chain id: $CHAIN_ID; user (manual claimant): $USER_ADDR"
+USER_ADDR_LC="${USER_ADDR,,}"
 
-# ── Infra account ids + isolated destination wallet ──────────────────────────
+# Stack-reuse safety: window every eth_getLogs query from the block at which
+# THIS run starts, so the queried range never outgrows the proxy's
+# MAX_GETLOGS_BLOCK_RANGE (10,000) on long-lived stacks. claim_events_for_gi
+# additionally chunk-paginates (5000-block chunks, same fallback as
+# scripts/monitoring/watch-completeness.sh) in case the run itself spans the cap.
+proxy_block_number() {
+    rpc eth_blockNumber '[]' \
+        | python3 -c "import json,sys; print(int(json.load(sys.stdin)['result'],16))"
+}
+START_BLOCK=$(proxy_block_number)
+[[ -n "$START_BLOCK" ]] || fail "could not read the proxy block number"
+
+# The sponsor identity — the claimsponsor.keystore key the bridge-service
+# ClaimTxManager signs with. scripts/ensure-sponsor-key.sh decrypts it into
+# fixtures/.env (SPONSOR_PRIVATE_KEY); run it if this stack never has.
+if [[ -z "${SPONSOR_PRIVATE_KEY:-}" ]]; then
+    log "SPONSOR_PRIVATE_KEY not in fixtures/.env — running ensure-sponsor-key.sh"
+    "$SCRIPT_DIR/ensure-sponsor-key.sh" >/dev/null
+    source "$FIXTURES_DIR/.env"
+fi
+[[ -n "${SPONSOR_PRIVATE_KEY:-}" ]] || fail "SPONSOR_PRIVATE_KEY unavailable — sponsor heal/verification impossible"
+SPONSOR_ADDR=$(cast wallet address --private-key "$SPONSOR_PRIVATE_KEY")
+SPONSOR_ADDR_LC="${SPONSOR_ADDR,,}"
+[[ "$SPONSOR_ADDR_LC" != "$USER_ADDR_LC" ]] || fail "sponsor key equals the user key — fixtures broken"
+
+log "proxy chain id: $CHAIN_ID; start block: $START_BLOCK"
+log "user (manual claimant): $USER_ADDR"
+log "sponsor (ClaimTxManager signer): $SPONSOR_ADDR"
+
+# ── Infra account ids + FRESH per-run isolated destination wallet ────────────
 ACCOUNTS=$(docker exec "$AGGLAYER_CONTAINER" \
     cat /var/lib/miden-agglayer-service/bridge_accounts.toml 2>/dev/null) \
     || fail "miden-agglayer not initialized yet"
 BRIDGE_ID=$(echo "$ACCOUNTS" | grep 'bridge = ' | sed 's/.*= "//;s/"//')
 FAUCET_ID=$(echo "$ACCOUNTS" | grep faucet_eth | sed 's/.*= "//;s/"//')
 
-B2AGG_STORE_DIR="${B2AGG_STORE_DIR:-$PROJECT_DIR/.b2agg-store/e2e-manual-user-claim}"
+# CAUSAL BALANCE ACCOUNTING: the destination wallet is provisioned FRESH for
+# every run (unique store dir), so no deposit from any earlier test or run can
+# ever mint into it — the balance is exactly the sum of THIS run's deposits,
+# asserted with equality (a delayed foreign mint or a double mint both FAIL).
+B2AGG_STORE_DIR="${B2AGG_STORE_DIR:-$PROJECT_DIR/.b2agg-store/e2e-manual-user-claim-$(date +%s)-$$}"
 source "$SCRIPT_DIR/lib-isolated-wallet.sh"
+
+SPONSOR_VERIFIED_AT_EXIT=0
+cleanup() {
+    local rc=$?
+    # Best-effort: never leave the shared stack with a wedged sponsor if the
+    # script died before the epilogue heal (subshell so any `fail` inside the
+    # heal cannot mask the original exit code).
+    if [[ $rc -ne 0 && "$SPONSOR_VERIFIED_AT_EXIT" != "1" ]]; then
+        warn "script failed before the sponsor heal epilogue — best-effort heal so the stack is not left wedged"
+        ( drain_sponsor_wedge 4 ) || warn "best-effort sponsor heal did not complete"
+    fi
+    _iso_wipe_store || true
+    exit "$rc"
+}
+trap cleanup EXIT
+
 provision_isolated_wallet "$BRIDGE_ID" "$FAUCET_ID" \
     || fail "could not provision isolated destination wallet"
 
 log "======================================================================"
 log "  MANUAL USER CLAIM e2e"
 log "======================================================================"
-log "Wallet:  $WALLET_ID (isolated store: $B2AGG_STORE_DIR)"
+log "Wallet:  $WALLET_ID (fresh per-run isolated store: $B2AGG_STORE_DIR)"
 log "Dest:    $DEST_ADDR (zero-padded, network $DEST_NETWORK)"
 log "User:    $USER_ADDR (manual claimant, anvil dev key)"
+log "Sponsor: $SPONSOR_ADDR (claimsponsor keystore)"
 
 BAL_BEFORE=$(iso_wallet_balance "$BRIDGE_ID" "$FAUCET_ID")
 BAL_BEFORE="${BAL_BEFORE:-0}"
-log "L2 wallet balance before: $BAL_BEFORE"
+[[ "$BAL_BEFORE" -eq 0 ]] \
+    || fail "fresh per-run wallet has non-zero balance $BAL_BEFORE — provisioning reused a store; accounting basis broken"
+log "L2 wallet balance before: $BAL_BEFORE (fresh wallet)"
 
-# ── Helpers ───────────────────────────────────────────────────────────────────
+# ── Deposit helpers ───────────────────────────────────────────────────────────
 
-# known_deposit_cnts → space-separated deposit_cnt list currently visible for
-# DEST_ADDR (the stack-reuse baseline).
-known_deposit_cnts() {
-    curl -sf "$BRIDGE_SERVICE_URL/bridges/$DEST_ADDR" 2>/dev/null | python3 -c "
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    print(' '.join(str(dep['deposit_cnt']) for dep in d.get('deposits', [])))
-except Exception:
-    pass
-"
-}
+BRIDGE_EVENT_TOPIC=$(cast keccak "BridgeEvent(uint8,uint32,address,uint32,address,uint256,bytes,uint32)")
+DEPOSITS_SENT=0
 
-# new_deposit_json <baseline-cnts> → the deposit JSON for OUR new L1→L2 deposit
-# (network_id 0, matching amount, cnt not in baseline), or "".
-new_deposit_json() {
-    local baseline="$1"
-    curl -sf "$BRIDGE_SERVICE_URL/bridges/$DEST_ADDR" 2>/dev/null | python3 -c "
-import json, sys
-baseline = set('$baseline'.split())
-try:
-    d = json.load(sys.stdin)
-except Exception:
-    sys.exit(0)
-for dep in d.get('deposits', []):
-    if str(dep['deposit_cnt']) in baseline:
-        continue
-    if dep.get('network_id') != 0:
-        continue
-    if dep.get('amount') != '$DEPOSIT_AMOUNT':
-        continue
-    print(json.dumps(dep))
-    break
-"
-}
-
-dep_field() { python3 -c "import json,sys; print(json.load(sys.stdin)['$1'])"; }
-
-# do_l1_deposit → sends bridgeAsset on L1; fails the script on error.
+# do_l1_deposit → sends bridgeAsset on L1 and DERIVES the deposit identity from
+# the transaction's own BridgeEvent (tx hash → event → depositCount), so the
+# later bridge-service selection is tied to THIS submission — never to amount
+# matching against a (possibly misparsed) baseline. Sets L1_DEP_TX /
+# L1_DEP_CNT; increments DEPOSITS_SENT. Fails the script on any parse gap.
 do_l1_deposit() {
-    local tx status
-    tx=$(cast send --rpc-url "$L1_RPC" \
+    local receipt
+    receipt=$(cast send --json --rpc-url "$L1_RPC" \
         --private-key "$FUNDED_KEY" \
         "$BRIDGE_ADDRESS" \
         'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
         "$DEST_NETWORK" "$DEST_ADDR" "$DEPOSIT_AMOUNT" \
         0x0000000000000000000000000000000000000000 true 0x \
-        --value "$DEPOSIT_AMOUNT" 2>&1)
-    status=$(printf '%s\n' "$tx" | awk '$1=="status"{print $2; exit}')
-    [[ "$status" == "1" ]] || fail "L1 deposit tx failed (status=$status): $tx"
+        --value "$DEPOSIT_AMOUNT" 2>&1) \
+        || fail "L1 deposit cast send failed: $receipt"
+    read -r L1_DEP_TX L1_DEP_CNT <<<"$(printf '%s' "$receipt" | python3 -c "
+import json, sys
+try:
+    r = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)                                   # fail closed on parse failure
+if r.get('status') not in ('0x1', 1, '1'):
+    sys.exit(1)
+bridge = '$BRIDGE_ADDRESS'.lower()
+topic = '$BRIDGE_EVENT_TOPIC'.lower()
+for lg in r.get('logs', []):
+    if lg.get('address', '').lower() != bridge:
+        continue
+    topics = lg.get('topics') or []
+    if not topics or topics[0].lower() != topic:
+        continue
+    data = lg.get('data', '')
+    # BridgeEvent head layout: [leafType][origNet][origAddr][destNet][destAddr]
+    # [amount][metadata offset][depositCount] — depositCount is head word 7.
+    if len(data) < 2 + 64 * 8:
+        sys.exit(1)
+    print(r['transactionHash'], int(data[2 + 64*7 : 2 + 64*8], 16))
+    sys.exit(0)
+sys.exit(1)                                       # no BridgeEvent → fail closed
+")" || true
+    [[ -n "${L1_DEP_TX:-}" && -n "${L1_DEP_CNT:-}" ]] \
+        || fail "could not extract BridgeEvent depositCount from the L1 deposit receipt (fail-closed): $receipt"
+    DEPOSITS_SENT=$((DEPOSITS_SENT + 1))
+    log "L1 deposit #$DEPOSITS_SENT: tx=$L1_DEP_TX deposit_cnt=$L1_DEP_CNT"
 }
+
+# deposit_json_for_cnt <deposit_cnt> → the bridge-service deposit JSON for OUR
+# deposit (matched by the L1-receipt-derived deposit_cnt + network_id 0).
+# FAIL-CLOSED: a JSON parse failure prints nothing (and exits non-zero), so the
+# caller keeps waiting / fails — it can never fall back to selecting some old
+# deposit the way an empty amount-match baseline could.
+deposit_json_for_cnt() {
+    curl -sf "$BRIDGE_SERVICE_URL/bridges/$DEST_ADDR?limit=100&offset=0" 2>/dev/null | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+for dep in d.get('deposits', []):
+    if str(dep.get('deposit_cnt')) == '$1' and dep.get('network_id') == 0:
+        print(json.dumps(dep))
+        sys.exit(0)
+sys.exit(1)
+"
+}
+
+# fetch_deposit_json <deposit_cnt> <timeout> → sets DEP_JSON (hard fail on miss)
+fetch_deposit_json() {
+    local cnt="$1" timeout="$2"
+    DEP_JSON=""
+    wait_for "deposit cnt=$cnt visible in bridge-service" \
+        "DEP_JSON=\$(deposit_json_for_cnt $cnt); [[ -n \"\$DEP_JSON\" ]]" "$timeout" 5
+    DEP_JSON=$(deposit_json_for_cnt "$cnt") || true
+    [[ -n "$DEP_JSON" ]] || fail "deposit cnt=$cnt not retrievable from bridge-service (fail-closed parse)"
+}
+
+dep_field() { python3 -c "import json,sys; print(json.load(sys.stdin)['$1'])"; }
 
 # dep_static_vars <deposit-json> → emits shell assignments for the deposit's
 # static claim fields (one python invocation; values are bridge-service hex
@@ -312,19 +429,202 @@ submit_user_claim() {
 # claim_events_for_gi <global_index> → prints "<count> <tx_hash_of_first>"
 # from the proxy's eth_getLogs for the ClaimEvent topic. globalIndex is the
 # first 32-byte word of the (all-non-indexed) event data.
+#
+# Range-cap-safe: queries [START_BLOCK, latest] (never from genesis — a reused
+# stack past 10,000 blocks would trip MAX_GETLOGS_BLOCK_RANGE) and falls back
+# to 5000-block chunk pagination if the window itself outgrows the cap (same
+# pattern as scripts/monitoring/watch-completeness.sh). RPC errors are READ
+# failures (non-zero exit → caller fails/retries), never "0 events".
 claim_events_for_gi() {
-    local gi="$1"
-    rpc eth_getLogs "[{\"fromBlock\":\"0x0\",\"toBlock\":\"latest\",\"topics\":[\"$CLAIM_EVENT_TOPIC\"]}]" \
-        | python3 -c "
-import json, sys
-gi = int('$gi')
+    local gi="$1" latest
+    latest=$(proxy_block_number) || return 1
+    python3 - "$L2_RPC" "$CLAIM_EVENT_TOPIC" "$gi" "$START_BLOCK" "$latest" <<'PY'
+import json, sys, urllib.request
+rpc, topic, gi, frm, to = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4]), int(sys.argv[5])
+def get_logs(f, t):
+    req = urllib.request.Request(rpc, json.dumps({"jsonrpc": "2.0", "id": 1,
+        "method": "eth_getLogs",
+        "params": [{"fromBlock": hex(f), "toBlock": hex(t), "topics": [topic]}]}).encode(),
+        {"Content-Type": "application/json"})
+    resp = json.load(urllib.request.urlopen(req, timeout=30))
+    if "error" in resp or "result" not in resp:
+        raise RuntimeError(f"getLogs RPC error: {resp.get('error')}")
+    return resp["result"]
 try:
-    logs = json.load(sys.stdin).get('result') or []
-except Exception:
-    print('0 -'); sys.exit(0)
-hits = [l for l in logs if len(l.get('data','')) >= 66 and int(l['data'][2:66], 16) == gi]
-print(len(hits), hits[0]['transactionHash'] if hits else '-')
-"
+    logs = get_logs(frm, to)                      # fast path: window under the cap
+except (RuntimeError, OSError):
+    try:
+        logs, s = [], frm                         # range-capped: 5000-block chunks
+        while s <= to:
+            logs += get_logs(s, min(s + 4999, to))
+            s += 5000
+    except (RuntimeError, OSError) as e:
+        print(f"claim_events_for_gi: {e}", file=sys.stderr)
+        sys.exit(3)                               # read failure, NOT zero events
+hits = [l for l in logs if len(l.get("data", "")) >= 66 and int(l["data"][2:66], 16) == gi]
+print(len(hits), hits[0]["transactionHash"] if hits else "-")
+PY
+}
+
+receipt_status_ok() { # <tx-hash>
+    rpc eth_getTransactionReceipt "[\"$1\"]" \
+        | python3 -c "import json,sys; r=json.load(sys.stdin).get('result'); exit(0 if r and r.get('status')=='0x1' else 1)"
+}
+
+receipt_from() { # <tx-hash> → lowercase from address (empty if absent)
+    rpc eth_getTransactionReceipt "[\"$1\"]" \
+        | python3 -c "import json,sys; r=json.load(sys.stdin).get('result') or {}; f=r.get('from') or ''; print('' if f=='null' else f.lower())"
+}
+
+# assert_receipt_signer <tx-hash> <expected-addr-lc> <who> — HARD: a receipt
+# with no 'from' field is a FAIL, never a skipped assertion.
+assert_receipt_signer() {
+    local from
+    from=$(receipt_from "$1")
+    [[ -n "$from" ]] || fail "receipt for $1 carries no 'from' field — cannot prove the $3 signed it (hard requirement)"
+    [[ "$from" == "$2" ]] || fail "receipt 'from' for $1 is $from, expected the $3 $2"
+    pass "receipt signer for $1 is the $3 ($2)"
+}
+
+# wait_balance_exact <expected-units> [<rounds>] — deposit-linked EXACT
+# accounting on the fresh per-run wallet: the balance must reach exactly
+# expected (sum of this run's deposits); anything above is an immediate FAIL
+# (a mint that this run's deposits cannot explain / a double mint).
+wait_balance_exact() {
+    local expected="$1" rounds="${2:-24}" i bal=0
+    log "Waiting for wallet balance == $expected exactly (sync + consume P2ID notes)..."
+    for i in $(seq 1 "$rounds"); do
+        sleep 10
+        bal=$(iso_wallet_balance "$BRIDGE_ID" "$FAUCET_ID")
+        bal="${bal:-0}"
+        log "balance check $i/$rounds: $bal (want exactly $expected)"
+        [[ "$bal" -gt "$expected" ]] \
+            && fail "balance $bal EXCEEDS the deposit-linked expectation $expected — an unaccounted or double mint"
+        [[ "$bal" -eq "$expected" ]] && { pass "balance is exactly $expected (== $DEPOSITS_SENT deposits × $EXPECTED_UNITS_PER_DEPOSIT units)"; return 0; }
+    done
+    fail "balance never reached exactly $expected (last: $bal)"
+}
+
+# ── Sponsor heal + functional verification ────────────────────────────────────
+
+SPONSOR_NOOPS_SENT=0
+ZERO32="0x0000000000000000000000000000000000000000000000000000000000000000"
+ZERO_PROOF="[$(python3 -c "print(','.join(['0x' + '00'*32] * 32))")]"
+
+sponsor_nonce() {
+    rpc eth_getTransactionCount "[\"$SPONSOR_ADDR\",\"latest\"]" \
+        | python3 -c "import json,sys; print(int(json.load(sys.stdin)['result'],16))"
+}
+
+# send_sponsor_noop <nonce> — consume one sponsor nonce with a ZERO-AMOUNT
+# claimAsset. The proxy accepts zero-amount claims synchronously and RPC-only
+# (worker_handle_claim_asset: "skipping zero-amount claim" — no Miden publish,
+# no ClaimEvent, no claim-lock write), so this burns exactly one nonce with no
+# bridge side effects. This is the operator remedy validated live (2026-07-13).
+send_sponsor_noop() {
+    local nonce="$1" gi calldata raw resp result
+    gi=$(( $(date +%s) % 1000000000 * 1000 + RANDOM % 1000 ))
+    calldata=$(cast calldata \
+        'claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)' \
+        "$ZERO_PROOF" "$ZERO_PROOF" "$gi" "$ZERO32" "$ZERO32" \
+        0 0x0000000000000000000000000000000000000000 \
+        "$DEST_NETWORK" 0x0000000000000000000000000000000000000000 0 0x)
+    raw=$(cast mktx --private-key "$SPONSOR_PRIVATE_KEY" --chain "$CHAIN_ID" --nonce "$nonce" \
+        --legacy --gas-price 1000000000 --gas-limit 5000000 \
+        "$BRIDGE_ADDRESS" "$calldata")
+    resp=$(rpc eth_sendRawTransaction "[\"$raw\"]")
+    result=$(echo "$resp" | python3 -c "import json,sys; print(json.load(sys.stdin).get('result') or '')" 2>/dev/null || true)
+    [[ -n "$result" ]] || fail "sponsor no-op at nonce $nonce was rejected — heal impossible: $resp"
+    SPONSOR_NOOPS_SENT=$((SPONSOR_NOOPS_SENT + 1))
+    log "consumed sponsor nonce $nonce with a zero-amount claimAsset no-op (tx $result)"
+}
+
+# sponsor_probe_round — observe the sponsor for 12s (≥ 5 ClaimTxManager 2s
+# monitor ticks) and heal ONE wedged head nonce if (and only if) the sponsor is
+# actively submitting, its account nonce is frozen, AND the proxy is answering
+# with hard rejections (dedup "claim already submitted" / R4 "nonce mismatch").
+# Transient C6 GER-not-seen retries are left alone. Sets PROBE_VERDICT (not
+# echoed: a $(…) capture would run in a subshell and lose the
+# SPONSOR_NOOPS_SENT increment) to: idle | advancing | transient | healed
+PROBE_VERDICT=""
+sponsor_probe_round() {
+    local nonce_before nonce_after win_ts window subs rejections
+    PROBE_VERDICT=""
+    nonce_before=$(sponsor_nonce)
+    win_ts=$(date -u +%Y-%m-%dT%H:%M:%S)
+    sleep 12
+    nonce_after=$(sponsor_nonce)
+    window=$(docker logs --tail 8000 "$AGGLAYER_CONTAINER" 2>&1 | strip_ansi \
+        | awk -v ts="$win_ts" '$1 >= ts')
+    subs=$(printf '%s\n' "$window" \
+        | grep -E "\"event\": ?\"eth_sendRawTransaction_received\"" \
+        | grep -cE "\"signer\": ?\"$SPONSOR_ADDR_LC\"" || true)
+    if [[ "${subs:-0}" -eq 0 ]]; then
+        PROBE_VERDICT="idle"; return 0
+    fi
+    if (( nonce_after > nonce_before )); then
+        PROBE_VERDICT="advancing"; return 0
+    fi
+    rejections=$(printf '%s\n' "$window" \
+        | grep -cE "nonce mismatch for $SPONSOR_ADDR_LC|claim already submitted for global_index" || true)
+    if [[ "${rejections:-0}" -eq 0 ]]; then
+        PROBE_VERDICT="transient"; return 0
+    fi
+    warn "sponsor WEDGED at nonce $nonce_after ($subs submissions, $rejections hard rejections in 12s) — consuming the head nonce"
+    send_sponsor_noop "$nonce_after"
+    PROBE_VERDICT="healed"
+}
+
+# drain_sponsor_wedge [<max-rounds>] — probe rounds until the sponsor is idle
+# or advancing (i.e. no head-blocked spam). Used between the legs and as the
+# best-effort cleanup path; the HARD functional guarantee is
+# verify_sponsor_functional below.
+drain_sponsor_wedge() {
+    local max="${1:-10}" round
+    for round in $(seq 1 "$max"); do
+        [[ "$SPONSOR_NOOPS_SENT" -lt "$MAX_SPONSOR_NOOPS" ]] \
+            || fail "sponsor heal exceeded MAX_SPONSOR_NOOPS=$MAX_SPONSOR_NOOPS no-ops — sponsor state is pathological, refusing to spin"
+        sponsor_probe_round
+        log "sponsor probe round $round/$max: $PROBE_VERDICT"
+        case "$PROBE_VERDICT" in
+            idle|advancing) return 0 ;;
+            transient|healed) ;; # observe again
+        esac
+    done
+    warn "sponsor still busy after $max probe rounds (last: $PROBE_VERDICT)"
+    return 0
+}
+
+# verify_sponsor_functional <phase-label> — the HARD sponsor guarantee: a fresh
+# deposit (which the user does NOT touch) must be autoclaimed BY THE SPONSOR.
+# While waiting, keeps probing/healing (the sponsor may re-wedge the moment its
+# next queued claim hits an already-consumed nonce). FAILS the test if the
+# sponsor does not claim it — never a warning.
+verify_sponsor_functional() {
+    local label="$1" vgi deadline now c t
+    step "Sponsor functional verification ($label) — fresh deposit MUST autoclaim"
+    do_l1_deposit
+    fetch_deposit_json "$L1_DEP_CNT" 300
+    vgi=$(echo "$DEP_JSON" | dep_field global_index)
+    log "verification deposit: cnt=$L1_DEP_CNT gi=$vgi (user will NOT claim it)"
+
+    deadline=$(( $(date +%s) + 600 ))
+    while :; do
+        read -r c t <<<"$(claim_events_for_gi "$vgi" || echo "0 -")"
+        [[ "${c:-0}" -ge 1 ]] && break
+        now=$(date +%s)
+        (( now >= deadline )) \
+            && fail "sponsor never claimed the verification deposit gi=$vgi within 600s — sponsor autoclaim is NOT functional ($label)"
+        # Probe + heal while waiting: consumes any (re-)wedged head nonce.
+        log "verification claim not landed yet — probing the sponsor ($(( deadline - now ))s left)"
+        drain_sponsor_wedge 1 || true
+    done
+
+    read -r c t <<<"$(claim_events_for_gi "$vgi")"
+    [[ "$c" == "1" ]] || fail "expected exactly 1 ClaimEvent for verification gi=$vgi, got $c"
+    wait_for "verification claim receipt (status 0x1)" "receipt_status_ok '$t'" 300 5
+    assert_receipt_signer "$t" "$SPONSOR_ADDR_LC" "SPONSOR"
+    pass "sponsor is functional ($label): fresh deposit gi=$vgi autoclaimed by the sponsor (tx $t)"
 }
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -335,22 +635,16 @@ step "Leg 1 — deposit L1→L2, then the USER claims it manually"
 LEG1_GI=""; LEG1_TX=""
 for attempt in $(seq 1 "$MAX_LEG1_ATTEMPTS"); do
     log "Leg 1 attempt $attempt/$MAX_LEG1_ATTEMPTS"
-    BASELINE_CNTS=$(known_deposit_cnts)
     do_l1_deposit
-    pass "L1 deposit sent"
-
-    DEP_JSON=""
-    wait_for "deposit visible to bridge-service" \
-        "DEP_JSON=\$(new_deposit_json \"$BASELINE_CNTS\"); [[ -n \"\$DEP_JSON\" ]]" 300 5
-    DEP_JSON=$(new_deposit_json "$BASELINE_CNTS")
+    pass "L1 deposit sent (tx $L1_DEP_TX → deposit_cnt $L1_DEP_CNT)"
+    fetch_deposit_json "$L1_DEP_CNT" 300
     GI=$(echo "$DEP_JSON" | dep_field global_index)
-    CNT=$(echo "$DEP_JSON" | dep_field deposit_cnt)
-    log "deposit_cnt=$CNT globalIndex=$GI"
+    log "deposit_cnt=$L1_DEP_CNT globalIndex=$GI"
 
     # Start submitting IMMEDIATELY (before ready_for_claim): the loop retries
-    # the C6 "GER not observed yet" rejections every 1s, so the user grabs the
-    # claim lock the moment the GER lands — usually beating the sponsor's 2s
-    # monitor.
+    # the C6 "GER not observed yet" rejections sub-second, so the user grabs
+    # the claim lock the moment the GER lands — usually beating the sponsor's
+    # 2s monitor.
     submit_user_claim "$DEP_JSON" 420
     case "$SUBMIT_OUTCOME" in
         user_won)
@@ -371,9 +665,7 @@ done
 
 # Receipt: pending until the SyntheticProjector observes the CLAIM note
 # consumed; then status must be success and the ClaimEvent rides this tx.
-wait_for "user claim receipt (projector finalisation)" \
-    "rpc eth_getTransactionReceipt '[\"$LEG1_TX\"]' | python3 -c \"import json,sys; r=json.load(sys.stdin).get('result'); exit(0 if r and r.get('status')=='0x1' else 1)\"" \
-    420 5
+wait_for "user claim receipt (projector finalisation)" "receipt_status_ok '$LEG1_TX'" 420 5
 pass "user claim receipt landed (status 0x1)"
 
 read -r EV_COUNT EV_TX <<<"$(claim_events_for_gi "$LEG1_GI")"
@@ -381,58 +673,48 @@ read -r EV_COUNT EV_TX <<<"$(claim_events_for_gi "$LEG1_GI")"
 [[ "${EV_TX,,}" == "${LEG1_TX,,}" ]] || fail "ClaimEvent tx hash $EV_TX != user's tx $LEG1_TX"
 pass "exactly ONE ClaimEvent for gi=$LEG1_GI, under the USER's tx hash"
 
-# Receipt 'from' must be the USER — no sponsor substitution anywhere.
-RECEIPT_FROM=$(rpc eth_getTransactionReceipt "[\"$LEG1_TX\"]" \
-    | python3 -c "import json,sys; print((json.load(sys.stdin)['result'].get('from') or '').lower())")
-if [[ -n "$RECEIPT_FROM" && "$RECEIPT_FROM" != "null" ]]; then
-    [[ "$RECEIPT_FROM" == "${USER_ADDR,,}" ]] \
-        || fail "receipt 'from' is $RECEIPT_FROM, expected the user $USER_ADDR"
-    pass "receipt signer is the USER ($USER_ADDR)"
-else
-    warn "receipt carries no 'from' field — skipping the signer assertion"
-fi
+# Receipt 'from' must be the USER — no sponsor substitution anywhere. HARD:
+# an absent 'from' is a FAIL, not a skipped assertion.
+assert_receipt_signer "$LEG1_TX" "$USER_ADDR_LC" "USER"
 
-# Wrapped balance: the deposit must have been minted to the Miden wallet.
-log "Checking wrapped balance (sync + consume P2ID notes)..."
-BALANCE="$BAL_BEFORE"
-for i in $(seq 1 18); do
-    sleep 10
-    BALANCE=$(iso_wallet_balance "$BRIDGE_ID" "$FAUCET_ID")
-    BALANCE="${BALANCE:-0}"
-    log "attempt $i/18: balance = $BALANCE (was $BAL_BEFORE)"
-    [[ "$BALANCE" -ge $((BAL_BEFORE + EXPECTED_UNITS_PER_DEPOSIT)) ]] && break
-done
-[[ "$BALANCE" -ge $((BAL_BEFORE + EXPECTED_UNITS_PER_DEPOSIT)) ]] \
-    || fail "wrapped balance did not increase by $EXPECTED_UNITS_PER_DEPOSIT (before=$BAL_BEFORE, now=$BALANCE)"
-pass "wrapped balance delta OK: $BAL_BEFORE → $BALANCE (user-claimed deposit minted)"
-BAL_AFTER_LEG1="$BALANCE"
+# Deposit-linked exact accounting: every deposit sent so far (the user-claimed
+# one, plus any sponsor-won attempts) mints to the fresh wallet — and NOTHING
+# else can. Equality, not >=.
+wait_balance_exact "$((DEPOSITS_SENT * EXPECTED_UNITS_PER_DEPOSIT))"
 
 # ══════════════════════════════════════════════════════════════════════════════
-# Leg 2 — dedup race: user's manual claim vs sponsor autoclaim, same gi
+# Between the legs — heal the sponsor the leg-1 front-run just wedged, and
+# HARD-verify it works, so leg 2 races a live sponsor (not a corpse whose head
+# nonce is stuck on the leg-1 gi).
+# ══════════════════════════════════════════════════════════════════════════════
+step "Inter-leg sponsor heal — leg 2 needs a LIVE sponsor to race"
+drain_sponsor_wedge 10
+verify_sponsor_functional "inter-leg"
+wait_balance_exact "$((DEPOSITS_SENT * EXPECTED_UNITS_PER_DEPOSIT))"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Leg 2 — dedup race: user's manual claim vs sponsor autoclaim, same gi.
+# Sponsor participation is PROVEN positively in both outcomes (never inferred
+# from ready_for_claim).
 # ══════════════════════════════════════════════════════════════════════════════
 step "Leg 2 — race the sponsor on the SAME globalIndex"
 
-BASELINE_CNTS=$(known_deposit_cnts)
 do_l1_deposit
-pass "second L1 deposit sent"
-
-DEP_JSON=""
-wait_for "second deposit visible to bridge-service" \
-    "DEP_JSON=\$(new_deposit_json \"$BASELINE_CNTS\"); [[ -n \"\$DEP_JSON\" ]]" 300 5
-DEP_JSON=$(new_deposit_json "$BASELINE_CNTS")
+pass "race L1 deposit sent (tx $L1_DEP_TX → deposit_cnt $L1_DEP_CNT)"
+fetch_deposit_json "$L1_DEP_CNT" 300
 GI2=$(echo "$DEP_JSON" | dep_field global_index)
-CNT2=$(echo "$DEP_JSON" | dep_field deposit_cnt)
+CNT2="$L1_DEP_CNT"
 log "race deposit_cnt=$CNT2 globalIndex=$GI2"
 
 # This time WAIT for ready_for_claim first, so the sponsor's ClaimTxManager
-# (2s monitor) is actively claiming when the user's submission goes in — a
-# genuine race on the same globalIndex.
+# (2s monitor, just verified functional) is actively claiming when the user's
+# submission goes in — a genuine race on the same globalIndex.
 wait_for "race deposit ready_for_claim" \
-    "curl -sf '$BRIDGE_SERVICE_URL/bridges/$DEST_ADDR' | python3 -c \"import json,sys; d=json.load(sys.stdin); exit(0 if any(dep['deposit_cnt']==$CNT2 and dep['ready_for_claim'] for dep in d['deposits']) else 1)\"" \
+    "curl -sf '$BRIDGE_SERVICE_URL/bridges/$DEST_ADDR?limit=100&offset=0' | python3 -c \"import json,sys; d=json.load(sys.stdin); exit(0 if any(str(dep['deposit_cnt'])=='$CNT2' and dep['ready_for_claim'] for dep in d['deposits']) else 1)\"" \
     600 5
-pass "race deposit is ready_for_claim — sponsor is live on it now"
+pass "race deposit is ready_for_claim"
 
-# Anchor the proxy log BEFORE the race so the dedup-rejection grep is scoped.
+# Anchor the proxy log BEFORE the race, for the sponsor-participation greps.
 # Timestamp anchor + `--tail` window, NOT a line-count over a full read:
 # docker's sequential log readers (plain read, --since) can die at a corrupt
 # entry mid-file on long-lived stacks (observed live: full read stopped hours
@@ -470,90 +752,222 @@ if [[ "$WINNER" == "user" ]]; then
         || fail "ClaimEvent tx $EV2_TX != the winning user's tx $WINNER_TX"
 else
     WINNER_TX="$EV2_TX"
-    # The user never got a tx accepted, so the event tx must be someone else's
-    # (the sponsor's) — sanity: the winner's receipt must exist.
     log "sponsor's winning tx: $WINNER_TX"
 fi
-wait_for "winner's receipt (status 0x1)" \
-    "rpc eth_getTransactionReceipt '[\"$WINNER_TX\"]' | python3 -c \"import json,sys; r=json.load(sys.stdin).get('result'); exit(0 if r and r.get('status')=='0x1' else 1)\"" \
-    300 5
+wait_for "winner's receipt (status 0x1)" "receipt_status_ok '$WINNER_TX'" 300 5
 pass "winner's tx hash $WINNER_TX carries the receipt + ClaimEvent"
 
-# The loser's dedup rejection, as observed BY THE PROXY. If the sponsor lost,
-# its rejected attempt shows up in the proxy log; if the user lost we already
-# asserted the JSON-RPC error above. Either way, force a DETERMINISTIC loser
-# too: one more user submission for the same (now claimed) gi must be
-# dedup-rejected.
-RAW=$(build_user_claim_raw "$DEP_JSON")
-if [[ -n "$RAW" ]]; then
+# ── POSITIVE sponsor-participation proof (the race must have TWO racers) ─────
+if [[ "$WINNER" == "sponsor" ]]; then
+    # Sponsor won → the winning receipt itself is the proof: signed by the
+    # sponsor key (hard; absent 'from' fails).
+    assert_receipt_signer "$WINNER_TX" "$SPONSOR_ADDR_LC" "SPONSOR"
+    pass "sponsor participation proven: the sponsor's own tx won gi=$GI2"
+else
+    # User won → first force the DETERMINISTIC loser: one more user submission
+    # for the same (now claimed) gi must be dedup-rejected...
+    RAW=$(build_user_claim_raw "$DEP_JSON")
+    [[ -n "$RAW" ]] || fail "could not rebuild the user claim for the deterministic dedup check"
     RESP=$(rpc eth_sendRawTransaction "[\"$RAW\"]")
     ERRMSG=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('error',{}).get('message') or '')" 2>/dev/null || true)
     [[ "$ERRMSG" == *"already submitted"* ]] \
-        || fail "post-race resubmission for gi=$GI2 was not dedup-rejected (got: '$ERRMSG', resp: $RESP)"
+        || fail "post-race user resubmission for gi=$GI2 was not dedup-rejected (got: '$ERRMSG', resp: $RESP)"
     pass "post-race user resubmission dedup-rejected: '$ERRMSG'"
-else
-    warn "could not rebuild the user claim for the deterministic dedup check"
+
+    # ...then prove the SPONSOR is racing gi2, positively: after the user's
+    # LAST submission above, any further "claim already submitted" rejection
+    # for THIS gi can only come from the sponsor's ClaimTxManager (2s retry
+    # loop on its signed gi2 tx). Anchor strictly after the resubmission, then
+    # require fresh gi2 dedup rejections AND the sponsor signer's own
+    # eth_sendRawTransaction submissions in the proxy log. If the sponsor
+    # never raced, this FAILS — dedup evidence manufactured by the user's own
+    # resubmission cannot satisfy it (it is before the anchor).
+    sleep 2
+    SPONSOR_PROOF_TS=$(date -u +%Y-%m-%dT%H:%M:%S)
+    log "observing 15s for the sponsor's own gi=$GI2 submissions (anchor $SPONSOR_PROOF_TS)..."
+    sleep 15
+    PROOF_WINDOW=$(docker logs --tail 8000 "$AGGLAYER_CONTAINER" 2>&1 | strip_ansi \
+        | awk -v ts="$SPONSOR_PROOF_TS" '$1 >= ts')
+    GI2_DEDUP_HITS=$(printf '%s\n' "$PROOF_WINDOW" \
+        | grep -cE "already submitted for global_index ${GI2}([^0-9]|$)" || true)
+    SPONSOR_SUBS=$(printf '%s\n' "$PROOF_WINDOW" \
+        | grep -E "\"event\": ?\"eth_sendRawTransaction_received\"" \
+        | grep -cE "\"signer\": ?\"$SPONSOR_ADDR_LC\"" || true)
+    # Race window submissions (from ready_for_claim onwards) for the log line.
+    RACE_WINDOW_SUBS=$(docker logs --tail 12000 "$AGGLAYER_CONTAINER" 2>&1 | strip_ansi \
+        | awk -v ts="$RACE_START_TS" '$1 >= ts' \
+        | grep -E "\"event\": ?\"eth_sendRawTransaction_received\"" \
+        | grep -cE "\"signer\": ?\"$SPONSOR_ADDR_LC\"" || true)
+    log "post-anchor gi2 dedup rejections: ${GI2_DEDUP_HITS:-0}; sponsor submissions post-anchor: ${SPONSOR_SUBS:-0} (since race start: ${RACE_WINDOW_SUBS:-0})"
+    [[ "${GI2_DEDUP_HITS:-0}" -ge 1 ]] \
+        || fail "no NEW dedup rejection for gi=$GI2 after the user's last submission — the sponsor never raced this gi (leg 2 had no second racer)"
+    [[ "${SPONSOR_SUBS:-0}" -ge 1 ]] \
+        || fail "no eth_sendRawTransaction from the sponsor signer $SPONSOR_ADDR_LC in the proxy log after the user's last submission — cannot attribute the gi2 rejections to the sponsor"
+    pass "sponsor participation proven: sponsor kept submitting gi=$GI2 after the user stopped ($GI2_DEDUP_HITS dedup rejections, $SPONSOR_SUBS sponsor submissions in 15s)"
 fi
 
-# The proxy-side view of the loser (ANSI stripped, anchored on the exact
-# dedup message + this gi — never a bare FAIL/error grep). The deterministic
-# resubmission above guarantees at least one hit exists.
-DEDUP_LOG_HITS=$(docker logs --tail 6000 "$AGGLAYER_CONTAINER" 2>&1 \
-    | strip_ansi \
-    | awk -v ts="$RACE_START_TS" '$1 >= ts' \
-    | grep -c "already submitted for global_index ${GI2}" || true)
-log "proxy log dedup rejections for gi=$GI2 since race start: $DEDUP_LOG_HITS"
-[[ "$DEDUP_LOG_HITS" -ge 1 ]] \
-    || fail "no dedup rejection for gi=$GI2 in the proxy log — the race never produced a loser?"
-pass "proxy log shows the dedup rejection for gi=$GI2 ($DEDUP_LOG_HITS hits)"
-
-# Final balance: both deposits (user-claimed + raced) must be minted.
-log "Final wrapped-balance check (both deposits)..."
-BALANCE="$BAL_AFTER_LEG1"
-for i in $(seq 1 18); do
-    sleep 10
-    BALANCE=$(iso_wallet_balance "$BRIDGE_ID" "$FAUCET_ID")
-    BALANCE="${BALANCE:-0}"
-    log "attempt $i/18: balance = $BALANCE (leg-1 level $BAL_AFTER_LEG1)"
-    [[ "$BALANCE" -ge $((BAL_AFTER_LEG1 + EXPECTED_UNITS_PER_DEPOSIT)) ]] && break
-done
-[[ "$BALANCE" -ge $((BAL_AFTER_LEG1 + EXPECTED_UNITS_PER_DEPOSIT)) ]] \
-    || fail "raced deposit never minted (balance $BALANCE, expected ≥ $((BAL_AFTER_LEG1 + EXPECTED_UNITS_PER_DEPOSIT)))"
-pass "raced deposit minted exactly once: balance $BAL_AFTER_LEG1 → $BALANCE"
-
 # ══════════════════════════════════════════════════════════════════════════════
-# Epilogue — DETECT (report-only) the sponsor ethtxmanager wedge
+# Epilogue — HEAL the sponsor wedge this run created and HARD-verify the stack
+# is left with a functional autoclaimer (suite-safety: this script must not
+# poison whatever runs after it).
 # ══════════════════════════════════════════════════════════════════════════════
-# FINDING (observed live, 2026-07-13 rel-v0158): when the user front-runs the
-# sponsor, aggkit's ClaimTxManager wedges. It has already signed its own claim
-# tx for the raced gi at its next nonce; the proxy rejects that tx FOREVER
-# ("claim already submitted" — the gi landed under the user's tx, hard dedup),
-# the R4 nonce gate never advances, and every later sponsor claim queues
-# behind it at nonce+1 ("nonce mismatch", observed live as tx.nonce=35 vs
-# expected=34 every 2s). On a real EVM chain the sponsor's claimAsset would
-# MINE as an AlreadyClaimed revert and consume the nonce; the proxy instead
-# rejects at RPC submission, so the nonce never burns — sponsor autoclaim is
-# dead for ALL later deposits from that point on. This epilogue only DETECTS
-# and reports the wedge; the operator remedy (verified live) is to consume the
-# sponsor's expected nonce with a benign accepted tx, e.g. a zero-amount
-# claimAsset signed by the fixture sponsor key, once per head-blocked tx.
-step "Epilogue — check whether this run wedged the sponsor autoclaimer"
-sleep 8
-RECENT=$(docker logs --tail 400 "$AGGLAYER_CONTAINER" 2>&1 \
-    | strip_ansi \
-    | awk -v ts="$(date -u -d '-9 seconds' +%Y-%m-%dT%H:%M:%S)" '$1 >= ts')
-if echo "$RECENT" | grep -qE "ERR claim already submitted for global_index (${LEG1_GI}|${GI2})\b"; then
-    warn "SPONSOR WEDGED: the proxy is still rejecting the sponsor's head tx for a"
-    warn "user-won gi every ~2s (hard dedup + R4 strict nonce = permanent block)."
-    warn "Sponsor autoclaim will NOT work for later deposits until an operator"
-    warn "consumes the sponsor's expected nonce (see comment above this check)."
-else
-    pass "no head-blocked dedup spam from the sponsor in the last 8s"
-fi
+step "Epilogue — sponsor heal + hard functional assertion"
+drain_sponsor_wedge 10
+verify_sponsor_functional "epilogue"
+SPONSOR_VERIFIED_AT_EXIT=1
+
+# Final deposit-linked accounting: EVERY deposit this run sent (leg 1 attempts,
+# two verification deposits, the raced deposit) minted exactly once — the fresh
+# wallet's balance equals the exact sum, nothing more.
+wait_balance_exact "$((DEPOSITS_SENT * EXPECTED_UNITS_PER_DEPOSIT))"
 
 echo ""
 log "======================================================================"
 log "  MANUAL USER CLAIM e2e DONE"
 log "    leg 1: user tx $LEG1_TX claimed gi=$LEG1_GI"
-log "    leg 2: winner=$WINNER tx=$WINNER_TX gi=$GI2 (single ClaimEvent, loser dedup-rejected)"
+log "    leg 2: winner=$WINNER tx=$WINNER_TX gi=$GI2 (single ClaimEvent, loser dedup-rejected, sponsor participation proven)"
+log "    sponsor: healed + verified functional ($SPONSOR_NOOPS_SENT wedged nonce(s) consumed)"
+log "    deposits: $DEPOSITS_SENT sent, balance exactly $((DEPOSITS_SENT * EXPECTED_UNITS_PER_DEPOSIT)) units"
 log "======================================================================"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# OPTIONAL: ALLOW-LIST LEG (ALLOWLIST_LEG=1) — DISPOSABLE STACKS ONLY.
+#
+# Recreates the proxy container WITHOUT --insecure-allow-any-signer and with an
+# explicit ALLOWED_SIGNERS list (user + sponsor + the stack's own aggoracle /
+# sequencer signers, which must stay allowed or GER injection dies and no claim
+# can ever pass C6), proves the manual user claim works on allow-list
+# membership alone plus that a non-listed signer is rejected on the allow-list
+# gate, then restores the original configuration. THE PROXY RESTARTS TWICE:
+# never run this mid-suite or on a stack anyone else is using.
+#
+# Assumes the stack was created from docker-compose.e2e.yml (override the file
+# list via ALLOWLIST_COMPOSE_FILES for overlay stacks).
+# ══════════════════════════════════════════════════════════════════════════════
+
+keystore_address() { # <keystore-path> <password> → 0x address (key never printed)
+    local key
+    key=$(cast wallet decrypt-keystore "$(basename "$1")" \
+            --keystore-dir "$(dirname "$1")" \
+            --unsafe-password "$2" 2>/dev/null \
+          | grep -oiE -m1 '(0x)?[0-9a-f]{64}' || true)
+    [[ -n "$key" ]] || return 1
+    cast wallet address --private-key "0x${key#0x}"
+}
+
+ALLOWLIST_OVERRIDE=""
+ALLOWLIST_ACTIVE=0
+
+restore_proxy_config() {
+    warn "restoring the original proxy configuration (container recreate)..."
+    local -a compose
+    read -r -a compose <<<"$ALLOWLIST_COMPOSE_CMD"
+    "${compose[@]}" up -d --no-deps --force-recreate miden-agglayer >/dev/null 2>&1 \
+        || fail "could not restore the original proxy config — STACK LEFT MODIFIED, restore manually: $ALLOWLIST_COMPOSE_CMD up -d --no-deps --force-recreate miden-agglayer"
+    wait_for "proxy healthy after restore" "rpc eth_chainId '[]' | grep -q '\"result\"'" 300 5
+    ALLOWLIST_ACTIVE=0
+    [[ -n "$ALLOWLIST_OVERRIDE" ]] && rm -f "$ALLOWLIST_OVERRIDE"
+    pass "original proxy configuration restored"
+}
+
+run_allowlist_leg() {
+    step "ALLOW-LIST LEG — proxy restart with explicit --allowed-signers (DISPOSABLE STACK ONLY)"
+    warn "this phase RECREATES $AGGLAYER_CONTAINER twice; it must never run mid-suite"
+
+    local ks_password="${KEYSTORE_PASSWORD:-pSnv6Dh5s9ahuzGzH9RoCDrKAMddaX3m}"
+    local aggoracle_addr sequencer_addr allowlist
+    aggoracle_addr=$(keystore_address "$FIXTURES_DIR/aggoracle.keystore" "$ks_password") \
+        || fail "could not derive the aggoracle signer address (fixtures/aggoracle.keystore)"
+    sequencer_addr=$(keystore_address "$FIXTURES_DIR/sequencer.keystore" "$ks_password") \
+        || fail "could not derive the sequencer signer address (fixtures/sequencer.keystore)"
+    allowlist="$USER_ADDR,$SPONSOR_ADDR,$aggoracle_addr,$sequencer_addr"
+    log "ALLOWED_SIGNERS = $allowlist"
+
+    # Reproduce the CURRENT container command minus --insecure-allow-any-signer
+    # (from docker inspect, so the override never drifts from the running
+    # config), plus the ALLOWED_SIGNERS env.
+    ALLOWLIST_OVERRIDE=$(mktemp /tmp/manual-user-claim-allowlist-XXXXXX.yml)
+    docker inspect "$AGGLAYER_CONTAINER" | python3 -c "
+import json, sys
+allow = sys.argv[1]
+cmd = json.load(sys.stdin)[0]['Config']['Cmd'] or []
+if '--insecure-allow-any-signer' not in cmd:
+    print('current proxy command has no --insecure-allow-any-signer; nothing to strip', file=sys.stderr)
+cmd = [c for c in cmd if c != '--insecure-allow-any-signer']
+out = ['services:', '  miden-agglayer:', '    environment:',
+       '      ALLOWED_SIGNERS: %s' % json.dumps(allow), '    command:']
+out += ['      - %s' % json.dumps(c) for c in cmd]
+print('\n'.join(out))
+" "$allowlist" > "$ALLOWLIST_OVERRIDE"
+
+    ALLOWLIST_COMPOSE_CMD="${ALLOWLIST_COMPOSE_CMD:-docker compose -p $COMPOSE_PROJECT_NAME ${ALLOWLIST_COMPOSE_FILES:--f $PROJECT_DIR/docker-compose.e2e.yml} --env-file $FIXTURES_DIR/.env}"
+    local -a compose
+    read -r -a compose <<<"$ALLOWLIST_COMPOSE_CMD"
+
+    ALLOWLIST_ACTIVE=1
+    # Preserve the failing command's exit code across the best-effort restore
+    # so cleanup() still sees it.
+    trap 'rc=$?; if [[ "$ALLOWLIST_ACTIVE" == "1" ]]; then ( restore_proxy_config ) || true; fi; (exit "$rc"); cleanup' EXIT
+    "${compose[@]}" -f "$ALLOWLIST_OVERRIDE" up -d --no-deps --force-recreate miden-agglayer \
+        || fail "could not recreate the proxy with the allow-list override"
+    wait_for "proxy healthy with allow-list config" "rpc eth_chainId '[]' | grep -q '\"result\"'" 300 5
+    docker inspect "$AGGLAYER_CONTAINER" --format '{{json .Config.Cmd}}' | grep -q 'insecure-allow-any-signer' \
+        && fail "override did not remove --insecure-allow-any-signer — open mode still active"
+    pass "proxy is running fail-closed with an explicit allow-list"
+
+    # Positive: the allow-listed USER's manual claim completes end-to-end.
+    do_l1_deposit
+    fetch_deposit_json "$L1_DEP_CNT" 300
+    local gi_al
+    gi_al=$(echo "$DEP_JSON" | dep_field global_index)
+    log "allow-list leg deposit: cnt=$L1_DEP_CNT gi=$gi_al"
+    submit_user_claim "$DEP_JSON" 420
+    case "$SUBMIT_OUTCOME" in
+        user_won)
+            pass "allow-listed USER's manual claim accepted under allow-list mode (tx $USER_TX)" ;;
+        dedup_rejected)
+            # The sponsor (also allow-listed) beat the user; the user's own
+            # submission still traversed the allow-list gate (the dedup lock
+            # sits BEHIND it), so membership is proven either way.
+            pass "sponsor (also allow-listed) won the claim; user's submission passed the allow-list gate into the dedup path" ;;
+        timeout)
+            fail "no claim landed for gi=$gi_al under allow-list mode — allow-list config broke the claim path" ;;
+    esac
+    wait_for "allow-list leg ClaimEvent" \
+        "read -r c t <<<\"\$(claim_events_for_gi '$gi_al')\"; [[ \"\$c\" -ge 1 ]]" 420 5
+    pass "claim completed under allow-list mode (gi=$gi_al)"
+
+    # Negative: a signer NOT on the list is rejected on the allow-list gate.
+    # anvil dev key #1 — TEST-ONLY, deliberately not in ALLOWED_SIGNERS.
+    local outsider_key="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+    local outsider_addr outsider_nonce raw resp errmsg
+    outsider_addr=$(cast wallet address --private-key "$outsider_key")
+    outsider_nonce=$(rpc eth_getTransactionCount "[\"$outsider_addr\",\"latest\"]" \
+        | python3 -c "import json,sys; print(int(json.load(sys.stdin)['result'],16))")
+    raw=$(cast mktx --private-key "$outsider_key" --chain "$CHAIN_ID" --nonce "$outsider_nonce" \
+        --legacy --gas-price 1000000000 --gas-limit 5000000 \
+        "$BRIDGE_ADDRESS" \
+        "$(cast calldata \
+            'claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)' \
+            "$ZERO_PROOF" "$ZERO_PROOF" 424242 "$ZERO32" "$ZERO32" \
+            0 0x0000000000000000000000000000000000000000 \
+            "$DEST_NETWORK" 0x0000000000000000000000000000000000000000 1 0x)")
+    resp=$(rpc eth_sendRawTransaction "[\"$raw\"]")
+    errmsg=$(echo "$resp" | python3 -c "import json,sys; print(json.load(sys.stdin).get('error',{}).get('message') or '')" 2>/dev/null || true)
+    [[ "$errmsg" == *"not on the allow-list"* ]] \
+        || fail "non-listed signer $outsider_addr was NOT rejected on the allow-list gate (got: '$errmsg', resp: $resp)"
+    pass "non-listed signer rejected on the allow-list gate: '$errmsg'"
+
+    restore_proxy_config
+    # The restart + allow-list window may have wedged the sponsor again (its
+    # monitor kept submitting throughout) — leave the stack verified-healthy.
+    drain_sponsor_wedge 10
+    verify_sponsor_functional "post-allow-list-leg"
+    pass "ALLOW-LIST LEG complete (original config restored, sponsor verified)"
+}
+
+if [[ "${ALLOWLIST_LEG:-0}" == "1" ]]; then
+    run_allowlist_leg
+else
+    log "ALLOWLIST_LEG not set — skipping the proxy-restarting allow-list leg (disposable stacks only)"
+fi

--- a/scripts/e2e-manual-user-claim.sh
+++ b/scripts/e2e-manual-user-claim.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+# ══════════════════════════════════════════════════════════════════════════════
+# e2e-manual-user-claim.sh — MANUAL USER CLAIM against the live proxy
+#
+# There is no sponsor concept in the proxy: an ordinary USER key's claimAsset
+# takes the identical eth_sendRawTransaction path as the bridge-service
+# ClaimTxManager sponsor's, and the claim dedup lock is keyed by globalIndex
+# only (signer-agnostic). This script drives that end-to-end:
+#
+#   Leg 1 — manual user claim wins:
+#     1. Bridge L1→L2 (bridgeAsset on Anvil) to an isolated Miden wallet.
+#     2. A USER key — the anvil dev key, NOT the claimsponsor keystore —
+#        pre-signs claimAsset (proof fetched from bridge-service) and submits
+#        it via raw eth_sendRawTransaction in a tight retry loop (retrying the
+#        C6 "GER not observed yet" rejections), racing the sponsor's 2s
+#        monitor. The user's 1s loop should land first; if the sponsor wins a
+#        round anyway, a fresh deposit is tried (up to MAX_LEG1_ATTEMPTS).
+#     3. Assert: user tx receipt (status 1), exactly ONE ClaimEvent for the
+#        globalIndex, the event under the USER's tx hash, and the wrapped
+#        balance delta on the Miden wallet.
+#
+#   Leg 2 — dedup race on the same globalIndex:
+#     4. Second deposit; wait until it is ready_for_claim (sponsor is now
+#        actively trying), then fire the user's manual claim on the SAME
+#        globalIndex. Whoever wins, assert: exactly ONE ClaimEvent for the gi;
+#        the loser observed the "claim already submitted" dedup rejection
+#        (the user's own rejected submission if the sponsor won; a
+#        deterministic extra user submission — plus a best-effort proxy-log
+#        grep for the sponsor's rejection — if the user won); and the winner's
+#        tx hash is the one carrying the ClaimEvent + receipt.
+#
+# USER key: anvil dev key #0 — a TEST-ONLY kurtosis credential already used by
+# e2e-security.sh and scripts/claim.sh. Fine in fixtures/scripts; never prod.
+#
+# Stack-reuse-safe: baselines deposit counts and balances; never restarts
+# containers. Run with COMPOSE_PROJECT_NAME=<project> to target a named stack.
+# ══════════════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURES_DIR="$PROJECT_DIR/fixtures"
+
+source "$FIXTURES_DIR/.env"
+
+L1_RPC="${L1_RPC:-http://localhost:8545}"
+L2_RPC="${L2_RPC:-http://localhost:8546}"
+BRIDGE_SERVICE_URL="${BRIDGE_SERVICE_URL:-http://localhost:18080}"
+
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-miden-agglayer}"
+AGGLAYER_CONTAINER="${AGGLAYER_CONTAINER:-${COMPOSE_PROJECT_NAME}-miden-agglayer-1}"
+
+# TEST-ONLY anvil dev key #0 (same fixture credential as e2e-security.sh /
+# scripts/claim.sh). Distinct from the stack's claimsponsor keystore signer.
+USER_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+# The L1-funded deposit key (same as e2e-l1-to-l2.sh).
+FUNDED_KEY="0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"
+
+DEST_NETWORK=1
+DEPOSIT_AMOUNT="10000000000000" # 10^13 wei → 1000 Miden units (scale 10^10)
+WEI_PER_MIDEN_UNIT=10000000000
+EXPECTED_UNITS_PER_DEPOSIT=$((DEPOSIT_AMOUNT / WEI_PER_MIDEN_UNIT))
+
+CLAIM_EVENT_TOPIC="0x1df3f2a973a00d6635911755c260704e95e8a5876997546798770f76396fda4d"
+MAX_LEG1_ATTEMPTS="${MAX_LEG1_ATTEMPTS:-3}"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[$(date +%H:%M:%S)]${NC} $*"; }
+step() { echo -e "${CYAN}[$(date +%H:%M:%S)] STEP:${NC} $*"; }
+warn() { echo -e "${YELLOW}[$(date +%H:%M:%S)] WARN:${NC} $*"; }
+fail() { echo -e "${RED}[$(date +%H:%M:%S)] FAIL:${NC} $*" >&2; exit 1; }
+pass() { echo -e "${GREEN}[$(date +%H:%M:%S)] PASS:${NC} $*"; }
+
+# Strip ANSI colour escapes before any log assertion (docker logs are
+# colourised; raw greps on field patterns silently miss).
+strip_ansi() { sed 's/\x1b\[[0-9;]*m//g'; }
+
+rpc() { # rpc <method> <params-json>
+    curl -s -m 300 -X POST "$L2_RPC" -H 'Content-Type: application/json' \
+        -d "{\"jsonrpc\":\"2.0\",\"method\":\"$1\",\"params\":$2,\"id\":1}"
+}
+
+wait_for() {
+    local desc="$1" cmd="$2" timeout="$3" interval="${4:-5}"
+    local elapsed=0
+    log "Waiting: $desc (timeout: ${timeout}s)..."
+    while ! ( set +o pipefail; eval "$cmd" ) 2>/dev/null; do
+        elapsed=$((elapsed + interval))
+        [[ $elapsed -ge $timeout ]] && fail "Timed out: $desc"
+        echo -n "."
+        sleep "$interval"
+    done
+    echo ""
+}
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+command -v cast    >/dev/null || fail "cast (foundry) not found"
+command -v curl    >/dev/null || fail "curl not found"
+command -v python3 >/dev/null || fail "python3 not found"
+cast block-number --rpc-url "$L1_RPC" >/dev/null 2>&1 || fail "L1 (Anvil) not reachable"
+docker inspect "$AGGLAYER_CONTAINER" >/dev/null 2>&1 \
+    || fail "proxy container $AGGLAYER_CONTAINER not found"
+
+BRIDGE_UP=false
+for _ in $(seq 1 30); do
+    if curl -sf "$BRIDGE_SERVICE_URL/bridges/0x0000000000000000000000000000000000000000" >/dev/null 2>&1; then
+        BRIDGE_UP=true; break
+    fi
+    sleep 2
+done
+[[ "$BRIDGE_UP" == "true" ]] || fail "bridge-service not reachable at $BRIDGE_SERVICE_URL"
+
+CHAIN_ID_HEX=$(rpc eth_chainId '[]' | python3 -c "import json,sys; print(json.load(sys.stdin)['result'])")
+CHAIN_ID=$((CHAIN_ID_HEX))
+USER_ADDR=$(cast wallet address --private-key "$USER_KEY")
+log "proxy chain id: $CHAIN_ID; user (manual claimant): $USER_ADDR"
+
+# ── Infra account ids + isolated destination wallet ──────────────────────────
+ACCOUNTS=$(docker exec "$AGGLAYER_CONTAINER" \
+    cat /var/lib/miden-agglayer-service/bridge_accounts.toml 2>/dev/null) \
+    || fail "miden-agglayer not initialized yet"
+BRIDGE_ID=$(echo "$ACCOUNTS" | grep 'bridge = ' | sed 's/.*= "//;s/"//')
+FAUCET_ID=$(echo "$ACCOUNTS" | grep faucet_eth | sed 's/.*= "//;s/"//')
+
+B2AGG_STORE_DIR="${B2AGG_STORE_DIR:-$PROJECT_DIR/.b2agg-store/e2e-manual-user-claim}"
+source "$SCRIPT_DIR/lib-isolated-wallet.sh"
+provision_isolated_wallet "$BRIDGE_ID" "$FAUCET_ID" \
+    || fail "could not provision isolated destination wallet"
+
+log "======================================================================"
+log "  MANUAL USER CLAIM e2e"
+log "======================================================================"
+log "Wallet:  $WALLET_ID (isolated store: $B2AGG_STORE_DIR)"
+log "Dest:    $DEST_ADDR (zero-padded, network $DEST_NETWORK)"
+log "User:    $USER_ADDR (manual claimant, anvil dev key)"
+
+BAL_BEFORE=$(iso_wallet_balance "$BRIDGE_ID" "$FAUCET_ID")
+BAL_BEFORE="${BAL_BEFORE:-0}"
+log "L2 wallet balance before: $BAL_BEFORE"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# known_deposit_cnts → space-separated deposit_cnt list currently visible for
+# DEST_ADDR (the stack-reuse baseline).
+known_deposit_cnts() {
+    curl -sf "$BRIDGE_SERVICE_URL/bridges/$DEST_ADDR" 2>/dev/null | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(' '.join(str(dep['deposit_cnt']) for dep in d.get('deposits', [])))
+except Exception:
+    pass
+"
+}
+
+# new_deposit_json <baseline-cnts> → the deposit JSON for OUR new L1→L2 deposit
+# (network_id 0, matching amount, cnt not in baseline), or "".
+new_deposit_json() {
+    local baseline="$1"
+    curl -sf "$BRIDGE_SERVICE_URL/bridges/$DEST_ADDR" 2>/dev/null | python3 -c "
+import json, sys
+baseline = set('$baseline'.split())
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for dep in d.get('deposits', []):
+    if str(dep['deposit_cnt']) in baseline:
+        continue
+    if dep.get('network_id') != 0:
+        continue
+    if dep.get('amount') != '$DEPOSIT_AMOUNT':
+        continue
+    print(json.dumps(dep))
+    break
+"
+}
+
+dep_field() { python3 -c "import json,sys; print(json.load(sys.stdin)['$1'])"; }
+
+# do_l1_deposit → sends bridgeAsset on L1; fails the script on error.
+do_l1_deposit() {
+    local tx status
+    tx=$(cast send --rpc-url "$L1_RPC" \
+        --private-key "$FUNDED_KEY" \
+        "$BRIDGE_ADDRESS" \
+        'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+        "$DEST_NETWORK" "$DEST_ADDR" "$DEPOSIT_AMOUNT" \
+        0x0000000000000000000000000000000000000000 true 0x \
+        --value "$DEPOSIT_AMOUNT" 2>&1)
+    status=$(printf '%s\n' "$tx" | awk '$1=="status"{print $2; exit}')
+    [[ "$status" == "1" ]] || fail "L1 deposit tx failed (status=$status): $tx"
+}
+
+# build_user_claim_raw <deposit-json> → prints the pre-signed raw claimAsset tx
+# for the USER key (empty on proof-not-ready). Nonce is re-read per call.
+build_user_claim_raw() {
+    local dep="$1" cnt gi orig_net orig_addr dest_net dest_addr amount metadata
+    local proof mer rer smt_local smt_rollup calldata nonce_hex nonce
+    cnt=$(echo "$dep" | dep_field deposit_cnt)
+    gi=$(echo "$dep" | dep_field global_index)
+    orig_net=$(echo "$dep" | dep_field orig_net)
+    orig_addr=$(echo "$dep" | dep_field orig_addr)
+    dest_net=$(echo "$dep" | dep_field dest_net)
+    dest_addr=$(echo "$dep" | dep_field dest_addr)
+    amount=$(echo "$dep" | dep_field amount)
+    metadata=$(echo "$dep" | dep_field metadata)
+    [[ -z "$metadata" || "$metadata" == "None" ]] && metadata="0x"
+
+    proof=$(curl -sf "$BRIDGE_SERVICE_URL/merkle-proof?deposit_cnt=$cnt&net_id=0" 2>/dev/null) || return 0
+    [[ -z "$proof" ]] && return 0
+    mer=$(echo "$proof" | python3 -c "import json,sys; print(json.load(sys.stdin)['proof']['main_exit_root'])") || return 0
+    rer=$(echo "$proof" | python3 -c "import json,sys; print(json.load(sys.stdin)['proof']['rollup_exit_root'])") || return 0
+    smt_local=$(echo "$proof" | python3 -c "
+import json, sys
+p = json.load(sys.stdin)['proof']['merkle_proof']
+while len(p) < 32: p.append('0x' + '00' * 32)
+print('[' + ','.join(p[:32]) + ']')
+") || return 0
+    smt_rollup=$(echo "$proof" | python3 -c "
+import json, sys
+p = json.load(sys.stdin)['proof']['rollup_merkle_proof']
+while len(p) < 32: p.append('0x' + '00' * 32)
+print('[' + ','.join(p[:32]) + ']')
+") || return 0
+
+    calldata=$(cast calldata \
+        'claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)' \
+        "$smt_local" "$smt_rollup" "$gi" "$mer" "$rer" \
+        "$orig_net" "$orig_addr" "$dest_net" "$dest_addr" "$amount" "$metadata") || return 0
+
+    nonce_hex=$(rpc eth_getTransactionCount "[\"$USER_ADDR\",\"latest\"]" \
+        | python3 -c "import json,sys; print(json.load(sys.stdin)['result'])") || return 0
+    nonce=$((nonce_hex))
+
+    cast mktx --private-key "$USER_KEY" --chain "$CHAIN_ID" --nonce "$nonce" \
+        --legacy --gas-price 1000000000 --gas-limit 5000000 \
+        "$BRIDGE_ADDRESS" "$calldata" 2>/dev/null || return 0
+}
+
+# submit_user_claim <deposit-json> <timeout-secs>
+# Tight retry loop: rebuild + submit the user's claim until accepted or the
+# dedup rejection fires. Sets:
+#   SUBMIT_OUTCOME = user_won | dedup_rejected | timeout
+#   USER_TX        = the user's accepted tx hash (user_won only)
+#   LAST_ERR       = last JSON-RPC error message
+submit_user_claim() {
+    local dep="$1" timeout="$2" started raw resp result errmsg
+    SUBMIT_OUTCOME="timeout"; USER_TX=""; LAST_ERR=""
+    started=$(date +%s)
+    while (( $(date +%s) - started < timeout )); do
+        raw=$(build_user_claim_raw "$dep")
+        if [[ -z "$raw" ]]; then
+            sleep 1; continue    # proof not available yet
+        fi
+        resp=$(rpc eth_sendRawTransaction "[\"$raw\"]")
+        result=$(echo "$resp" | python3 -c "import json,sys; print(json.load(sys.stdin).get('result') or '')" 2>/dev/null || true)
+        errmsg=$(echo "$resp" | python3 -c "import json,sys; print(json.load(sys.stdin).get('error',{}).get('message') or '')" 2>/dev/null || true)
+        if [[ -n "$result" ]]; then
+            SUBMIT_OUTCOME="user_won"; USER_TX="$result"; return 0
+        fi
+        LAST_ERR="$errmsg"
+        if [[ "$errmsg" == *"already submitted"* ]]; then
+            SUBMIT_OUTCOME="dedup_rejected"; return 0
+        fi
+        # C6 GER-not-seen and transient rejections: retry.
+        sleep 1
+    done
+    return 0
+}
+
+# claim_events_for_gi <global_index> → prints "<count> <tx_hash_of_first>"
+# from the proxy's eth_getLogs for the ClaimEvent topic. globalIndex is the
+# first 32-byte word of the (all-non-indexed) event data.
+claim_events_for_gi() {
+    local gi="$1"
+    rpc eth_getLogs "[{\"fromBlock\":\"0x0\",\"toBlock\":\"latest\",\"topics\":[\"$CLAIM_EVENT_TOPIC\"]}]" \
+        | python3 -c "
+import json, sys
+gi = int('$gi')
+try:
+    logs = json.load(sys.stdin).get('result') or []
+except Exception:
+    print('0 -'); sys.exit(0)
+hits = [l for l in logs if len(l.get('data','')) >= 66 and int(l['data'][2:66], 16) == gi]
+print(len(hits), hits[0]['transactionHash'] if hits else '-')
+"
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Leg 1 — manual user claim (user submits instead of waiting for the sponsor)
+# ══════════════════════════════════════════════════════════════════════════════
+step "Leg 1 — deposit L1→L2, then the USER claims it manually"
+
+LEG1_GI=""; LEG1_TX=""
+for attempt in $(seq 1 "$MAX_LEG1_ATTEMPTS"); do
+    log "Leg 1 attempt $attempt/$MAX_LEG1_ATTEMPTS"
+    BASELINE_CNTS=$(known_deposit_cnts)
+    do_l1_deposit
+    pass "L1 deposit sent"
+
+    DEP_JSON=""
+    wait_for "deposit visible to bridge-service" \
+        "DEP_JSON=\$(new_deposit_json \"$BASELINE_CNTS\"); [[ -n \"\$DEP_JSON\" ]]" 300 5
+    DEP_JSON=$(new_deposit_json "$BASELINE_CNTS")
+    GI=$(echo "$DEP_JSON" | dep_field global_index)
+    CNT=$(echo "$DEP_JSON" | dep_field deposit_cnt)
+    log "deposit_cnt=$CNT globalIndex=$GI"
+
+    # Start submitting IMMEDIATELY (before ready_for_claim): the loop retries
+    # the C6 "GER not observed yet" rejections every 1s, so the user grabs the
+    # claim lock the moment the GER lands — usually beating the sponsor's 2s
+    # monitor.
+    submit_user_claim "$DEP_JSON" 420
+    case "$SUBMIT_OUTCOME" in
+        user_won)
+            LEG1_GI="$GI"; LEG1_TX="$USER_TX"
+            pass "USER's manual claim accepted: tx=$LEG1_TX (gi=$GI)"
+            break
+            ;;
+        dedup_rejected)
+            warn "sponsor won the claim for gi=$GI (user got the dedup rejection: '$LAST_ERR')"
+            warn "retrying leg 1 with a fresh deposit"
+            ;;
+        timeout)
+            fail "user claim never accepted nor dedup-rejected within 420s (last error: '$LAST_ERR')"
+            ;;
+    esac
+done
+[[ -n "$LEG1_TX" ]] || fail "user never won a manual claim in $MAX_LEG1_ATTEMPTS attempts — cannot demonstrate the manual-user-claim path"
+
+# Receipt: pending until the SyntheticProjector observes the CLAIM note
+# consumed; then status must be success and the ClaimEvent rides this tx.
+wait_for "user claim receipt (projector finalisation)" \
+    "rpc eth_getTransactionReceipt '[\"$LEG1_TX\"]' | python3 -c \"import json,sys; r=json.load(sys.stdin).get('result'); exit(0 if r and r.get('status')=='0x1' else 1)\"" \
+    420 5
+pass "user claim receipt landed (status 0x1)"
+
+read -r EV_COUNT EV_TX <<<"$(claim_events_for_gi "$LEG1_GI")"
+[[ "$EV_COUNT" == "1" ]] || fail "expected exactly 1 ClaimEvent for gi=$LEG1_GI, got $EV_COUNT"
+[[ "${EV_TX,,}" == "${LEG1_TX,,}" ]] || fail "ClaimEvent tx hash $EV_TX != user's tx $LEG1_TX"
+pass "exactly ONE ClaimEvent for gi=$LEG1_GI, under the USER's tx hash"
+
+# Receipt 'from' must be the USER — no sponsor substitution anywhere.
+RECEIPT_FROM=$(rpc eth_getTransactionReceipt "[\"$LEG1_TX\"]" \
+    | python3 -c "import json,sys; print((json.load(sys.stdin)['result'].get('from') or '').lower())")
+if [[ -n "$RECEIPT_FROM" && "$RECEIPT_FROM" != "null" ]]; then
+    [[ "$RECEIPT_FROM" == "${USER_ADDR,,}" ]] \
+        || fail "receipt 'from' is $RECEIPT_FROM, expected the user $USER_ADDR"
+    pass "receipt signer is the USER ($USER_ADDR)"
+else
+    warn "receipt carries no 'from' field — skipping the signer assertion"
+fi
+
+# Wrapped balance: the deposit must have been minted to the Miden wallet.
+log "Checking wrapped balance (sync + consume P2ID notes)..."
+BALANCE="$BAL_BEFORE"
+for i in $(seq 1 18); do
+    sleep 10
+    BALANCE=$(iso_wallet_balance "$BRIDGE_ID" "$FAUCET_ID")
+    BALANCE="${BALANCE:-0}"
+    log "attempt $i/18: balance = $BALANCE (was $BAL_BEFORE)"
+    [[ "$BALANCE" -ge $((BAL_BEFORE + EXPECTED_UNITS_PER_DEPOSIT)) ]] && break
+done
+[[ "$BALANCE" -ge $((BAL_BEFORE + EXPECTED_UNITS_PER_DEPOSIT)) ]] \
+    || fail "wrapped balance did not increase by $EXPECTED_UNITS_PER_DEPOSIT (before=$BAL_BEFORE, now=$BALANCE)"
+pass "wrapped balance delta OK: $BAL_BEFORE → $BALANCE (user-claimed deposit minted)"
+BAL_AFTER_LEG1="$BALANCE"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Leg 2 — dedup race: user's manual claim vs sponsor autoclaim, same gi
+# ══════════════════════════════════════════════════════════════════════════════
+step "Leg 2 — race the sponsor on the SAME globalIndex"
+
+BASELINE_CNTS=$(known_deposit_cnts)
+do_l1_deposit
+pass "second L1 deposit sent"
+
+DEP_JSON=""
+wait_for "second deposit visible to bridge-service" \
+    "DEP_JSON=\$(new_deposit_json \"$BASELINE_CNTS\"); [[ -n \"\$DEP_JSON\" ]]" 300 5
+DEP_JSON=$(new_deposit_json "$BASELINE_CNTS")
+GI2=$(echo "$DEP_JSON" | dep_field global_index)
+CNT2=$(echo "$DEP_JSON" | dep_field deposit_cnt)
+log "race deposit_cnt=$CNT2 globalIndex=$GI2"
+
+# This time WAIT for ready_for_claim first, so the sponsor's ClaimTxManager
+# (2s monitor) is actively claiming when the user's submission goes in — a
+# genuine race on the same globalIndex.
+wait_for "race deposit ready_for_claim" \
+    "curl -sf '$BRIDGE_SERVICE_URL/bridges/$DEST_ADDR' | python3 -c \"import json,sys; d=json.load(sys.stdin); exit(0 if any(dep['deposit_cnt']==$CNT2 and dep['ready_for_claim'] for dep in d['deposits']) else 1)\"" \
+    600 5
+pass "race deposit is ready_for_claim — sponsor is live on it now"
+
+# Anchor the proxy log BEFORE the race so the dedup-rejection grep is scoped.
+LOGS_BEFORE=$(docker logs "$AGGLAYER_CONTAINER" 2>&1 | wc -l)
+
+submit_user_claim "$DEP_JSON" 420
+WINNER=""; WINNER_TX=""
+case "$SUBMIT_OUTCOME" in
+    user_won)
+        WINNER="user"; WINNER_TX="$USER_TX"
+        pass "race: USER won (tx=$USER_TX); sponsor is the loser"
+        ;;
+    dedup_rejected)
+        WINNER="sponsor"
+        [[ "$LAST_ERR" == *"already submitted"* ]] \
+            || fail "loser's rejection is not the dedup path: '$LAST_ERR'"
+        pass "race: SPONSOR won; user (loser) got the dedup rejection: '$LAST_ERR'"
+        ;;
+    timeout)
+        fail "race leg: user claim neither accepted nor dedup-rejected in 420s (last: '$LAST_ERR')"
+        ;;
+esac
+
+# Exactly ONE ClaimEvent for gi2, and its tx is the winner's.
+wait_for "ClaimEvent for the race gi" \
+    "read -r c t <<<\"\$(claim_events_for_gi '$GI2')\"; [[ \"\$c\" -ge 1 ]]" 420 5
+read -r EV2_COUNT EV2_TX <<<"$(claim_events_for_gi "$GI2")"
+[[ "$EV2_COUNT" == "1" ]] || fail "expected exactly 1 ClaimEvent for gi=$GI2, got $EV2_COUNT"
+pass "exactly ONE ClaimEvent for the raced gi=$GI2"
+
+if [[ "$WINNER" == "user" ]]; then
+    [[ "${EV2_TX,,}" == "${WINNER_TX,,}" ]] \
+        || fail "ClaimEvent tx $EV2_TX != the winning user's tx $WINNER_TX"
+else
+    WINNER_TX="$EV2_TX"
+    # The user never got a tx accepted, so the event tx must be someone else's
+    # (the sponsor's) — sanity: the winner's receipt must exist.
+    log "sponsor's winning tx: $WINNER_TX"
+fi
+wait_for "winner's receipt (status 0x1)" \
+    "rpc eth_getTransactionReceipt '[\"$WINNER_TX\"]' | python3 -c \"import json,sys; r=json.load(sys.stdin).get('result'); exit(0 if r and r.get('status')=='0x1' else 1)\"" \
+    300 5
+pass "winner's tx hash $WINNER_TX carries the receipt + ClaimEvent"
+
+# The loser's dedup rejection, as observed BY THE PROXY. If the sponsor lost,
+# its rejected attempt shows up in the proxy log; if the user lost we already
+# asserted the JSON-RPC error above. Either way, force a DETERMINISTIC loser
+# too: one more user submission for the same (now claimed) gi must be
+# dedup-rejected.
+RAW=$(build_user_claim_raw "$DEP_JSON")
+if [[ -n "$RAW" ]]; then
+    RESP=$(rpc eth_sendRawTransaction "[\"$RAW\"]")
+    ERRMSG=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('error',{}).get('message') or '')" 2>/dev/null || true)
+    [[ "$ERRMSG" == *"already submitted"* ]] \
+        || fail "post-race resubmission for gi=$GI2 was not dedup-rejected (got: '$ERRMSG', resp: $RESP)"
+    pass "post-race user resubmission dedup-rejected: '$ERRMSG'"
+else
+    warn "could not rebuild the user claim for the deterministic dedup check"
+fi
+
+# Best-effort: the proxy-side view of the loser (ANSI stripped, anchored on
+# the exact dedup message + this gi — never a bare FAIL/error grep).
+DEDUP_LOG_HITS=$(docker logs "$AGGLAYER_CONTAINER" 2>&1 \
+    | tail -n +$((LOGS_BEFORE + 1)) \
+    | strip_ansi \
+    | grep -c "already submitted for global_index ${GI2}" || true)
+log "proxy log dedup rejections for gi=$GI2 since race start: $DEDUP_LOG_HITS"
+[[ "$DEDUP_LOG_HITS" -ge 1 ]] \
+    || fail "no dedup rejection for gi=$GI2 in the proxy log — the race never produced a loser?"
+pass "proxy log shows the dedup rejection for gi=$GI2 ($DEDUP_LOG_HITS hits)"
+
+# Final balance: both deposits (user-claimed + raced) must be minted.
+log "Final wrapped-balance check (both deposits)..."
+BALANCE="$BAL_AFTER_LEG1"
+for i in $(seq 1 18); do
+    sleep 10
+    BALANCE=$(iso_wallet_balance "$BRIDGE_ID" "$FAUCET_ID")
+    BALANCE="${BALANCE:-0}"
+    log "attempt $i/18: balance = $BALANCE (leg-1 level $BAL_AFTER_LEG1)"
+    [[ "$BALANCE" -ge $((BAL_AFTER_LEG1 + EXPECTED_UNITS_PER_DEPOSIT)) ]] && break
+done
+[[ "$BALANCE" -ge $((BAL_AFTER_LEG1 + EXPECTED_UNITS_PER_DEPOSIT)) ]] \
+    || fail "raced deposit never minted (balance $BALANCE, expected ≥ $((BAL_AFTER_LEG1 + EXPECTED_UNITS_PER_DEPOSIT)))"
+pass "raced deposit minted exactly once: balance $BAL_AFTER_LEG1 → $BALANCE"
+
+echo ""
+log "======================================================================"
+log "  MANUAL USER CLAIM e2e DONE"
+log "    leg 1: user tx $LEG1_TX claimed gi=$LEG1_GI"
+log "    leg 2: winner=$WINNER tx=$WINNER_TX gi=$GI2 (single ClaimEvent, loser dedup-rejected)"
+log "======================================================================"

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -48,6 +48,13 @@ case "$test_filter" in
         # tests (it needs the steady-state reconciler/projector, no restarts).
         "$SCRIPT_DIR/e2e-claim-provenance.sh"
         echo ""
+        # Manual user claim: a non-sponsor USER key claims its own deposit via
+        # raw eth_sendRawTransaction, plus the signer-agnostic dedup race
+        # against the sponsor on the same globalIndex. Steady-state (no
+        # restarts), so it runs with the other claim-path tests before the
+        # proxy-restarting group.
+        "$SCRIPT_DIR/e2e-manual-user-claim.sh"
+        echo ""
         # Proxy-restarting tests run LAST (they must not race the other
         # scripts' steady-state assumptions), in this order: the cursor test
         # does a plain restart and asserts the sweep RESUMES from the
@@ -134,6 +141,9 @@ case "$test_filter" in
         ;;
     claim-provenance)
         "$SCRIPT_DIR/e2e-claim-provenance.sh"
+        ;;
+    manual-user-claim)
+        "$SCRIPT_DIR/e2e-manual-user-claim.sh"
         ;;
     l2l2)
         # SIMPLE L2<->L2 pipeline group (NOT in `all` — needs the

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -48,13 +48,6 @@ case "$test_filter" in
         # tests (it needs the steady-state reconciler/projector, no restarts).
         "$SCRIPT_DIR/e2e-claim-provenance.sh"
         echo ""
-        # Manual user claim: a non-sponsor USER key claims its own deposit via
-        # raw eth_sendRawTransaction, plus the signer-agnostic dedup race
-        # against the sponsor on the same globalIndex. Steady-state (no
-        # restarts), so it runs with the other claim-path tests before the
-        # proxy-restarting group.
-        "$SCRIPT_DIR/e2e-manual-user-claim.sh"
-        echo ""
         # Proxy-restarting tests run LAST (they must not race the other
         # scripts' steady-state assumptions), in this order: the cursor test
         # does a plain restart and asserts the sweep RESUMES from the
@@ -96,6 +89,19 @@ case "$test_filter" in
         else
             echo "SKIP L2<->L2 + native tiers — L2B overlay not up (base stack). Run 'make e2e-l2l2-up' to include them."
         fi
+        echo ""
+        # VERY LAST in the suite — defense in depth: the manual-user-claim
+        # script deliberately front-runs the sponsor's autoclaimer, which
+        # wedges the sponsor's ethtxmanager head nonce MID-RUN. The script
+        # heals the sponsor itself before exiting (consumes the wedged nonces
+        # with benign no-op txs and HARD-asserts that a fresh deposit
+        # autoclaims), but if it dies mid-leg the sponsor may stay wedged — so
+        # nothing that depends on sponsor autoclaim may run after it. Its legs
+        # are L1→L2-only (GER injection via aggoracle, no certificate
+        # settlement), so running after cantina13's poison leaf is safe. The
+        # optional ALLOWLIST_LEG=1 phase (restarts the proxy) is NOT enabled
+        # here — it is only for disposable stacks, run manually.
+        "$SCRIPT_DIR/e2e-manual-user-claim.sh"
         ;;
     tip-consistency)
         "$SCRIPT_DIR/e2e-rpc-tip-consistency.sh"

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -1672,6 +1672,452 @@ mod tests {
         );
     }
 
+    // ── MANUAL USER CLAIM tests ─────────────────────────────────────────
+    //
+    // There is NO sponsor concept in this proxy: the bridge-service sponsor's
+    // claims and an ordinary user's manual claims take the IDENTICAL path
+    // through `service_send_raw_txn` (signer recovery → nonce → allow-list →
+    // claim dispatch), and the claim dedup lock is keyed by globalIndex only.
+    // These tests pin that behavior from both sides: a user CAN manually claim
+    // (their own or anyone's deposit) if allow-listed, and the dedup / TTL
+    // takeover semantics are signer-agnostic.
+
+    /// Shared helpers for the manual-user-claim tests.
+    ///
+    /// Build + encode a legacy tx REALLY signed by `key` at an explicit
+    /// `nonce`. Unlike `encode_legacy_tx_signed` (same-nonce concurrency
+    /// helper, nonce pinned to 0), this one is general-purpose. Returns the
+    /// hex payload and the tx hash (for receipt / store assertions).
+    fn encode_tx_signed_with_nonce(
+        key: &alloy::signers::local::PrivateKeySigner,
+        input: Vec<u8>,
+        nonce: u64,
+    ) -> (String, TxHash) {
+        use alloy::consensus::SignableTransaction;
+        use alloy::signers::SignerSync;
+        let txn = TxLegacy {
+            nonce,
+            input: input.into(),
+            chain_id: Some(1),
+            ..Default::default()
+        };
+        let signature = key
+            .sign_hash_sync(&txn.signature_hash())
+            .expect("signing the legacy test tx must succeed");
+        let envelope: TxEnvelope = txn.into_signed(signature).into();
+        let hash = match &envelope {
+            TxEnvelope::Legacy(s) => *s.hash(),
+            _ => unreachable!("constructed as legacy"),
+        };
+        let mut encoded = Vec::new();
+        envelope.encode_2718(&mut encoded);
+        (format!("0x{}", ::hex::encode(encoded)), hash)
+    }
+
+    /// A valid `claimAsset` calldata for `create_test_service`'s network (1).
+    /// Zero exit roots pair with `seed_zero_ger` for the C6 gate.
+    fn claim_calldata(global_index: U256, destination: Address, amount: U256) -> Vec<u8> {
+        claimAssetCall {
+            smtProofLocalExitRoot: [FixedBytes::ZERO; 32],
+            smtProofRollupExitRoot: [FixedBytes::ZERO; 32],
+            globalIndex: global_index,
+            mainnetExitRoot: FixedBytes::ZERO,
+            rollupExitRoot: FixedBytes::ZERO,
+            originNetwork: 0,
+            originTokenAddress: Address::ZERO,
+            destinationNetwork: 1,
+            destinationAddress: destination,
+            amount,
+            metadata: Default::default(),
+        }
+        .abi_encode()
+    }
+
+    /// Zero-padded MidenAccountId — resolvable by `address_mapper` without a
+    /// store mapping, so a claim to it gets PAST the RD-860 swallow and onto
+    /// the real lock + publish path.
+    fn resolvable_dest() -> Address {
+        alloy::primitives::address!("0x00000000ac0000000000dd110000ee000000fc00")
+    }
+
+    /// Mark the all-zero mainnet/rollup GER pair injected so the C6 pre-check
+    /// passes (mirrors `test_claim_asset_no_event_on_failure`'s seeding).
+    async fn seed_zero_ger(store: &std::sync::Arc<dyn crate::store::Store>) {
+        let ger = crate::ger::combined_ger(&[0u8; 32], &[0u8; 32]);
+        store
+            .commit_ger_event_atomic(
+                1,
+                [0u8; 32],
+                "0xger-seed",
+                &ger,
+                Some([0u8; 32]),
+                Some([0u8; 32]),
+                0,
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn count_claim_events(store: &std::sync::Arc<dyn crate::store::Store>) -> usize {
+        let filter = crate::log_synthesis::LogFilter {
+            from_block: Some("0x0".to_string()),
+            to_block: Some("0xFFFF".to_string()),
+            ..Default::default()
+        };
+        store
+            .get_logs(&filter, 0xFFFF)
+            .await
+            .unwrap()
+            .iter()
+            .filter(|l| {
+                l.topics.first().map(|t| t.as_str())
+                    == Some(crate::log_synthesis::CLAIM_EVENT_TOPIC)
+            })
+            .count()
+    }
+
+    /// MANUAL USER CLAIM happy path — an ordinary, explicitly allow-listed
+    /// USER key (NOT open mode, NOT any sponsor identity) submits a valid
+    /// `claimAsset` and is accepted end-to-end: ClaimEvent emitted, receipt
+    /// recorded, and the recorded signer is the USER's address. Pins that a
+    /// user needs nothing beyond allow-list membership to claim manually —
+    /// there is no sponsor-only gate anywhere on the path.
+    ///
+    /// Unit-harness note: the stub `MidenClient` never runs the publish
+    /// closure, so the only claim route that completes SYNCHRONOUSLY is the
+    /// RD-860 unresolvable-destination swallow — which still exercises the
+    /// full RPC pipeline (chain-id, nonce, allow-list, dispatch) and emits the
+    /// synthetic ClaimEvent + receipt. The user here claims a deposit destined
+    /// to their own EVM address (no Miden mapping registered → swallow). The
+    /// real-Miden happy path is covered by scripts/e2e-manual-user-claim.sh.
+    #[tokio::test]
+    async fn manual_user_claim_succeeds() {
+        let user_key = alloy::signers::local::PrivateKeySigner::random();
+        let user_addr = user_key.address();
+
+        let mut service = create_test_service();
+        // A real allow-list containing ONLY the user — the manual claim must
+        // pass on allow-list membership alone.
+        service.allow_any_signer = false;
+        service.allowed_signers = Some(vec![user_addr]);
+        let store = service.store.clone();
+
+        let gi = U256::from(0x1001u64);
+        let calldata = claim_calldata(gi, user_addr, U256::from(1_000_000u64));
+        let (input_hex, expected_hash) = encode_tx_signed_with_nonce(&user_key, calldata, 0);
+
+        let tx_hash = service_send_raw_txn(service, input_hex)
+            .await
+            .expect("allow-listed user's manual claim must be accepted");
+        assert_eq!(
+            tx_hash, expected_hash,
+            "returned hash must be the user's tx hash"
+        );
+
+        assert_eq!(
+            count_claim_events(&store).await,
+            1,
+            "exactly one ClaimEvent must be emitted for the user's claim"
+        );
+        let txn = store
+            .txn_get(tx_hash)
+            .await
+            .unwrap()
+            .expect("the user's claim tx must be recorded");
+        assert_eq!(
+            txn.signer, user_addr,
+            "the recorded signer must be the USER (no sponsor substitution anywhere)"
+        );
+        assert!(
+            store.txn_receipt(tx_hash).await.unwrap().is_some(),
+            "a receipt must exist for the user's claim tx"
+        );
+        assert_eq!(
+            store.nonce_get(&format!("{user_addr:#x}")).await.unwrap(),
+            1,
+            "the user's tracked nonce must advance on acceptance"
+        );
+    }
+
+    /// Signer-agnostic dedup, in-flight then landed. Signer A ("the sponsor")
+    /// has a submission genuinely in flight for gi=X (lock record present,
+    /// younger than the TTL, no ClaimEvent yet — created directly on the
+    /// store, exactly the state `service_send_raw_txn` holds between
+    /// `acquire_claim_lock` and publish completion). Signer B — a DIFFERENT
+    /// key — submits a full valid claimAsset for the SAME gi:
+    ///   1. within the TTL → rejected on the "already submitted" path, with
+    ///      ZERO side effects for B (no publish, no nonce advance, no tx);
+    ///   2. after A's claim LANDS (ClaimEvent recorded) → B stays HARD
+    ///      rejected, even with the TTL treated as expired — landed dedup
+    ///      holds forever, for any signer.
+    #[tokio::test]
+    async fn user_sponsor_double_submit_same_global_index() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        let miden = service.miden_client.clone();
+        seed_zero_ger(&store).await;
+
+        let gi = U256::from(0x2002u64);
+        store.try_claim(gi).await.expect("A's submission locks gi");
+
+        // B: different key, same globalIndex, within the (default 120s) TTL.
+        let key_b = alloy::signers::local::PrivateKeySigner::random();
+        let addr_b = key_b.address();
+        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
+
+        let err = service_send_raw_txn(service.clone(), input_b.clone())
+            .await
+            .expect_err("a different signer's claim for an in-flight gi must be rejected");
+        assert!(
+            err.to_string().contains("already submitted"),
+            "must be the dedup rejection: {err:#}"
+        );
+        // The rejection must leave NO trace of B's attempt.
+        assert!(
+            !miden.test_was_called(),
+            "B must never reach the Miden publish while A is in flight"
+        );
+        assert_eq!(
+            store.nonce_get(&format!("{addr_b:#x}")).await.unwrap(),
+            0,
+            "a rejected claim must not advance B's nonce"
+        );
+        assert!(
+            store.txn_get(tx_b).await.unwrap().is_none(),
+            "no tx entry may be recorded for B's rejected claim"
+        );
+
+        // A's claim LANDS: a ClaimEvent now exists for gi.
+        store
+            .commit_manual_claim_event_atomic(
+                "manual-user-claim-test-note".into(),
+                "0x00000000000000000000000000000000000000aa",
+                5,
+                [0u8; 32],
+                "0x1111111111111111111111111111111111111111111111111111111111111111",
+                gi.to_be_bytes::<32>(),
+                0,
+                &[0u8; 20],
+                &[0u8; 20],
+                1_000,
+            )
+            .await
+            .unwrap();
+
+        // B retries the same tx — still hard-rejected (LANDED beats everything).
+        let err = service_send_raw_txn(service, input_b)
+            .await
+            .expect_err("a landed gi must stay rejected for any signer");
+        assert!(
+            err.to_string().contains("already submitted"),
+            "landed dedup keeps the original rejection: {err:#}"
+        );
+        // ...and even with the TTL forced to zero (i.e. long expired), the
+        // LANDED check wins over orphan recovery, regardless of submitter.
+        let err = acquire_claim_lock(&store, gi, std::time::Duration::ZERO)
+            .await
+            .expect_err("LANDED must beat TTL-expiry recovery");
+        assert!(err.to_string().contains("already submitted"));
+    }
+
+    /// TTL takeover by a DIFFERENT signer — PINS CURRENT (deliberate) BEHAVIOR:
+    /// the claim submission lock is SIGNER-AGNOSTIC. The lock record stores no
+    /// signer at all (`InMemoryStore::claimed` maps globalIndex → Instant;
+    /// `acquire_claim_lock` takes no signer), so once a record is orphaned
+    /// (no ClaimEvent + TTL expired), ANY allow-listed party may supersede it
+    /// and finish the stranded claim. This is intentional: the claim's effect
+    /// is identical regardless of submitter — destination, amount, and token
+    /// are bound by the claimAsset calldata (whose proof commits to the L1
+    /// leaf), so a takeover changes only who paid to submit, never where the
+    /// funds go. The same property holds on the L1 PolygonZkEVMBridge, where
+    /// claimAsset is fully permissionless.
+    #[tokio::test]
+    async fn ttl_expired_lock_superseded_by_different_signer() {
+        let concrete = std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let store: std::sync::Arc<dyn crate::store::Store> = concrete.clone();
+        let service = crate::test_helpers::create_test_service_with_store(store.clone());
+        let miden = service.miden_client.clone();
+        seed_zero_ger(&store).await;
+
+        let gi = U256::from(0x3003u64);
+        // Signer A's submission crashed mid-flight: lock record present, no
+        // ClaimEvent ever landed...
+        store.try_claim(gi).await.expect("A's submission locks gi");
+        // ...and the record has out-lived CLAIM_RESUBMIT_TTL_SECS (backdated —
+        // no sleeping, no process-global env mutation).
+        concrete.test_backdate_claim(
+            gi,
+            claim_resubmit_ttl() + std::time::Duration::from_secs(10),
+        );
+
+        // Signer B (a different key — the record wouldn't know: it carries no
+        // signer) submits the same gi through the FULL RPC path.
+        let key_b = alloy::signers::local::PrivateKeySigner::random();
+        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_b, _) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
+
+        let err = service_send_raw_txn(service, input_b)
+            .await
+            .expect_err("the stub MidenClient cannot complete the publish");
+        // The orphaned record was superseded and B's claim PROCEEDED: the
+        // failure is the unit stub's publish failure, NOT the dedup rejection.
+        assert!(
+            !err.to_string().contains("already submitted"),
+            "an orphaned (TTL-expired) record must not keep rejecting: {err:#}"
+        );
+        assert!(
+            miden.test_was_called(),
+            "B's claim must reach the Miden publish — the orphaned lock was superseded"
+        );
+    }
+
+    /// Allow-list × claimAsset — the existing R2/C2 tests exercise the gate
+    /// with insertGlobalExitRoot calldata only; this pins it on the CLAIM path
+    /// specifically, including the fail-closed default, and that the rejection
+    /// happens BEFORE any claim side effect. The claim is fully valid (GER
+    /// seeded, resolvable destination), so if the gate failed to fire it WOULD
+    /// proceed to the lock — making the no-side-effect assertions meaningful.
+    #[tokio::test]
+    async fn unauthorized_signer_claim_rejected() {
+        let user_key = alloy::signers::local::PrivateKeySigner::random();
+        let user_addr = user_key.address();
+        let gi = U256::from(0x4004u64);
+        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_hex, tx_hash) = encode_tx_signed_with_nonce(&user_key, calldata, 0);
+
+        // (a) allow-list configured, signer NOT on it.
+        let mut service = create_test_service();
+        service.allow_any_signer = false;
+        let foreign: Address = "0xdeAddeaDdEadDeaDDEaDDeadDEADDeaDDEAdDEaD"
+            .parse()
+            .unwrap();
+        service.allowed_signers = Some(vec![foreign]);
+        let store = service.store.clone();
+        let miden = service.miden_client.clone();
+        seed_zero_ger(&store).await;
+
+        let err = service_send_raw_txn(service, input_hex.clone())
+            .await
+            .expect_err("non-allow-listed signer's claimAsset must be rejected");
+        assert!(
+            err.to_string().contains("not on the allow-list"),
+            "unexpected: {err:#}"
+        );
+        // Rejected BEFORE any lock / receipt / nonce / Miden side effect.
+        assert!(
+            !store.is_claimed(&gi).await.unwrap(),
+            "no claimed_indices entry may exist for a rejected signer's gi"
+        );
+        assert!(
+            store.txn_get(tx_hash).await.unwrap().is_none(),
+            "no tx entry may be recorded"
+        );
+        assert!(
+            store.txn_receipt(tx_hash).await.unwrap().is_none(),
+            "no receipt may be recorded"
+        );
+        assert_eq!(
+            store.nonce_get(&format!("{user_addr:#x}")).await.unwrap(),
+            0,
+            "the nonce must not advance for a rejected signer"
+        );
+        assert!(!miden.test_was_called(), "Miden must never be touched");
+        assert_eq!(count_claim_events(&store).await, 0);
+
+        // (b) fail-closed default (audit C2): NO allow-list configured at all →
+        // the same valid claimAsset is rejected identically.
+        let mut service = create_test_service();
+        service.allow_any_signer = false;
+        service.allowed_signers = None;
+        let store = service.store.clone();
+        seed_zero_ger(&store).await;
+
+        let err = service_send_raw_txn(service, input_hex)
+            .await
+            .expect_err("claimAsset must be rejected under the fail-closed default");
+        assert!(
+            err.to_string().contains("not on the allow-list"),
+            "unexpected: {err:#}"
+        );
+        assert!(!store.is_claimed(&gi).await.unwrap());
+    }
+
+    /// Claims are PERMISSIONLESS — pins the EVM-bridge-equivalent design: on
+    /// the L1 PolygonZkEVMBridge anyone may call claimAsset for any leaf, and
+    /// the funds go to the destinationAddress bound in the (merkle-proven)
+    /// calldata, never to the caller. The proxy mirrors that: the submitter
+    /// only needs to pass the allow-list; NOTHING compares the recovered
+    /// signer to destinationAddress. Signer C claims a deposit whose
+    /// destination is someone else entirely, on both claim routes.
+    #[tokio::test]
+    async fn claim_for_someone_elses_deposit_permissionless() {
+        let key_c = alloy::signers::local::PrivateKeySigner::random();
+        let addr_c = key_c.address();
+
+        let mut service = create_test_service();
+        service.allow_any_signer = false;
+        service.allowed_signers = Some(vec![addr_c]);
+        let store = service.store.clone();
+        let miden = service.miden_client.clone();
+        seed_zero_ger(&store).await;
+
+        // Leg 1 — REAL claim route: destination is a resolvable Miden-mapped
+        // address that is NOT C. The claim passes every signer gate, acquires
+        // the lock, and reaches the Miden publish (the unit stub cannot
+        // complete it — but the failure is the stub's, not any
+        // signer≠destination authorization error, because no such check
+        // exists).
+        let gi_real = U256::from(0x5005u64);
+        assert_ne!(resolvable_dest(), addr_c);
+        let calldata = claim_calldata(gi_real, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_hex, _) = encode_tx_signed_with_nonce(&key_c, calldata, 0);
+        let err = service_send_raw_txn(service.clone(), input_hex)
+            .await
+            .expect_err("the stub MidenClient cannot complete the publish");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("allow-list") && !msg.contains("already submitted"),
+            "someone-else's-deposit claim must not be rejected on any authorization \
+             or dedup path: {msg}"
+        );
+        assert!(
+            miden.test_was_called(),
+            "C's claim for someone else's deposit must reach the Miden publish"
+        );
+
+        // Leg 2 — synchronous accept (RD-860 swallow route, the only one that
+        // completes under the stub): destination is a third party's EVM
+        // address ≠ C. Accepted, ClaimEvent emitted, and the recorded signer
+        // is C — the destination in the calldata is untouched by who signed.
+        let gi_swallow = U256::from(0x5006u64);
+        let someone_else = Address::from([0x77u8; 20]);
+        assert_ne!(someone_else, addr_c);
+        // Leg 1's publish failed, so C's nonce is still 0.
+        let calldata = claim_calldata(gi_swallow, someone_else, U256::from(1_000_000u64));
+        let (input_hex, tx_hash) = encode_tx_signed_with_nonce(&key_c, calldata, 0);
+        let accepted = service_send_raw_txn(service, input_hex)
+            .await
+            .expect("permissionless claim for someone else's deposit must be accepted");
+        assert_eq!(accepted, tx_hash);
+        assert_eq!(count_claim_events(&store).await, 1);
+        let txn = store.txn_get(tx_hash).await.unwrap().expect("tx recorded");
+        assert_eq!(
+            txn.signer, addr_c,
+            "the recorded signer is the submitter; the destination stays the \
+             calldata's, not the signer's"
+        );
+        let rec = store
+            .get_unclaimable_claim(&gi_swallow)
+            .await
+            .unwrap()
+            .expect("swallow route records the unclaimable entry");
+        assert_eq!(
+            rec.destination_address, someone_else,
+            "funds are bound to the calldata's destination regardless of submitter"
+        );
+    }
+
     /// No double-submit race: a record YOUNGER than the TTL (a submission genuinely in
     /// flight) keeps rejecting resubmissions even though no ClaimEvent exists yet.
     #[tokio::test]

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -139,6 +139,26 @@ impl InMemoryStore {
         }
     }
 
+    /// Test-only: age an existing claim-lock record by `age`, so TTL-expiry
+    /// paths (`try_reclaim_expired` via `acquire_claim_lock`) can be exercised
+    /// through the full RPC pipeline without sleeping for the real
+    /// `CLAIM_RESUBMIT_TTL_SECS` or mutating process-global env (unsafe under
+    /// parallel tests on edition 2024).
+    ///
+    /// Panics if `global_index` has no record, or if the process has not been
+    /// alive long enough for `Instant::now() - age` to be representable (never
+    /// the case for the ~2 min TTLs the tests use on any real machine).
+    #[cfg(test)]
+    pub fn test_backdate_claim(&self, global_index: U256, age: std::time::Duration) {
+        let mut claimed = self.claimed.write();
+        let acquired_at = claimed
+            .get_mut(&global_index)
+            .expect("test_backdate_claim: no claim record for global_index");
+        *acquired_at = acquired_at
+            .checked_sub(age)
+            .expect("test_backdate_claim: process uptime shorter than backdate age");
+    }
+
     /// Emit a synthetic BridgeEvent log. Private helper for the atomic B2AGG
     /// commit — it used to be a `Store` trait convenience method, but the only
     /// remaining caller is `commit_b2agg_event_atomic` below (PgStore inlines

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -45,10 +45,19 @@ pub struct InMemoryStore {
     // Nonces
     nonces: RwLock<HashMap<String, u64>>,
 
-    // Claims — value = when `try_claim` acquired the lock, so orphaned records
-    // (crash between the lock write and the CLAIM landing) can be superseded
-    // after a TTL (`try_reclaim_expired`, SOAK FINDING #1).
+    // Claims — value = when `try_claim` acquired the lock (as read from
+    // `claim_clock_now`), so orphaned records (crash between the lock write and
+    // the CLAIM landing) can be superseded after a TTL (`try_reclaim_expired`,
+    // SOAK FINDING #1).
     claimed: RwLock<HashMap<U256, std::time::Instant>>,
+
+    // Test-only skew for the claim-lock clock. `test_backdate_claim` ages
+    // records by moving this clock FORWARD instead of subtracting from the
+    // stored `Instant`s — `Instant::now() - age` underflows (panics) whenever
+    // the process has been alive for less than `age` (short test binaries, or
+    // a raised CLAIM_RESUBMIT_TTL_SECS). See `claim_clock_now`.
+    #[cfg(test)]
+    claim_clock_skew: RwLock<std::time::Duration>,
 
     // Unclaimable claims — first-write wins per global_index (RD-860).
     unclaimable: RwLock<HashMap<U256, UnclaimableClaim>>,
@@ -122,6 +131,8 @@ impl InMemoryStore {
             transactions: Mutex::new(LruCache::new(NonZeroUsize::new(10_000).unwrap())),
             nonces: RwLock::new(HashMap::new()),
             claimed: RwLock::new(HashMap::new()),
+            #[cfg(test)]
+            claim_clock_skew: RwLock::new(std::time::Duration::ZERO),
             unclaimable: RwLock::new(HashMap::new()),
             unbridgeable_bridge_outs: RwLock::new(HashMap::new()),
             address_mappings: RwLock::new(HashMap::new()),
@@ -139,24 +150,39 @@ impl InMemoryStore {
         }
     }
 
-    /// Test-only: age an existing claim-lock record by `age`, so TTL-expiry
-    /// paths (`try_reclaim_expired` via `acquire_claim_lock`) can be exercised
-    /// through the full RPC pipeline without sleeping for the real
-    /// `CLAIM_RESUBMIT_TTL_SECS` or mutating process-global env (unsafe under
-    /// parallel tests on edition 2024).
+    /// The claim-lock clock: `Instant::now()`, plus the test-only forward skew.
+    /// Every claim-lock timestamp read/write (`try_claim`, `try_reclaim_expired`)
+    /// goes through this, so tests can age records by advancing the clock —
+    /// which is always representable — instead of `Instant` subtraction, which
+    /// underflows (panics) when the process uptime is shorter than the age.
+    fn claim_clock_now(&self) -> std::time::Instant {
+        let now = std::time::Instant::now();
+        #[cfg(test)]
+        let now = now + *self.claim_clock_skew.read();
+        now
+    }
+
+    /// Test-only: age the existing claim-lock record for `global_index` by
+    /// `age`, so TTL-expiry paths (`try_reclaim_expired` via
+    /// `acquire_claim_lock`) can be exercised through the full RPC pipeline
+    /// without sleeping for the real `CLAIM_RESUBMIT_TTL_SECS` or mutating
+    /// process-global env (unsafe under parallel tests on edition 2024).
     ///
-    /// Panics if `global_index` has no record, or if the process has not been
-    /// alive long enough for `Instant::now() - age` to be representable (never
-    /// the case for the ~2 min TTLs the tests use on any real machine).
+    /// Implemented as a forward skew of the store's claim clock (all records
+    /// age together — each test constructs its own store, so that is exactly
+    /// the record under test), never as `Instant::now() - age` arithmetic:
+    /// that subtraction underflows (panics) whenever the process has been
+    /// alive for less than `age` — e.g. a short test binary with a raised
+    /// `CLAIM_RESUBMIT_TTL_SECS`.
+    ///
+    /// Panics only if `global_index` has no record (a test-authoring error).
     #[cfg(test)]
     pub fn test_backdate_claim(&self, global_index: U256, age: std::time::Duration) {
-        let mut claimed = self.claimed.write();
-        let acquired_at = claimed
-            .get_mut(&global_index)
-            .expect("test_backdate_claim: no claim record for global_index");
-        *acquired_at = acquired_at
-            .checked_sub(age)
-            .expect("test_backdate_claim: process uptime shorter than backdate age");
+        assert!(
+            self.claimed.read().contains_key(&global_index),
+            "test_backdate_claim: no claim record for global_index {global_index}"
+        );
+        *self.claim_clock_skew.write() += age;
     }
 
     /// Emit a synthetic BridgeEvent log. Private helper for the atomic B2AGG
@@ -685,7 +711,7 @@ impl Store for InMemoryStore {
         if claimed.contains_key(&global_index) {
             anyhow::bail!("claim already submitted for global_index {global_index}");
         }
-        claimed.insert(global_index, std::time::Instant::now());
+        claimed.insert(global_index, self.claim_clock_now());
         Ok(())
     }
 
@@ -696,10 +722,11 @@ impl Store for InMemoryStore {
     ) -> anyhow::Result<bool> {
         // One write lock end-to-end = atomic check-and-refresh: exactly one of any
         // concurrent recoveries wins; the losers observe the refreshed timestamp.
+        let now = self.claim_clock_now();
         let mut claimed = self.claimed.write();
         match claimed.get_mut(&global_index) {
-            Some(acquired_at) if acquired_at.elapsed() >= ttl => {
-                *acquired_at = std::time::Instant::now();
+            Some(acquired_at) if now.saturating_duration_since(*acquired_at) >= ttl => {
+                *acquired_at = now;
                 Ok(true)
             }
             _ => Ok(false),

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -57,7 +57,14 @@ pub async fn seed_test_faucets(store: &dyn Store) {
 /// paths don't each have to configure an allow-list. Production defaults remain
 /// fail-closed (`allow_any_signer = false`, `allowed_signers = None`).
 pub fn create_test_service() -> ServiceState {
-    let store: Arc<dyn crate::store::Store> = Arc::new(InMemoryStore::new());
+    create_test_service_with_store(Arc::new(InMemoryStore::new()))
+}
+
+/// Like [`create_test_service`], but over a caller-provided store. Lets tests
+/// keep a concrete handle (e.g. `Arc<InMemoryStore>` for its `#[cfg(test)]`
+/// helpers such as `test_backdate_claim`) while the service holds the same
+/// instance behind `Arc<dyn Store>`.
+pub fn create_test_service_with_store(store: Arc<dyn Store>) -> ServiceState {
     let block_state = Arc::new(BlockState::new());
     let miden_client = MidenClient::new_test();
     let accounts = test_accounts_config();


### PR DESCRIPTION
## Summary

Certifies the existing permissionless claim semantics of the Miden AggLayer proxy: an ordinary **allow-listed user**, not only the bridge-service sponsor, can submit a valid `claimAsset` transaction through `eth_sendRawTransaction`.

The caller pays for and authorizes the submission, but cannot redirect the bridge result: destination, token, amount, and proof remain bound by the deposit. Claim ownership is signer-independent, and duplicate suppression is keyed by `globalIndex`.

This PR adds focused Rust coverage plus a live L1-to-Miden scenario that proves both a user-signed claim and a real user-versus-sponsor race. It also captures and recovers an important proxy/EVM behavioral difference: when the user wins, the proxy rejects the sponsor duplicate at RPC admission, so the rejected transaction does not consume its nonce and can wedge the sponsor transaction manager.

```mermaid
flowchart LR
    L1[L1 bridge deposit] --> BS[bridge-service<br/>proof API and autoclaimer]
    BS -->|sponsor-signed claimAsset| RPC[miden-agglayer<br/>eth_sendRawTransaction]
    U[ordinary allow-listed user] -->|user-signed claimAsset| RPC
    RPC --> AUTH[signer authorization<br/>and per-signer nonce]
    AUTH --> LOCK[signer-agnostic<br/>globalIndex claim lock]
    LOCK -->|one winner| M[Miden bridge CLAIM]
    LOCK -->|all later submissions| DEDUP[already submitted]
    M --> W[fresh isolated<br/>destination wallet]
    M --> EVT[ClaimEvent and receipt<br/>under winner tx hash]
```

## Rust coverage

- an explicitly allow-listed non-sponsor key can submit `claimAsset`;
- the transaction and receipt retain the actual user signer;
- two signers cannot claim the same in-flight `globalIndex`;
- a landed claim remains permanently deduplicated regardless of signer or TTL;
- an expired orphan claim lock can be taken over by another authorized signer;
- unauthorized and fail-closed claims are rejected before nonce, lock, receipt, or Miden side effects;
- an authorized caller may submit a claim for a different proven destination without becoming the beneficiary.

The in-memory claim clock used to age orphan locks is `#[cfg(test)]`. It advances an injected store-local clock instead of subtracting from `Instant`, avoiding the short-process-uptime underflow that affected the previous backdating helper.

## Live end-to-end certification

`scripts/e2e-manual-user-claim.sh` runs two claim legs against the live proxy.

### Leg 1: ordinary user claims

1. Provision a fresh, per-run isolated Miden wallet with a zero balance.
2. Submit an L1 bridge deposit and derive its exact identity from the transaction receipt's `BridgeEvent` and `depositCount`.
3. Build a real `claimAsset` transaction from the bridge-service proof, sign it with a normal Anvil user key, and retry transient GER-not-observed responses quickly enough to race the sponsor.
4. Require the user to win at least one attempt.
5. Assert a successful receipt, `receipt.from == user`, exactly one `ClaimEvent` for the deposit, and the event under the user's transaction hash.

Every deposit made by the run is tracked. Because the wallet is fresh, its balance must equal exactly:

```text
deposits sent by this run × expected units per deposit
```

This detects missing, delayed, unexplained, and double mints; it is not a lower-bound or unrelated historical-balance check.

### Sponsor recovery and verification

If the user front-runs the sponsor, the sponsor can remain stuck retrying its duplicate transaction at the same nonce. On an EVM chain that transaction would normally be mined as a revert and consume the nonce; this proxy refuses it before inclusion.

The test recovers the sponsor by consuming each wedged head nonce with a benign zero-amount `claimAsset` no-op. It then submits a fresh deposit that the user never touches and requires it to be autoclaimed successfully with `receipt.from == sponsor`. This is a hard assertion both between the two legs and again before exit.

### Leg 2: real signer-agnostic race

1. Submit a second deposit and wait until it is ready for claim.
2. Race the same `globalIndex` between the user and the now-verified sponsor.
3. Require exactly one `ClaimEvent` and a successful winner receipt.
4. If the sponsor wins, prove participation from the winning receipt signer.
5. If the user wins, prove the sponsor continued submitting that exact `globalIndex` after the user's final submission, using fresh GI-specific dedup logs plus sponsor-signer RPC submission logs.
6. Heal and hard-verify the sponsor again before exiting.

## Reliability and suite placement

- deposit selection is tied to the just-submitted L1 receipt and fails closed on malformed API data;
- receipt signer checks are mandatory, never warning-only;
- `eth_getLogs` starts at this run's initial proxy block and falls back to 5,000-block pagination below the 10,000-block cap;
- timestamp filtering uses portable UTC timestamps and does not depend on GNU `date -d`;
- best-effort failure cleanup attempts to heal the sponsor and removes the isolated wallet store;
- the scenario runs **last** in `scripts/e2e-test.sh all`, so an interrupted race cannot poison subsequent sponsor-dependent tests.

Run the normal scenario with:

```bash
./scripts/e2e-test.sh manual-user-claim
```

## Optional explicit allow-list phase

`ALLOWLIST_LEG=1` enables an additional phase for **disposable stacks only**. It recreates the proxy without `--insecure-allow-any-signer`, configures an explicit list containing the user, sponsor, aggoracle, and sequencer, and proves:

- the allow-listed ordinary user reaches and completes the claim path;
- a signer outside the list is rejected by the authorization gate;
- the original proxy configuration is restored afterward and sponsor functionality is checked again.

```bash
ALLOWLIST_LEG=1 ./scripts/e2e-test.sh manual-user-claim
```

This phase is intentionally excluded from `all` because it recreates the proxy container twice.

## Scope

This PR pins and certifies existing claim semantics. It does **not** add a sponsor-only path, a new claim API, a new production authorization mechanism, or a way for the submitter to change the proof-bound beneficiary. Production claim processing is unchanged; the supporting clock and store hooks are test-only.
