### PR TITLE
fix(release): harden source-build acceptance and provenance gates

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,3 +20,4 @@ jobs:
       - run: make lint
       - run: make build
       - run: make test-unit
+      - run: make test-scripts

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,12 @@ test: test-unit test-e2e ## Run everything: unit tests, then spin up stack and r
 test-unit: ## Run unit tests (no docker needed)
 	cargo test --workspace --profile=$(CARGO_PROFILE) --lib
 
+.PHONY: test-scripts
+test-scripts: ## Syntax-check + run the shell guard test harnesses (no docker needed)
+	bash -n scripts/release-acceptance.sh
+	bash -n scripts/release-acceptance-guards.test.sh
+	bash scripts/release-acceptance-guards.test.sh
+
 .PHONY: test-e2e
 test-e2e: ## Spin up docker stack, run E2E tests, tear down (fully self-contained)
 	@echo "╔══════════════════════════════════════════════════════════════╗"

--- a/scripts/monitoring/immutability-monitor.py
+++ b/scripts/monitoring/immutability-monitor.py
@@ -1,4 +1,4 @@
-import json,sys,time,urllib.request,hashlib
+import json,sys,time,urllib.request,hashlib,signal
 RPC="http://127.0.0.1:8546"
 TOPICS={"B2AGG":"0x501781209a1f8899323b96b4ef08b168df93e0a90c673d1e4cce39366cb62f9b",
         "CLAIM":"0x1df3f2a973a00d6635911755c260704e95e8a5876997546798770f76396fda4d",
@@ -14,6 +14,13 @@ def block_logs():
     return {b:hashlib.sha256("|".join(sorted(v)).encode()).hexdigest()[:12] for b,v in per.items()}
 dur=int(sys.argv[1]) if len(sys.argv)>1 else 3600
 seen={}; viol=0; polls=0; resets=0; t_end=time.time()+dur; maxb=0
+def _summary():
+    print(f"════ IMMUTABILITY: polls={polls} blocks_tracked={len(seen)} resets={resets} VIOLATIONS={viol} (0=immutable) ════",flush=True)
+def _on_term(_sig,_frm):
+    # Graceful stop (release-acceptance sends SIGTERM): flush the tallied summary so
+    # a supervisor has POSITIVE evidence (polls>0) that this monitor actually ran.
+    _summary(); sys.exit(0)
+signal.signal(signal.SIGTERM, _on_term)
 print(f"immutability monitor: track every block's logs; flag change after first-seen; reset baseline on chain regression. dur={dur}s",flush=True)
 while time.time()<t_end:
     try: cur=block_logs()
@@ -28,4 +35,4 @@ while time.time()<t_end:
             viol+=1; print(f"  ★ IMMUTABILITY VIOLATION: block {b} logs CHANGED {seen[b]}->{h} (poll {polls})",flush=True); seen[b]=h
         elif b not in seen: seen[b]=h
     time.sleep(5)
-print(f"════ IMMUTABILITY: polls={polls} blocks_tracked={len(seen)} resets={resets} VIOLATIONS={viol} (0=immutable) ════",flush=True)
+_summary()

--- a/scripts/release-acceptance-guards.test.sh
+++ b/scripts/release-acceptance-guards.test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# ══════════════════════════════════════════════════════════════════════════════
+# Behavioral tests for the provenance guards in scripts/release-acceptance.sh.
+#
+# Self-contained, no bats, no real docker/git/build. It SOURCES the acceptance
+# script (whose `main` is gated behind a BASH_SOURCE==$0 check, so nothing runs on
+# source) and then overrides `git` and `docker` with shell-function MOCKS. Because
+# the guards call `git`/`docker` as bare commands, a shell function of the same
+# name shadows the real binary at call time — so each guard runs against the mock
+# with no PATH juggling.
+#
+# Each case runs a guard in a SUBSHELL: the guards call `fail` (which `exit 1`s),
+# so a rejected case exits the subshell non-zero and an accepted case exits 0.
+#
+#   Usage:  bash scripts/release-acceptance-guards.test.sh
+#   Exit 0 = all cases passed, non-zero = at least one case behaved wrongly.
+# ══════════════════════════════════════════════════════════════════════════════
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=release-acceptance.sh
+source "$HERE/release-acceptance.sh"
+
+RC=0
+pass() { printf '  ok      %s\n' "$1"; }
+oops() { printf '  FAILED  %s\n' "$1"; RC=1; }
+
+# Each case runs its body (per-case env overrides + a guard call) via `eval` in a
+# SUBSHELL, so the sourced guard functions and the git/docker mocks are in scope
+# while per-case variable overrides and any `exit` from `fail` stay contained.
+# assert_reject: body must exit non-zero (guard called fail).
+assert_reject() {
+    local desc="$1" body="$2"
+    if ( eval "$body" ) >/dev/null 2>&1; then oops "expected REJECT: $desc"; else pass "reject: $desc"; fi
+}
+# assert_accept: body must exit zero (guard passed).
+assert_accept() {
+    local desc="$1" body="$2"
+    if ( eval "$body" ) >/dev/null 2>&1; then pass "accept: $desc"; else oops "expected ACCEPT: $desc"; fi
+}
+
+# ── Mocks ─────────────────────────────────────────────────────────────────────
+# Behavior is driven by MOCK_* environment variables set per-case in a subshell.
+#   HEAD_SHA / OTHER_SHA are valid 40-char hex so the SHA regex branch is real.
+HEAD_SHA_FIX="0000000000000000000000000000000000000001"
+OTHER_SHA_FIX="0000000000000000000000000000000000000002"
+
+git() {
+    case "$1" in
+        status)
+            [ "${MOCK_GIT_STATUS_FAIL:-0}" = 1 ] && return 1
+            printf '%s' "${MOCK_GIT_STATUS:-}"
+            return 0 ;;
+        rev-parse)
+            [ "${MOCK_REVPARSE_FAIL:-0}" = 1 ] && return 1
+            local rev="${*: -1}"                     # last positional = the rev
+            case "$rev" in
+                HEAD)
+                    [ "${MOCK_HEAD_FAIL:-0}" = 1 ] && return 1
+                    printf '%s\n' "${MOCK_HEAD_SHA}"; return 0 ;;
+                refs/tags/*)
+                    if [ -n "${MOCK_TAG_SHA:-}" ]; then printf '%s\n' "$MOCK_TAG_SHA"; return 0
+                    else return 1; fi ;;                # unknown tag → non-zero, no output
+                *)                                     # "<sha>^{commit}"
+                    printf '%s\n' "${MOCK_SHA_RESOLVE}"; return 0 ;;
+            esac ;;
+        cat-file)
+            [ "${MOCK_SHA_EXISTS:-1}" = 1 ] && return 0 || return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+docker() {
+    if [ "$1" = "inspect" ]; then
+        [ "${MOCK_DOCKER_INSPECT_FAIL:-0}" = 1 ] && return 1
+        printf '%s\n' "${MOCK_RUNNING_ID}"; return 0
+    fi
+    if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then
+        [ "${MOCK_IMG_INSPECT_FAIL:-0}" = 1 ] && return 1
+        printf '%s\n' "${MOCK_BUILT_ID}"; return 0
+    fi
+    if [ "$1" = "tag" ]; then
+        [ "${MOCK_DOCKER_TAG_FAIL:-0}" = 1 ] && return 1
+        return 0
+    fi
+    return 0
+}
+
+# Happy-path baseline; each case exports overrides inside its own subshell.
+export MOCK_GIT_STATUS=""
+export MOCK_HEAD_SHA="$HEAD_SHA_FIX"
+export MOCK_SHA_RESOLVE="$HEAD_SHA_FIX"
+export MOCK_SHA_EXISTS=1
+export MOCK_TAG_SHA=""
+export MOCK_RUNNING_ID="sha256:abc"
+export MOCK_BUILT_ID="sha256:abc"
+export PROJECT="proj"
+export RELEASE_IMAGE="miden-agglayer-e2e:vTEST"
+
+echo "── verify_clean_worktree ──────────────────────────────────────────────"
+assert_accept "clean tree"                 'MOCK_GIT_STATUS=""; verify_clean_worktree'
+assert_reject "modified tracked file"      'MOCK_GIT_STATUS=" M src/main.rs"; verify_clean_worktree'
+assert_reject "staged file"                'MOCK_GIT_STATUS="A  new.rs"; verify_clean_worktree'
+assert_reject "untracked file"             'MOCK_GIT_STATUS="?? stray.txt"; verify_clean_worktree'
+assert_reject "git status failure"         'MOCK_GIT_STATUS_FAIL=1; verify_clean_worktree'
+
+echo "── verify_exact_ref ───────────────────────────────────────────────────"
+assert_accept "full SHA == HEAD"           "RELEASE_REF=$HEAD_SHA_FIX; verify_exact_ref"
+assert_accept "existing tag peels to HEAD" "RELEASE_REF=v0.15.5 MOCK_TAG_SHA=$HEAD_SHA_FIX; verify_exact_ref"
+assert_reject "mutable ref: HEAD"          'RELEASE_REF=HEAD; verify_exact_ref'
+assert_reject "mutable ref: branch name"   'RELEASE_REF=main; verify_exact_ref'
+assert_reject "mutable ref: origin/main"   'RELEASE_REF=origin/main; verify_exact_ref'
+assert_reject "revision expression HEAD~1" 'RELEASE_REF=HEAD~1; verify_exact_ref'
+assert_reject "unknown tag"                'RELEASE_REF=v9.9.9 MOCK_TAG_SHA=""; verify_exact_ref'
+assert_reject "full SHA, object missing"   "RELEASE_REF=$HEAD_SHA_FIX MOCK_SHA_EXISTS=0; verify_exact_ref"
+assert_reject "full SHA resolves != HEAD"  "RELEASE_REF=$OTHER_SHA_FIX MOCK_SHA_RESOLVE=$OTHER_SHA_FIX; verify_exact_ref"
+assert_reject "tag peels != HEAD"          "RELEASE_REF=v0.15.5 MOCK_TAG_SHA=$OTHER_SHA_FIX; verify_exact_ref"
+assert_reject "git HEAD resolution failure" "RELEASE_REF=$HEAD_SHA_FIX MOCK_HEAD_FAIL=1; verify_exact_ref"
+
+echo "── verify_running_image ───────────────────────────────────────────────"
+assert_accept "running == built"           'MOCK_RUNNING_ID="sha256:x" MOCK_BUILT_ID="sha256:x"; verify_running_image'
+assert_reject "docker inspect fails"       'MOCK_DOCKER_INSPECT_FAIL=1; verify_running_image'
+assert_reject "running ID empty"           'MOCK_RUNNING_ID=""; verify_running_image'
+assert_reject "docker image inspect fails" 'MOCK_IMG_INSPECT_FAIL=1; verify_running_image'
+assert_reject "built ID empty"             'MOCK_BUILT_ID=""; verify_running_image'
+assert_reject "running != built mismatch"  'MOCK_RUNNING_ID="sha256:a" MOCK_BUILT_ID="sha256:b"; verify_running_image'
+assert_reject "docker tag fails"           'MOCK_DOCKER_TAG_FAIL=1; verify_running_image'
+
+echo "───────────────────────────────────────────────────────────────────────"
+if [ "$RC" -eq 0 ]; then echo "ALL GUARD TESTS PASSED"; else echo "GUARD TESTS FAILED"; fi
+exit "$RC"

--- a/scripts/release-acceptance-guards.test.sh
+++ b/scripts/release-acceptance-guards.test.sh
@@ -117,14 +117,44 @@ assert_reject "full SHA resolves != HEAD"  "RELEASE_REF=$OTHER_SHA_FIX MOCK_SHA_
 assert_reject "tag peels != HEAD"          "RELEASE_REF=v0.15.5 MOCK_TAG_SHA=$OTHER_SHA_FIX; verify_exact_ref"
 assert_reject "git HEAD resolution failure" "RELEASE_REF=$HEAD_SHA_FIX MOCK_HEAD_FAIL=1; verify_exact_ref"
 
-echo "── verify_running_image ───────────────────────────────────────────────"
+echo "── verify_running_image (verifies + echoes id; does NOT tag) ──────────"
 assert_accept "running == built"           'MOCK_RUNNING_ID="sha256:x" MOCK_BUILT_ID="sha256:x"; verify_running_image'
 assert_reject "docker inspect fails"       'MOCK_DOCKER_INSPECT_FAIL=1; verify_running_image'
 assert_reject "running ID empty"           'MOCK_RUNNING_ID=""; verify_running_image'
 assert_reject "docker image inspect fails" 'MOCK_IMG_INSPECT_FAIL=1; verify_running_image'
 assert_reject "built ID empty"             'MOCK_BUILT_ID=""; verify_running_image'
 assert_reject "running != built mismatch"  'MOCK_RUNNING_ID="sha256:a" MOCK_BUILT_ID="sha256:b"; verify_running_image'
-assert_reject "docker tag fails"           'MOCK_DOCKER_TAG_FAIL=1; verify_running_image'
+# verify_running_image must echo the verified id on success (caller captures it).
+assert_accept "echoes verified id"         '[ "$(MOCK_RUNNING_ID=sha256:zz MOCK_BUILT_ID=sha256:zz verify_running_image)" = "sha256:zz" ]'
+
+echo "── tag_release_image (only after every gate passes) ───────────────────"
+assert_accept "tags accepted build"        'RUNNING_ID="sha256:x"; tag_release_image'
+assert_reject "docker tag fails"           'RUNNING_ID="sha256:x" MOCK_DOCKER_TAG_FAIL=1; tag_release_image'
+assert_reject "no verified id to tag"      'RUNNING_ID=""; tag_release_image'
+
+echo "── verify_monitor_evidence (positive evidence + no fail-open) ─────────"
+TDIR="$(mktemp -d)"; trap 'rm -rf "$TDIR"' EXIT
+printf '%s\n' '[12:00:00] completeness watcher up: project=proj' 'OK notes=5 logs=5 cut=40' > "$TDIR/watch.ok"
+printf '%s\n' '[12:00:00] completeness watcher up: project=proj' > "$TDIR/watch.nocycle"
+printf '%s\n' 'OK notes=5 logs=5 cut=40' > "$TDIR/watch.nostart"
+printf '%s\n' '[12:00:00] completeness watcher up: project=proj' 'OK notes=5 logs=5 cut=40' \
+       '[12:01:00] ████ COMPLETENESS VIOLATION DETECTED ████' > "$TDIR/watch.viol"
+printf '%s\n' '════ IMMUTABILITY: polls=7 blocks_tracked=3 resets=0 VIOLATIONS=0 (0=immutable) ════' > "$TDIR/immut.ok"
+printf '%s\n' 'immutability monitor: track ... dur=21600s' > "$TDIR/immut.nosummary"
+printf '%s\n' '════ IMMUTABILITY: polls=0 blocks_tracked=0 resets=0 VIOLATIONS=0 (0=immutable) ════' > "$TDIR/immut.zeropolls"
+printf '%s\n' '════ IMMUTABILITY: polls=7 blocks_tracked=3 resets=0 VIOLATIONS=2 (0=immutable) ════' > "$TDIR/immut.viol"
+: > "$TDIR/empty"
+assert_accept "healthy monitors"           "verify_monitor_evidence $TDIR/watch.ok $TDIR/immut.ok"
+assert_reject "watcher output missing"     "verify_monitor_evidence $TDIR/does-not-exist $TDIR/immut.ok"
+assert_reject "watcher output empty"       "verify_monitor_evidence $TDIR/empty $TDIR/immut.ok"
+assert_reject "immut output missing"       "verify_monitor_evidence $TDIR/watch.ok $TDIR/does-not-exist"
+assert_reject "immut output empty"         "verify_monitor_evidence $TDIR/watch.ok $TDIR/empty"
+assert_reject "watcher never started"      "verify_monitor_evidence $TDIR/watch.nostart $TDIR/immut.ok"
+assert_reject "watcher no diff cycle"      "verify_monitor_evidence $TDIR/watch.nocycle $TDIR/immut.ok"
+assert_reject "immut no summary (crashed)" "verify_monitor_evidence $TDIR/watch.ok $TDIR/immut.nosummary"
+assert_reject "immut polls=0"              "verify_monitor_evidence $TDIR/watch.ok $TDIR/immut.zeropolls"
+assert_reject "watcher violation"          "verify_monitor_evidence $TDIR/watch.viol $TDIR/immut.ok"
+assert_reject "immut violation"            "verify_monitor_evidence $TDIR/watch.ok $TDIR/immut.viol"
 
 echo "───────────────────────────────────────────────────────────────────────"
 if [ "$RC" -eq 0 ]; then echo "ALL GUARD TESTS PASSED"; else echo "GUARD TESTS FAILED"; fi

--- a/scripts/release-acceptance.sh
+++ b/scripts/release-acceptance.sh
@@ -7,7 +7,8 @@
 # violations).
 #
 # Usage:
-#   RELEASE_IMAGE=miden-agglayer-e2e:vX.Y.Z ./scripts/release-acceptance.sh
+#   RELEASE_REF=vX.Y.Z RELEASE_IMAGE=miden-agglayer-e2e:vX.Y.Z ./scripts/release-acceptance.sh
+#   # RELEASE_REF (tag or SHA) is enforced: the worktree must be a CLEAN checkout of it.
 #   # or build from a tag first:
 #   #   git worktree add /tmp/rel vX.Y.Z && docker build -t miden-agglayer-e2e:vX.Y.Z /tmp/rel
 #
@@ -25,15 +26,54 @@ ts() { TZ=${TZ_DISPLAY:-Europe/Berlin} date '+%H:%M:%S'; }
 step() { echo "[$(ts)] ════ $* ════"; }
 fail() { echo "[$(ts)] ACCEPTANCE FAIL: $*"; exit 1; }
 
-docker image inspect "$RELEASE_IMAGE" >/dev/null 2>&1 || fail "image $RELEASE_IMAGE not present"
-docker tag "$RELEASE_IMAGE" miden-agglayer-e2e:latest
+# ── Provenance ENFORCEMENT (release-acceptance-provenance) ────────────────────
+# The image built below is only as trustworthy as the checkout it is built from.
+# BEFORE building, prove the checkout IS the claimed immutable release and is not
+# locally modified — otherwise the acceptance would certify drifted/dirty source.
+#
+#   RELEASE_REF  (required) — the exact release tag or commit SHA being accepted.
+#   The HEAD must resolve to it, and — for a tag — HEAD must be EXACTLY that tag.
+: "${RELEASE_REF:?set RELEASE_REF to the exact release tag or SHA being accepted}"
 
-step "fresh bringup on $RELEASE_IMAGE"
+# 1. Clean worktree: no tracked modifications, staged changes, or untracked files.
+#    A dirty tree means the built image would not match the claimed ref's source.
+DIRTY="$(git status --porcelain)"
+[ -z "$DIRTY" ] || fail "worktree is DIRTY — refusing to accept a non-pristine checkout:
+$DIRTY"
+
+# 2. Exact ref: HEAD must resolve to RELEASE_REF's commit …
+HEAD_SHA="$(git rev-parse HEAD)"
+if ! REF_SHA="$(git rev-parse --verify "${RELEASE_REF}^{commit}" 2>/dev/null)"; then
+    fail "RELEASE_REF '$RELEASE_REF' does not resolve to a commit in this repo"
+fi
+[ "$HEAD_SHA" = "$REF_SHA" ] \
+    || fail "HEAD $HEAD_SHA is not the claimed release $RELEASE_REF ($REF_SHA)"
+
+# 3. … and if RELEASE_REF names a tag, HEAD must be EXACTLY that tag (not merely a
+#    commit that happens to share the sha with an unrelated ref).
+if git rev-parse --verify --quiet "refs/tags/${RELEASE_REF}" >/dev/null; then
+    git describe --tags --exact-match HEAD 2>/dev/null | grep -qx "$RELEASE_REF" \
+        || fail "HEAD is not exactly tag $RELEASE_REF (git describe --exact-match mismatch)"
+fi
+echo "[$(ts)] provenance verified: clean worktree at $RELEASE_REF ($HEAD_SHA)"
+
+# Provenance model: the checkout was PROVEN above to be a clean tree at the exact
+# RELEASE_REF, so the bringup's `up -d --build` builds the proxy image from that release's
+# sources by construction. Image-ID equality vs a pre-built tag is NOT checkable (a
+# cache-mounted cargo RUN step makes IDs non-deterministic across builds); we assert the
+# running proxy IS the image this run built and re-point $RELEASE_IMAGE at it.
+RUN_START=$(date -u +%s)
+step "fresh bringup from the release checkout ($(git -C . describe --tags --always 2>/dev/null))"
 make e2e-l2l2-up > "$OUT/up.log" 2>&1 || fail "bringup (see $OUT/up.log)"
-docker inspect "${PROJECT}-miden-agglayer-1" --format '{{.Image}}' | grep -q \
-    "$(docker image inspect "$RELEASE_IMAGE" --format '{{.Id}}')" \
-    || fail "running proxy is not $RELEASE_IMAGE (stale image trap)"
-echo "[$(ts)] image verified: $RELEASE_IMAGE"
+RUNNING_ID=$(docker inspect "${PROJECT}-miden-agglayer-1" --format '{{.Image}}')
+[ "$RUNNING_ID" = "$(docker image inspect miden-agglayer-e2e:latest --format '{{.Id}}')" ] \
+    || fail "running proxy is not the image this run built"
+# NOTE: no freshness check — a full cache hit to a previous build of this same
+# immutable tag checkout is the SAME code (that is what caches are for). The
+# stale-image trap this script guards against is worktree-source drift, which an
+# immutable tag context rules out by construction.
+docker tag "$RUNNING_ID" "$RELEASE_IMAGE"
+echo "[$(ts)] image verified: built this run from the release checkout; tagged $RELEASE_IMAGE"
 
 step "monitors up (completeness watcher + immutability)"
 INTERVAL=10 MARGIN=2 ./scripts/monitoring/watch-completeness.sh > "$OUT/watch.output" 2>&1 &

--- a/scripts/release-acceptance.sh
+++ b/scripts/release-acceptance.sh
@@ -43,7 +43,7 @@ set -uo pipefail
 
 ts() { TZ=${TZ_DISPLAY:-Europe/Berlin} date '+%H:%M:%S'; }
 step() { echo "[$(ts)] ════ $* ════"; }
-fail() { echo "[$(ts)] ACCEPTANCE FAIL: $*"; exit 1; }
+fail() { echo "[$(ts)] ACCEPTANCE FAIL: $*" >&2; exit 1; }
 
 # ── Guard functions (unit-testable; see scripts/release-acceptance-guards.test.sh)
 # Each guard resolves its facts DIRECTLY and calls `fail` on any ambiguity,
@@ -86,10 +86,13 @@ immutable tag or full commit SHA"
         || fail "HEAD $HEAD_SHA is not the claimed release $ref ($REF_SHA)"
 }
 
-# Provenance-by-construction: the running proxy must be exactly the image this run
-# built from the verified checkout. Capture the running image ID and the built
-# image ID INDEPENDENTLY, require BOTH non-empty, compare, then re-tag — every
-# docker call guarded so nothing fails open. Sets RUNNING_ID on success.
+# Provenance-by-construction: the running proxy must be exactly the image this
+# run's build selected from the verified checkout. Capture the running image ID
+# and the built image ID INDEPENDENTLY, require BOTH non-empty, compare — every
+# docker call guarded so nothing fails open. ECHOES the verified image ID on
+# success (the caller captures it); does NOT tag here — tagging $RELEASE_IMAGE
+# onto a build happens only after every gate passes (see tag_release_image), so a
+# later failure never leaves the release tag on a rejected build.
 verify_running_image() {
     local running built
     running="$(docker inspect "${PROJECT}-miden-agglayer-1" --format '{{.Image}}')" \
@@ -99,19 +102,60 @@ verify_running_image() {
         || fail "docker image inspect of the built image (miden-agglayer-e2e:latest) failed"
     [ -n "$built" ] || fail "built image ID is empty — cannot verify provenance"
     [ "$running" = "$built" ] \
-        || fail "running proxy is not the image built from the verified checkout (running=$running built=$built)"
-    docker tag "$running" "$RELEASE_IMAGE" \
-        || fail "docker tag $running -> $RELEASE_IMAGE failed"
-    RUNNING_ID="$running"
+        || fail "running proxy is not the image selected by this run's build from the verified checkout (running=$running built=$built)"
+    printf '%s\n' "$running"
+}
+
+# Point $RELEASE_IMAGE at the accepted build — ONLY after every gate has passed.
+tag_release_image() {
+    [ -n "${RUNNING_ID:-}" ] || fail "no verified image ID to tag (internal error)"
+    docker tag "$RUNNING_ID" "$RELEASE_IMAGE" \
+        || fail "docker tag $RUNNING_ID -> $RELEASE_IMAGE failed"
+}
+
+# Positive monitor evidence: prove BOTH monitors actually ran and produced real
+# samples — never let a crashed monitor or an empty/unreadable log pass as "zero
+# violations". Args: watcher-output-file immutability-output-file. Reads the
+# immutability monitor's own tallied summary (polls / VIOLATIONS), which its
+# SIGTERM handler flushes on graceful stop.
+verify_monitor_evidence() {
+    local wout="$1" iout="$2" summary polls iviol wviol
+    # Files must exist, be readable, and be non-empty.
+    [ -r "$wout" ] && [ -s "$wout" ] \
+        || fail "completeness watcher produced no readable output ($wout) — cannot certify completeness"
+    [ -r "$iout" ] && [ -s "$iout" ] \
+        || fail "immutability monitor produced no readable output ($iout) — cannot certify immutability"
+    # Watcher: startup line + at least one COMPLETED diff cycle (positive evidence
+    # it actually sampled the chain, not just launched then died).
+    grep -aq "completeness watcher up" "$wout" \
+        || fail "completeness watcher never started (see $wout)"
+    grep -aq "OK notes=" "$wout" \
+        || fail "completeness watcher completed no clean diff cycle — no positive evidence it sampled the chain (see $wout)"
+    # Immutability: its own summary must be present with polls>0.
+    summary="$(grep -aE "IMMUTABILITY: polls=" "$iout" | tail -1)"
+    [ -n "$summary" ] \
+        || fail "immutability monitor emitted no poll summary — it crashed before flushing (see $iout)"
+    polls="$(printf '%s' "$summary" | sed -n 's/.*polls=\([0-9][0-9]*\).*/\1/p')"
+    [ -n "$polls" ] && [ "$polls" -gt 0 ] \
+        || fail "immutability monitor recorded 0 polls — it never sampled the chain (see $iout)"
+    # Violations, from authoritative sources.
+    wviol="$(grep -ac "COMPLETENESS VIOLATION DETECTED" "$wout")"
+    [ "${wviol:-0}" -eq 0 ] || fail "completeness watcher flagged $wviol violation(s) (see $wout)"
+    iviol="$(printf '%s' "$summary" | sed -n 's/.*VIOLATIONS=\([0-9][0-9]*\).*/\1/p')"
+    [ -n "$iviol" ] && [ "$iviol" -eq 0 ] \
+        || fail "immutability monitor flagged ${iviol:-?} violation(s) (see $iout)"
+    echo "[$(ts)] monitors: watcher sampled OK, immutability polls=$polls, 0 violations"
 }
 
 main() {
-    cd "$(dirname "${BASH_SOURCE[0]}")/.."
+    # Guard the cd: with set -e absent, a failed cd would silently continue in the
+    # caller's directory and validate/build the WRONG checkout.
+    cd "$(dirname "${BASH_SOURCE[0]}")/.." || fail "cannot cd to the repo root"
     : "${RELEASE_IMAGE:?set RELEASE_IMAGE to the release image tag}"
     : "${RELEASE_REF:?set RELEASE_REF to the exact release tag or full commit SHA being accepted}"
     PROJECT="${COMPOSE_PROJECT_NAME:-$(basename "$PWD")}"
     export COMPOSE_PROJECT_NAME="$PROJECT"
-    OUT="${ACCEPT_DIR:-/tmp/release-acceptance}"; mkdir -p "$OUT"
+    OUT="${ACCEPT_DIR:-/tmp/release-acceptance}"; mkdir -p "$OUT" || fail "cannot create output dir $OUT"
 
     # ── Provenance ENFORCEMENT (release-acceptance-provenance) ────────────────
     # The image built below is only as trustworthy as the checkout it is built
@@ -127,22 +171,25 @@ main() {
     # from that release's sources BY CONSTRUCTION. Image-ID equality vs a pre-built
     # tag is NOT checkable (a cache-mounted cargo RUN step makes IDs
     # non-deterministic across builds); we instead assert the running proxy IS the
-    # image this run built and re-point $RELEASE_IMAGE at it.
+    # image this run's build selected, capture that verified ID, and only tag
+    # $RELEASE_IMAGE onto it AFTER every gate passes.
     step "fresh bringup — build proxy from the verified checkout at $RELEASE_REF ($HEAD_SHA)"
     make e2e-l2l2-up > "$OUT/up.log" 2>&1 || fail "bringup (see $OUT/up.log)"
-    verify_running_image
+    RUNNING_ID="$(verify_running_image)" || fail "running-proxy image verification failed (see above)"
     # NOTE: no freshness check — a full cache hit to a previous build of this same
-    # immutable checkout is the SAME code (that is what caches are for). The
+    # immutable checkout is the SAME code (that is what caches are for). A full
+    # cache hit means the running image was SELECTED by this run's build, not
+    # literally rebuilt; either way it is the verified checkout's code. The
     # stale-image trap this script guards against is worktree-source drift, which
     # the proven-clean immutable-ref checkout rules out by construction.
-    echo "[$(ts)] image verified: running proxy built from the verified checkout; tagged $RELEASE_IMAGE"
+    echo "[$(ts)] image verified: running proxy is the image selected by this run's build from the verified checkout ($RUNNING_ID)"
 
     step "monitors up (completeness watcher + immutability)"
     INTERVAL=10 MARGIN=2 ./scripts/monitoring/watch-completeness.sh > "$OUT/watch.output" 2>&1 &
     WPID=$!
     python3 scripts/monitoring/immutability-monitor.py 21600 > "$OUT/immut.output" 2>&1 &
     IPID=$!
-    trap 'kill $WPID $IPID 2>/dev/null' EXIT
+    trap 'kill "$WPID" "$IPID" 2>/dev/null' EXIT
 
     step "1/2: full 'all' e2e suite"
     ./scripts/e2e-test.sh > "$OUT/suite.log" 2>&1 || fail "e2e suite (see $OUT/suite.log)"
@@ -152,12 +199,34 @@ main() {
     ./scripts/e2e-loadtest-mixed.sh > "$OUT/n30.log" 2>&1 || fail "N=30 (see $OUT/n30.log + /tmp/mixed-verify.out)"
     echo "[$(ts)] N=30: GREEN"
 
-    step "invariant sweep"
-    V=$(grep -ac "COMPLETENESS VIOLATION" "$OUT/watch.output" 2>/dev/null | head -1)
-    I=$(grep -acE "VIOLATION|CHANGED|mismatch" "$OUT/immut.output" 2>/dev/null | head -1)
-    [ "${V:-0}" -eq 0 ] || fail "completeness watcher flagged $V violation(s)"
-    [ "${I:-0}" -eq 0 ] || fail "immutability monitor flagged $I violation(s)"
-    sed 's/\x1b\[[0-9;]*m//g' /tmp/mixed-verify.out | grep -aE "B2AGG->|CLAIM->|GER->|VERDICT"
+    step "monitor liveness + invariant sweep"
+    # Liveness FIRST: both monitors must still be alive after the whole run — a
+    # monitor that crashed mid-run would otherwise leave a short, violation-free
+    # log that reads as a clean pass.
+    kill -0 "$WPID" 2>/dev/null || fail "completeness watcher died during the run (see $OUT/watch.output)"
+    kill -0 "$IPID" 2>/dev/null || fail "immutability monitor died during the run (see $OUT/immut.output)"
+    # Stop gracefully so the immutability monitor's SIGTERM handler flushes its
+    # tallied summary (polls / VIOLATIONS), then wait for that flush.
+    kill "$WPID" 2>/dev/null
+    kill "$IPID" 2>/dev/null
+    wait "$IPID" 2>/dev/null
+    verify_monitor_evidence "$OUT/watch.output" "$OUT/immut.output"
+
+    # Final N=30 evidence: the mixed-verifier file must exist, be non-empty, carry
+    # the direction lines, AND report a PASS verdict — never let a missing/empty
+    # file be extracted into an empty "success".
+    local mixed="/tmp/mixed-verify.out" evidence
+    [ -r "$mixed" ] && [ -s "$mixed" ] \
+        || fail "mixed-verifier evidence $mixed missing or empty — N=30 verdict unverifiable"
+    evidence="$(sed 's/\x1b\[[0-9;]*m//g' "$mixed" | grep -aE "B2AGG->|CLAIM->|GER->|VERDICT")" \
+        || fail "mixed-verifier evidence $mixed has no B2AGG/CLAIM/GER/VERDICT lines"
+    printf '%s\n' "$evidence"
+    printf '%s\n' "$evidence" | grep -aqE "VERDICT:[[:space:]]*PASS" \
+        || fail "mixed-verifier VERDICT is not PASS (see $mixed)"
+
+    # Every gate has passed — NOW tag the accepted build as $RELEASE_IMAGE.
+    tag_release_image
+    echo "[$(ts)] tagged accepted build $RUNNING_ID as $RELEASE_IMAGE"
 
     step "SOURCE-BUILD ACCEPTANCE PASSED — $RELEASE_IMAGE from $RELEASE_REF: 1× e2e + N=30 green, 0 violations"
 }

--- a/scripts/release-acceptance.sh
+++ b/scripts/release-acceptance.sh
@@ -1,100 +1,169 @@
 #!/usr/bin/env bash
 # ══════════════════════════════════════════════════════════════════════════════
-# Release acceptance test: fresh bringup on the RELEASE artifact → 1× full e2e
+# SOURCE-BUILD release acceptance: prove the checkout IS the claimed immutable
+# release, build the proxy image FROM that verified source, then run 1× full e2e
 # suite → N=30 mixed loadtest → verdict. The final gate before accepting a cut
 # release (agreed 2026-07-13: small acceptance instead of a re-soak — the RC was
 # already soaked: 500+ ops, 19 chaos events, 0 completeness/immutability
 # violations).
 #
-# Usage:
-#   RELEASE_REF=vX.Y.Z RELEASE_IMAGE=miden-agglayer-e2e:vX.Y.Z ./scripts/release-acceptance.sh
-#   # RELEASE_REF (tag or SHA) is enforced: the worktree must be a CLEAN checkout of it.
-#   # or build from a tag first:
-#   #   git worktree add /tmp/rel vX.Y.Z && docker build -t miden-agglayer-e2e:vX.Y.Z /tmp/rel
+# SCOPE / CONTRACT (read this before trusting the verdict):
+#   This is a SOURCE-BUILD acceptance. It certifies the SOURCE at the exact
+#   RELEASE_REF: it proves the worktree is a clean checkout of that immutable ref
+#   and builds the proxy image locally from those sources. It does NOT test a
+#   pre-published registry artifact. Equivalence between this local build and any
+#   image already pushed to a registry is OUT OF SCOPE — mutable docker base tags
+#   and OS/cargo package repositories mean a rebuild is not bit-identical to an
+#   earlier push. If you need to accept a *published* digest, pull that digest and
+#   run it; that is a different contract and this script does not implement it.
 #
-# The release image is tagged :latest for the compose bringup. Monitors
-# (external completeness watcher + getLogs immutability monitor) run for the
-# whole acceptance; any genuine violation fails it.
+# Usage:
+#   RELEASE_REF=<full-SHA-or-exact-tag> RELEASE_IMAGE=miden-agglayer-e2e:vX.Y.Z \
+#       ./scripts/release-acceptance.sh
+#
+#   RELEASE_REF must be EITHER a full 40/64-char hex commit SHA, OR an existing
+#   annotated/lightweight tag. Mutable refs (HEAD, branch names, revision
+#   expressions like origin/main or HEAD~1) are REJECTED — the accepted artifact
+#   must be immutable and independently re-derivable. The worktree must be a CLEAN
+#   checkout whose HEAD equals that ref, e.g.:
+#     git worktree add /tmp/rel vX.Y.Z && cd /tmp/rel
+#     RELEASE_REF=vX.Y.Z RELEASE_IMAGE=miden-agglayer-e2e:vX.Y.Z \
+#         /path/to/scripts/release-acceptance.sh
+#
+# The locally-built release image is tagged :latest for the compose bringup and
+# re-tagged $RELEASE_IMAGE after we verify the running proxy IS the image this run
+# built. Monitors (external completeness watcher + getLogs immutability monitor)
+# run for the whole acceptance; any genuine violation fails it.
+#
+# NOTE ON set -e: this script deliberately does NOT use `set -e` because it relies
+# on intended non-zero exits (grep counts, `|| fail` guards, `[ … ]` tests). Every
+# fallible command is instead guarded explicitly with `|| fail`.
 # ══════════════════════════════════════════════════════════════════════════════
 set -uo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
-: "${RELEASE_IMAGE:?set RELEASE_IMAGE to the release image tag}"
-PROJECT="${COMPOSE_PROJECT_NAME:-$(basename "$PWD")}"
-export COMPOSE_PROJECT_NAME="$PROJECT"
-OUT="${ACCEPT_DIR:-/tmp/release-acceptance}"; mkdir -p "$OUT"
+
 ts() { TZ=${TZ_DISPLAY:-Europe/Berlin} date '+%H:%M:%S'; }
 step() { echo "[$(ts)] ════ $* ════"; }
 fail() { echo "[$(ts)] ACCEPTANCE FAIL: $*"; exit 1; }
 
-# ── Provenance ENFORCEMENT (release-acceptance-provenance) ────────────────────
-# The image built below is only as trustworthy as the checkout it is built from.
-# BEFORE building, prove the checkout IS the claimed immutable release and is not
-# locally modified — otherwise the acceptance would certify drifted/dirty source.
-#
-#   RELEASE_REF  (required) — the exact release tag or commit SHA being accepted.
-#   The HEAD must resolve to it, and — for a tag — HEAD must be EXACTLY that tag.
-: "${RELEASE_REF:?set RELEASE_REF to the exact release tag or SHA being accepted}"
+# ── Guard functions (unit-testable; see scripts/release-acceptance-guards.test.sh)
+# Each guard resolves its facts DIRECTLY and calls `fail` on any ambiguity,
+# missing datum, or mismatch. None of them "fail open".
 
-# 1. Clean worktree: no tracked modifications, staged changes, or untracked files.
-#    A dirty tree means the built image would not match the claimed ref's source.
-DIRTY="$(git status --porcelain)"
-[ -z "$DIRTY" ] || fail "worktree is DIRTY — refusing to accept a non-pristine checkout:
-$DIRTY"
+# Clean worktree: no tracked modifications, staged changes, or untracked files.
+# --untracked-files=all so a repo-local status.showUntrackedFiles=no cannot hide
+# stray files; --porcelain=v1 pins the machine format regardless of git version.
+verify_clean_worktree() {
+    local dirty
+    dirty="$(git status --porcelain=v1 --untracked-files=all)" \
+        || fail "git status failed — cannot prove the worktree is clean"
+    [ -z "$dirty" ] || fail "worktree is DIRTY — refusing to accept a non-pristine checkout:
+$dirty"
+}
 
-# 2. Exact ref: HEAD must resolve to RELEASE_REF's commit …
-HEAD_SHA="$(git rev-parse HEAD)"
-if ! REF_SHA="$(git rev-parse --verify "${RELEASE_REF}^{commit}" 2>/dev/null)"; then
-    fail "RELEASE_REF '$RELEASE_REF' does not resolve to a commit in this repo"
+# Immutable exact ref: RELEASE_REF must be a full commit SHA OR an existing tag,
+# resolved DIRECTLY (never via git describe, which is ambiguous when several tags
+# point at one commit, and never via a regex over ref names). HEAD must equal the
+# resolved commit. Sets HEAD_SHA and REF_SHA on success.
+verify_exact_ref() {
+    local ref="${RELEASE_REF}"
+    HEAD_SHA="$(git rev-parse --verify HEAD)" \
+        || fail "cannot resolve HEAD to a commit"
+    if [[ "$ref" =~ ^[0-9a-f]{40}$ ]] || [[ "$ref" =~ ^[0-9a-f]{64}$ ]]; then
+        # Full hex SHA: prove the object exists and is (or peels to) a commit.
+        git cat-file -e "${ref}^{commit}" 2>/dev/null \
+            || fail "RELEASE_REF '$ref' is a full SHA but no such commit exists in this repo"
+        REF_SHA="$(git rev-parse --verify "${ref}^{commit}")" \
+            || fail "RELEASE_REF '$ref' could not be resolved to a commit"
+    elif REF_SHA="$(git rev-parse --verify --quiet "refs/tags/${ref}^{commit}" 2>/dev/null)" \
+            && [ -n "$REF_SHA" ]; then
+        : # RELEASE_REF is an existing tag; REF_SHA is its peeled commit.
+    else
+        fail "RELEASE_REF '$ref' is neither a full commit SHA nor an existing tag —
+mutable refs (HEAD, branch names, revision expressions) are rejected; pass an
+immutable tag or full commit SHA"
+    fi
+    [ "$HEAD_SHA" = "$REF_SHA" ] \
+        || fail "HEAD $HEAD_SHA is not the claimed release $ref ($REF_SHA)"
+}
+
+# Provenance-by-construction: the running proxy must be exactly the image this run
+# built from the verified checkout. Capture the running image ID and the built
+# image ID INDEPENDENTLY, require BOTH non-empty, compare, then re-tag — every
+# docker call guarded so nothing fails open. Sets RUNNING_ID on success.
+verify_running_image() {
+    local running built
+    running="$(docker inspect "${PROJECT}-miden-agglayer-1" --format '{{.Image}}')" \
+        || fail "docker inspect of the running proxy container failed"
+    [ -n "$running" ] || fail "running proxy image ID is empty — cannot verify provenance"
+    built="$(docker image inspect miden-agglayer-e2e:latest --format '{{.Id}}')" \
+        || fail "docker image inspect of the built image (miden-agglayer-e2e:latest) failed"
+    [ -n "$built" ] || fail "built image ID is empty — cannot verify provenance"
+    [ "$running" = "$built" ] \
+        || fail "running proxy is not the image built from the verified checkout (running=$running built=$built)"
+    docker tag "$running" "$RELEASE_IMAGE" \
+        || fail "docker tag $running -> $RELEASE_IMAGE failed"
+    RUNNING_ID="$running"
+}
+
+main() {
+    cd "$(dirname "${BASH_SOURCE[0]}")/.."
+    : "${RELEASE_IMAGE:?set RELEASE_IMAGE to the release image tag}"
+    : "${RELEASE_REF:?set RELEASE_REF to the exact release tag or full commit SHA being accepted}"
+    PROJECT="${COMPOSE_PROJECT_NAME:-$(basename "$PWD")}"
+    export COMPOSE_PROJECT_NAME="$PROJECT"
+    OUT="${ACCEPT_DIR:-/tmp/release-acceptance}"; mkdir -p "$OUT"
+
+    # ── Provenance ENFORCEMENT (release-acceptance-provenance) ────────────────
+    # The image built below is only as trustworthy as the checkout it is built
+    # from. BEFORE building, prove the checkout IS the claimed immutable release
+    # and is not locally modified — otherwise the acceptance would certify
+    # drifted/dirty source.
+    verify_clean_worktree
+    verify_exact_ref
+    echo "[$(ts)] provenance verified: clean worktree at $RELEASE_REF ($HEAD_SHA)"
+
+    # Provenance model: the checkout was PROVEN above to be a clean tree at the
+    # exact RELEASE_REF, so the bringup's `up -d --build` builds the proxy image
+    # from that release's sources BY CONSTRUCTION. Image-ID equality vs a pre-built
+    # tag is NOT checkable (a cache-mounted cargo RUN step makes IDs
+    # non-deterministic across builds); we instead assert the running proxy IS the
+    # image this run built and re-point $RELEASE_IMAGE at it.
+    step "fresh bringup — build proxy from the verified checkout at $RELEASE_REF ($HEAD_SHA)"
+    make e2e-l2l2-up > "$OUT/up.log" 2>&1 || fail "bringup (see $OUT/up.log)"
+    verify_running_image
+    # NOTE: no freshness check — a full cache hit to a previous build of this same
+    # immutable checkout is the SAME code (that is what caches are for). The
+    # stale-image trap this script guards against is worktree-source drift, which
+    # the proven-clean immutable-ref checkout rules out by construction.
+    echo "[$(ts)] image verified: running proxy built from the verified checkout; tagged $RELEASE_IMAGE"
+
+    step "monitors up (completeness watcher + immutability)"
+    INTERVAL=10 MARGIN=2 ./scripts/monitoring/watch-completeness.sh > "$OUT/watch.output" 2>&1 &
+    WPID=$!
+    python3 scripts/monitoring/immutability-monitor.py 21600 > "$OUT/immut.output" 2>&1 &
+    IPID=$!
+    trap 'kill $WPID $IPID 2>/dev/null' EXIT
+
+    step "1/2: full 'all' e2e suite"
+    ./scripts/e2e-test.sh > "$OUT/suite.log" 2>&1 || fail "e2e suite (see $OUT/suite.log)"
+    echo "[$(ts)] suite: ALL TESTS COMPLETE"
+
+    step "2/2: N=30 mixed loadtest"
+    ./scripts/e2e-loadtest-mixed.sh > "$OUT/n30.log" 2>&1 || fail "N=30 (see $OUT/n30.log + /tmp/mixed-verify.out)"
+    echo "[$(ts)] N=30: GREEN"
+
+    step "invariant sweep"
+    V=$(grep -ac "COMPLETENESS VIOLATION" "$OUT/watch.output" 2>/dev/null | head -1)
+    I=$(grep -acE "VIOLATION|CHANGED|mismatch" "$OUT/immut.output" 2>/dev/null | head -1)
+    [ "${V:-0}" -eq 0 ] || fail "completeness watcher flagged $V violation(s)"
+    [ "${I:-0}" -eq 0 ] || fail "immutability monitor flagged $I violation(s)"
+    sed 's/\x1b\[[0-9;]*m//g' /tmp/mixed-verify.out | grep -aE "B2AGG->|CLAIM->|GER->|VERDICT"
+
+    step "SOURCE-BUILD ACCEPTANCE PASSED — $RELEASE_IMAGE from $RELEASE_REF: 1× e2e + N=30 green, 0 violations"
+}
+
+# Only run the acceptance when executed directly; when sourced (by the guard test
+# harness) just expose the functions above.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
 fi
-[ "$HEAD_SHA" = "$REF_SHA" ] \
-    || fail "HEAD $HEAD_SHA is not the claimed release $RELEASE_REF ($REF_SHA)"
-
-# 3. … and if RELEASE_REF names a tag, HEAD must be EXACTLY that tag (not merely a
-#    commit that happens to share the sha with an unrelated ref).
-if git rev-parse --verify --quiet "refs/tags/${RELEASE_REF}" >/dev/null; then
-    git describe --tags --exact-match HEAD 2>/dev/null | grep -qx "$RELEASE_REF" \
-        || fail "HEAD is not exactly tag $RELEASE_REF (git describe --exact-match mismatch)"
-fi
-echo "[$(ts)] provenance verified: clean worktree at $RELEASE_REF ($HEAD_SHA)"
-
-# Provenance model: the checkout was PROVEN above to be a clean tree at the exact
-# RELEASE_REF, so the bringup's `up -d --build` builds the proxy image from that release's
-# sources by construction. Image-ID equality vs a pre-built tag is NOT checkable (a
-# cache-mounted cargo RUN step makes IDs non-deterministic across builds); we assert the
-# running proxy IS the image this run built and re-point $RELEASE_IMAGE at it.
-RUN_START=$(date -u +%s)
-step "fresh bringup from the release checkout ($(git -C . describe --tags --always 2>/dev/null))"
-make e2e-l2l2-up > "$OUT/up.log" 2>&1 || fail "bringup (see $OUT/up.log)"
-RUNNING_ID=$(docker inspect "${PROJECT}-miden-agglayer-1" --format '{{.Image}}')
-[ "$RUNNING_ID" = "$(docker image inspect miden-agglayer-e2e:latest --format '{{.Id}}')" ] \
-    || fail "running proxy is not the image this run built"
-# NOTE: no freshness check — a full cache hit to a previous build of this same
-# immutable tag checkout is the SAME code (that is what caches are for). The
-# stale-image trap this script guards against is worktree-source drift, which an
-# immutable tag context rules out by construction.
-docker tag "$RUNNING_ID" "$RELEASE_IMAGE"
-echo "[$(ts)] image verified: built this run from the release checkout; tagged $RELEASE_IMAGE"
-
-step "monitors up (completeness watcher + immutability)"
-INTERVAL=10 MARGIN=2 ./scripts/monitoring/watch-completeness.sh > "$OUT/watch.output" 2>&1 &
-WPID=$!
-python3 scripts/monitoring/immutability-monitor.py 21600 > "$OUT/immut.output" 2>&1 &
-IPID=$!
-trap 'kill $WPID $IPID 2>/dev/null' EXIT
-
-step "1/2: full 'all' e2e suite"
-./scripts/e2e-test.sh > "$OUT/suite.log" 2>&1 || fail "e2e suite (see $OUT/suite.log)"
-echo "[$(ts)] suite: ALL TESTS COMPLETE"
-
-step "2/2: N=30 mixed loadtest"
-./scripts/e2e-loadtest-mixed.sh > "$OUT/n30.log" 2>&1 || fail "N=30 (see $OUT/n30.log + /tmp/mixed-verify.out)"
-echo "[$(ts)] N=30: GREEN"
-
-step "invariant sweep"
-V=$(grep -ac "COMPLETENESS VIOLATION" "$OUT/watch.output" 2>/dev/null | head -1)
-I=$(grep -acE "VIOLATION|CHANGED|mismatch" "$OUT/immut.output" 2>/dev/null | head -1)
-[ "${V:-0}" -eq 0 ] || fail "completeness watcher flagged $V violation(s)"
-[ "${I:-0}" -eq 0 ] || fail "immutability monitor flagged $I violation(s)"
-sed 's/\x1b\[[0-9;]*m//g' /tmp/mixed-verify.out | grep -aE "B2AGG->|CLAIM->|GER->|VERDICT"
-
-step "ACCEPTANCE PASSED — $RELEASE_IMAGE: 1× e2e + N=30 green, 0 violations"


### PR DESCRIPTION
## Why

Release acceptance builds the proxy through Compose, so the source checkout must be proven to match the intended immutable release ref. A dirty, mutable, mismatched, or unverifiable checkout must never be certified, and a failed acceptance must never leave the release tag pointing at a rejected build.

## What this changes

- accepts only a full commit SHA or an existing exact tag;
- requires `HEAD` to equal the resolved commit;
- requires a clean worktree, including untracked files;
- builds locally from that verified checkout;
- proves the running proxy uses the image selected by that source build;
- defers `$RELEASE_IMAGE` tagging until all acceptance gates pass;
- makes Git, Docker, setup, monitor-output, and verdict failures explicit;
- adds isolated negative tests and runs them in CI.

## Provenance contract

This is explicitly **source-build acceptance**. It certifies a locally built image from a clean immutable source ref.

It does **not** prove equivalence to a separately published registry image or digest. Published-artifact acceptance is a different workflow.

```mermaid
flowchart LR
    Ref[Full SHA or exact tag] --> Clean[Clean exact checkout]
    Clean --> Build[Compose source build]
    Build --> Identity[Running image ID matches selected build]
    Identity --> Gates[E2E + load + monitoring gates]
    Gates --> Tag[Tag accepted local image]
```

## Guards and tests

- Git status/ref-resolution failures reject the run.
- Mutable refs and revision expressions are rejected.
- Docker inspection failures, empty IDs, image mismatch, and tag failure reject the run.
- Repository/output setup failures reject the run.
- Release tagging happens only after the E2E, load, monitoring, and verdict gates.
- `make test-scripts` syntax-checks the scripts and runs **37** isolated guard cases in CI.

## Current review status

Head `b4fee9b` closes the original Copilot findings and the four blockers from the previous re-review. Six outdated Copilot threads were replied to and resolved.

Two fail-closed completion items remain:

1. prove monitor coverage spans the workload—not merely one historical watcher cycle / one immutability poll—by requiring readiness plus fresh post-load evidence (or a final audit) and accounting for prolonged read failures;
2. scope mixed-verifier evidence to the current run, force verification/tool availability, require each B2AGG/CLAIM/GER row plus PASS, and pin the advertised N=30 parameters so inherited environment overrides cannot weaken acceptance.

The full release-acceptance workflow is intentionally not run by ordinary PR CI; the generic L2↔L2 job is currently skipped on this PR.

## Scope

This hardens future release cuts. It cannot retroactively produce provenance evidence for v0.15.8.
