### PR TITLE
fix(rpc): make claim and GER retries crash-safe and EVM-compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,13 +373,12 @@ e2e-cantina10: e2e-up ## Spin up stack + Cantina #10 concurrent first-claim fauc
 	$(COMPOSE_ENV) ./scripts/e2e-cantina10-concurrent-faucet.sh
 
 # --- RD-940 e2e -----------------------------------------------------------
-# All RD-940 e2e scripts require the writer worker active. The `e2e-rd940-up`
-# helper sets AGGLAYER_ENABLE_WRITER_WORKER=true before bringing up the stack.
+# The single writer is always active; this helper only applies worker-specific
+# queue/receipt settings used by the RD-940 scenarios.
 
 .PHONY: e2e-rd940-up
-e2e-rd940-up: e2e-clean-data ## Bring up the stack with the RD-940 writer worker enabled
-	AGGLAYER_ENABLE_WRITER_WORKER=true \
-	  AGGLAYER_WRITER_QUEUE_DEPTH=$${AGGLAYER_WRITER_QUEUE_DEPTH:-64} \
+e2e-rd940-up: e2e-clean-data ## Bring up the stack with RD-940 test settings
+	AGGLAYER_WRITER_QUEUE_DEPTH=$${AGGLAYER_WRITER_QUEUE_DEPTH:-64} \
 	  AGGLAYER_WRITER_TX_TTL=$${AGGLAYER_WRITER_TX_TTL:-300} \
 	  AGGLAYER_CLAIM_RECEIPT_EXPIRATION_BLOCKS=$${AGGLAYER_CLAIM_RECEIPT_EXPIRATION_BLOCKS:-120} \
 	  $(E2E_COMPOSE) up -d --build --wait

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -244,11 +244,6 @@ services:
       # miden-client's on-disk store fails at startup with
       # "Invalid cross-device link".
       TMPDIR: /var/lib/miden-agglayer-service/tmp
-      # RD-940 — async writer worker. Default false to keep the baseline
-      # e2e suite running the legacy synchronous handler unchanged; the
-      # RD-940 e2e scripts flip it via
-      # `AGGLAYER_ENABLE_WRITER_WORKER=true make e2e-up`.
-      AGGLAYER_ENABLE_WRITER_WORKER: "${AGGLAYER_ENABLE_WRITER_WORKER:-false}"
       AGGLAYER_WRITER_QUEUE_DEPTH: "${AGGLAYER_WRITER_QUEUE_DEPTH:-64}"
       AGGLAYER_WRITER_TX_TTL: "${AGGLAYER_WRITER_TX_TTL:-300}"
       AGGLAYER_CLAIM_RECEIPT_EXPIRATION_BLOCKS: "${AGGLAYER_CLAIM_RECEIPT_EXPIRATION_BLOCKS:-120}"

--- a/docs/design/RD-940-async-writer.md
+++ b/docs/design/RD-940-async-writer.md
@@ -91,7 +91,7 @@ In-flight map (`DashMap<TxHash, JobState>`) is a hot read cache backing `eth_get
 - On `TrySendError::Full`: JSON-RPC error `-32005 "writer queue saturated; retry"`. HTTP 200 JSON-body (axum-jrpc convention). Spec E confirms aggkit's ethtxmanager retries on `-32005`.
 - Single worker task mirroring `L1InfoTreeIndexer::spawn`, with a `oneshot` shutdown signal. Worker is a **translator only** — no retry logic of its own; existing self-heal at `src/claim.rs:591-628` and `src/ger.rs:201-224` already handles recoverable errors. A pool adds nothing because `MidenClient::with(...)` is a channel-of-1 (`src/miden_client.rs:126`).
 - `WriteJob` carries decoded params + `eth_tx_hash` (idempotency key). Decode on the request thread so malformed payloads cannot poison the queue.
-- Per-signer lock (`src/service_state.rs:21-44`): serialises nonce classification and admission. Writer mode releases it after durable admission/enqueue; the legacy synchronous mode remains serial for the full dispatch.
+- Per-signer lock (`src/service_state.rs:21-44`): serialises nonce classification and admission, then releases it after durable admission/enqueue. The bounded single writer is the only production dispatch path.
 
 ### 2.2 ClaimGuard placement — Spec B, recommendation (b) with amendments
 

--- a/docs/design/RD-940-async-writer.md
+++ b/docs/design/RD-940-async-writer.md
@@ -50,7 +50,7 @@ The async write path replaces today's sync-on-Miden-commit `eth_sendRawTransacti
 **Five load-bearing decisions** (resolved cross-spec conflicts, see §6):
 
 1. **`ClaimGuard` is acquired _inside_ the worker, not at enqueue.** First step of the worker job, immediately before `publish_claim`. Eliminates the only real defect class (`Queued × restart`, `Submitting × restart`) — without it a crash before dequeue leaves a wedged row in `claimed_indices` and aggkit retries are blocked.
-2. **`txn_begin` runs in the worker, not the handler.** The in-memory queue is the v1 durability boundary; restarts drop in-flight jobs whose hashes have already been returned (accepted v1 scope). `eth_getTransactionReceipt` returns JSON `null` indistinguishable from "not yet mined" — the contract lives in the runbook + alert, not the wire.
+2. **Durable intent precedes nonce acceptance.** The handler idempotently persists the full signed envelope before the nonce CAS. The mpsc is only a dispatch buffer: after restart, a same-hash rebroadcast reconstructs and re-enqueues an unlinked pending intent without advancing the nonce twice.
 3. **`eth_sendRawTransaction` is idempotent on tx-hash _before_ R4 nonce check.** If the hash already exists in the in-flight `DashMap` or `txn_data`, short-circuit to `Ok(hash)` without re-enqueueing or bumping nonce. Required to survive aggkit's ethtxmanager re-broadcast within its 2-min `WaitTxToBeMined` (`fixtures/aggkit-config.toml:43`). Today's code has no such early-return; this is a forced addition.
 4. **`eth_getTransactionCount` finally honours its block tag.** `latest` = next-committed; `pending` = next-accepted. Current code ignores the tag (`src/service.rs:370-377`) — claim-sponsor's `nonce_cache.go:35` reads `latest` and will race itself if pool-queued txs leak into `latest`.
 5. **5-minute hard TTL on every accepted hash.** On expiry, worker writes `txn_commit(hash, Err("ttl"), block_num, block_hash)` so the receipt transitions `null → status:0x0`. Bounds the contract: every hash reaches a terminal state. No more IAIC-shaped forever-pending traps (`docs/POSTMORTEM_2026-05-11_IAIC_TO_ADNF.md`).
@@ -98,7 +98,7 @@ In-flight map (`DashMap<TxHash, JobState>`) is a hot read cache backing `eth_get
 - **Where the lock is taken:** worker dequeues → `store.try_claim(global_index)` → `ClaimGuard::new` → `publish_claim`. The HTTP request future never holds the lock. This is the resolution of the A↔B conflict (§6).
 - **Drop semantics:** `Handle::try_current().spawn(unclaim)` runs on the worker tokio runtime. Worker-panic supervision (pattern: `src/miden_client.rs:150-162`) catches and respawns; per-job `AssertUnwindSafe` wrapper catches the panic and writes `Failed { err: "panic..." }` so the receipt transitions deterministically.
 - **Retry across self-heal:** guard held across both attempts of `IncorrectAccountInitialCommitment` recovery (`src/claim.rs:607-628`). Only released on terminal outcome.
-- **Recovery from `Queued × restart`:** v1 contract is "if you got a hash from us and we restarted before commit, the hash is forever-pending — re-submit". Because the lock is _not_ taken until dequeue, restart leaves no orphan `claimed_indices` row; aggkit's next retry simply re-enters the pipeline cleanly. Structural reason (b) wins over (a).
+- **Recovery from `Queued × restart`:** the pending transaction row is the durable intent. A same-hash rebroadcast after the reservation lease expires re-decodes the stored signed envelope, resumes the job, and accepts either the pre-CAS nonce or its already-advanced value. A different hash can never take over the nonce slot.
 - **`MidenSubmitted × worker-panic`** residual-risk cell: the proven tx may sit in Miden mempool while ClaimGuard releases. Resolved by existing self-heal + `claim_watcher` (`src/claim_watcher.rs:1-27`) which decodes consumed CLAIMs from Miden sync and back-fills the ClaimEvent. Loud and ugly under load but recoverable.
 
 ### 2.3 BlockMonitor unification — Spec C
@@ -141,7 +141,7 @@ aggkit's **only** on-proxy signer is `aggoracle`. `aggsender` uses gRPC `SendCer
 
 ## 4. Failure modes + observability — Spec F
 
-Worst-case row: `Queued × {sigkill, host-restart, worker-oom}` → in-memory queue dropped, hashes returned to callers are forever-pending. v1 scope, surfaced via `agglayer_writer_dropped_on_restart_total`. Self-heal floor for `Submitting/MidenSubmitted`: `claim_watcher_synthesised_total` (`src/metrics.rs:106`).
+`Queued × {sigkill, host-restart, worker-oom}` is recoverable from the durable unlinked envelope on same-hash rebroadcast. Nonce reservations are renewed while live and are permanently bound to the first hash. Self-heal floor for `Submitting/MidenSubmitted`: `claim_watcher_synthesised_total` (`src/metrics.rs:106`).
 
 **New Prometheus metrics:**
 
@@ -151,7 +151,7 @@ Worst-case row: `Queued × {sigkill, host-restart, worker-oom}` → in-memory qu
 | `agglayer_writer_inflight_jobs` | gauge | informational |
 | `agglayer_writer_job_duration_seconds{kind,outcome}` | histogram | p99 `>60s` 10m → page |
 | `agglayer_writer_job_failures_total{kind,reason}` | counter | burst `>0.5/s` 5m → page |
-| `agglayer_writer_dropped_on_restart_total` | counter | **hard page on `increase[1h]>0`** — v1 tripwire |
+| `agglayer_writer_dropped_on_restart_total` | counter | **hard page on `increase[1h]>0`** — restart-pressure tripwire; durable envelope remains recoverable |
 | `agglayer_writer_queue_full_rejections_total{kind}` | counter | `rate[5m]>0.1` 5m → page |
 | `agglayer_writer_drain_outcome_total{outcome}` | counter | dashboard only |
 
@@ -159,7 +159,7 @@ Worst-case row: `Queued × {sigkill, host-restart, worker-oom}` → in-memory qu
 
 **Graceful shutdown:** new `writer_shutdown_tx: tokio::sync::watch` plumbed into `ServiceState`. SIGTERM flips it; new sendRawTx returns `-32005 "service shutting down"`; worker drains for up to 20 s; `state.miden_client.shutdown()` runs only after worker exit. Bump k8s `terminationGracePeriodSeconds` 30 → 45 s.
 
-**Caller-facing contract** (to add to `docs/operations/monitoring.md` + new `Failure mode I` in `docs/operations/runbook.md`): "If `eth_sendRawTransaction` returned a tx hash AND the service restarted before the hash transitioned to a committed receipt, the hash is forever-pending. The caller MUST re-submit. v1 has no on-disk queue."
+**Caller-facing contract:** "If `eth_sendRawTransaction` returned a hash and the process restarted before dispatch, re-submit the same signed transaction. The durable envelope resumes after its lease expires; a replacement hash at that nonce is rejected."
 
 **Logging:** one tracing span per job, fields `tx_hash`, `job_id` (ULID), `kind`, `signer`, `queue_wait_ms`, `miden_submit_ms`, `commit_ms`. INFO emits one line per terminal (~10 GB/day at 500 req/s; well within bali envelope).
 
@@ -183,7 +183,7 @@ Worst-case row: `Queued × {sigkill, host-restart, worker-oom}` → in-memory qu
 | `e2e-iaic-mempool-conflict.sh MODE=expect_no_iaic PARALLEL=10` | **v1 regression sentinel** |
 | `e2e-fuzz-bridge` | extend with `FUZZ_ROUND_ASYNC_BURST` |
 
-**New e2e** (`scripts/e2e-rd940-*.sh`, ~14 min): `async-submit` (golden path), `pending-receipt` (hexutil-safe JSON shape), `queue-backpressure` (600 req/s vs cap 64), `restart-inflight` (kill mid-flight, assert forever-pending + same-hash idempotent resubmit), `worker-panic` (assert ClaimGuard release + watcher backfill), `claim-guard-cancellation` (32 concurrent disconnects).
+**New e2e** (`scripts/e2e-rd940-*.sh`, ~14 min): `async-submit` (golden path), `pending-receipt` (hexutil-safe JSON shape), `queue-backpressure` (600 req/s vs cap 64), `restart-inflight` (kill before dequeue, wait for lease expiry, assert same-hash durable recovery with no second nonce advance), `worker-panic` (assert ClaimGuard release + watcher backfill), `claim-guard-cancellation` (32 concurrent disconnects).
 
 **Acceptance gate (v1):** 50 req/s × 10 min, drop-rate <1%, accept-latency p50 <20 ms / p99 <100 ms, worker-job-duration p50 <10 s / p99 <60 s, `dropped_on_restart = 0`, zero nonce gaps, LET-divergence = 0. **Total v1-gate CI cycle ≈ 40 min wall-clock.**
 
@@ -192,7 +192,7 @@ Worst-case row: `Queued × {sigkill, host-restart, worker-oom}` → in-memory qu
 | # | Conflict | Resolution | Rationale |
 |---|---|---|---|
 | 1 | ClaimGuard placement (A: enqueue / B: worker) | Worker | Eliminates `Queued/Submitting × restart` wedge defects. v1 in-memory queue means a crash before dequeue must leave _no_ on-disk lock. |
-| 2 | `txn_begin` placement (A handler / F worker) | Worker | Consistent with #1 and v1 no-persistence contract. Receipt-null-after-restart is documented behaviour. |
+| 2 | Durable intent placement | Handler before nonce CAS | Prevents nonce advancement without recoverable work; downstream handoffs use idempotent begin/update. | Worker | Consistent with #1 and v1 no-persistence contract. Receipt-null-after-restart is documented behaviour. |
 | 3 | R4 nonce equality (A) vs idempotent re-broadcast (D/E) | Hash-dedup _before_ R4 nonce | aggkit's ethtxmanager re-broadcasts within `WaitTxToBeMined=2m`. R4 against bumped nonce returns "nonce mismatch" and wedges aggkit; early-return on known hash preserves R4's replay defence on novel hashes. |
 | 4 | `eth_getTransactionCount` semantics (D punted / E forced) | `latest` = next-committed, `pending` = next-accepted; honour tag (today ignored at `src/service.rs:370-377`) | claim-sponsor's `nonce_cache.go:35` reads `latest` and breaks if pool-queued txs leak in. |
 | 5 | Queue cap 64 vs 500 req/s gate | v1 gate at 50 req/s; 500 → nightly stress | At cap 64 and p50 ≈ 10 s, sustainable throughput ~6 jobs/s. 500 req/s is 100× current bali load. |
@@ -216,6 +216,6 @@ Worst-case row: `Queued × {sigkill, host-restart, worker-oom}` → in-memory qu
 - **No persistence in v1** deliberate. v1.5 lands a `worker_jobs` table or WAL-style journal — Spec B amendment 2 sketches the shape; `WriteJob` is already serializable so migration is additive.
 - **`MidenSubmitted × worker-panic`** retains a self-heal-via-claim_watcher floor; loud and ugly under load but recoverable. Acceptable for v1.
 - **Adjacent tickets:** RD-913 (persisted trackers) needs explicit coordination (§2.3). RD-891 (gas budget) orthogonal — merges independently. RD-862 (GER decomposition race) structurally already cured; BlockMonitor preserves the cure.
-- **Not in scope for RD-940:** worker pool, durable queue, `gateway_getTxStatus` RPC, `pending` block enumeration, real wallclock block timestamps. Explicitly deferred.
+- **Not in scope for RD-940:** worker pool, a standalone queue table, `gateway_getTxStatus` RPC, `pending` block enumeration, real wallclock block timestamps. Explicitly deferred.
 
 — end consolidated spec —

--- a/docs/design/RD-940-async-writer.md
+++ b/docs/design/RD-940-async-writer.md
@@ -4,9 +4,9 @@
 >
 > This is the design-of-record for the implementation that ships under [`feat/rd-940-async-writer`](https://github.com/gateway-fm/miden-agglayer/tree/feat/rd-940-async-writer). Linear ticket: [RD-940](https://linear.app/gateway-fm/issue/RD-940).
 
-## Ship status (2026-05-27)
+## Ship status (updated 2026-07-15)
 
-The feat branch lands the writer worker + RPC wire contract + observability surface as a **flag-gated default-off** rollout. Every section below that is marked ✅ ships in this PR; the BlockMonitor unification (§2.3) is the one explicit deferral, captured under "Phase 3 deferred" below.
+The implementation lands the writer worker + RPC wire contract + observability surface as a **flag-gated default-off** rollout. The full BlockMonitor unification (§2.3) remains explicitly deferred.
 
 | Section | Status | Commit |
 |---|---|---|
@@ -17,10 +17,10 @@ The feat branch lands the writer worker + RPC wire contract + observability surf
 | §2.4 RPC wire contract | ✅ shipped — geth pending shape, top-level null pre-commit, `eth_getBlockByNumber("pending")` aliased | Phase 4 (`ae35fe9`) |
 | §3 consumer interop | ✅ shipped — `-32005` mapping, idempotent re-broadcast, `eth_getTransactionCount` tag honour | Phase 1+2 (`95d6e4f`, `e1dfe0c`) |
 | §4 metrics + observability | ✅ shipped — 8 metrics, tracing spans per job, graceful drain, `dropped_on_restart` tmpfile | Phase 5 (`9da5aa2`) |
-| §5 unit tests | ✅ shipped — 12 new tests on top of 167 pre-existing; 179 lib + 4 bin pass | Phases 1–4 |
+| §5 unit tests | ✅ shipped — admission, receipt, nonce, lease, and claim-fence regressions | Phases 1–4 + #55 hardening |
 | §5 e2e scripts | **⏸️ deferred** — require live fixture environment; will land in follow-up | follow-up PR |
 | `service_get_txn_receipt.rs:40` `from` co-fix | ✅ shipped | Phase 4 (`ae35fe9`) |
-| 5-minute TTL → status:0x0 (Decision 5) | ✅ shipped — TTL sweeper writes failure receipt | Phase 4 (`ae35fe9`) |
+| 5-minute writer TTL (Decision 5) | ✅ shipped — consumer expires queue-aged work before dispatch; sweeper only renews leases and evicts terminal cache entries | Phase 4 (`ae35fe9`) + crash-safety hardening |
 | `docs/operations/runbook.md` + `monitoring.md` | ✅ shipped — Failure Mode I + 8-metric alert table | Phase 7 |
 | Default flag flip false→true | **⏸️ deferred** — operational rollout in a follow-up after canary validation | follow-up PR |
 
@@ -38,22 +38,22 @@ The follow-up PR will own §2.3 in its entirety + the cross-emitter race elimina
 
 The six new `scripts/e2e-rd940-*.sh` scripts described in §5 (async-submit golden path, pending-receipt wire shape, queue-backpressure 600 req/s, restart-inflight, worker-panic, claim-guard-cancellation) require a running fixture environment (miden-node + bridge contracts + aggkit) that can't be stood up from a code review. They will land in a follow-up PR alongside `scripts/setup-iaic-fixture.sh` that lets the IAIC regression sentinel run strict in CI.
 
-The unit-test coverage (179 lib + 4 bin tests) covers the load-bearing per-component invariants. Two failure modes are explicitly only catchable in e2e and are flagged as accepted Phase-1 risk:
+Unit tests cover the load-bearing per-component invariants. Two failure modes still require a live-stack test:
 
 - aggkit ethtxmanager-loop interaction under real wire JSON (the `insta` snapshot test in `build_inflight_pending_tx_json_emits_geth_wire_shape` pins the Rust-side shape; an aggkit-side parse smoke is the follow-up).
 - 50 req/s × 10 min v1 acceptance gate (drop-rate <1%, p99 < 60 s) needs a real Miden node — runs on bali staging once the flag is enabled.
 
 ## TL;DR
 
-The async write path replaces today's sync-on-Miden-commit `eth_sendRawTransaction` (`src/service_send_raw_txn.rs:407-595`) with: cheap synchronous validation on the request thread → bounded `tokio::sync::mpsc(64)` enqueue → single writer-worker task → `MidenClient::with(...)` (preserved channel-of-1 invariant from `src/miden_client.rs:126`) → `BlockMonitor::record(...)` (new sole writer of `latest_block_number` and synthetic logs) → durable receipt via `store.txn_commit`. The HTTP handler returns the tx hash as soon as the job is on the queue.
+The async write path performs cheap request validation, reserves `(signer, nonce)`, persists the full signed envelope as an unlinked pending intent, CAS-advances the nonce, and then enqueues into a bounded `tokio::sync::mpsc(64)`. A single worker dispatches through `MidenClient::with(...)`; the SyntheticProjector finalises the receipt and event after note consumption. The mpsc is a dispatch buffer, not the durability boundary.
 
 **Five load-bearing decisions** (resolved cross-spec conflicts, see §6):
 
-1. **`ClaimGuard` is acquired _inside_ the worker, not at enqueue.** First step of the worker job, immediately before `publish_claim`. Eliminates the only real defect class (`Queued × restart`, `Submitting × restart`) — without it a crash before dequeue leaves a wedged row in `claimed_indices` and aggkit retries are blocked.
+1. **The fenced `ClaimGuard` is acquired inside the worker, not at enqueue.** Before external submission, its owner/fence and exact note handoff are sealed durably; stale owners cannot release or overwrite a successor.
 2. **Durable intent precedes nonce acceptance.** The handler idempotently persists the full signed envelope before the nonce CAS. The mpsc is only a dispatch buffer: after restart, a same-hash rebroadcast reconstructs and re-enqueues an unlinked pending intent without advancing the nonce twice.
-3. **`eth_sendRawTransaction` is idempotent on tx-hash _before_ R4 nonce check.** If the hash already exists in the in-flight `DashMap` or `txn_data`, short-circuit to `Ok(hash)` without re-enqueueing or bumping nonce. Required to survive aggkit's ethtxmanager re-broadcast within its 2-min `WaitTxToBeMined` (`fixtures/aggkit-config.toml:43`). Today's code has no such early-return; this is a forced addition.
+3. **`eth_sendRawTransaction` classifies known hashes _before_ R4 nonce rejection.** In-flight, handed-off, and terminal hashes deduplicate to `Ok(hash)`; an unlinked pending intent is the one exception and resumes dispatch without advancing its nonce twice.
 4. **`eth_getTransactionCount` finally honours its block tag.** `latest` = next-committed; `pending` = next-accepted. Current code ignores the tag (`src/service.rs:370-377`) — claim-sponsor's `nonce_cache.go:35` reads `latest` and will race itself if pool-queued txs leak into `latest`.
-5. **5-minute hard TTL on every accepted hash.** On expiry, worker writes `txn_commit(hash, Err("ttl"), block_num, block_hash)` so the receipt transitions `null → status:0x0`. Bounds the contract: every hash reaches a terminal state. No more IAIC-shaped forever-pending traps (`docs/POSTMORTEM_2026-05-11_IAIC_TO_ADNF.md`).
+5. **5-minute owner-local queue TTL and terminal-cache TTL.** After dequeue, the consuming worker fails an over-age queued item _before_ constructing its dispatch future. Once dispatch starts, no independent sweeper may publish `status:0x0`: `MidenClient::with(...)` hands the closure to another task, so dropping the outer waiter does not cancel the Miden operation. A completed dispatch error may fail only when no durable exact-note handoff exists; ambiguous handed-off work remains pending for projector/reconciler recovery. Terminal cache entries are evicted after the same TTL.
 
 **v1 acceptance gate:** 50 req/s × 10 min, drop-rate < 1%, p99 worker-job-duration < 60 s (inside aggkit's 2 m `WaitTxToBeMined`), zero `agglayer_writer_dropped_on_restart_total`, zero per-signer nonce gaps. 500 req/s stays as a nightly stress benchmark — at queue cap 64 and p50 commit ≈ 10 s, sustainable throughput tops out near 6 jobs/s by design.
 
@@ -65,21 +65,21 @@ The async write path replaces today's sync-on-Miden-commit `eth_sendRawTransacti
                        HTTP request thread                             writer worker (single)                Miden node
                      ─────────────────────────                       ─────────────────────────              ─────────────
 service_send_raw_txn                                   mpsc(64)
-  │ decode envelope (`:408`)                            ──▶  recv  ──▶  ClaimGuard::new (R9 lock)
+  │ decode + deterministic validation                   ──▶  recv  ──▶  fenced ClaimGuard
   │ R4 chain_id                                                          │ MidenClient::with(...)
-  │ R2 signer allow-list                                                 │   submit_proven_transaction ──▶  apply
-  │ per-signer-lock acquire (`:447`)                                     │   wait_for_transaction_commit◀──  commit
-  │ ★ tx-hash dedup early-return   ◀── NEW                               │ txn_begin / txn_commit
-  │ R4 nonce equality                                                    │ BlockMonitor::record(event)
-  │ R9 try_claim + ClaimGuard ─── REMOVED (moved to worker)              │   = sole writer of latest_block
-  │ store.nonce_increment                                                │   = sole emitter of synth log row
+  │ R2 signer allow-list                                                 │   seal claim fence + note link
+  │ per-signer lock + nonce equality                                     │   submit_proven_transaction ──▶ apply
+  │ tx-hash/durable-intent classification                                │ SyntheticProjector
+  │ reserve (signer, nonce) lease                                        │   = receipt/event finalisation
+  │ txn_begin_if_absent(full envelope)
+  │ nonce_advance_cas
   │ try_send(WriteJob)        ───────────────────────────────────────────┘
   │ release per-signer lock
   ▼
 return tx_hash
 ```
 
-`BlockMonitor` absorbs `BlockState`, `StoreSyncListener`, and the inline emitters in `claim.rs`, `ger.rs`, `bridge_out.rs`, `claim_watcher.rs`. It implements `SyncListener`; `StoreSyncListener` and `BlockState::on_sync` both delete. Public surface: `record(BlockEvent) -> Result<u64>` for writers, `current_tip() / get_block_by_*` for read RPCs.
+The shipped `BlockMonitor` is currently a monotonic tip mirror over `BlockState`. Full ownership of block headers, listeners, and event writers remains the explicit Phase-3 follow-up below.
 
 In-flight map (`DashMap<TxHash, JobState>`) is a hot read cache backing `eth_getTransactionByHash` for not-yet-committed envelopes; it is **not** a durability boundary. Entries linger 5 min past terminal then a sweeper evicts (mirrors `L1InfoTreeIndexer::spawn`, `src/l1_info_tree_indexer.rs:124-223`).
 
@@ -91,19 +91,19 @@ In-flight map (`DashMap<TxHash, JobState>`) is a hot read cache backing `eth_get
 - On `TrySendError::Full`: JSON-RPC error `-32005 "writer queue saturated; retry"`. HTTP 200 JSON-body (axum-jrpc convention). Spec E confirms aggkit's ethtxmanager retries on `-32005`.
 - Single worker task mirroring `L1InfoTreeIndexer::spawn`, with a `oneshot` shutdown signal. Worker is a **translator only** — no retry logic of its own; existing self-heal at `src/claim.rs:591-628` and `src/ger.rs:201-224` already handles recoverable errors. A pool adds nothing because `MidenClient::with(...)` is a channel-of-1 (`src/miden_client.rs:126`).
 - `WriteJob` carries decoded params + `eth_tx_hash` (idempotency key). Decode on the request thread so malformed payloads cannot poison the queue.
-- Per-signer lock (`src/service_state.rs:21-44`): held across **enqueue only** — its job is nonce-counter atomicity, not submission ordering. Holding across submit re-serialises pipelined signers and defeats async.
+- Per-signer lock (`src/service_state.rs:21-44`): serialises nonce classification and admission. Writer mode releases it after durable admission/enqueue; the legacy synchronous mode remains serial for the full dispatch.
 
 ### 2.2 ClaimGuard placement — Spec B, recommendation (b) with amendments
 
-- **Where the lock is taken:** worker dequeues → `store.try_claim(global_index)` → `ClaimGuard::new` → `publish_claim`. The HTTP request future never holds the lock. This is the resolution of the A↔B conflict (§6).
-- **Drop semantics:** `Handle::try_current().spawn(unclaim)` runs on the worker tokio runtime. Worker-panic supervision (pattern: `src/miden_client.rs:150-162`) catches and respawns; per-job `AssertUnwindSafe` wrapper catches the panic and writes `Failed { err: "panic..." }` so the receipt transitions deterministically.
-- **Retry across self-heal:** guard held across both attempts of `IncorrectAccountInitialCommitment` recovery (`src/claim.rs:607-628`). Only released on terminal outcome.
+- **Where the lock is taken:** worker dequeues → `try_claim_fenced(global_index, tx_hash, lease)` → `ClaimGuard` → `publish_claim`. The request thread owns only the nonce reservation.
+- **Drop semantics:** before submission, cancellation conditionally releases only the caller's current fence. After the exact note handoff is sealed as `submitted`, stale release and lease reclaim are fail-closed.
+- **Retry across self-heal:** retry is allowed only before the durable note handoff. Once that boundary exists, an ambiguous result does not build a second random note.
 - **Recovery from `Queued × restart`:** the pending transaction row is the durable intent. A same-hash rebroadcast after the reservation lease expires re-decodes the stored signed envelope, resumes the job, and accepts either the pre-CAS nonce or its already-advanced value. A different hash can never take over the nonce slot.
-- **`MidenSubmitted × worker-panic`** residual-risk cell: the proven tx may sit in Miden mempool while ClaimGuard releases. Resolved by existing self-heal + `claim_watcher` (`src/claim_watcher.rs:1-27`) which decodes consumed CLAIMs from Miden sync and back-fills the ClaimEvent. Loud and ugly under load but recoverable.
+- **`MidenSubmitted × worker-panic`** is fail-closed: the submitted fence and tx↔note link remain durable, and the projector/watcher can attribute later note consumption to the original hash.
 
-### 2.3 BlockMonitor unification — Spec C
+### 2.3 BlockMonitor unification — Spec C (target design; deferred)
 
-`BlockMonitor` is the **sole** caller of `store.set_latest_block_number` (and the sole allocator via `store.advance_block_number`). It owns:
+The current implementation ships only `current_tip()` / `record_tip()`. The deferred structural target makes `BlockMonitor` the sole caller of `store.set_latest_block_number` and has it own:
 - the synthetic-block header cache (absorbs `BlockState::blocks` / `BlockState::hash_to_number`, `src/block_state.rs:137-148`);
 - an `AtomicU64` tip mirror for `eth_blockNumber` (hot-read, no async hop);
 - the single write entrypoint `async fn record(&self, BlockEvent) -> Result<u64>` wrapping the existing `store.commit_*_atomic` helpers (`src/store/mod.rs:208-231, 339-368, 438-471`) so the "log first / cursor second" ordering is a property of `record()` rather than a tribal-knowledge comment at four call sites (`src/bridge_out.rs:555-561`, `src/ger.rs:226-231`, `src/claim.rs:557-561`).
@@ -136,7 +136,7 @@ aggkit's **only** on-proxy signer is `aggoracle`. `aggsender` uses gRPC `SendCer
 - aggoracle uses `github.com/0xPolygon/zkevm-ethtx-manager v0.2.18` with `WaitPeriodMonitorTx=5s`, `FrequencyToMonitorTxs=1s`, `WaitTxToBeMined=2m`, `EstimateGasMaxRetries=0` (unbounded). Re-broadcasts stuck txs by bumping gas + re-signing. Proxy MUST accept duplicate `eth_sendRawTransaction` calls with the same tx-hash idempotently (Decision 3).
 - claim-sponsor's `RetryNumber=10` (`bridge-config.toml:66`) — finite retry budget. Calls `NonceAt(ctx, from, nil)` = `latest`; `nonce_cache.go:35` LRU breaks if `latest` leaks pool-queued txs. Decision 4 fixes this.
 - **Stay strictly geth-compatible.** Do NOT add `gateway_getTxStatus` or any non-`eth_` namespace. aggkit's state machine maps cleanly to geth semantics; a new RPC would require forking aggkit or a translation shim.
-- **Receipt with `status:0x0` on Miden rejection** non-negotiable. On terminal failure (incl. TTL expiry) worker writes `txn_commit(hash, Err(...))` so aggoracle transitions to `Failed` instead of retrying forever (IAIC re-incarnation surface from postmortem line 117).
+- **Receipt with `status:0x0` on definite pre-handoff failure** is non-negotiable. This includes queue-age expiry before dispatch and completed Miden rejections for which the store disproves an exact-note handoff. Submitting or handed-off work is never terminalised concurrently; an ambiguous outcome remains pending so a still-running Miden closure cannot later contradict a failure receipt.
 - **IAIC-class regression guard:** every async dispatch funnels through `MidenClient::with(...)` (`src/miden_client.rs:126`). The worker may dequeue concurrently in a future version, but Miden submission is always serial.
 
 ## 4. Failure modes + observability — Spec F
@@ -165,13 +165,7 @@ aggkit's **only** on-proxy signer is `aggoracle`. `aggsender` uses gRPC `SendCer
 
 ## 5. Test plan + acceptance gate — Spec G
 
-**Unit tests** (`cargo test --lib`, ~3 min CI):
-- `writer_worker`: enqueue/submit/commit/fail, panic catch + `Failed` write, per-signer arrival-order, idempotent resubmit-same-hash, backpressure 32 producers × 1000 enqueues, shutdown drain ≤20 s.
-- In-flight map: TTL expiry → synthetic-failure receipt, 150 k-entry memory bound, concurrent read-during-write.
-- ClaimGuard: one test per F-matrix cell (Queued/Submitting/MidenSubmitted × disconnect/panic/shutdown/sigkill), guard-held-across-self-heal, drop-outside-runtime logs error.
-- BlockMonitor: `record` is sole writer (grep assertion), log-first/cursor-second order, 8-task concurrent record distinct block numbers, `tick` does not overrun `record`, stale-low atomic safe / stale-high impossible, RD-862 fixture replay 0 orphans, `from` populated in receipt.
-- RPC wire: `getTxByHash` pending JSON shape, `getReceipt` top-level null, `getReceipt` status:0x0 after TTL, JSON snapshot pin, `eth_getTransactionCount` pending vs latest diverge.
-- `WriteJob` bincode round-trip (lands v1.5 wire shape early).
+**Unit tests** (`cargo test --lib`): writer enqueue/failure/TTL behavior; pending RPC wire shape; nonce CAS and reservation lifecycle; durable-intent recovery after a lost enqueue; landed/in-flight claim classification; fenced stale-owner release; and accept-and-revert receipt/nonce invariants.
 
 **Existing e2e** (`make test-e2e-coverage`, ~12 min):
 
@@ -192,8 +186,8 @@ aggkit's **only** on-proxy signer is `aggoracle`. `aggsender` uses gRPC `SendCer
 | # | Conflict | Resolution | Rationale |
 |---|---|---|---|
 | 1 | ClaimGuard placement (A: enqueue / B: worker) | Worker | Eliminates `Queued/Submitting × restart` wedge defects. v1 in-memory queue means a crash before dequeue must leave _no_ on-disk lock. |
-| 2 | Durable intent placement | Handler before nonce CAS | Prevents nonce advancement without recoverable work; downstream handoffs use idempotent begin/update. | Worker | Consistent with #1 and v1 no-persistence contract. Receipt-null-after-restart is documented behaviour. |
-| 3 | R4 nonce equality (A) vs idempotent re-broadcast (D/E) | Hash-dedup _before_ R4 nonce | aggkit's ethtxmanager re-broadcasts within `WaitTxToBeMined=2m`. R4 against bumped nonce returns "nonce mismatch" and wedges aggkit; early-return on known hash preserves R4's replay defence on novel hashes. |
+| 2 | Durable intent placement | Handler before nonce CAS | Prevents nonce advancement without recoverable work; downstream handoffs use idempotent begin/update. |
+| 3 | R4 nonce equality (A) vs idempotent re-broadcast (D/E) | Classify known hash before R4 rejection | In-flight/handed-off/terminal hashes deduplicate; an unlinked durable intent resumes with its already-advanced nonce. Novel stale hashes still fail R4. |
 | 4 | `eth_getTransactionCount` semantics (D punted / E forced) | `latest` = next-committed, `pending` = next-accepted; honour tag (today ignored at `src/service.rs:370-377`) | claim-sponsor's `nonce_cache.go:35` reads `latest` and breaks if pool-queued txs leak in. |
 | 5 | Queue cap 64 vs 500 req/s gate | v1 gate at 50 req/s; 500 → nightly stress | At cap 64 and p50 ≈ 10 s, sustainable throughput ~6 jobs/s. 500 req/s is 100× current bali load. |
 
@@ -201,7 +195,7 @@ aggkit's **only** on-proxy signer is `aggoracle`. `aggsender` uses gRPC `SendCer
 
 1. **Queue depth 64** — agreeable, or size against an observed aggsender burst (~100+ changes drain math)? — **Answered (build): 64, env-overridable.**
 2. **Nonce-burn on failure** — stay advanced (recommended) vs rewind? — **Default: stay advanced.**
-3. **TTL default 5 min** — env-configurable? — **Default: yes, env-overridable.**
+3. **TTL default 5 min** — env-configurable? — **Default: yes, env-overridable; applies to queue-age admission and terminal-cache eviction, never concurrent submitting-work failure.**
 4. **`expected_mint_record` store API** for RD-913 coordination — extend `commit_manual_claim_event_atomic` or new variant? (RD-913 owner's call.) — **Deferred; hook point only.**
 5. **`dropped_on_restart` persistence** — tmpfile in `/tmp`, k8s `emptyDir`, or SIGKILL → 0 + queue-depth-history-before-kill as the signal? — **Default: tmpfile in `/tmp/agglayer-writer-queue-snapshot`.**
 6. **`-32005` vs `-32603`** on backpressure? — **Answered (build): -32005.**
@@ -213,8 +207,8 @@ aggkit's **only** on-proxy signer is `aggoracle`. `aggsender` uses gRPC `SendCer
 ## 8. Risks + scope notes
 
 - **+50% spike risk (RPC contract / receipt-availability race)** fully covered by Decisions 3, 4, 5 + Spec D's wire-shape audit. Residual: alloy upgrade regression — mitigated by JSON snapshot test.
-- **No persistence in v1** deliberate. v1.5 lands a `worker_jobs` table or WAL-style journal — Spec B amendment 2 sketches the shape; `WriteJob` is already serializable so migration is additive.
-- **`MidenSubmitted × worker-panic`** retains a self-heal-via-claim_watcher floor; loud and ugly under load but recoverable. Acceptable for v1.
+- **No standalone durable queue table in v1.** The signed transaction row is the durable admission intent; same-hash rebroadcast reconstructs dispatch after a restart. A future queue/outbox table would add autonomous recovery without requiring that rebroadcast.
+- **`MidenSubmitted × worker-panic`** retains the submitted claim fence and exact note link; the projector/watcher remains the recovery floor.
 - **Adjacent tickets:** RD-913 (persisted trackers) needs explicit coordination (§2.3). RD-891 (gas budget) orthogonal — merges independently. RD-862 (GER decomposition race) structurally already cured; BlockMonitor preserves the cure.
 - **Not in scope for RD-940:** worker pool, a standalone queue table, `gateway_getTxStatus` RPC, `pending` block enumeration, real wallclock block timestamps. Explicitly deferred.
 

--- a/docs/operations/UPGRADE-v0.15.2.md
+++ b/docs/operations/UPGRADE-v0.15.2.md
@@ -104,23 +104,18 @@ being claimed within minutes of the swap, no redeploy).
 | Healing re-sweep (per ~1k Miden blocks of history) | a few minutes; scales with history — chunked 200 blocks/tick, non-blocking, normal traffic continues |
 | Full verification | ~10 min |
 
-## 4b. Recommended: enable the writer worker at upgrade time
+## 4b. Writer worker is mandatory
 
 The large rehearsal surfaced a **pre-existing** (also-in-v0.15.2) race: a
 node hiccup can make aggkit's ethtxmanager emit GER txs out of nonce order;
 the proxy's R4 replay-guard rejects the early nonce and **aggkit's
 ethtxmanager wedges permanently** (observed: no self-recovery in 20 min —
-one rejected nonce and it stops sending). This build ships the fix — the
-future-nonce wait — but it is only active with the writer worker enabled:
+one rejected nonce and it stops sending). This build ships the bounded
+future-nonce wait in the mandatory single-writer path. No feature flag is
+required. The path also eliminates benign nonce-mismatch churn from autoclaim
+bursts.
 
-```
-AGGLAYER_ENABLE_WRITER_WORKER=true    # + AGGLAYER_WRITER_QUEUE_DEPTH / _TX_TTL defaults
-```
-
-Enable it as part of the upgrade (or immediately after verification). Also
-eliminates the benign nonce-mismatch log churn from autoclaim bursts.
-
-**If the wedge is hit anyway** (writer worker off): symptom is a deposit
+**If the wedge is hit anyway**: symptom is a deposit
 stuck `ready_for_claim=false` while aggkit logs show an R4 nonce rejection
 and no sends since. Remedy, in order of preference: (1) replay aggkit's own
 already-signed raw txs from its logs via `eth_sendRawTransaction` in nonce

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -364,7 +364,7 @@ silent when `AGGLAYER_ENABLE_WRITER_WORKER=false`.
 | `agglayer_writer_inflight_jobs` | gauge | `try_enqueue`, worker, TTL sweeper | Size of the inflight DashMap — Queued + Submitting + pre-eviction terminal. |
 | `agglayer_writer_job_duration_seconds{kind,outcome}` | histogram | worker `process` | Time from dequeue to terminal. `kind=claim\|ger_insert`, `outcome=committed\|failed`. |
 | `agglayer_writer_queue_full_rejections_total{kind}` | counter | `try_enqueue` | Backpressure events (returns JSON-RPC `-32005`). |
-| `agglayer_writer_job_failures_total{kind,reason}` | counter | worker fail path + TTL sweeper | Terminal Failed transitions. `reason=miden\|ttl\|panic\|store`. |
+| `agglayer_writer_job_failures_total{kind,reason}` | counter | worker fail path | Terminal Failed transitions. `reason=ttl` means queue age expired before dispatch; Submitting work is never failed by the maintenance sweeper. |
 | `agglayer_writer_dropped_on_restart_total` | counter | main.rs at boot | Residual jobs read from `/tmp/agglayer-writer-queue-snapshot`. |
 | `agglayer_writer_drain_outcome_total{outcome}` | counter | main.rs after `service::serve` | `outcome=clean\|partial`. |
 | `rpc_future_nonce_wait_total` | counter | `service_send_raw_txn` | Out-of-order submissions that entered the bounded future-nonce wait instead of erroring (writer mode only). Dashboard-level: measures how much reordering the worker absorbs. |
@@ -376,7 +376,7 @@ silent when `AGGLAYER_ENABLE_WRITER_WORKER=false`.
 | **WriterQueueWarn** | `agglayer_writer_queue_depth > 0.8 * AGGLAYER_WRITER_QUEUE_DEPTH` for 10 m | warn | Sustained backpressure; queue is filling faster than the single worker can drain. Capacity-plan or bump `AGGLAYER_WRITER_QUEUE_DEPTH`. |
 | **WriterQueueCritical** | `agglayer_writer_queue_depth > 0.95 * AGGLAYER_WRITER_QUEUE_DEPTH` for 2 m | page | One step from `-32005` rejections; aggkit ethtxmanager retry budgets will start tripping. |
 | **WriterJobDurationP99** | `histogram_quantile(0.99, rate(agglayer_writer_job_duration_seconds_bucket[10m])) > 60` | page | p99 > 60 s breaks aggkit's `WaitTxToBeMined = 2 m` envelope (Spec E). Miden submission is degraded. |
-| **WriterJobFailures** | `rate(agglayer_writer_job_failures_total[5m]) > 0.5` for 5 m | page | Burst of dispatch failures. Drill down by `kind` + `reason` to distinguish Miden errors from TTL expiries. |
+| **WriterJobFailures** | `rate(agglayer_writer_job_failures_total[5m]) > 0.5` for 5 m | page | Burst of worker failures. Drill down by `kind` + `reason`; `ttl` identifies queue saturation/age before dispatch, while `miden` identifies a completed dispatch error. |
 | **WriterDroppedOnRestart** | `increase(agglayer_writer_dropped_on_restart_total[1h]) > 0` | **hard page** | Restart-pressure tripwire: dispatch was lost but the signed envelope remains durable for same-hash recovery. See `docs/operations/runbook.md` Failure mode I. |
 | **WriterQueueFullRejections** | `rate(agglayer_writer_queue_full_rejections_total[5m]) > 0.1` for 5 m | page | aggkit retries `-32005` transparently up to its budget; sustained backpressure exhausts the budget and surfaces as a stuck tx. |
 | **WriterDrainOutcomePartial** | none — dashboard only | n/a | Counts non-clean shutdowns over time; correlate with restart events when investigating `dropped_on_restart` increments. |

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -377,7 +377,7 @@ silent when `AGGLAYER_ENABLE_WRITER_WORKER=false`.
 | **WriterQueueCritical** | `agglayer_writer_queue_depth > 0.95 * AGGLAYER_WRITER_QUEUE_DEPTH` for 2 m | page | One step from `-32005` rejections; aggkit ethtxmanager retry budgets will start tripping. |
 | **WriterJobDurationP99** | `histogram_quantile(0.99, rate(agglayer_writer_job_duration_seconds_bucket[10m])) > 60` | page | p99 > 60 s breaks aggkit's `WaitTxToBeMined = 2 m` envelope (Spec E). Miden submission is degraded. |
 | **WriterJobFailures** | `rate(agglayer_writer_job_failures_total[5m]) > 0.5` for 5 m | page | Burst of dispatch failures. Drill down by `kind` + `reason` to distinguish Miden errors from TTL expiries. |
-| **WriterDroppedOnRestart** | `increase(agglayer_writer_dropped_on_restart_total[1h]) > 0` | **hard page** | v1 tripwire: real unrecovered work. See `docs/operations/runbook.md` Failure mode I. |
+| **WriterDroppedOnRestart** | `increase(agglayer_writer_dropped_on_restart_total[1h]) > 0` | **hard page** | Restart-pressure tripwire: dispatch was lost but the signed envelope remains durable for same-hash recovery. See `docs/operations/runbook.md` Failure mode I. |
 | **WriterQueueFullRejections** | `rate(agglayer_writer_queue_full_rejections_total[5m]) > 0.1` for 5 m | page | aggkit retries `-32005` transparently up to its budget; sustained backpressure exhausts the budget and surfaces as a stuck tx. |
 | **WriterDrainOutcomePartial** | none — dashboard only | n/a | Counts non-clean shutdowns over time; correlate with restart events when investigating `dropped_on_restart` increments. |
 | **WriterInflightSize** | none — dashboard only | n/a | Informational; size of the DashMap. Should track `queue_depth + jobs in flight at Miden`. |

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -161,7 +161,7 @@ Treat each one as a hard-page criterion at any non-zero rate.
 | `spent-before-import recovery: bridge-consumed B2AGG verified via sync_transactions` | R1 catcher 3 success. | None |
 | `spent-before-import recovery: consumed B2AGG was NOT consumed by any bridge transaction ...` | MA#3 fail-closed skip (reclaim/unknown consumer). | Investigate |
 | `note reconciler failed (transient — will retry next tick)` | One reconciler pass failed; retried. Sustained repetition = node RPC trouble. | Investigate if sustained |
-| `nonce mismatch for 0x...: tx.nonce = N, expected M` | Out-of-order / replayed submission rejected (R4 guard). A background *churn* of these from autoclaim is benign — aggkit retries; the churn is eliminated by the writer worker's future-nonce wait (`AGGLAYER_ENABLE_WRITER_WORKER=true` waits up to 30 s for the gap nonce; `rpc_future_nonce_wait_total` counts the waits). | None unless a signer is stuck |
+| `nonce mismatch for 0x...: tx.nonce = N, expected M` | Out-of-order / replayed submission rejected (R4 guard). The single writer waits up to 30 s for a future-nonce gap; `rpc_future_nonce_wait_total` counts those waits. | None unless a signer is stuck |
 | `JSON-RPC unsupported method: web3_clientVersion` (also `parity_netPeers`, `debug_*`, `net_peerCount`, …) | Internet wallet-scanner probe noise — observed continuously on a host whose 8546 was bound to `0.0.0.0`. | Verify the port is loopback/private (runbook §1.2); otherwise ignore |
 | `account data wasn't found` / `incorrect account initial commitment` followed by `reimported from node` | R3 self-heal firing and (usually) curing. | Investigate only if it loops |
 | `reset_miden_store: deleted` / `=== RESTORE: complete ===` | R2 one-shot markers — should only appear during an operator-initiated recovery. | Confirm an operator is driving |
@@ -351,10 +351,8 @@ groups:
 # RD-940 writer worker
 
 This section codifies the alert thresholds for the eight Prometheus
-metrics introduced by the RD-940 async writer worker
-(`docs/design/RD-940-async-writer.md` Spec F §4). All series are
-registered unconditionally in `src/metrics.rs::init_metrics`; they are
-silent when `AGGLAYER_ENABLE_WRITER_WORKER=false`.
+metrics introduced by the RD-940 single writer
+(`docs/design/RD-940-async-writer.md` Spec F §4).
 
 ## Metric reference
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -73,7 +73,6 @@ its shape for new environments.
 
 | Flag / env | Default | Notes |
 |---|---|---|
-| `--enable-writer-worker` / `AGGLAYER_ENABLE_WRITER_WORKER` | `false` | Async `eth_sendRawTransaction` dispatch. Runtime toggle; see the RD-940 section at the end of this doc for the flag-flip procedure and restart-loss contract. Also enables the bounded future-nonce wait (out-of-order submissions wait up to 30 s for the missing nonce instead of erroring). |
 | `AGGLAYER_WRITER_QUEUE_DEPTH` (env only) | `64` | mpsc capacity. |
 | `AGGLAYER_WRITER_TX_TTL` (env only) | `300` | Maximum queue age before the consuming worker fails a job prior to dispatch; also terminal-cache retention. Submitting work is never failed by the sweeper. |
 | `AGGLAYER_CLAIM_RECEIPT_EXPIRATION_BLOCKS` (env only) | `120` | Miden-block lifetime of pending claim receipts waiting for the projector to observe claim-note consumption. |
@@ -804,50 +803,44 @@ snapshotting residual jobs. Kubernetes' default
 `terminationGracePeriodSeconds = 30 s` includes the time between the
 SIGTERM and the SIGKILL that follows; with axum's own shutdown delay
 plus the 20 s drain plus a small buffer, **bali's pod spec MUST set
-`terminationGracePeriodSeconds: 45`** before `AGGLAYER_ENABLE_WRITER_WORKER`
-is flipped to `true` in production.
+`terminationGracePeriodSeconds: 45`** before deploying this release.
 
 This change lives in the downstream `gateway-deploy` repo (not in
-miden-agglayer). Coordinate the deploy-spec edit with the agglayer
-flag-flip; rolling them out in lockstep avoids a window where the drain
-is silently truncated by SIGKILL.
+miden-agglayer). Coordinate the deploy-spec edit with the agglayer rollout;
+deploying it first avoids a window where the drain is silently truncated by
+SIGKILL.
 
 There is no HPA or PDB on the miden-agglayer pod today, so the bump has
 no cascading effect.
 
-## Flag-flip procedure (enabling the writer worker)
+## Single-writer deployment procedure
 
 1. **Pre-flight checks.**
    - `kubectl get deploy/miden-agglayer -o yaml` shows
      `terminationGracePeriodSeconds: 45`.
    - Latest miden-agglayer build includes the RD-940 commits.
-   - Prometheus is scraping the new metrics
-     (`agglayer_writer_queue_depth` should be present even when the
-     flag is off — registered unconditionally).
+   - Prometheus is scraping the writer metrics.
    - Alerts in `monitoring.md` are armed.
-2. **Set the env var.** `AGGLAYER_ENABLE_WRITER_WORKER=true` in the
-   bali deployment spec. Restart the pod.
+2. **Deploy and restart the pod.** The single writer starts unconditionally.
 3. **First 10 minutes — eyes on the dashboard.**
    - `agglayer_writer_queue_depth` should stay well under 0.5 × cap
      (32 with the default cap of 64).
    - `agglayer_writer_job_failures_total{reason="ttl"}` should stay 0.
      Any non-zero rate means a job waited in the local queue longer than
      `AGGLAYER_WRITER_TX_TTL` (default 300 s) before dispatch began.
-   - `agglayer_writer_dropped_on_restart_total` must be 0 (this is the
-     first boot under the flag; non-zero here means the previous boot
-     was already running the worker and left residue).
+   - `agglayer_writer_dropped_on_restart_total` must be 0; non-zero means the
+     previous boot left queued or submitting work.
 4. **First 24 hours.** Compare `agglayer_writer_job_duration_seconds`
    p99 against aggkit's `WaitTxToBeMined` budget (2 m). Stay below 60
    s; alert if the p99 climbs above 90 s for 10 min.
-5. **Rollback.** Set `AGGLAYER_ENABLE_WRITER_WORKER=false` and restart.
-   The proxy reverts to the legacy synchronous handler with zero code
-   change. The flag is a runtime toggle, not a build feature.
+5. **Rollback.** There is no synchronous-mode toggle: it violates the invariant
+   that accepted work outlives the HTTP request. Roll back the whole release
+   only after draining or accounting for all pending transactions.
 
 ## Environment-variable overrides
 
 | Env var | Default | Effect |
 |---|---|---|
-| `AGGLAYER_ENABLE_WRITER_WORKER` | `false` | Master toggle for the RD-940 async path. Also enables the bounded future-nonce wait (30 s) that absorbs out-of-order autoclaim submissions. |
 | `AGGLAYER_WRITER_QUEUE_DEPTH` | `64` | mpsc capacity. At 64 + p50 commit ≈ 10 s, sustainable throughput tops near 6 jobs/s. Bump if `queue_full_rejections` rate climbs. |
 | `AGGLAYER_WRITER_TX_TTL` | `300` (5 min) | Maximum queue age before the consuming worker writes `status:0x0` without starting dispatch; also retention time for terminal in-memory entries. The sweeper renews live reservations and evicts terminal entries, but never fails Submitting work concurrently. |
 | `AGGLAYER_CLAIM_RECEIPT_EXPIRATION_BLOCKS` | `120` | Miden-block lifetime for pending claim receipts that wait for the projector to observe claim-note consumption. Increase if valid claims expire before projection under load. |

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -75,7 +75,7 @@ its shape for new environments.
 |---|---|---|
 | `--enable-writer-worker` / `AGGLAYER_ENABLE_WRITER_WORKER` | `false` | Async `eth_sendRawTransaction` dispatch. Runtime toggle; see the RD-940 section at the end of this doc for the flag-flip procedure and restart-loss contract. Also enables the bounded future-nonce wait (out-of-order submissions wait up to 30 s for the missing nonce instead of erroring). |
 | `AGGLAYER_WRITER_QUEUE_DEPTH` (env only) | `64` | mpsc capacity. |
-| `AGGLAYER_WRITER_TX_TTL` (env only) | `300` | Seconds before a stuck job is forced to Failed. |
+| `AGGLAYER_WRITER_TX_TTL` (env only) | `300` | Maximum queue age before the consuming worker fails a job prior to dispatch; also terminal-cache retention. Submitting work is never failed by the sweeper. |
 | `AGGLAYER_CLAIM_RECEIPT_EXPIRATION_BLOCKS` (env only) | `120` | Miden-block lifetime of pending claim receipts waiting for the projector to observe claim-note consumption. |
 
 ### One-shot / recovery flags
@@ -831,8 +831,8 @@ no cascading effect.
    - `agglayer_writer_queue_depth` should stay well under 0.5 × cap
      (32 with the default cap of 64).
    - `agglayer_writer_job_failures_total{reason="ttl"}` should stay 0.
-     Any non-zero rate means a Miden submission is stuck longer than
-     `AGGLAYER_WRITER_TX_TTL` (default 300 s).
+     Any non-zero rate means a job waited in the local queue longer than
+     `AGGLAYER_WRITER_TX_TTL` (default 300 s) before dispatch began.
    - `agglayer_writer_dropped_on_restart_total` must be 0 (this is the
      first boot under the flag; non-zero here means the previous boot
      was already running the worker and left residue).
@@ -849,5 +849,5 @@ no cascading effect.
 |---|---|---|
 | `AGGLAYER_ENABLE_WRITER_WORKER` | `false` | Master toggle for the RD-940 async path. Also enables the bounded future-nonce wait (30 s) that absorbs out-of-order autoclaim submissions. |
 | `AGGLAYER_WRITER_QUEUE_DEPTH` | `64` | mpsc capacity. At 64 + p50 commit ≈ 10 s, sustainable throughput tops near 6 jobs/s. Bump if `queue_full_rejections` rate climbs. |
-| `AGGLAYER_WRITER_TX_TTL` | `300` (5 min) | Seconds before the TTL sweeper forcibly transitions a stuck non-terminal hash to Failed + writes a `status:0x0` receipt. Sits inside aggkit's `WaitTxToBeMined = 2 m` with margin. |
+| `AGGLAYER_WRITER_TX_TTL` | `300` (5 min) | Maximum queue age before the consuming worker writes `status:0x0` without starting dispatch; also retention time for terminal in-memory entries. The sweeper renews live reservations and evicts terminal entries, but never fails Submitting work concurrently. |
 | `AGGLAYER_CLAIM_RECEIPT_EXPIRATION_BLOCKS` | `120` | Miden-block lifetime for pending claim receipts that wait for the projector to observe claim-note consumption. Increase if valid claims expire before projection under load. |

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -775,66 +775,27 @@ For incident scenarios touching the bridge as a whole, also consult
 `docs/POSTMORTEM_2026-05-11_IAIC_TO_ADNF.md` and the linked Cantina
 audit notes.
 
-## Failure mode I — forever-pending tx after restart (RD-940)
+## Failure mode I — durable writer recovery after restart (RD-940)
 
-**Symptom:** `eth_getTransactionReceipt(hash)` returns JSON `null`
-indefinitely for a hash that `eth_sendRawTransaction` previously
-returned. aggkit's ethtxmanager polls the receipt forever and the tx
-never transitions to Committed or Failed.
+**Symptom:** a previously accepted hash remains pending after a worker restart.
 
-**Cause:** The writer worker (`AGGLAYER_ENABLE_WRITER_WORKER=true`) keeps
-in-flight WriteJobs in a bounded `tokio::sync::mpsc(64)` channel + a
-DashMap inflight cache. **There is no on-disk durable queue in v1.**
-When the proxy restarts via SIGKILL, k8s OOM-kill, or host eviction,
-every job that hadn't yet been `txn_commit`-ed to the store is lost. The
-tx-hashes we returned to callers are not recoverable; the work must be
-re-submitted by the caller.
-
-A graceful SIGTERM shutdown will:
-1. signal the worker to stop accepting new dispatches,
-2. wait up to 20 s for in-flight Miden round-trips to complete,
-3. snapshot the count of still-non-terminal jobs to
-   `/tmp/agglayer-writer-queue-snapshot`, and
-4. emit `agglayer_writer_drain_outcome_total{outcome=partial}`.
-
-On the next boot we read that snapshot and increment
-`agglayer_writer_dropped_on_restart_total` by the count. **This counter
-is the v1 tripwire — every increment is real, unrecovered work.** Hard
-page on `increase(agglayer_writer_dropped_on_restart_total[1h]) > 0`.
-
-A SIGKILL leaves the tmpfile absent — the counter stays at 0. Combined
-with the `agglayer_writer_queue_depth` history just before the kill,
-that's still enough to size the loss window.
+**Cause:** the mpsc dispatch buffer is process-local, but the full signed envelope
+is persisted as an unlinked pending transaction before the nonce CAS. The nonce
+reservation is permanently bound to that hash and its live lease stops renewing
+when the process dies.
 
 ### Response
 
-1. **Identify the lost cohort.** Cross-reference
-   `agglayer_writer_queue_depth` for the 30 s window before the
-   restart against the proxy's structured logs
-   (`target=writer_worker::job` events with `kind` and `signer` fields).
-   Any hash that appears in a `writer_worker: job committed` or
-   `writer_worker: job failed` log line before the restart was already
-   terminal in the store; those are not lost.
-2. **Notify the affected callers.** Today this is aggoracle (the only
-   on-proxy signer in aggkit's stack — see
-   `docs/design/RD-940-async-writer.md` Spec E). aggoracle's
-   ethtxmanager will eventually time out at its `WaitTxToBeMined = 2 m`
-   threshold and re-broadcast; the tx-hash dedup early-return
-   (`service_send_raw_txn.rs`) ensures the re-broadcast is idempotent
-   if it lands within the receipt's lifetime, otherwise it gets a
-   fresh nonce and proceeds normally.
-3. **Document each incident.** Increments of
-   `agglayer_writer_dropped_on_restart_total` must be triaged into
-   Linear under RD-940 follow-up so the v1.5 durable-queue prioritisation
-   stays honest.
-
-### Resolution roadmap
-
-v1.5 (RD-940 follow-up) lands a `worker_jobs` table or WAL-style journal.
-`WriteJob` already implements `Clone` + carries an ULID `job_id` so the
-on-disk shape is additive. Until then, **every accepted tx hash is at
-risk of being lost on restart** — operators must treat this as the
-explicit contract.
+1. Re-broadcast the **same signed transaction** after the reservation lease
+   (`NONCE_RESERVATION_LEASE_SECS`, default 90 s) expires. The service re-decodes
+   the durable envelope, accepts the already-advanced nonce, and enqueues once.
+2. Never replace it with a different hash at the same nonce; replacement is
+   fail-closed because the prior external outcome may be ambiguous.
+3. If the transaction already has a note link, do not force recovery: the
+   external submission boundary was crossed and the projector owns finalisation.
+4. `agglayer_writer_dropped_on_restart_total` remains a restart-pressure signal,
+   not a count of unrecoverable work. Alert and investigate repeated restarts or
+   queue saturation, then verify same-hash recovery and nonce continuity.
 
 ## Coordinated downstream change — k8s `terminationGracePeriodSeconds`
 

--- a/migrations/011_nonce_reservations.sql
+++ b/migrations/011_nonce_reservations.sql
@@ -26,11 +26,3 @@ CREATE TABLE IF NOT EXISTS nonce_reservations (
     created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (signer, nonce)
 );
-
--- Fenced claim leases. Existing rows are migrated fail-closed as submitted: they
--- may represent work that reached Miden before this ownership protocol existed.
-ALTER TABLE claimed_indices
-    ADD COLUMN IF NOT EXISTS owner_tx_hash TEXT,
-    ADD COLUMN IF NOT EXISTS fence_token BIGINT NOT NULL DEFAULT 0,
-    ADD COLUMN IF NOT EXISTS claim_state TEXT NOT NULL DEFAULT 'submitted',
-    ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ;

--- a/migrations/011_nonce_reservations.sql
+++ b/migrations/011_nonce_reservations.sql
@@ -1,16 +1,28 @@
--- #55 BLOCKER 1 — atomic (signer, nonce) reservation.
+-- #55 BLOCKER 1 — atomic (signer, nonce) admission reservation with a LEASE +
+-- FENCING TOKEN (fenced ownership lifecycle).
 --
--- Before any queue/dispatch side effect, a submission reserves its (signer, nonce)
--- slot mapped to its tx_hash. The reservation is an insert-if-absent keyed on
--- (signer, nonce): the FIRST tx to reserve a slot WINS and executes; a later
--- DIFFERENT tx at the same slot LOSES and is rejected (never executes); the SAME
--- tx re-reserving is idempotent. This makes nonce acceptance correct across
--- rolling replicas sharing one PostgreSQL — the process-local per-signer lock only
--- serialises within one replica.
+-- A submission must WIN a fenced lease on its (signer, nonce) slot before any
+-- queue/dispatch/receipt side effect. Exactly one replica ever executes a given
+-- (signer, nonce) at a time:
+--   * state 'executing'         — a replica currently owns admission; its lease
+--                                 (lease_expires_at) is valid. The SAME tx from
+--                                 another replica must NOT execute (dedup); a
+--                                 DIFFERENT tx is hard-rejected.
+--   * state 'released_success'  — admission completed (a receipt exists / is
+--                                 being produced); the SAME tx dedups.
+--   * state 'released_failure'  — the prior attempt failed before completing; the
+--                                 SAME tx may take over ownership (fence++) and
+--                                 retry admission.
+-- A lease that has EXPIRED (owner crashed mid-admission) is likewise takeover-able
+-- by the SAME tx. Every takeover bumps fence_token; only the current fence owner
+-- may release, so a delayed crashed owner cannot clobber the new owner's state.
 CREATE TABLE IF NOT EXISTS nonce_reservations (
-    signer     TEXT   NOT NULL,
-    nonce      BIGINT NOT NULL,
-    tx_hash    TEXT   NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    signer           TEXT   NOT NULL,
+    nonce            BIGINT NOT NULL,
+    tx_hash          TEXT   NOT NULL,
+    state            TEXT   NOT NULL DEFAULT 'executing',
+    lease_expires_at TIMESTAMPTZ NOT NULL,
+    fence_token      BIGINT NOT NULL DEFAULT 1,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (signer, nonce)
 );

--- a/migrations/011_nonce_reservations.sql
+++ b/migrations/011_nonce_reservations.sql
@@ -26,3 +26,11 @@ CREATE TABLE IF NOT EXISTS nonce_reservations (
     created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (signer, nonce)
 );
+
+-- Fenced claim leases. Existing rows are migrated fail-closed as submitted: they
+-- may represent work that reached Miden before this ownership protocol existed.
+ALTER TABLE claimed_indices
+    ADD COLUMN IF NOT EXISTS owner_tx_hash TEXT,
+    ADD COLUMN IF NOT EXISTS fence_token BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS claim_state TEXT NOT NULL DEFAULT 'submitted',
+    ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ;

--- a/migrations/011_nonce_reservations.sql
+++ b/migrations/011_nonce_reservations.sql
@@ -1,0 +1,16 @@
+-- #55 BLOCKER 1 — atomic (signer, nonce) reservation.
+--
+-- Before any queue/dispatch side effect, a submission reserves its (signer, nonce)
+-- slot mapped to its tx_hash. The reservation is an insert-if-absent keyed on
+-- (signer, nonce): the FIRST tx to reserve a slot WINS and executes; a later
+-- DIFFERENT tx at the same slot LOSES and is rejected (never executes); the SAME
+-- tx re-reserving is idempotent. This makes nonce acceptance correct across
+-- rolling replicas sharing one PostgreSQL — the process-local per-signer lock only
+-- serialises within one replica.
+CREATE TABLE IF NOT EXISTS nonce_reservations (
+    signer     TEXT   NOT NULL,
+    nonce      BIGINT NOT NULL,
+    tx_hash    TEXT   NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (signer, nonce)
+);

--- a/migrations/012_submission_handoffs.sql
+++ b/migrations/012_submission_handoffs.sql
@@ -1,0 +1,21 @@
+-- Fenced claim ownership. Existing claimed rows predate the handoff protocol
+-- and may already have reached Miden, so upgrade them fail-closed as submitted.
+ALTER TABLE claimed_indices
+    ADD COLUMN IF NOT EXISTS owner_tx_hash TEXT,
+    ADD COLUMN IF NOT EXISTS fence_token BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS claim_state TEXT NOT NULL DEFAULT 'submitted',
+    ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ;
+
+-- A note link is first durable as `prepared`, immediately before the external
+-- submit. It becomes `submitted` only after commit or exact-note observation.
+-- Legacy links are known historical handoffs and therefore upgrade fail-closed.
+-- The durable note reconciler confirms exact NoteIds before advancing its
+-- cursor. A prepared link may be cleared only once that cursor is strictly past
+-- the executed Miden transaction's last possible inclusion block.
+ALTER TABLE tx_note_links
+    ADD COLUMN IF NOT EXISTS handoff_state TEXT NOT NULL DEFAULT 'submitted',
+    ADD COLUMN IF NOT EXISTS note_id TEXT,
+    ADD COLUMN IF NOT EXISTS prepared_expiration_block BIGINT;
+
+CREATE INDEX IF NOT EXISTS idx_tx_note_links_prepared_note_id
+    ON tx_note_links (note_id) WHERE handoff_state = 'prepared';

--- a/scripts/e2e-manual-user-claim.sh
+++ b/scripts/e2e-manual-user-claim.sh
@@ -417,10 +417,25 @@ submit_user_claim() {
         result=$(echo "$resp" | python3 -c "import json,sys; print(json.load(sys.stdin).get('result') or '')" 2>/dev/null || true)
         errmsg=$(echo "$resp" | python3 -c "import json,sys; print(json.load(sys.stdin).get('error',{}).get('message') or '')" 2>/dev/null || true)
         if [[ -n "$result" ]]; then
-            SUBMIT_OUTCOME="user_won"; USER_TX="$result"; return 0
+            USER_TX="$result"
+            # #55 — a returned hash is NOT automatically a user win. If the sponsor
+            # already LANDED this gi, the proxy ACCEPTS the user's tx and writes an
+            # IMMEDIATE status-0x0 (reverted) receipt with EMPTY logs / NO ClaimEvent
+            # (geth-faithful AlreadyClaimed) — the user did NOT win. A genuine win's
+            # receipt is null (pending) here and finalises to status 0x1 later.
+            # accept-and-revert's receipt is written synchronously; one re-check
+            # covers RPC propagation.
+            local st; st=$(receipt_status "$result")
+            [[ -z "$st" ]] && { sleep 1; st=$(receipt_status "$result"); }
+            if [[ "$st" == "0x0" ]]; then
+                SUBMIT_OUTCOME="accept_reverted"; return 0
+            fi
+            SUBMIT_OUTCOME="user_won"; return 0
         fi
         LAST_ERR="$errmsg"
         if [[ "$errmsg" == *"already submitted"* ]]; then
+            # Sponsor's claim is IN FLIGHT (no ClaimEvent yet): the proxy hard-rejects
+            # a second submitter (InFlight). Once it LANDS, a resubmit accept-reverts.
             SUBMIT_OUTCOME="dedup_rejected"; return 0
         fi
         # C6 GER-not-seen and transient rejections: retry quickly.
@@ -472,6 +487,21 @@ PY
 receipt_status_ok() { # <tx-hash>
     rpc eth_getTransactionReceipt "[\"$1\"]" \
         | python3 -c "import json,sys; r=json.load(sys.stdin).get('result'); exit(0 if r and r.get('status')=='0x1' else 1)"
+}
+
+# receipt_status <tx-hash> → raw status ("0x0" | "0x1") or "" when the receipt is
+# still null (pending). #55: accept-and-revert writes an IMMEDIATE status-0x0
+# receipt; a genuine claim is null until the projector finalises it, then 0x1.
+receipt_status() { # <tx-hash>
+    rpc eth_getTransactionReceipt "[\"$1\"]" \
+        | python3 -c "import json,sys; r=json.load(sys.stdin).get('result') or {}; print(r.get('status') or '')"
+}
+
+# receipt_logs_empty <tx-hash> → exit 0 iff the receipt exists and carries ZERO
+# logs (the accept-and-revert shape: no ClaimEvent). Non-existent/1+ logs → non-zero.
+receipt_logs_empty() { # <tx-hash>
+    rpc eth_getTransactionReceipt "[\"$1\"]" \
+        | python3 -c "import json,sys; r=json.load(sys.stdin).get('result'); exit(0 if r and len(r.get('logs') or [])==0 else 1)"
 }
 
 receipt_from() { # <tx-hash> → lowercase from address (empty if absent)
@@ -750,8 +780,14 @@ for attempt in $(seq 1 "$MAX_LEG1_ATTEMPTS"); do
             break
             ;;
         dedup_rejected)
-            warn "sponsor won the claim for gi=$GI (user got the dedup rejection: '$LAST_ERR')"
+            warn "sponsor's claim is in flight for gi=$GI (user got the dedup rejection: '$LAST_ERR')"
             warn "retrying leg 1 with a fresh deposit"
+            ;;
+        accept_reverted)
+            # #55 — the sponsor already LANDED this gi; the user's tx was
+            # accept-and-reverted (status-0x0 receipt). The user did NOT win —
+            # retry with a fresh deposit to demonstrate the manual-win path.
+            warn "sponsor already landed gi=$GI; user's tx was accept-and-reverted (tx $USER_TX) — retrying with a fresh deposit"
             ;;
         timeout)
             fail "user claim never accepted nor dedup-rejected within 420s (last error: '$LAST_ERR')"
@@ -820,6 +856,10 @@ pass "race deposit is ready_for_claim"
 # END and stays reliable; ISO-8601 timestamps compare lexicographically.
 RACE_START_TS=$(date -u +%Y-%m-%dT%H:%M:%S)
 
+# #55 — snapshot the accept-and-revert metric before the race so the
+# sponsor-participation proof (user-won branch) can assert it increments as the
+# sponsor's own gi2 retries get accept-and-reverted after the gi lands.
+DEDUP_BEFORE_RACE=$(metric_value "$DEDUP_METRIC")
 submit_user_claim "$DEP_JSON" 420
 WINNER=""; WINNER_TX=""
 case "$SUBMIT_OUTCOME" in
@@ -828,13 +868,26 @@ case "$SUBMIT_OUTCOME" in
         pass "race: USER won (tx=$USER_TX); sponsor is the loser"
         ;;
     dedup_rejected)
+        # Sponsor's claim was IN FLIGHT (locked, no ClaimEvent yet) when the user
+        # submitted → InFlight hard-reject. The sponsor won the lock.
         WINNER="sponsor"
         [[ "$LAST_ERR" == *"already submitted"* ]] \
-            || fail "loser's rejection is not the dedup path: '$LAST_ERR'"
-        pass "race: SPONSOR won; user (loser) got the dedup rejection: '$LAST_ERR'"
+            || fail "loser's rejection is not the in-flight dedup path: '$LAST_ERR'"
+        pass "race: SPONSOR won (in-flight lock); user (loser) got the dedup rejection: '$LAST_ERR'"
+        ;;
+    accept_reverted)
+        # #55 — the sponsor had already LANDED gi2 when the user submitted; the
+        # user's tx was ACCEPT-AND-REVERTED (status-0x0 receipt, empty logs, NO
+        # ClaimEvent). The SPONSOR won.
+        WINNER="sponsor"
+        [[ "$(receipt_status "$USER_TX")" == "0x0" ]] \
+            || fail "accept_reverted outcome but user tx $USER_TX receipt is not status 0x0"
+        receipt_logs_empty "$USER_TX" \
+            || fail "accept-and-revert receipt for $USER_TX must carry EMPTY logs (no ClaimEvent)"
+        pass "race: SPONSOR won (already landed); user's tx accept-and-reverted (status-0x0, no ClaimEvent): $USER_TX"
         ;;
     timeout)
-        fail "race leg: user claim neither accepted nor dedup-rejected in 420s (last: '$LAST_ERR')"
+        fail "race leg: user claim neither accepted, dedup-rejected, nor accept-and-reverted in 420s (last: '$LAST_ERR')"
         ;;
 esac
 
@@ -862,46 +915,57 @@ if [[ "$WINNER" == "sponsor" ]]; then
     assert_receipt_signer "$WINNER_TX" "$SPONSOR_ADDR_LC" "SPONSOR"
     pass "sponsor participation proven: the sponsor's own tx won gi=$GI2"
 else
-    # User won → first force the DETERMINISTIC loser: one more user submission
-    # for the same (now claimed) gi must be dedup-rejected...
+    # User won → force the DETERMINISTIC loser. #55: the user's claim has LANDED
+    # (its receipt is status 0x1, ClaimEvent exists — asserted above), so ONE more
+    # user submission for the SAME gi is now ACCEPT-AND-REVERTED (geth-faithful
+    # AlreadyClaimed): it returns a hash with a status-0x0 receipt, EMPTY logs, NO
+    # new ClaimEvent, and increments the dedup-reverted metric — it is NOT a hard
+    # "already submitted" error anymore.
+    DEDUP_BEFORE_RESUB=$(metric_value "$DEDUP_METRIC")
     RAW=$(build_user_claim_raw "$DEP_JSON")
-    [[ -n "$RAW" ]] || fail "could not rebuild the user claim for the deterministic dedup check"
+    [[ -n "$RAW" ]] || fail "could not rebuild the user claim for the deterministic accept-and-revert check"
     RESP=$(rpc eth_sendRawTransaction "[\"$RAW\"]")
-    ERRMSG=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('error',{}).get('message') or '')" 2>/dev/null || true)
-    [[ "$ERRMSG" == *"already submitted"* ]] \
-        || fail "post-race user resubmission for gi=$GI2 was not dedup-rejected (got: '$ERRMSG', resp: $RESP)"
-    pass "post-race user resubmission dedup-rejected: '$ERRMSG'"
+    RESUB_TX=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('result') or '')" 2>/dev/null || true)
+    RESUB_ERR=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('error',{}).get('message') or '')" 2>/dev/null || true)
+    [[ -n "$RESUB_TX" ]] \
+        || fail "post-race user resubmission for gi=$GI2 was NOT accepted — expected #55 accept-and-revert, got error '$RESUB_ERR' (resp: $RESP)"
+    # Its receipt must be an immediate status-0x0 revert with empty logs.
+    wait_for "resubmission accept-and-revert receipt (status 0x0)" \
+        "[[ \"\$(receipt_status '$RESUB_TX')\" == '0x0' ]]" 60 2
+    receipt_logs_empty "$RESUB_TX" \
+        || fail "accept-and-revert receipt for the resubmission $RESUB_TX must carry EMPTY logs (no ClaimEvent)"
+    DEDUP_AFTER_RESUB=$(metric_value "$DEDUP_METRIC")
+    [[ "$DEDUP_AFTER_RESUB" -gt "$DEDUP_BEFORE_RESUB" ]] \
+        || fail "$DEDUP_METRIC did not increment on the post-win user resubmission ($DEDUP_BEFORE_RESUB → $DEDUP_AFTER_RESUB) — accept-and-revert did not fire"
+    # Still exactly ONE ClaimEvent for gi2 (accept-and-revert emits none).
+    read -r EV2B_COUNT _ <<<"$(claim_events_for_gi "$GI2")"
+    [[ "$EV2B_COUNT" == "1" ]] || fail "post-resubmission gi2 has $EV2B_COUNT ClaimEvents — accept-and-revert must not emit a second"
+    pass "post-race user resubmission ACCEPT-AND-REVERTED (status-0x0 $RESUB_TX, no ClaimEvent, metric $DEDUP_BEFORE_RESUB→$DEDUP_AFTER_RESUB)"
 
-    # ...then prove the SPONSOR is racing gi2, positively: after the user's
-    # LAST submission above, any further "claim already submitted" rejection
-    # for THIS gi can only come from the sponsor's ClaimTxManager (2s retry
-    # loop on its signed gi2 tx). Anchor strictly after the resubmission, then
-    # require fresh gi2 dedup rejections AND the sponsor signer's own
-    # eth_sendRawTransaction submissions in the proxy log. If the sponsor
-    # never raced, this FAILS — dedup evidence manufactured by the user's own
-    # resubmission cannot satisfy it (it is before the anchor).
+    # ...then prove the SPONSOR raced gi2, positively: after the user's LAST
+    # submission the sponsor's ClaimTxManager keeps re-broadcasting its own signed
+    # gi2 tx, which — the gi having landed — is ACCEPT-AND-REVERTED each time. So
+    # the sponsor's participation shows as its own eth_sendRawTransaction
+    # submissions in the proxy log AND further increments of the dedup-reverted
+    # metric, anchored strictly AFTER the user's resubmission (so the user's own
+    # accept-and-revert above cannot satisfy it).
     sleep 2
     SPONSOR_PROOF_TS=$(date -u +%Y-%m-%dT%H:%M:%S)
-    log "observing 15s for the sponsor's own gi=$GI2 submissions (anchor $SPONSOR_PROOF_TS)..."
-    sleep 15
+    DEDUP_AT_ANCHOR=$(metric_value "$DEDUP_METRIC")
+    log "observing 20s for the sponsor's own gi=$GI2 submissions (anchor $SPONSOR_PROOF_TS)..."
+    sleep 20
     PROOF_WINDOW=$(docker logs --tail 8000 "$AGGLAYER_CONTAINER" 2>&1 | strip_ansi \
         | awk -v ts="$SPONSOR_PROOF_TS" '$1 >= ts')
-    GI2_DEDUP_HITS=$(printf '%s\n' "$PROOF_WINDOW" \
-        | grep -cE "already submitted for global_index ${GI2}([^0-9]|$)" || true)
     SPONSOR_SUBS=$(printf '%s\n' "$PROOF_WINDOW" \
         | grep -E "\"event\": ?\"eth_sendRawTransaction_received\"" \
         | grep -cE "\"signer\": ?\"$SPONSOR_ADDR_LC\"" || true)
-    # Race window submissions (from ready_for_claim onwards) for the log line.
-    RACE_WINDOW_SUBS=$(docker logs --tail 12000 "$AGGLAYER_CONTAINER" 2>&1 | strip_ansi \
-        | awk -v ts="$RACE_START_TS" '$1 >= ts' \
-        | grep -E "\"event\": ?\"eth_sendRawTransaction_received\"" \
-        | grep -cE "\"signer\": ?\"$SPONSOR_ADDR_LC\"" || true)
-    log "post-anchor gi2 dedup rejections: ${GI2_DEDUP_HITS:-0}; sponsor submissions post-anchor: ${SPONSOR_SUBS:-0} (since race start: ${RACE_WINDOW_SUBS:-0})"
-    [[ "${GI2_DEDUP_HITS:-0}" -ge 1 ]] \
-        || fail "no NEW dedup rejection for gi=$GI2 after the user's last submission — the sponsor never raced this gi (leg 2 had no second racer)"
+    DEDUP_AFTER_WINDOW=$(metric_value "$DEDUP_METRIC")
+    log "post-anchor sponsor submissions: ${SPONSOR_SUBS:-0}; $DEDUP_METRIC $DEDUP_AT_ANCHOR→$DEDUP_AFTER_WINDOW (since race: ${DEDUP_BEFORE_RACE})"
     [[ "${SPONSOR_SUBS:-0}" -ge 1 ]] \
-        || fail "no eth_sendRawTransaction from the sponsor signer $SPONSOR_ADDR_LC in the proxy log after the user's last submission — cannot attribute the gi2 rejections to the sponsor"
-    pass "sponsor participation proven: sponsor kept submitting gi=$GI2 after the user stopped ($GI2_DEDUP_HITS dedup rejections, $SPONSOR_SUBS sponsor submissions in 15s)"
+        || fail "no eth_sendRawTransaction from the sponsor signer $SPONSOR_ADDR_LC after the user's last submission — the sponsor never raced gi=$GI2 (no second racer)"
+    [[ "$DEDUP_AFTER_WINDOW" -gt "$DEDUP_AT_ANCHOR" ]] \
+        || fail "$DEDUP_METRIC did not increment after the user stopped ($DEDUP_AT_ANCHOR → $DEDUP_AFTER_WINDOW) — the sponsor's own gi=$GI2 retries were not accept-and-reverted (cannot attribute continued claiming to the sponsor)"
+    pass "sponsor participation proven: sponsor kept submitting gi=$GI2 after the user stopped ($SPONSOR_SUBS submissions; dedup-reverted $DEDUP_AT_ANCHOR→$DEDUP_AFTER_WINDOW)"
 fi
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -1028,11 +1092,12 @@ print('\n'.join(out))
     case "$SUBMIT_OUTCOME" in
         user_won)
             pass "allow-listed USER's manual claim accepted under allow-list mode (tx $USER_TX)" ;;
-        dedup_rejected)
-            # The sponsor (also allow-listed) beat the user; the user's own
-            # submission still traversed the allow-list gate (the dedup lock
-            # sits BEHIND it), so membership is proven either way.
-            pass "sponsor (also allow-listed) won the claim; user's submission passed the allow-list gate into the dedup path" ;;
+        dedup_rejected|accept_reverted)
+            # The sponsor (also allow-listed) beat the user — via in-flight dedup
+            # (dedup_rejected) or, if it already landed, #55 accept-and-revert. The
+            # user's submission still traversed the allow-list gate (the claim lock /
+            # landed classification sits BEHIND it), so membership is proven either way.
+            pass "sponsor (also allow-listed) won the claim ($SUBMIT_OUTCOME); user's submission passed the allow-list gate" ;;
         timeout)
             fail "no claim landed for gi=$gi_al under allow-list mode — allow-list config broke the claim path" ;;
     esac

--- a/scripts/e2e-manual-user-claim.sh
+++ b/scripts/e2e-manual-user-claim.sh
@@ -419,14 +419,23 @@ submit_user_claim() {
         if [[ -n "$result" ]]; then
             USER_TX="$result"
             # #55 — a returned hash is NOT automatically a user win. If the sponsor
-            # already LANDED this gi, the proxy ACCEPTS the user's tx and writes an
-            # IMMEDIATE status-0x0 (reverted) receipt with EMPTY logs / NO ClaimEvent
+            # already LANDED this gi, the proxy ACCEPTS the user's tx and writes a
+            # status-0x0 (reverted) receipt with EMPTY logs / NO ClaimEvent
             # (geth-faithful AlreadyClaimed) — the user did NOT win. A genuine win's
-            # receipt is null (pending) here and finalises to status 0x1 later.
-            # accept-and-revert's receipt is written synchronously; one re-check
-            # covers RPC propagation.
-            local st; st=$(receipt_status "$result")
-            [[ -z "$st" ]] && { sleep 1; st=$(receipt_status "$result"); }
+            # receipt finalises to status 0x1.
+            #
+            # BLOCKER 5 — in WRITER (async) mode the accept-and-revert receipt is
+            # written by the worker AFTER the queue, so a single 1s re-check is not
+            # enough. POLL until the receipt reaches a TERMINAL status: 0x1 → genuine
+            # user win (exit immediately); 0x0 → accept-and-reverted. If it never
+            # terminalises within the bound it is a slow projector on a genuine win,
+            # so default to user_won and let the downstream status-1 wait confirm it.
+            local st="" polled=0
+            while (( polled < 180 )); do
+                st=$(receipt_status "$result")
+                [[ "$st" == "0x0" || "$st" == "0x1" ]] && break
+                sleep 2; polled=$((polled+2))
+            done
             if [[ "$st" == "0x0" ]]; then
                 SUBMIT_OUTCOME="accept_reverted"; return 0
             fi

--- a/scripts/e2e-manual-user-claim.sh
+++ b/scripts/e2e-manual-user-claim.sh
@@ -519,6 +519,21 @@ sponsor_nonce() {
         | python3 -c "import json,sys; print(int(json.load(sys.stdin)['result'],16))"
 }
 
+# ── #55 accept-and-revert observability ──────────────────────────────────────
+# The proxy exposes Prometheus counters on the L2_RPC port's /metrics. The
+# `claim_landed_dedup_reverted_total` counter increments each time a claimAsset
+# targeting an ALREADY-LANDED globalIndex is ACCEPTED with a reverted (status
+# 0x0) receipt instead of hard-rejected — the geth-faithful AlreadyClaimed that
+# keeps the sponsor's nonce sequence in lockstep. metric_value reads it (missing
+# => 0, it is only emitted after the first increment); an unreachable /metrics is
+# a HARD fail — a down proxy must not read as "0" (task #26 sweep lesson).
+DEDUP_METRIC="claim_landed_dedup_reverted_total"
+metric_value() { # <metric-name>
+    local body
+    body=$(curl -sf "${L2_RPC}/metrics") || fail "metrics endpoint unreachable: ${L2_RPC}/metrics"
+    awk -v n="$1" '$1==n{print $2; f=1; exit} END{if(!f)print 0}' <<<"$body" | sed 's/\..*//'
+}
+
 # send_sponsor_noop <nonce> — consume one sponsor nonce with a ZERO-AMOUNT
 # claimAsset. The proxy accepts zero-amount claims synchronously and RPC-only
 # (worker_handle_claim_asset: "skipping zero-amount claim" — no Miden publish,
@@ -630,9 +645,88 @@ verify_sponsor_functional() {
     pass "sponsor is functional ($label): fresh deposit gi=$vgi autoclaimed by the sponsor (tx $t)"
 }
 
+# verify_sponsor_recovers_automatically <label> — the HARD #55 regression. After
+# the user front-ran a globalIndex the sponsor had already signed + persisted a
+# monitored tx for, the sponsor is wedged PRE-FIX: its doomed tx is hard-rejected
+# at RPC ("already submitted") without consuming its nonce, so ClaimTxManager
+# re-broadcasts forever ("nonce mismatch") and every later claim queues behind
+# it. WITH the #55 accept-and-revert fix the sponsor recovers on its own: when it
+# re-broadcasts the doomed tx (the gi has since LANDED), the proxy ACCEPTS it and
+# writes a reverted (status 0x0) receipt, consuming the nonce, so ethtxmanager
+# marks it mined-failed and advances — geth-faithful AlreadyClaimed.
+#
+# This asserts that recovery WITHOUT ANY MANUAL HEAL (deliberately NO
+# drain_sponsor_wedge / zero-amount no-ops — the whole point is the fix heals it
+# for us):
+#   1. a fresh deposit the user never touches is autoclaimed BY THE SPONSOR
+#      within a bound (pre-fix this hangs forever → the regression);
+#   2. no PERMANENT nonce-mismatch wedge — after a settle window the sponsor's
+#      account nonce has advanced and there is ZERO fresh sponsor nonce-mismatch
+#      spam in the most recent proxy-log window (transient mismatches DURING the
+#      heal are expected; a permanent wedge is a continuous stream);
+#   3. the `claim_landed_dedup_reverted_total` metric incremented over the run —
+#      positive proof the recovery came via accept-and-revert, not luck.
+verify_sponsor_recovers_automatically() {
+    local label="$1" vgi deadline now c t nonce_a nonce_b settle_ts fresh_mismatch dedup_after
+    step "Sponsor AUTO-recovery ($label) — #55: fresh deposit MUST autoclaim with NO manual heal"
+    do_l1_deposit
+    fetch_deposit_json "$L1_DEP_CNT" 300
+    vgi=$(echo "$DEP_JSON" | dep_field global_index)
+    log "auto-recovery deposit: cnt=$L1_DEP_CNT gi=$vgi (user will NOT claim it; NO nonce drain will be issued)"
+
+    # NO drain_sponsor_wedge here — the fix must heal the sponsor by itself.
+    deadline=$(( $(date +%s) + 600 ))
+    while :; do
+        read -r c t <<<"$(claim_events_for_gi "$vgi" || echo "0 -")"
+        [[ "${c:-0}" -ge 1 ]] && break
+        now=$(date +%s)
+        (( now >= deadline )) \
+            && fail "sponsor never autoclaimed gi=$vgi within 600s WITHOUT a manual heal — sponsor did NOT auto-recover from the front-run wedge (#55 regression)"
+        log "auto-recovery claim not landed yet — waiting on the sponsor to self-heal ($(( deadline - now ))s left)"
+        sleep 10
+    done
+
+    read -r c t <<<"$(claim_events_for_gi "$vgi")"
+    [[ "$c" == "1" ]] || fail "expected exactly 1 ClaimEvent for auto-recovery gi=$vgi, got $c"
+    wait_for "auto-recovery claim receipt (status 0x1)" "receipt_status_ok '$t'" 300 5
+    assert_receipt_signer "$t" "$SPONSOR_ADDR_LC" "SPONSOR"
+    pass "sponsor AUTO-recovered ($label): fresh deposit gi=$vgi autoclaimed by the sponsor (tx $t), NO manual heal"
+
+    # (2) No PERMANENT nonce-mismatch wedge. Settle, then require ZERO fresh
+    # sponsor nonce-mismatch lines in the most-recent window (ANSI-strip;
+    # `--tail` seeks from the END — reliable on long-lived stacks, unlike
+    # `--since` which can truncate at a corrupt entry).
+    nonce_a=$(sponsor_nonce)
+    sleep 15
+    nonce_b=$(sponsor_nonce)
+    settle_ts=$(date -u +%Y-%m-%dT%H:%M:%S)
+    sleep 15
+    fresh_mismatch=$(docker logs --tail 8000 "$AGGLAYER_CONTAINER" 2>&1 | strip_ansi \
+        | awk -v ts="$settle_ts" '$1 >= ts' \
+        | grep -cE "nonce mismatch for $SPONSOR_ADDR_LC" || true)
+    log "sponsor nonce: before-settle=$nonce_a after-settle=$nonce_b; fresh nonce-mismatch lines since settle=$fresh_mismatch"
+    [[ "${fresh_mismatch:-0}" -eq 0 ]] \
+        || fail "sponsor STILL emitting nonce-mismatch spam ($fresh_mismatch lines in ~15s after a settle) — permanent wedge NOT healed (#55 regression)"
+    pass "no permanent sponsor nonce-mismatch wedge ($label): 0 fresh mismatch lines since settle"
+
+    # (3) The accept-and-revert metric incremented over the run — positive proof
+    # the sponsor's doomed tx was accept-and-reverted (nonce consumed), i.e. the
+    # recovery came through the #55 fix.
+    dedup_after=$(metric_value "$DEDUP_METRIC")
+    log "$DEDUP_METRIC: baseline=$DEDUP_BEFORE now=$dedup_after"
+    [[ "$dedup_after" -gt "$DEDUP_BEFORE" ]] \
+        || fail "$DEDUP_METRIC did not increment ($DEDUP_BEFORE → $dedup_after) — the sponsor's already-landed claim was NOT accept-and-reverted; recovery was not via the #55 fix"
+    pass "$DEDUP_METRIC incremented ($DEDUP_BEFORE → $dedup_after): sponsor's landed-gi claim was accepted-and-reverted"
+}
+
 # ══════════════════════════════════════════════════════════════════════════════
 # Leg 1 — manual user claim (user submits instead of waiting for the sponsor)
 # ══════════════════════════════════════════════════════════════════════════════
+# #55 — snapshot the accept-and-revert counter BEFORE any front-run so the
+# inter-leg auto-recovery assertion can prove it incremented.
+DEDUP_BEFORE=$(metric_value "$DEDUP_METRIC")
+log "baseline $DEDUP_METRIC = $DEDUP_BEFORE"
+
 step "Leg 1 — deposit L1→L2, then the USER claims it manually"
 
 LEG1_GI=""; LEG1_TX=""
@@ -686,13 +780,14 @@ assert_receipt_signer "$LEG1_TX" "$USER_ADDR_LC" "USER"
 wait_balance_exact "$((DEPOSITS_SENT * EXPECTED_UNITS_PER_DEPOSIT))"
 
 # ══════════════════════════════════════════════════════════════════════════════
-# Between the legs — heal the sponsor the leg-1 front-run just wedged, and
-# HARD-verify it works, so leg 2 races a live sponsor (not a corpse whose head
-# nonce is stuck on the leg-1 gi).
+# Between the legs — #55 REGRESSION: the leg-1 front-run wedged the sponsor's
+# head nonce (it signed + persisted its own claim tx for the raced gi). PRE-FIX
+# this was un-healable without operator intervention (drain_sponsor_wedge
+# consuming the wedged nonces by hand). WITH the accept-and-revert fix the
+# sponsor RECOVERS AUTOMATICALLY — HARD-assert that, WITHOUT any manual heal, so
+# leg 2 races a genuinely self-healed sponsor (and #55 stays fixed forever).
 # ══════════════════════════════════════════════════════════════════════════════
-step "Inter-leg sponsor heal — leg 2 needs a LIVE sponsor to race"
-drain_sponsor_wedge 10
-verify_sponsor_functional "inter-leg"
+verify_sponsor_recovers_automatically "inter-leg"
 wait_balance_exact "$((DEPOSITS_SENT * EXPECTED_UNITS_PER_DEPOSIT))"
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/scripts/e2e-manual-user-claim.sh
+++ b/scripts/e2e-manual-user-claim.sh
@@ -22,23 +22,15 @@
 #        USER (hard), and the wallet balance == EXACTLY the deposits sent so
 #        far × the per-deposit mint (deposit-linked accounting).
 #
-#   Sponsor heal + functional verification (between the legs AND as the
+#   Sponsor recovery + functional verification (between the legs AND as the
 #   epilogue — both HARD):
-#     Front-running the sponsor wedges aggkit/bridge-service's ClaimTxManager:
-#     it has signed its own claim tx for the raced gi at its next nonce; the
-#     proxy rejects that tx FOREVER ("claim already submitted" — hard dedup),
-#     the R4 nonce gate never advances, and every later sponsor claim queues
-#     behind it ("nonce mismatch" spam every ~2s). On a real EVM chain the
-#     sponsor's claimAsset would MINE as an AlreadyClaimed revert and consume
-#     the nonce; the proxy rejects at RPC submission, so the nonce never burns.
-#     THE HEAL (validated live, 2026-07-13 rel-v0158): consume each wedged
-#     head nonce with a benign zero-amount claimAsset no-op signed by the
-#     sponsor key (the proxy accepts zero-amount claims immediately, RPC-only:
-#     no Miden publish, no ClaimEvent, no claim lock — src/service_send_raw_txn.rs
-#     "skipping zero-amount claim"), until the sponsor's submissions stop being
-#     nonce-frozen. Then HARD-assert the sponsor is functional: a fresh deposit
-#     must autoclaim with receipt.from == the sponsor. The test FAILS if the
-#     sponsor cannot be healed — never a warning.
+#     Front-running used to wedge aggkit/bridge-service's ClaimTxManager: the
+#     proxy hard-rejected the sponsor's already-signed transaction without
+#     consuming its nonce. The fixed behavior accepts that exact transaction,
+#     returns a terminal status-0 receipt, and consumes its nonce just as an EVM
+#     AlreadyClaimed revert would. The inter-leg check proves automatic recovery
+#     without a manual nonce drain. The epilogue retains the zero-amount no-op
+#     helper only as cleanup for stacks that were already wedged before the test.
 #
 #   Leg 2 — dedup race on the same globalIndex (sponsor participation PROVEN):
 #     Second deposit; wait until it is ready_for_claim, then fire the user's
@@ -46,11 +38,10 @@
 #     Whoever wins, assert: exactly ONE ClaimEvent for the gi; and POSITIVE
 #     sponsor participation —
 #       · sponsor won → the winning receipt's from == the SPONSOR address;
-#       · user won   → after the user's last (deterministic, dedup-rejected)
-#         submission, NEW "claim already submitted" rejections for this gi
-#         keep appearing in the proxy log (only the sponsor submits it by
-#         then), AND the sponsor signer's eth_sendRawTransaction submissions
-#         are visible in the proxy's nonce_snoop log.
+#       · user won   → capture the sponsor's exact transaction hash from
+#         the nonce-snoop submissions beginning at the pre-race timestamp,
+#         decode that transaction's claimAsset globalIndex, and prove that exact
+#         hash reaches a terminal status-0 receipt with no logs.
 #     The test FAILS if the sponsor never raced gi2.
 #
 #   Optional ALLOWLIST_LEG=1 phase (DISPOSABLE STACKS ONLY — restarts the
@@ -518,6 +509,76 @@ receipt_from() { # <tx-hash> → lowercase from address (empty if absent)
         | python3 -c "import json,sys; r=json.load(sys.stdin).get('result') or {}; f=r.get('from') or ''; print('' if f=='null' else f.lower())"
 }
 
+# sponsor_submission_hashes_since <ISO timestamp> → unique sponsor hashes
+# observed by eth_sendRawTransaction from the start of the race. This is only a
+# candidate set: the sponsor may submit unrelated claims concurrently, so the
+# caller MUST decode each transaction and match the exact globalIndex.
+sponsor_submission_hashes_since() {
+    local since="$1"
+    docker logs --tail 20000 "$AGGLAYER_CONTAINER" 2>&1 | strip_ansi \
+        | awk -v ts="$since" '$1 >= ts' \
+        | grep -E '"event": ?"eth_sendRawTransaction_received"' \
+        | grep -iE "\"signer\": ?\"$SPONSOR_ADDR_LC\"" \
+        | python3 -c '
+import re, sys
+seen = set()
+for line in sys.stdin:
+    for tx_hash in re.findall(r"\"tx_hash\"\s*:\s*\"(0x[0-9a-fA-F]{64})\"", line):
+        tx_hash = tx_hash.lower()
+        if tx_hash not in seen:
+            seen.add(tx_hash)
+            print(tx_hash)
+' || true
+}
+
+# sponsor_claim_global_index <tx-hash> → decimal globalIndex, or no output
+# when the hash is not yet queryable, is not sponsor-signed, or is not a full
+# claimAsset call. The two bytes32[32] proofs occupy the first 64 ABI words;
+# globalIndex is the next word after the four-byte selector.
+sponsor_claim_global_index() {
+    local tx_hash="$1"
+    rpc eth_getTransactionByHash "[\"$tx_hash\"]" | python3 -c '
+import json, sys
+expected = sys.argv[1].lower()
+try:
+    tx = json.load(sys.stdin).get("result") or {}
+except Exception:
+    sys.exit(0)
+if (tx.get("from") or "").lower() != expected:
+    sys.exit(0)
+data = (tx.get("input") or "").removeprefix("0x")
+word_start = 8 + (64 * 64)
+if len(data) < word_start + 64:
+    sys.exit(0)
+try:
+    print(int(data[word_start:word_start + 64], 16))
+except ValueError:
+    pass
+' "$SPONSOR_ADDR_LC"
+}
+
+# find_exact_sponsor_racer <ISO timestamp> <globalIndex> <timeout-secs>
+# Prints the exact sponsor tx hash whose signed claimAsset calldata names the
+# raced globalIndex. Rejected early attempts may not be queryable immediately;
+# keep polling until the same signed hash is durably accepted.
+find_exact_sponsor_racer() {
+    local since="$1" expected_gi="$2" timeout="$3" deadline hash observed_gi
+    expected_gi=$(python3 -c 'import sys; v=sys.argv[1]; print(int(v, 16) if v.lower().startswith("0x") else int(v, 10))' "$expected_gi")
+    deadline=$(( $(date +%s) + timeout ))
+    while (( $(date +%s) < deadline )); do
+        while read -r hash; do
+            [[ -n "$hash" ]] || continue
+            observed_gi=$(sponsor_claim_global_index "$hash" || true)
+            if [[ "$observed_gi" == "$expected_gi" ]]; then
+                echo "$hash"
+                return 0
+            fi
+        done < <(sponsor_submission_hashes_since "$since")
+        sleep 2
+    done
+    return 1
+}
+
 # assert_receipt_signer <tx-hash> <expected-addr-lc> <who> — HARD: a receipt
 # with no 'from' field is a FAIL, never a skipped assertion.
 assert_receipt_signer() {
@@ -865,10 +926,6 @@ pass "race deposit is ready_for_claim"
 # END and stays reliable; ISO-8601 timestamps compare lexicographically.
 RACE_START_TS=$(date -u +%Y-%m-%dT%H:%M:%S)
 
-# #55 — snapshot the accept-and-revert metric before the race so the
-# sponsor-participation proof (user-won branch) can assert it increments as the
-# sponsor's own gi2 retries get accept-and-reverted after the gi lands.
-DEDUP_BEFORE_RACE=$(metric_value "$DEDUP_METRIC")
 submit_user_claim "$DEP_JSON" 420
 WINNER=""; WINNER_TX=""
 case "$SUBMIT_OUTCOME" in
@@ -951,30 +1008,24 @@ else
     [[ "$EV2B_COUNT" == "1" ]] || fail "post-resubmission gi2 has $EV2B_COUNT ClaimEvents — accept-and-revert must not emit a second"
     pass "post-race user resubmission ACCEPT-AND-REVERTED (status-0x0 $RESUB_TX, no ClaimEvent, metric $DEDUP_BEFORE_RESUB→$DEDUP_AFTER_RESUB)"
 
-    # ...then prove the SPONSOR raced gi2, positively: after the user's LAST
-    # submission the sponsor's ClaimTxManager keeps re-broadcasting its own signed
-    # gi2 tx, which — the gi having landed — is ACCEPT-AND-REVERTED each time. So
-    # the sponsor's participation shows as its own eth_sendRawTransaction
-    # submissions in the proxy log AND further increments of the dedup-reverted
-    # metric, anchored strictly AFTER the user's resubmission (so the user's own
-    # accept-and-revert above cannot satisfy it).
-    sleep 2
-    SPONSOR_PROOF_TS=$(date -u +%Y-%m-%dT%H:%M:%S)
-    DEDUP_AT_ANCHOR=$(metric_value "$DEDUP_METRIC")
-    log "observing 20s for the sponsor's own gi=$GI2 submissions (anchor $SPONSOR_PROOF_TS)..."
-    sleep 20
-    PROOF_WINDOW=$(docker logs --tail 8000 "$AGGLAYER_CONTAINER" 2>&1 | strip_ansi \
-        | awk -v ts="$SPONSOR_PROOF_TS" '$1 >= ts')
-    SPONSOR_SUBS=$(printf '%s\n' "$PROOF_WINDOW" \
-        | grep -E "\"event\": ?\"eth_sendRawTransaction_received\"" \
-        | grep -cE "\"signer\": ?\"$SPONSOR_ADDR_LC\"" || true)
-    DEDUP_AFTER_WINDOW=$(metric_value "$DEDUP_METRIC")
-    log "post-anchor sponsor submissions: ${SPONSOR_SUBS:-0}; $DEDUP_METRIC $DEDUP_AT_ANCHOR→$DEDUP_AFTER_WINDOW (since race: ${DEDUP_BEFORE_RACE})"
-    [[ "${SPONSOR_SUBS:-0}" -ge 1 ]] \
-        || fail "no eth_sendRawTransaction from the sponsor signer $SPONSOR_ADDR_LC after the user's last submission — the sponsor never raced gi=$GI2 (no second racer)"
-    [[ "$DEDUP_AFTER_WINDOW" -gt "$DEDUP_AT_ANCHOR" ]] \
-        || fail "$DEDUP_METRIC did not increment after the user stopped ($DEDUP_AT_ANCHOR → $DEDUP_AFTER_WINDOW) — the sponsor's own gi=$GI2 retries were not accept-and-reverted (cannot attribute continued claiming to the sponsor)"
-    pass "sponsor participation proven: sponsor kept submitting gi=$GI2 after the user stopped ($SPONSOR_SUBS submissions; dedup-reverted $DEDUP_AT_ANCHOR→$DEDUP_AFTER_WINDOW)"
+    # ...then prove the SPONSOR was the actual second racer, not merely that
+    # unrelated sponsor traffic happened later. Start from the pre-race anchor,
+    # enumerate sponsor-signed submissions, fetch each exact transaction, and
+    # decode claimAsset.globalIndex. The matching hash must itself reach a
+    # terminal status-0 receipt with empty logs. This is causal evidence for the
+    # raced gi; no global metric delta or post-finalisation traffic inference can
+    # satisfy it.
+    SPONSOR_LOSER_TX=$(find_exact_sponsor_racer "$RACE_START_TS" "$GI2" 300) \
+        || fail "no sponsor-signed claimAsset transaction for raced gi=$GI2 was captured from race anchor $RACE_START_TS"
+    wait_for "exact sponsor racer receipt (status 0x0)" \
+        "[[ \"\$(receipt_status '$SPONSOR_LOSER_TX')\" == '0x0' ]]" 300 2
+    receipt_logs_empty "$SPONSOR_LOSER_TX" \
+        || fail "exact sponsor racer $SPONSOR_LOSER_TX for gi=$GI2 must have empty logs"
+    assert_receipt_signer "$SPONSOR_LOSER_TX" "$SPONSOR_ADDR_LC" "SPONSOR"
+    read -r EV2C_COUNT _ <<<"$(claim_events_for_gi "$GI2")"
+    [[ "$EV2C_COUNT" == "1" ]] \
+        || fail "exact sponsor loser produced another ClaimEvent for gi=$GI2 (count=$EV2C_COUNT)"
+    pass "sponsor participation proven exactly: sponsor tx $SPONSOR_LOSER_TX targeted gi=$GI2 and terminally reverted (status-0x0, no logs)"
 fi
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -996,8 +1047,8 @@ echo ""
 log "======================================================================"
 log "  MANUAL USER CLAIM e2e DONE"
 log "    leg 1: user tx $LEG1_TX claimed gi=$LEG1_GI"
-log "    leg 2: winner=$WINNER tx=$WINNER_TX gi=$GI2 (single ClaimEvent, loser dedup-rejected, sponsor participation proven)"
-log "    sponsor: healed + verified functional ($SPONSOR_NOOPS_SENT wedged nonce(s) consumed)"
+log "    leg 2: winner=$WINNER tx=$WINNER_TX gi=$GI2 (single ClaimEvent, sponsor participation proven by exact tx)"
+log "    sponsor: recovery + functionality verified ($SPONSOR_NOOPS_SENT pre-existing wedged nonce(s) cleaned up)"
 log "    deposits: $DEPOSITS_SENT sent, balance exactly $((DEPOSITS_SENT * EXPECTED_UNITS_PER_DEPOSIT)) units"
 log "======================================================================"
 

--- a/scripts/e2e-manual-user-claim.sh
+++ b/scripts/e2e-manual-user-claim.sh
@@ -619,19 +619,41 @@ sponsor_nonce() {
         | python3 -c "import json,sys; print(int(json.load(sys.stdin)['result'],16))"
 }
 
-# ── #55 accept-and-revert observability ──────────────────────────────────────
-# The proxy exposes Prometheus counters on the L2_RPC port's /metrics. The
-# `claim_landed_dedup_reverted_total` counter increments each time a claimAsset
-# targeting an ALREADY-LANDED globalIndex is ACCEPTED with a reverted (status
-# 0x0) receipt instead of hard-rejected — the geth-faithful AlreadyClaimed that
-# keeps the sponsor's nonce sequence in lockstep. metric_value reads it (missing
-# => 0, it is only emitted after the first increment); an unreachable /metrics is
-# a HARD fail — a down proxy must not read as "0" (task #26 sweep lesson).
+# ── #55 already-claimed reconciliation observability ─────────────────────────
+# AggKit may encounter an already-landed claim in either of two valid places:
+# before submission, where eth_estimateGas returns AlreadyClaimed() and
+# isClaimed(...) returns true; or after a transaction was already signed, where
+# eth_sendRawTransaction accepts it and exposes a status-0/no-log receipt. Pin
+# both counters so the test can prove which path healed the sponsor. A later
+# deterministic resubmission still requires the receipt path explicitly.
 DEDUP_METRIC="claim_landed_dedup_reverted_total"
+ESTIMATE_ALREADY_CLAIMED_METRIC="rpc_estimate_gas_already_claimed_total"
 metric_value() { # <metric-name>
     local body
     body=$(curl -sf "${L2_RPC}/metrics") || fail "metrics endpoint unreachable: ${L2_RPC}/metrics"
     awk -v n="$1" '$1==n{print $2; f=1; exit} END{if(!f)print 0}' <<<"$body" | sed 's/\..*//'
+}
+
+proxy_is_claimed() { # <Solidity globalIndex>
+    local gi="$1" leaf source calldata result
+    read -r leaf source <<<"$(python3 -c '
+import sys
+gi = int(sys.argv[1], 0)
+leaf = gi & 0xffffffff
+rollup = (gi >> 32) & 0xffffffff
+mainnet = (gi >> 64) & 0xffffffff
+if mainnet == 1 and rollup == 0:
+    source = 0
+elif mainnet == 0 and rollup < 0xffffffff:
+    source = rollup + 1
+else:
+    raise SystemExit("invalid globalIndex layout")
+print(leaf, source)
+' "$gi")" || return 1
+    calldata=$(cast calldata 'isClaimed(uint32,uint32)' "$leaf" "$source") || return 1
+    result=$(rpc eth_call "[{\"to\":\"$BRIDGE_ADDRESS\",\"data\":\"$calldata\"},\"latest\"]" \
+        | python3 -c "import json,sys; print(json.load(sys.stdin).get('result') or '')") || return 1
+    [[ -n "$result" ]] && [[ $((result)) -eq 1 ]]
 }
 
 # send_sponsor_noop <nonce> — consume one sponsor nonce with a ZERO-AMOUNT
@@ -746,14 +768,9 @@ verify_sponsor_functional() {
 }
 
 # verify_sponsor_recovers_automatically <label> — the HARD #55 regression. After
-# the user front-ran a globalIndex the sponsor had already signed + persisted a
-# monitored tx for, the sponsor is wedged PRE-FIX: its doomed tx is hard-rejected
-# at RPC ("already submitted") without consuming its nonce, so ClaimTxManager
-# re-broadcasts forever ("nonce mismatch") and every later claim queues behind
-# it. WITH the #55 accept-and-revert fix the sponsor recovers on its own: when it
-# re-broadcasts the doomed tx (the gi has since LANDED), the proxy ACCEPTS it and
-# writes a reverted (status 0x0) receipt, consuming the nonce, so ethtxmanager
-# marks it mined-failed and advances — geth-faithful AlreadyClaimed.
+# the user front-ran a globalIndex, AggKit must reconcile it without a nonce
+# wedge. It may do that before submission via estimateGas AlreadyClaimed() +
+# isClaimed=true, or after signing via an accepted status-0/no-log receipt.
 #
 # This asserts that recovery WITHOUT ANY MANUAL HEAL (deliberately NO
 # drain_sponsor_wedge / zero-amount no-ops — the whole point is the fix heals it
@@ -761,13 +778,13 @@ verify_sponsor_functional() {
 #   1. a fresh deposit the user never touches is autoclaimed BY THE SPONSOR
 #      within a bound (pre-fix this hangs forever → the regression);
 #   2. no PERMANENT nonce-mismatch wedge — after a settle window the sponsor's
-#      account nonce has advanced and there is ZERO fresh sponsor nonce-mismatch
-#      spam in the most recent proxy-log window (transient mismatches DURING the
-#      heal are expected; a permanent wedge is a continuous stream);
-#   3. the `claim_landed_dedup_reverted_total` metric incremented over the run —
-#      positive proof the recovery came via accept-and-revert, not luck.
+#      account nonce is stable or advancing and there is ZERO fresh
+#      nonce-mismatch spam (transient mismatches DURING a receipt-path heal are
+#      expected; a permanent wedge is a continuous stream);
+#   3. one reconciliation-path metric incremented, with isClaimed=true required
+#      for the estimateGas path — positive proof recovery was not luck.
 verify_sponsor_recovers_automatically() {
-    local label="$1" vgi deadline now c t nonce_a nonce_b settle_ts fresh_mismatch dedup_after
+    local label="$1" vgi deadline now c t nonce_a nonce_b settle_ts fresh_mismatch dedup_after estimate_after
     step "Sponsor AUTO-recovery ($label) — #55: fresh deposit MUST autoclaim with NO manual heal"
     do_l1_deposit
     fetch_deposit_json "$L1_DEP_CNT" 300
@@ -809,23 +826,32 @@ verify_sponsor_recovers_automatically() {
         || fail "sponsor STILL emitting nonce-mismatch spam ($fresh_mismatch lines in ~15s after a settle) — permanent wedge NOT healed (#55 regression)"
     pass "no permanent sponsor nonce-mismatch wedge ($label): 0 fresh mismatch lines since settle"
 
-    # (3) The accept-and-revert metric incremented over the run — positive proof
-    # the sponsor's doomed tx was accept-and-reverted (nonce consumed), i.e. the
-    # recovery came through the #55 fix.
+    # (3) Positive proof of the exact reconciliation path. The deterministic
+    # race leg below separately pins the sendRaw status-0/no-log contract.
     dedup_after=$(metric_value "$DEDUP_METRIC")
+    estimate_after=$(metric_value "$ESTIMATE_ALREADY_CLAIMED_METRIC")
     log "$DEDUP_METRIC: baseline=$DEDUP_BEFORE now=$dedup_after"
-    [[ "$dedup_after" -gt "$DEDUP_BEFORE" ]] \
-        || fail "$DEDUP_METRIC did not increment ($DEDUP_BEFORE → $dedup_after) — the sponsor's already-landed claim was NOT accept-and-reverted; recovery was not via the #55 fix"
-    pass "$DEDUP_METRIC incremented ($DEDUP_BEFORE → $dedup_after): sponsor's landed-gi claim was accepted-and-reverted"
+    log "$ESTIMATE_ALREADY_CLAIMED_METRIC: baseline=$ESTIMATE_ALREADY_CLAIMED_BEFORE now=$estimate_after"
+    if [[ "$dedup_after" -gt "$DEDUP_BEFORE" ]]; then
+        pass "$DEDUP_METRIC incremented ($DEDUP_BEFORE → $dedup_after): signed duplicate received status-0/no-log reconciliation"
+    elif [[ "$estimate_after" -gt "$ESTIMATE_ALREADY_CLAIMED_BEFORE" ]]; then
+        proxy_is_claimed "$LEG1_GI" \
+            || fail "$ESTIMATE_ALREADY_CLAIMED_METRIC incremented but isClaimed for exact front-run gi=$LEG1_GI is not true"
+        pass "$ESTIMATE_ALREADY_CLAIMED_METRIC incremented ($ESTIMATE_ALREADY_CLAIMED_BEFORE → $estimate_after) and isClaimed(gi=$LEG1_GI)=true: AggKit reconciled before submission"
+    else
+        fail "neither already-claimed reconciliation metric incremented: sendRaw $DEDUP_BEFORE→$dedup_after, estimateGas $ESTIMATE_ALREADY_CLAIMED_BEFORE→$estimate_after"
+    fi
 }
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Leg 1 — manual user claim (user submits instead of waiting for the sponsor)
 # ══════════════════════════════════════════════════════════════════════════════
-# #55 — snapshot the accept-and-revert counter BEFORE any front-run so the
-# inter-leg auto-recovery assertion can prove it incremented.
+# #55 — snapshot both valid already-claimed reconciliation counters before the
+# front-run so the inter-leg assertion can prove which path healed AggKit.
 DEDUP_BEFORE=$(metric_value "$DEDUP_METRIC")
+ESTIMATE_ALREADY_CLAIMED_BEFORE=$(metric_value "$ESTIMATE_ALREADY_CLAIMED_METRIC")
 log "baseline $DEDUP_METRIC = $DEDUP_BEFORE"
+log "baseline $ESTIMATE_ALREADY_CLAIMED_METRIC = $ESTIMATE_ALREADY_CLAIMED_BEFORE"
 
 step "Leg 1 — deposit L1→L2, then the USER claims it manually"
 

--- a/scripts/e2e-rd940-async-submit.sh
+++ b/scripts/e2e-rd940-async-submit.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # RD-940 e2e — async-submit golden path
 #
-# With AGGLAYER_ENABLE_WRITER_WORKER=true on the agglayer service,
-# eth_sendRawTransaction should return the tx hash within ~100ms (request-thread
+# The mandatory single writer makes eth_sendRawTransaction return the tx hash
+# within ~100ms (request-thread
 # validate + enqueue, no Miden round-trip held inline). The receipt then arrives
 # asynchronously after the worker dispatches.
 #
@@ -16,8 +16,7 @@
 #      and stays at the pre-tx value on `latest` until commit.
 #
 # Pre-req:
-#   - Stack up with AGGLAYER_ENABLE_WRITER_WORKER=true
-#       AGGLAYER_ENABLE_WRITER_WORKER=true make e2e-up
+#   - Stack up with `make e2e-up`
 #   - L1→L2 path seeded (script depends on aggsender having submitted a GER
 #     recently so we can submit insertGlobalExitRoot against a fresh root)
 set -euo pipefail
@@ -46,12 +45,11 @@ pass() { echo -e "${GREEN}[$(date +%H:%M:%S)] PASS:${NC} $*"; }
 worker_active() {
     local logs
     logs=$(docker logs "$AGGLAYER_CONTAINER" 2>&1) || return 1
-    grep -q "RD-940 writer worker spawned" <<<"$logs"
+    grep -q "single writer worker spawned" <<<"$logs"
 }
 
 if ! worker_active; then
-    fail "agglayer container is not running with AGGLAYER_ENABLE_WRITER_WORKER=true. \
-         Restart the stack with: AGGLAYER_ENABLE_WRITER_WORKER=true make e2e-up"
+    fail "single writer is not active; restart the stack with: make e2e-up"
 fi
 pass "writer worker is active in $AGGLAYER_CONTAINER"
 

--- a/scripts/e2e-rd940-queue-backpressure.sh
+++ b/scripts/e2e-rd940-queue-backpressure.sh
@@ -32,9 +32,9 @@ pass() { echo -e "${GREEN}[$(date +%H:%M:%S)] PASS:${NC} $*"; }
 # closes the pipe early.
 AGGLAYER_CONT="${AGGLAYER_CONTAINER:-${COMPOSE_PROJECT_NAME:-miden-agglayer}-miden-agglayer-1}"
 LOGS=$(docker logs "$AGGLAYER_CONT" 2>&1)
-if ! grep -q "RD-940 writer worker spawned" <<<"$LOGS"; then
-    fail "writer worker not active — start stack with \
-         AGGLAYER_ENABLE_WRITER_WORKER=true AGGLAYER_WRITER_QUEUE_DEPTH=1 make e2e-up"
+if ! grep -q "single writer worker spawned" <<<"$LOGS"; then
+    fail "single writer not active — start stack with \
+         AGGLAYER_WRITER_QUEUE_DEPTH=1 make e2e-up"
 fi
 
 OUTDIR=$(mktemp -d)

--- a/scripts/e2e-rd940-restart-inflight.sh
+++ b/scripts/e2e-rd940-restart-inflight.sh
@@ -37,8 +37,8 @@ pass() { echo -e "${GREEN}[$(date +%H:%M:%S)] PASS:${NC} $*"; }
 # Phase 1: confirm worker is active. Buffer logs before grep to avoid the
 # set -o pipefail × SIGPIPE false-failure when `grep -q` closes the pipe.
 LOGS=$(docker logs "$AGGLAYER_CONTAINER" 2>&1)
-if ! grep -q "RD-940 writer worker spawned" <<<"$LOGS"; then
-    fail "writer worker not active — start with AGGLAYER_ENABLE_WRITER_WORKER=true make e2e-up"
+if ! grep -q "single writer worker spawned" <<<"$LOGS"; then
+    fail "single writer not active — start with make e2e-up"
 fi
 pass "worker is active on baseline boot"
 

--- a/src/applied_state.rs
+++ b/src/applied_state.rs
@@ -1,0 +1,322 @@
+//! Authoritative bridge-state reads used by the EVM compatibility surface.
+//!
+//! Submission locks (`claimed_indices`) deliberately do not participate here:
+//! they include in-flight work. An operation is "applied" only when either the
+//! synthetic landed projection exists or the synchronized Miden bridge account
+//! contains the corresponding GER/nullifier entry.
+
+use crate::service_state::ServiceState;
+use alloy::primitives::U256;
+use anyhow::Context;
+use miden_base_agglayer::AggLayerBridge;
+#[cfg(not(test))]
+use miden_base_agglayer::ExitRoot;
+use miden_protocol::crypto::hash::poseidon2::Poseidon2;
+#[cfg(not(test))]
+use miden_protocol::note::NoteId;
+use miden_protocol::{Felt, Word};
+#[cfg(not(test))]
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExactNoteOutcome {
+    NotApplied,
+    AppliedByExactNote,
+    AppliedElsewhere,
+    Uncertain,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NoteObservation {
+    NotRequested,
+    Missing,
+    Unconsumed,
+    Consumed,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BridgeSnapshot {
+    ger_applied: Option<bool>,
+    claim_applied: Option<bool>,
+    note: NoteObservation,
+}
+
+/// Decode the Solidity global-index layout into the nullifier coordinates
+/// stored by the Miden bridge: `(leaf_index, source_bridge_network)`.
+pub(crate) fn claim_coordinates(global_index: U256) -> anyhow::Result<(u32, u32)> {
+    let bytes = global_index.to_be_bytes::<32>();
+    if bytes[..20].iter().any(|byte| *byte != 0) {
+        anyhow::bail!("globalIndex has non-zero leading 160 bits");
+    }
+    let mainnet_flag = u32::from_be_bytes(bytes[20..24].try_into().expect("four bytes"));
+    let rollup_index = u32::from_be_bytes(bytes[24..28].try_into().expect("four bytes"));
+    let leaf_index = u32::from_be_bytes(bytes[28..32].try_into().expect("four bytes"));
+    let source = match (mainnet_flag, rollup_index) {
+        (1, 0) => 0,
+        (0, rollup) => rollup
+            .checked_add(1)
+            .context("rollup globalIndex cannot map to a uint32 source network")?,
+        (1, _) => anyhow::bail!("mainnet globalIndex has a non-zero rollup index"),
+        _ => anyhow::bail!("globalIndex mainnet flag must be 0 or 1"),
+    };
+    Ok((leaf_index, source))
+}
+
+/// Build the Solidity global index used by `claimAsset` from the arguments to
+/// `isClaimed(uint32,uint32)`.
+pub(crate) fn global_index_for_claim(leaf_index: u32, source: u32) -> U256 {
+    if source == 0 {
+        (U256::from(1u8) << 64) | U256::from(leaf_index)
+    } else {
+        (U256::from(source - 1) << 32) | U256::from(leaf_index)
+    }
+}
+
+fn claim_is_set(
+    storage: &miden_protocol::account::AccountStorage,
+    global_index: U256,
+) -> anyhow::Result<bool> {
+    let (leaf_index, source) = claim_coordinates(global_index)?;
+    let nullifier_elements = [
+        Felt::new(u64::from(leaf_index)).context("encoding claim leaf index as Felt")?,
+        Felt::new(u64::from(source)).context("encoding claim source network as Felt")?,
+    ];
+    let nullifier = Poseidon2::hash_elements(&nullifier_elements);
+    let value = storage
+        .get_map_item(AggLayerBridge::claim_nullifiers_slot_name(), nullifier)
+        .context("reading bridge claim-nullifier map")?;
+    Ok(value == Word::from([1u32, 0, 0, 0]))
+}
+
+#[cfg(test)]
+async fn bridge_snapshot(
+    _service: &ServiceState,
+    ger: Option<[u8; 32]>,
+    claim: Option<U256>,
+    note_id: Option<String>,
+) -> anyhow::Result<BridgeSnapshot> {
+    Ok(BridgeSnapshot {
+        ger_applied: ger.map(|_| false),
+        claim_applied: claim.map(|_| false),
+        note: if note_id.is_some() {
+            NoteObservation::Missing
+        } else {
+            NoteObservation::NotRequested
+        },
+    })
+}
+
+#[cfg(not(test))]
+async fn bridge_snapshot(
+    service: &ServiceState,
+    ger: Option<[u8; 32]>,
+    claim: Option<U256>,
+    note_id: Option<String>,
+) -> anyhow::Result<BridgeSnapshot> {
+    let result: Arc<Mutex<Option<BridgeSnapshot>>> = Arc::new(Mutex::new(None));
+    let result_in = result.clone();
+    let bridge_id = service.accounts.0.bridge.0;
+
+    service
+        .miden_client
+        .with(move |client| {
+            Box::new(async move {
+                let bridge = client
+                    .get_account(bridge_id)
+                    .await
+                    .context("reading Miden bridge account")?
+                    .context("Miden bridge account is not available locally after sync")?;
+
+                let ger_applied = ger
+                    .map(|root| {
+                        AggLayerBridge::is_ger_registered(ExitRoot::new(root), &bridge)
+                            .context("reading bridge GER map")
+                    })
+                    .transpose()?;
+                let claim_applied = claim
+                    .map(|gi| claim_is_set(bridge.storage(), gi))
+                    .transpose()?;
+                let note = match note_id {
+                    None => NoteObservation::NotRequested,
+                    Some(note_id) => {
+                        let note_id = NoteId::try_from_hex(&note_id)
+                            .context("parsing exact handoff NoteId")?;
+                        match client
+                            .get_output_note(note_id)
+                            .await
+                            .context("reading exact handoff output note")?
+                        {
+                            None => NoteObservation::Missing,
+                            Some(note) if note.is_consumed() => NoteObservation::Consumed,
+                            Some(_) => NoteObservation::Unconsumed,
+                        }
+                    }
+                };
+                *result_in.lock().expect("bridge snapshot mutex poisoned") = Some(BridgeSnapshot {
+                    ger_applied,
+                    claim_applied,
+                    note,
+                });
+                Ok(())
+            })
+        })
+        .await?;
+
+    let snapshot = result
+        .lock()
+        .expect("bridge snapshot mutex poisoned")
+        .take();
+    snapshot.context("Miden bridge-state request completed without a snapshot")
+}
+
+pub(crate) async fn ger_applied(service: &ServiceState, ger: &[u8; 32]) -> anyhow::Result<bool> {
+    if service.store.is_ger_injected(ger).await? {
+        return Ok(true);
+    }
+    bridge_snapshot(service, Some(*ger), None, None)
+        .await?
+        .ger_applied
+        .context("GER state was not requested")
+}
+
+pub(crate) async fn claim_applied(
+    service: &ServiceState,
+    global_index: U256,
+) -> anyhow::Result<bool> {
+    if service
+        .store
+        .has_claim_event_for_global_index(&global_index.to_be_bytes::<32>())
+        .await?
+    {
+        return Ok(true);
+    }
+    bridge_snapshot(service, None, Some(global_index), None)
+        .await?
+        .claim_applied
+        .context("claim state was not requested")
+}
+
+/// Read claim and GER state with at most one serialized Miden-client request.
+pub(crate) async fn claim_and_ger_applied(
+    service: &ServiceState,
+    global_index: U256,
+    ger: &[u8; 32],
+) -> anyhow::Result<(bool, bool)> {
+    let projected_claim = service
+        .store
+        .has_claim_event_for_global_index(&global_index.to_be_bytes::<32>())
+        .await?;
+    let projected_ger = service.store.is_ger_injected(ger).await?;
+    if projected_claim && projected_ger {
+        return Ok((true, true));
+    }
+    let snapshot = bridge_snapshot(
+        service,
+        (!projected_ger).then_some(*ger),
+        (!projected_claim).then_some(global_index),
+        None,
+    )
+    .await?;
+    Ok((
+        projected_claim || snapshot.claim_applied.unwrap_or(false),
+        projected_ger || snapshot.ger_applied.unwrap_or(false),
+    ))
+}
+
+fn classify_exact_note(applied: bool, note: NoteObservation) -> ExactNoteOutcome {
+    if !applied {
+        return ExactNoteOutcome::NotApplied;
+    }
+    match note {
+        NoteObservation::Consumed => ExactNoteOutcome::AppliedByExactNote,
+        NoteObservation::Unconsumed => ExactNoteOutcome::AppliedElsewhere,
+        NoteObservation::Missing | NoteObservation::NotRequested => ExactNoteOutcome::Uncertain,
+    }
+}
+
+pub(crate) async fn reconcile_ger_handoff(
+    service: &ServiceState,
+    ger: [u8; 32],
+    note_id: String,
+) -> anyhow::Result<ExactNoteOutcome> {
+    let projected = service.store.is_ger_injected(&ger).await?;
+    let snapshot = bridge_snapshot(service, Some(ger), None, Some(note_id)).await?;
+    Ok(classify_exact_note(
+        projected || snapshot.ger_applied.unwrap_or(false),
+        snapshot.note,
+    ))
+}
+
+pub(crate) async fn reconcile_claim_handoff(
+    service: &ServiceState,
+    global_index: U256,
+    note_id: String,
+) -> anyhow::Result<ExactNoteOutcome> {
+    let projected = service
+        .store
+        .has_claim_event_for_global_index(&global_index.to_be_bytes::<32>())
+        .await?;
+    let snapshot = bridge_snapshot(service, None, Some(global_index), Some(note_id)).await?;
+    Ok(classify_exact_note(
+        projected || snapshot.claim_applied.unwrap_or(false),
+        snapshot.note,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_claimed_arguments_round_trip_to_global_index() {
+        let mainnet = global_index_for_claim(42, 0);
+        assert_eq!(claim_coordinates(mainnet).unwrap(), (42, 0));
+
+        let rollup = global_index_for_claim(99, 7);
+        assert_eq!(claim_coordinates(rollup).unwrap(), (99, 7));
+        assert_eq!(rollup, (U256::from(6u8) << 32) | U256::from(99u8));
+    }
+
+    #[test]
+    fn claim_nullifier_reads_leaf_and_source_qualified_key() {
+        use miden_protocol::account::{AccountStorage, StorageMap, StorageMapKey, StorageSlot};
+
+        let leaf = 42u32;
+        let source = 7u32;
+        let key = Poseidon2::hash_elements(&[
+            Felt::new(u64::from(leaf)).unwrap(),
+            Felt::new(u64::from(source)).unwrap(),
+        ]);
+        let mut map = StorageMap::new();
+        map.insert(StorageMapKey::new(key), Word::from([1u32, 0, 0, 0]))
+            .unwrap();
+        let storage = AccountStorage::new(vec![StorageSlot::with_map(
+            AggLayerBridge::claim_nullifiers_slot_name().clone(),
+            map,
+        )])
+        .unwrap();
+
+        assert!(claim_is_set(&storage, global_index_for_claim(leaf, source)).unwrap());
+        assert!(!claim_is_set(&storage, global_index_for_claim(leaf, source + 1)).unwrap());
+    }
+
+    #[test]
+    fn exact_note_confirmation_never_guesses() {
+        assert_eq!(
+            classify_exact_note(true, NoteObservation::Unconsumed),
+            ExactNoteOutcome::AppliedElsewhere
+        );
+        assert_eq!(
+            classify_exact_note(true, NoteObservation::Consumed),
+            ExactNoteOutcome::AppliedByExactNote
+        );
+        assert_eq!(
+            classify_exact_note(true, NoteObservation::Missing),
+            ExactNoteOutcome::Uncertain
+        );
+        assert_eq!(
+            classify_exact_note(false, NoteObservation::Unconsumed),
+            ExactNoteOutcome::NotApplied
+        );
+    }
+}

--- a/src/applied_state.rs
+++ b/src/applied_state.rs
@@ -218,8 +218,8 @@ pub(crate) async fn claim_and_ger_applied(
         .has_claim_event_for_global_index(&global_index.to_be_bytes::<32>())
         .await?;
     let projected_ger = service.store.is_ger_injected(ger).await?;
-    if projected_claim && projected_ger {
-        return Ok((true, true));
+    if projected_claim {
+        return Ok((true, projected_ger));
     }
     let snapshot = bridge_snapshot(
         service,

--- a/src/applied_state.rs
+++ b/src/applied_state.rs
@@ -5,14 +5,14 @@
 //! synthetic landed projection exists or the synchronized Miden bridge account
 //! contains the corresponding GER/nullifier entry.
 
+use crate::miden_client::MidenClientLib;
 use crate::service_state::ServiceState;
+use crate::store::Store;
 use alloy::primitives::U256;
 use anyhow::Context;
-use miden_base_agglayer::AggLayerBridge;
-#[cfg(not(test))]
-use miden_base_agglayer::ExitRoot;
+use miden_base_agglayer::{AggLayerBridge, ExitRoot};
+use miden_protocol::account::AccountId;
 use miden_protocol::crypto::hash::poseidon2::Poseidon2;
-#[cfg(not(test))]
 use miden_protocol::note::NoteId;
 use miden_protocol::{Felt, Word};
 #[cfg(not(test))]
@@ -88,6 +88,50 @@ fn claim_is_set(
     Ok(value == Word::from([1u32, 0, 0, 0]))
 }
 
+async fn bridge_snapshot_with_client(
+    client: &mut MidenClientLib,
+    bridge_id: AccountId,
+    ger: Option<[u8; 32]>,
+    claim: Option<U256>,
+    note_id: Option<String>,
+) -> anyhow::Result<BridgeSnapshot> {
+    let bridge = client
+        .get_account(bridge_id)
+        .await
+        .context("reading Miden bridge account")?
+        .context("Miden bridge account is not available locally after sync")?;
+
+    let ger_applied = ger
+        .map(|root| {
+            AggLayerBridge::is_ger_registered(ExitRoot::new(root), &bridge)
+                .context("reading bridge GER map")
+        })
+        .transpose()?;
+    let claim_applied = claim
+        .map(|gi| claim_is_set(bridge.storage(), gi))
+        .transpose()?;
+    let note = match note_id {
+        None => NoteObservation::NotRequested,
+        Some(note_id) => {
+            let note_id = NoteId::try_from_hex(&note_id).context("parsing exact handoff NoteId")?;
+            match client
+                .get_output_note(note_id)
+                .await
+                .context("reading exact handoff output note")?
+            {
+                None => NoteObservation::Missing,
+                Some(note) if note.is_consumed() => NoteObservation::Consumed,
+                Some(_) => NoteObservation::Unconsumed,
+            }
+        }
+    };
+    Ok(BridgeSnapshot {
+        ger_applied,
+        claim_applied,
+        note,
+    })
+}
+
 #[cfg(test)]
 async fn bridge_snapshot(
     _service: &ServiceState,
@@ -121,52 +165,19 @@ async fn bridge_snapshot(
         .miden_client
         .with(move |client| {
             Box::new(async move {
-                let bridge = client
-                    .get_account(bridge_id)
-                    .await
-                    .context("reading Miden bridge account")?
-                    .context("Miden bridge account is not available locally after sync")?;
-
-                let ger_applied = ger
-                    .map(|root| {
-                        AggLayerBridge::is_ger_registered(ExitRoot::new(root), &bridge)
-                            .context("reading bridge GER map")
-                    })
-                    .transpose()?;
-                let claim_applied = claim
-                    .map(|gi| claim_is_set(bridge.storage(), gi))
-                    .transpose()?;
-                let note = match note_id {
-                    None => NoteObservation::NotRequested,
-                    Some(note_id) => {
-                        let note_id = NoteId::try_from_hex(&note_id)
-                            .context("parsing exact handoff NoteId")?;
-                        match client
-                            .get_output_note(note_id)
-                            .await
-                            .context("reading exact handoff output note")?
-                        {
-                            None => NoteObservation::Missing,
-                            Some(note) if note.is_consumed() => NoteObservation::Consumed,
-                            Some(_) => NoteObservation::Unconsumed,
-                        }
-                    }
-                };
-                *result_in.lock().expect("bridge snapshot mutex poisoned") = Some(BridgeSnapshot {
-                    ger_applied,
-                    claim_applied,
-                    note,
-                });
+                let snapshot =
+                    bridge_snapshot_with_client(client, bridge_id, ger, claim, note_id).await?;
+                *result_in.lock().expect("bridge snapshot mutex poisoned") = Some(snapshot);
                 Ok(())
             })
         })
         .await?;
 
-    let snapshot = result
+    result
         .lock()
         .expect("bridge snapshot mutex poisoned")
-        .take();
-    snapshot.context("Miden bridge-state request completed without a snapshot")
+        .take()
+        .context("Miden bridge-state request completed without a snapshot")
 }
 
 pub(crate) async fn ger_applied(service: &ServiceState, ger: &[u8; 32]) -> anyhow::Result<bool> {
@@ -234,31 +245,46 @@ fn classify_exact_note(applied: bool, note: NoteObservation) -> ExactNoteOutcome
     }
 }
 
-pub(crate) async fn reconcile_ger_handoff(
-    service: &ServiceState,
+pub(crate) async fn reconcile_ger_handoff_with_client(
+    store: &dyn Store,
+    client: &mut MidenClientLib,
+    bridge_id: AccountId,
     ger: [u8; 32],
     note_id: String,
 ) -> anyhow::Result<ExactNoteOutcome> {
-    let projected = service.store.is_ger_injected(&ger).await?;
-    let snapshot = bridge_snapshot(service, Some(ger), None, Some(note_id)).await?;
+    if store.is_ger_injected(&ger).await? {
+        // GER event + a still-pending receipt can only be another transaction:
+        // normal projection persists the event and its linked receipt atomically.
+        return Ok(ExactNoteOutcome::AppliedElsewhere);
+    }
+    let snapshot =
+        bridge_snapshot_with_client(client, bridge_id, Some(ger), None, Some(note_id)).await?;
     Ok(classify_exact_note(
-        projected || snapshot.ger_applied.unwrap_or(false),
+        snapshot.ger_applied.unwrap_or(false),
         snapshot.note,
     ))
 }
 
-pub(crate) async fn reconcile_claim_handoff(
-    service: &ServiceState,
+pub(crate) async fn reconcile_claim_handoff_with_client(
+    store: &dyn Store,
+    client: &mut MidenClientLib,
+    bridge_id: AccountId,
     global_index: U256,
     note_id: String,
 ) -> anyhow::Result<ExactNoteOutcome> {
-    let projected = service
-        .store
+    if store
         .has_claim_event_for_global_index(&global_index.to_be_bytes::<32>())
-        .await?;
-    let snapshot = bridge_snapshot(service, None, Some(global_index), Some(note_id)).await?;
+        .await?
+    {
+        // ClaimEvent + a still-pending receipt can only be another transaction:
+        // normal projection persists the event and its linked receipt atomically.
+        return Ok(ExactNoteOutcome::AppliedElsewhere);
+    }
+    let snapshot =
+        bridge_snapshot_with_client(client, bridge_id, None, Some(global_index), Some(note_id))
+            .await?;
     Ok(classify_exact_note(
-        projected || snapshot.claim_applied.unwrap_or(false),
+        snapshot.claim_applied.unwrap_or(false),
         snapshot.note,
     ))
 }

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -784,6 +784,7 @@ async fn publish_claim_internal(
     latest_block_num: BlockNumber,
     reject_zero_padding: bool,
     expected_mints: Option<&Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
+    submission_fence: crate::service_send_raw_txn::ClaimSubmissionFence,
     // Opt-in local prover used as a fallback when the remote prover
     // configured on the surrounding `MidenClient` fails. `None` when
     // either (a) no remote prover is configured (the active prover IS
@@ -939,6 +940,10 @@ async fn publish_claim_internal(
     // prove step for the remote→local prover fallback above), so it must
     // call the chokepoint check itself before touching the node.
     crate::miden_client::ensure_writable(accounts.service.0)?;
+    // Atomically seal the current claim fence and persist the note handoff
+    // before the first external side effect. A stale reclaimed owner cannot
+    // submit or overwrite the successor note link.
+    submission_fence.mark_submitted(&note_commitment).await?;
     let _submission_height = client
         .submit_proven_transaction(proven_tx, &tx_result)
         .await?;
@@ -1076,7 +1081,7 @@ async fn publish_claim_internal(
 /// Miden consumption block) when it observes the CLAIM note consumed — no
 /// synthetic log, tip advance, or receipt completion happens in this path.
 #[allow(clippy::too_many_arguments)]
-pub async fn publish_claim(
+pub(crate) async fn publish_claim(
     params: claimAssetCall,
     client: &MidenClient,
     accounts: crate::AccountsConfig,
@@ -1087,6 +1092,7 @@ pub async fn publish_claim(
     signer: alloy::primitives::Address,
     reject_zero_padding: bool,
     expected_mints: Option<Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
+    submission_fence: crate::service_send_raw_txn::ClaimSubmissionFence,
 ) -> anyhow::Result<PublishClaimTxn> {
     // Submit with runtime self-heal, mirroring the pattern in
     // `src/ger.rs::insert_ger`. If the inner Miden submission rejects with
@@ -1114,11 +1120,23 @@ pub async fn publish_claim(
         signer,
         reject_zero_padding,
         expected_mints.clone(),
+        submission_fence.clone(),
     )
     .await
     {
         Ok(value) => Ok(value),
         Err(err) if crate::account_recovery::is_recoverable_account_error(&err) => {
+            if store
+                .get_note_link_for_tx(&format!("{txn_hash:#x}"))
+                .await?
+                .is_some()
+            {
+                tracing::error!(
+                    eth_tx = %txn_hash, error = %err,
+                    "claim outcome is ambiguous after durable handoff; refusing to build a second note"
+                );
+                return Err(err);
+            }
             tracing::warn!(
                 err = %err,
                 eth_tx = %txn_hash,
@@ -1136,6 +1154,7 @@ pub async fn publish_claim(
                 signer,
                 reject_zero_padding,
                 expected_mints,
+                submission_fence,
             )
             .await
         }
@@ -1155,6 +1174,7 @@ async fn attempt_publish_claim(
     signer: alloy::primitives::Address,
     reject_zero_padding: bool,
     expected_mints: Option<Arc<crate::expected_mint_tracker::ExpectedMintTracker>>,
+    submission_fence: crate::service_send_raw_txn::ClaimSubmissionFence,
 ) -> anyhow::Result<PublishClaimTxn> {
     // Snapshot the opt-in local-prover fallback BEFORE entering the
     // `client.with(...)` closure — the closure receives a
@@ -1177,6 +1197,7 @@ async fn attempt_publish_claim(
                     latest_block_num,
                     reject_zero_padding,
                     expected_mints.as_ref(),
+                    submission_fence,
                     local_prover_fallback,
                 )
                 .await?;
@@ -1186,7 +1207,7 @@ async fn attempt_publish_claim(
                 // Miden block — so the receipt block == the log block. This path
                 // records ONLY a PENDING receipt (txn_begin) + the tx↔note link below.
                 store
-                    .txn_begin(
+                    .txn_begin_if_absent(
                         txn_hash,
                         crate::store::TxnEntry {
                             // id: None hides this tx from the StoreSyncListener's

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -863,6 +863,7 @@ async fn publish_claim_internal(
         .execute_transaction(accounts.service.0, txn_request)
         .await?;
     let exec_tx = tx_result.executed_transaction();
+    let expiration_block = exec_tx.expiration_block_num().as_u64();
     for (i, note) in exec_tx.output_notes().iter().enumerate() {
         let variant = match note {
             miden_protocol::transaction::RawOutputNote::Full(_) => "Full",
@@ -940,10 +941,12 @@ async fn publish_claim_internal(
     // prove step for the remote→local prover fallback above), so it must
     // call the chokepoint check itself before touching the node.
     crate::miden_client::ensure_writable(accounts.service.0)?;
-    // Atomically seal the current claim fence and persist the note handoff
-    // before the first external side effect. A stale reclaimed owner cannot
-    // submit or overwrite the successor note link.
-    submission_fence.mark_submitted(&note_commitment).await?;
+    // Atomically seal the current claim fence and persist the exact note
+    // identity before the first external side effect. It remains PREPARED
+    // until commit or exact-note observation proves inclusion.
+    submission_fence
+        .prepare(&note_commitment, &claim_note_id, expiration_block)
+        .await?;
     let _submission_height = client
         .submit_proven_transaction(proven_tx, &tx_result)
         .await?;
@@ -1000,6 +1003,7 @@ async fn publish_claim_internal(
     )
     .await?;
     if committed {
+        submission_fence.confirm(&note_commitment).await?;
         tracing::info!("claim tx {txn_id} committed to block");
         // Cantina #7: mark Landed once `wait_for_transaction_commit`
         // confirms the CLAIM tx was committed. Aggkit's miden-client
@@ -1222,18 +1226,9 @@ async fn attempt_publish_claim(
                         },
                     )
                     .await?;
-                // Tie the real claim eth-tx to the on-chain CLAIM note so the
-                // SyntheticProjector emits the ClaimEvent under THIS tx hash —
-                // whose tx carries the `claimAsset` calldata aggkit decodes for the
-                // claim's GER boundary — instead of a derived hash with empty
-                // calldata (which made aggkit's L2BridgeSyncer fail
-                // "input too short: 0 bytes" and stall certificate settlement).
-                store
-                    .record_tx_note_link(&format!("{txn_hash:#x}"), &value.note_commitment)
-                    .await?;
                 tracing::info!(
                     eth_tx = %txn_hash,
-                    "claim tx recorded pending + note↔tx link; projector finalises \
+                    "claim tx recorded pending; durable note handoff lets projector finalise \
                      receipt + ClaimEvent on consumption (cancellation-safe)"
                 );
                 let _ = result_inner.set(value);

--- a/src/claim_watcher.rs
+++ b/src/claim_watcher.rs
@@ -320,7 +320,7 @@ mod tests {
 
     /// The store-side dedup contract the projector's claim derivation relies on:
     /// feeding the same global_index twice through the store paths must produce a
-    /// single ClaimEvent and a single cursor advance. Drives the store primitives
+    /// single ClaimEvent without sealing a partial synthetic block. Drives the store primitives
     /// directly to pin the dedup logic.
     #[tokio::test]
     async fn store_dedup_paths_are_idempotent() {
@@ -351,15 +351,11 @@ mod tests {
         // Both dedup predicates now return true.
         assert!(store.is_claim_note_processed(&note_id).await.unwrap());
         assert!(store.has_claim_event_for_global_index(&gi).await.unwrap());
-        assert_eq!(store.get_latest_block_number().await.unwrap(), 1);
+        assert_eq!(store.get_latest_block_number().await.unwrap(), 0);
 
-        // A second commit with the same note_id must NOT advance the block
-        // or duplicate the log — note that the InMemoryStore default impl
-        // re-inserts (the HashMap upsert), but the cursor advance is to the
-        // same block_number, and downstream dedup catches re-emission.
-        // The PgStore variant uses `ON CONFLICT DO NOTHING` so it's a true
-        // no-op. The InMemoryStore observable invariant is "ClaimEvent
-        // lookup still returns true and cursor doesn't go BACKWARD".
+        // A second commit with the same note_id is a true no-op: it neither
+        // duplicates the log nor advances the block tip. The projector owns
+        // block sealing after every note in that block has been processed.
         store
             .commit_manual_claim_event_atomic(
                 note_id.clone(),
@@ -377,6 +373,6 @@ mod tests {
             .unwrap();
         assert!(store.is_claim_note_processed(&note_id).await.unwrap());
         assert!(store.has_claim_event_for_global_index(&gi).await.unwrap());
-        assert!(store.get_latest_block_number().await.unwrap() >= 1);
+        assert_eq!(store.get_latest_block_number().await.unwrap(), 0);
     }
 }

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -49,21 +49,13 @@ pub fn combined_ger(mainnet: &[u8; 32], rollup: &[u8; 32]) -> [u8; 32] {
 /// `InputNoteRecord::details_commitment()`) AND the pending receipt row
 /// (`txn_begin`).
 ///
-/// Handoff-before-projection (PR #127 review, point 6 + follow-up): BOTH the
-/// link and the pending receipt are written INSIDE this closure, immediately
-/// after the Miden tx commits and strictly BEFORE the serialized
-/// `MidenClient::with` slot is released. The SyntheticProjector observes note
-/// consumption through the same serialized client, so it cannot tick between
-/// the note landing and the handoff existing — the GER event always rides the
-/// REAL eth-tx hash (never the derived fallback) and `txn_commit` always
-/// finds the pending row to finalise. (Pre-fix, the link was recorded here
-/// but the pending row was only created by `handle_ger_result` AFTER
-/// `insert_ger` returned and released the client; the projector could acquire
-/// the client in that gap, resolve the real linked hash, and try to finalise
-/// a receipt whose `txn_begin` didn't exist yet — on PostgreSQL that
-/// silently finalised zero rows and the late `txn_begin` then left the real
-/// receipt pending forever.) Mirrors the identical pattern in
-/// `claim::attempt_publish_claim`.
+/// Crash-safe handoff: after local execution and proof succeed, BOTH the exact
+/// note link and pending receipt are written inside this closure immediately
+/// BEFORE `submit_proven_transaction`. A crash or ambiguous RPC result can
+/// therefore never leave an externally submitted random note without its real
+/// eth transaction identity, and a same-hash retry observes the link and does
+/// not submit a second note. The serialized client also keeps projection behind
+/// this handoff. This mirrors the claim submission boundary.
 ///
 /// Cantina #21 (PR #127 review, points 1/4): this function deliberately does
 /// NOT wait for the NTX builder to consume the note into the bridge account.
@@ -107,11 +99,35 @@ async fn submit_update_ger_note(
                 let tx_request = TransactionRequestBuilder::new()
                     .own_output_notes(vec![note])
                     .build()?;
-                let tx_id = crate::metrics::meter_proof(
+                crate::miden_client::ensure_writable(ger_manager_id)?;
+                let tx_result = client
+                    .execute_transaction(ger_manager_id, tx_request)
+                    .await?;
+                let tx_id = tx_result.executed_transaction().id();
+                let proven_tx = crate::metrics::meter_proof(
                     crate::metrics::ProofKind::Ger,
-                    crate::miden_client::submit_new_transaction(client, ger_manager_id, tx_request),
+                    client.prove_transaction(&tx_result),
                 )
                 .await?;
+
+                // The note identity and pending receipt become durable immediately
+                // before the first external submit. A crash after this point is
+                // fail-closed: same-hash rebroadcasts observe the link and never
+                // build a second random UpdateGerNote.
+                record_ger_submission_handoff(
+                    &*store,
+                    txn_hash,
+                    &note_commitment,
+                    txn_envelope,
+                    signer,
+                )
+                .await?;
+                let submission_height = client
+                    .submit_proven_transaction(proven_tx, &tx_result)
+                    .await?;
+                client
+                    .apply_transaction(&tx_result, submission_height)
+                    .await?;
                 tracing::info!(
                     tx_id = %tx_id,
                     ger = %hex::encode(ger_bytes),
@@ -129,51 +145,18 @@ async fn submit_update_ger_note(
                     anyhow::bail!("UpdateGerNote tx {tx_id} not committed after 30s");
                 }
                 tracing::info!(tx_id = %tx_id, "UpdateGerNote transaction committed");
-
-                // Record the durable handoff (link + pending receipt) WHILE
-                // STILL HOLDING the serialized client — see the function
-                // docstring (handoff-before-projection). Recording after the
-                // commit (not before the submit) keeps the recoverable-retry
-                // path in `insert_ger` correct: a failed attempt records
-                // nothing, so the retry's fresh note gets the first (and
-                // only) link for this eth-tx and a single pending row.
-                record_ger_submission_handoff(
-                    &*store,
-                    txn_hash,
-                    &note_commitment,
-                    txn_envelope,
-                    signer,
-                )
-                .await?;
                 Ok(())
             })
         })
         .await
 }
 
-/// The durable eth-tx handoff for a committed `UpdateGerNote` submission:
-/// record the eth-tx ↔ note link AND create the pending receipt row that the
-/// SyntheticProjector finalises (`txn_commit`) when it observes the note
-/// consumed. This is the EXACT code `submit_update_ger_note` runs inside the
-/// serialized `MidenClient::with` closure, factored out so tests can drive
-/// the real submission ordering (handoff → client released → projection)
-/// without a live Miden node.
-///
-/// Ordering within the handoff — link FIRST, pending row SECOND — is what
-/// makes a partial failure retry-safe (no stray pending row):
-///
-///   - Link write fails → nothing durable exists; a resubmission of the same
-///     eth-tx re-runs the whole path cleanly.
-///   - Link lands but `txn_begin` fails → there is a link but NO pending row.
-///     The projector tolerates the missing row (`let _ = txn_commit` in
-///     `project_ger_note`; both stores now error identically on the missing
-///     row) and still emits the GER event under the real linked hash, from
-///     which `service_get_txn_receipt` can synthesise the receipt. A
-///     resubmission re-runs the path: `record_tx_note_link` is first-write-
-///     wins (no-op) and `txn_begin` creates the one pending row.
-///   - The reverse order would allow the original bug shape: a pending row
-///     with no link, which the projector can never finalise (derived-hash
-///     fallback) — pending forever.
+/// Durable pre-submit handoff for an `UpdateGerNote`: record the exact note link
+/// and idempotently create or enrich the pending receipt before the external
+/// submit. In normal RPC flow the unlinked pending row already exists as the
+/// durable admission intent. Link failure leaves that intent retryable; once the
+/// link lands, recovery is fail-closed and cannot build a second random note.
+/// The projector can always attribute a later consumption to the real eth hash.
 pub(crate) async fn record_ger_submission_handoff(
     store: &dyn crate::store::Store,
     txn_hash: TxHash,
@@ -181,16 +164,19 @@ pub(crate) async fn record_ger_submission_handoff(
     txn_envelope: TxEnvelope,
     signer: Address,
 ) -> anyhow::Result<()> {
-    store
-        .record_tx_note_link(&format!("{txn_hash:#x}"), note_commitment)
-        .await?;
+    let tx_key = format!("{txn_hash:#x}");
+    store.record_tx_note_link(&tx_key, note_commitment).await?;
+    let linked = store.get_note_link_for_tx(&tx_key).await?;
+    if linked.as_deref() != Some(note_commitment) {
+        anyhow::bail!("transaction {tx_key} is already linked to a different GER note");
+    }
     // `id: None` hides this row from the StoreSyncListener's commit-pending
     // sweep (which finalises by Miden tx id at the note's CREATION block);
     // the projector finalises it at the CONSUMPTION block instead — receipt
     // block == GER-log block. No `expires_at`: GER receipts are finalised by
     // consumption, not TTL (matches the pre-existing pending-row semantics).
     store
-        .txn_begin(
+        .txn_begin_if_absent(
             txn_hash,
             crate::store::TxnEntry {
                 id: None,
@@ -262,6 +248,17 @@ pub async fn insert_ger(
         {
             Ok(()) => {}
             Err(err) if crate::account_recovery::is_recoverable_account_error(&err) => {
+                if store
+                    .get_note_link_for_tx(&format!("{txn_hash:#x}"))
+                    .await?
+                    .is_some()
+                {
+                    tracing::error!(
+                        %txn_hash, error = %err,
+                        "GER submission outcome is ambiguous after durable handoff; refusing to rebuild a second note"
+                    );
+                    return Err(err);
+                }
                 tracing::warn!(
                     err = %err,
                     ger = %hex::encode(ger_bytes),
@@ -279,11 +276,8 @@ pub async fn insert_ger(
                     "ger_manager",
                 )
                 .await?;
-                // Retry-safety: the first attempt failed BEFORE its handoff
-                // (account errors surface at submit/commit time, and the
-                // handoff only runs after commit confirmation), so no link or
-                // pending row exists yet — the retry's fresh note records
-                // both exactly once.
+                // No durable link exists, so the failure occurred before the
+                // external submission boundary and a fresh local retry is safe.
                 submit_update_ger_note(
                     miden_client,
                     accounts.clone(),

--- a/src/ger.rs
+++ b/src/ger.rs
@@ -84,6 +84,7 @@ async fn submit_update_ger_note(
                 let bridge_id = inner_accounts.bridge.0;
                 let ger = ExitRoot::new(ger_bytes);
                 let note = UpdateGerNote::create(ger, ger_manager_id, bridge_id, client.rng())?;
+                let note_id = note.id().to_string();
                 // Commitment of the on-chain note, matching the projector's
                 // consumed-note key (`InputNoteRecord::details_commitment()`).
                 let note_commitment = hex::encode(
@@ -104,6 +105,10 @@ async fn submit_update_ger_note(
                     .execute_transaction(ger_manager_id, tx_request)
                     .await?;
                 let tx_id = tx_result.executed_transaction().id();
+                let expiration_block = tx_result
+                    .executed_transaction()
+                    .expiration_block_num()
+                    .as_u64();
                 let proven_tx = crate::metrics::meter_proof(
                     crate::metrics::ProofKind::Ger,
                     client.prove_transaction(&tx_result),
@@ -118,6 +123,8 @@ async fn submit_update_ger_note(
                     &*store,
                     txn_hash,
                     &note_commitment,
+                    &note_id,
+                    expiration_block,
                     txn_envelope,
                     signer,
                 )
@@ -144,6 +151,13 @@ async fn submit_update_ger_note(
                 if !committed {
                     anyhow::bail!("UpdateGerNote tx {tx_id} not committed after 30s");
                 }
+                let tx_key = format!("{txn_hash:#x}");
+                if !store
+                    .confirm_note_handoff(&tx_key, &note_commitment)
+                    .await?
+                {
+                    anyhow::bail!("GER note handoff changed before commit confirmation");
+                }
                 tracing::info!(tx_id = %tx_id, "UpdateGerNote transaction committed");
                 Ok(())
             })
@@ -161,15 +175,15 @@ pub(crate) async fn record_ger_submission_handoff(
     store: &dyn crate::store::Store,
     txn_hash: TxHash,
     note_commitment: &str,
+    note_id: &str,
+    expiration_block: u64,
     txn_envelope: TxEnvelope,
     signer: Address,
 ) -> anyhow::Result<()> {
     let tx_key = format!("{txn_hash:#x}");
-    store.record_tx_note_link(&tx_key, note_commitment).await?;
-    let linked = store.get_note_link_for_tx(&tx_key).await?;
-    if linked.as_deref() != Some(note_commitment) {
-        anyhow::bail!("transaction {tx_key} is already linked to a different GER note");
-    }
+    store
+        .prepare_note_handoff(&tx_key, note_commitment, note_id, expiration_block)
+        .await?;
     // `id: None` hides this row from the StoreSyncListener's commit-pending
     // sweep (which finalises by Miden tx id at the note's CREATION block);
     // the projector finalises it at the CONSUMPTION block instead — receipt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod account_recovery;
 pub mod accounts_config;
 pub mod address_mapper;
+pub(crate) mod applied_state;
 pub mod block_monitor;
 pub mod block_state;
 pub mod bridge_address;

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,16 +215,6 @@ struct Command {
     #[arg(long, env = "MIDEN_PROVER_FALLBACK_TO_LOCAL", default_value_t = false)]
     miden_prover_fallback_to_local: bool,
 
-    /// RD-940 async writer-worker dispatch toggle. When `false` (the default
-    /// during the RD-940 rollout up to Phase 7), `eth_sendRawTransaction` runs
-    /// the existing synchronous handler unchanged. When `true`, requests are
-    /// validated on the request thread and Miden submission is enqueued to the
-    /// single writer-worker task — see `docs/design/RD-940-async-writer.md`.
-    /// The flag is plumbed end-to-end starting at Phase 0; the actual fork on
-    /// it lands in Phase 1.
-    #[arg(long, env = "AGGLAYER_ENABLE_WRITER_WORKER", default_value_t = false)]
-    enable_writer_worker: bool,
-
     /// Hard read-only guarantee for recovery drills / cold reindexes against
     /// production networks. When set, EVERY transaction submission is refused
     /// at the single chokepoint all chain mutations funnel through
@@ -371,7 +361,6 @@ impl std::fmt::Debug for Command {
                 "miden_prover_fallback_to_local",
                 &self.miden_prover_fallback_to_local,
             )
-            .field("enable_writer_worker", &self.enable_writer_worker)
             .field("read_only", &self.read_only)
             .finish()
     }
@@ -747,42 +736,28 @@ async fn main() -> anyhow::Result<()> {
     state.expected_mints = expected_mints_handle;
     state.miden_store_dir = miden_store_dir.clone().unwrap_or_default();
     state.miden_api_key = command.miden_api_key;
-    state.enable_writer_worker = command.enable_writer_worker;
-
-    // RD-940 — spawn the writer worker if the flag is set. The worker is a
-    // single tokio task with a bounded mpsc queue between it and
-    // `eth_sendRawTransaction`; see `docs/design/RD-940-async-writer.md`.
+    // The bounded single writer is the only production write path. Accepted
+    // work must outlive the HTTP request that admitted it; a synchronous
+    // fallback would reintroduce cancellation windows after nonce advancement.
     //
     // The handle is plumbed into `ServiceState` (a `Clone` struct) BEFORE
     // `service::serve` clones the state per request, so every dispatcher sees
     // the same writer channel and inflight DashMap. Phase 5: the oneshot
     // shutdown sender is held in a local so we can fire it on graceful
     // SIGTERM and drain the queue before the process exits.
-    let writer_shutdown: Option<tokio::sync::oneshot::Sender<()>> = if command.enable_writer_worker
-    {
-        let queue_depth =
-            miden_agglayer_service::writer_worker::WriterWorker::parse_queue_depth_env();
-        let tx_ttl = miden_agglayer_service::writer_worker::WriterWorker::parse_tx_ttl_env();
-        let (handle, writer_shutdown_tx) =
-            miden_agglayer_service::writer_worker::WriterWorker::spawn(
-                state.clone(),
-                queue_depth,
-                tx_ttl,
-            );
-        tracing::info!(
-            queue_depth,
-            tx_ttl_secs = tx_ttl.as_secs(),
-            "RD-940 writer worker spawned"
-        );
-        state.writer_handle = Some(Arc::new(handle));
-        Some(writer_shutdown_tx)
-    } else {
-        tracing::info!(
-            "RD-940 writer worker disabled (enable_writer_worker=false); \
-             eth_sendRawTransaction runs the legacy synchronous handler"
-        );
-        None
-    };
+    let queue_depth = miden_agglayer_service::writer_worker::WriterWorker::parse_queue_depth_env();
+    let tx_ttl = miden_agglayer_service::writer_worker::WriterWorker::parse_tx_ttl_env();
+    let (handle, writer_shutdown) = miden_agglayer_service::writer_worker::WriterWorker::spawn(
+        state.clone(),
+        queue_depth,
+        tx_ttl,
+    );
+    tracing::info!(
+        queue_depth,
+        tx_ttl_secs = tx_ttl.as_secs(),
+        "single writer worker spawned"
+    );
+    state.writer_handle = Some(Arc::new(handle));
 
     // L1 InfoTree indexer — eliminates the RD-862 GER decomposition race by
     // proactively indexing every (mainnet, rollup) pair as L1 emits it,
@@ -980,40 +955,38 @@ async fn main() -> anyhow::Result<()> {
     // count to the dropped_on_restart tmpfile for the next boot. The
     // budget (20 s) sits inside aggkit's `WaitTxToBeMined = 2 m` so even
     // a partial drain doesn't leave aggkit wedged.
-    if let Some(shutdown_tx) = writer_shutdown {
-        let _ = shutdown_tx.send(());
-        tracing::info!("RD-940 writer worker: drain signal sent");
-        // Light wait — the worker exits its recv loop on the next
-        // iteration. We don't await a JoinHandle (Phase 1 didn't expose
-        // one). A short sleep gives the worker time to flip terminal_at
-        // on anything currently mid-dispatch.
-        tokio::time::sleep(std::time::Duration::from_secs(20)).await;
-        let residual = state
-            .writer_handle
-            .as_ref()
-            .map(|h| h.inflight_non_terminal_count())
-            .unwrap_or(0);
-        if residual > 0 {
-            tracing::warn!(
-                residual,
-                "RD-940 graceful drain: {residual} job(s) still in non-terminal state; \
-                 writing snapshot to {} for next-boot dropped_on_restart accounting",
-                miden_agglayer_service::writer_worker::DROP_SNAPSHOT_PATH
-            );
-            miden_agglayer_service::writer_worker::write_drop_snapshot(residual as u64);
-            ::metrics::counter!(
-                "agglayer_writer_drain_outcome_total",
-                "outcome" => "partial",
-            )
-            .increment(1);
-        } else {
-            tracing::info!("RD-940 graceful drain: queue empty, clean shutdown");
-            ::metrics::counter!(
-                "agglayer_writer_drain_outcome_total",
-                "outcome" => "clean",
-            )
-            .increment(1);
-        }
+    let _ = writer_shutdown.send(());
+    tracing::info!("single writer worker: drain signal sent");
+    // Light wait — the worker exits its recv loop on the next
+    // iteration. We don't await a JoinHandle (Phase 1 didn't expose
+    // one). A short sleep gives the worker time to flip terminal_at
+    // on anything currently mid-dispatch.
+    tokio::time::sleep(std::time::Duration::from_secs(20)).await;
+    let residual = state
+        .writer_handle
+        .as_ref()
+        .map(|h| h.inflight_non_terminal_count())
+        .unwrap_or(0);
+    if residual > 0 {
+        tracing::warn!(
+            residual,
+            "RD-940 graceful drain: {residual} job(s) still in non-terminal state; \
+             writing snapshot to {} for next-boot dropped_on_restart accounting",
+            miden_agglayer_service::writer_worker::DROP_SNAPSHOT_PATH
+        );
+        miden_agglayer_service::writer_worker::write_drop_snapshot(residual as u64);
+        ::metrics::counter!(
+            "agglayer_writer_drain_outcome_total",
+            "outcome" => "partial",
+        )
+        .increment(1);
+    } else {
+        tracing::info!("RD-940 graceful drain: queue empty, clean shutdown");
+        ::metrics::counter!(
+            "agglayer_writer_drain_outcome_total",
+            "outcome" => "clean",
+        )
+        .increment(1);
     }
 
     state.miden_client.shutdown()?;
@@ -1084,7 +1057,6 @@ mod hardening_tests {
             miden_prover_url: prover_url,
             miden_prover_timeout_secs: 120,
             miden_prover_fallback_to_local: false,
-            enable_writer_worker: false,
             read_only: false,
         }
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -88,6 +88,14 @@ pub fn init_metrics() {
          crash in the receipt→nonce window is the recovery WORKING (the signer is NOT wedged); a \
          steady climb without restarts would signal a store that is losing nonce writes."
     );
+    describe_counter!(
+        "rpc_nonce_reservation_lost_total",
+        "#55 BLOCKER 1 cross-replica guard: a submission LOST the atomic (signer, nonce) \
+         reservation to a DIFFERENT tx that already owned the slot, so it was rejected without \
+         executing (no enqueue/dispatch/receipt). Nonzero means two txs raced the same nonce \
+         slot (across replicas or a stale replacement) and the reservation kept exactly one; the \
+         winner advances the nonce and the loser is dropped, mirroring geth."
+    );
     describe_counter!("ger_injections_total", "Total GER injections");
     describe_gauge!(
         "projector_visibility_barrier_held_blocks",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -320,9 +320,7 @@ pub fn init_metrics() {
          other call sites). Recorded on both success and error paths."
     );
 
-    // RD-940 — async writer worker observability (Spec F §4). Registered
-    // unconditionally so the metric series exist even when
-    // `enable_writer_worker = false`; the sync path simply never emits.
+    // RD-940 — single writer observability (Spec F §4).
     describe_gauge!(
         "agglayer_writer_queue_depth",
         "RD-940: current number of WriteJobs sitting in the writer-worker \

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -70,6 +70,15 @@ pub fn init_metrics() {
          and the sponsor's resubmission accepted. Nonzero after a crash in the submit window is \
          the recovery WORKING; a steady climb without restarts means claims are failing to land."
     );
+    describe_counter!(
+        "claim_landed_dedup_reverted_total",
+        "#55 accept-and-revert: a claimAsset targeting an ALREADY-LANDED globalIndex (a real \
+         ClaimEvent already exists) was ACCEPTED with a reverted (status 0x0) receipt instead of \
+         hard-rejected at the JSON-RPC layer — so the submitter's nonce is consumed, geth-faithful \
+         AlreadyClaimed. Nonzero means a sponsor/user cross-claimed the same gi and the sponsor's \
+         nonce sequence was kept in lockstep (autoclaim NOT wedged). A steady climb means heavy \
+         claim front-running, not a bug."
+    );
     describe_counter!("ger_injections_total", "Total GER injections");
     describe_gauge!(
         "projector_visibility_barrier_held_blocks",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -79,6 +79,15 @@ pub fn init_metrics() {
          nonce sequence was kept in lockstep (autoclaim NOT wedged). A steady climb means heavy \
          claim front-running, not a bug."
     );
+    describe_counter!(
+        "rpc_nonce_repaired_after_commit_gap_total",
+        "#55 BLOCKER-2 crash-gap repair: on a same-hash rebroadcast, the signer's expected \
+         nonce was still equal to the known tx's nonce — meaning the tx's durable receipt was \
+         persisted but its nonce advance was lost to a crash BETWEEN the two on the sync accept \
+         path — so the nonce was advanced to complete the interrupted accept. Nonzero after a \
+         crash in the receipt→nonce window is the recovery WORKING (the signer is NOT wedged); a \
+         steady climb without restarts would signal a store that is losing nonce writes."
+    );
     describe_counter!("ger_injections_total", "Total GER injections");
     describe_gauge!(
         "projector_visibility_barrier_held_blocks",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -360,9 +360,9 @@ pub fn init_metrics() {
         "agglayer_writer_dropped_on_restart_total",
         "RD-940: queue-depth snapshot read on boot from the previous \
          process's graceful shutdown. A non-zero value means the previous \
-         restart dropped that many in-flight jobs whose hashes had already \
-         been returned to callers — those callers MUST re-submit. \
-         **Hard page on increase[1h]>0** — v1 tripwire (no on-disk queue). \
+         restart lost that many in-memory dispatches whose signed envelopes \
+         remain durable — those callers MUST re-submit the SAME hash. \
+         **Hard page on increase[1h]>0** — restart-pressure tripwire. \
          The metric is silent under SIGKILL because the tmpfile is only \
          written on graceful drain; combined with pre-kill queue-depth \
          history this still pinpoints the loss window."

--- a/src/miden_client.rs
+++ b/src/miden_client.rs
@@ -419,6 +419,44 @@ impl MidenClient {
         }
     }
 
+    /// Test stub whose first serialized client request remains blocked until
+    /// the returned sender is signalled. Used to prove read-only RPC polling
+    /// never queues behind an in-progress Miden writer.
+    #[cfg(test)]
+    pub fn new_test_blocked() -> (Self, std::sync::mpsc::Sender<()>) {
+        let store_dir = tempfile::tempdir().unwrap().keep();
+        let keystore_path = store_dir.join("keystore");
+        std::fs::create_dir_all(&keystore_path).unwrap();
+        let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
+        let (sender, mut receiver) = mpsc::channel::<Request>(1);
+        let (done_sender, _done_receiver) = oneshot::channel::<()>();
+        let (release_sender, release_receiver) = std::sync::mpsc::channel::<()>();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_clone = call_count.clone();
+
+        thread::spawn(move || {
+            if let Some(req) = receiver.blocking_recv() {
+                call_count_clone.fetch_add(1, Ordering::SeqCst);
+                let _ = release_receiver.recv();
+                let _ = req.response_sender.send(Ok(()));
+            }
+        });
+
+        (
+            Self {
+                keystore,
+                task: std::sync::Mutex::new(None),
+                sender,
+                done_sender: std::sync::Mutex::new(Some(done_sender)),
+                alive: Arc::new(AtomicBool::new(true)),
+                local_prover_fallback: None,
+                listeners_paused: Arc::new(AtomicBool::new(false)),
+                call_count,
+            },
+            release_sender,
+        )
+    }
+
     /// Returns the number of times `.with()` was called on this test stub.
     #[cfg(test)]
     pub fn test_call_count(&self) -> usize {

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -1212,6 +1212,13 @@ pub(crate) async fn project_claim_note(
         return Ok(ClaimProjectOutcome::Skipped);
     }
 
+    // Exact local observation is authoritative even if an earlier projector
+    // already emitted the event. Promote the durable handoff before either
+    // dedup return so expiration recovery cannot later reopen this claim.
+    let observed_tx_hash = store
+        .confirm_note_handoff_by_commitment(&note_id_str)
+        .await?;
+
     // Dedup 1: was this CLAIM already replayed by an earlier restore (or by the
     // live watcher)?
     if store.is_claim_note_processed(&note_id_str).await? {
@@ -1267,9 +1274,12 @@ pub(crate) async fn project_claim_note(
     // aggkit fails "input too short: 0 bytes" and never settles the certificate.
     // Fall back to the derived hash only for notes with no recorded link (e.g.
     // restore replaying history predating the link, or notes submitted out-of-band).
-    let (tx_hash, linked) = match store.get_tx_for_note(&note_id_str).await? {
-        Some(real_tx) => (real_tx, true),
-        None => (derive_manual_claim_tx_hash(&note_id_str), false),
+    let tx_hash = match observed_tx_hash {
+        Some(real_tx) => real_tx,
+        None => match store.get_tx_for_note(&note_id_str).await? {
+            Some(real_tx) => real_tx,
+            None => derive_manual_claim_tx_hash(&note_id_str),
+        },
     };
 
     store
@@ -1286,25 +1296,6 @@ pub(crate) async fn project_claim_note(
             decoded.amount,
         )
         .await?;
-
-    // The projector OWNS receipt completion: finalise the real claim tx's receipt
-    // at THIS (consumption) block — the same block the ClaimEvent is emitted — so the
-    // receipt block == the log block. `publish_claim` left it pending (`id: None`) for
-    // exactly this. Tolerate a missing pending entry (derived-hash fallback, which has
-    // no real `txn_begin`; or an expired/pruned tx, or restore predating the tx
-    // record): the receipt is then synthesised from the log by `service_get_txn_receipt`,
-    // so a missing entry must not abort the projection.
-    if let Some(h) = linked
-        .then(|| tx_hash.parse::<alloy::primitives::TxHash>().ok())
-        .flatten()
-    {
-        let _ = store
-            .txn_commit(h, Ok(()), block_number, block_hash)
-            .await
-            .inspect_err(|e| {
-                tracing::debug!(tx = %tx_hash, "claim receipt not finalised: {e}");
-            });
-    }
 
     ::metrics::counter!("claim_watcher_synthesised_total").increment(1);
     tracing::info!(
@@ -1514,6 +1505,13 @@ pub(crate) async fn project_ger_note(
         }
     }
 
+    let note_commitment = hex::encode(note.details_commitment().as_bytes());
+    // Promote before storage/dedup exits: seeing our exact note proves that a
+    // prepared handoff must not be cleared and rebuilt after expiration.
+    let observed_tx_hash = store
+        .confirm_note_handoff_by_commitment(&note_commitment)
+        .await?;
+
     let storage = details.storage();
     let items = storage.items();
     if items.len() < UpdateGerNote::NUM_STORAGE_ITEMS {
@@ -1550,15 +1548,17 @@ pub(crate) async fn project_ger_note(
     // the note↔tx link `insert_ger` recorded), falling back to a derived hash only
     // for notes with no recorded link (restore replaying history predating the link,
     // or out-of-band injects).
-    let note_commitment = hex::encode(note.details_commitment().as_bytes());
-    let (tx_hash, linked) = match store.get_tx_for_note(&note_commitment).await? {
-        Some(real_tx) => (real_tx, true),
-        None => {
-            let mut hasher = Keccak256::new();
-            hasher.update(b"restore-ger-miden-");
-            hasher.update(note_commitment.as_bytes());
-            (format!("0x{}", hex::encode(hasher.finalize())), false)
-        }
+    let tx_hash = match observed_tx_hash {
+        Some(real_tx) => real_tx,
+        None => match store.get_tx_for_note(&note_commitment).await? {
+            Some(real_tx) => real_tx,
+            None => {
+                let mut hasher = Keccak256::new();
+                hasher.update(b"restore-ger-miden-");
+                hasher.update(note_commitment.as_bytes());
+                format!("0x{}", hex::encode(hasher.finalize()))
+            }
+        },
     };
 
     store
@@ -1572,24 +1572,6 @@ pub(crate) async fn project_ger_note(
             timestamp,
         )
         .await?;
-
-    // The projector OWNS receipt completion: finalise the real insertGlobalExitRoot
-    // tx's receipt at THIS (consumption) block — the same block the GER log is emitted
-    // — so receipt block == log block. `insert_ger` left it pending (`id: None`).
-    // Tolerate a missing pending entry (derived-hash fallback, or restore predating the
-    // link): the receipt is then synthesised from the log by `service_get_txn_receipt`,
-    // so a missing entry must not abort the projection.
-    if let Some(h) = linked
-        .then(|| tx_hash.parse::<alloy::primitives::TxHash>().ok())
-        .flatten()
-    {
-        let _ = store
-            .txn_commit(h, Ok(()), block_number, block_hash)
-            .await
-            .inspect_err(|e| {
-                tracing::debug!(tx = %tx_hash, "GER receipt not finalised: {e}");
-            });
-    }
 
     tracing::info!(
         note_id = %hex::encode(note.details_commitment().as_bytes()),
@@ -1955,7 +1937,11 @@ mod tests {
 
         assert!(store.is_claim_note_processed(&note_id).await.unwrap());
         assert!(store.has_claim_event_for_global_index(&gi).await.unwrap());
-        assert_eq!(store.get_latest_block_number().await.unwrap(), 1);
+        assert_eq!(
+            store.get_latest_block_number().await.unwrap(),
+            0,
+            "an individual note projection must not seal its block"
+        );
 
         // Idempotency: Dedup 1 short-circuits on a second pass. We model
         // this by checking the predicate restore_claims uses BEFORE doing
@@ -3103,11 +3089,14 @@ mod tests {
         let real_tx = TxHash::from([0xEEu8; 32]);
         let real_tx_str = format!("{real_tx:#x}");
         let note_commitment = hex::encode(note.details_commitment().as_bytes());
+        let note_id = "test-ger-note-id";
         let signer = alloy::primitives::Address::from([0x42u8; 20]);
         crate::ger::record_ger_submission_handoff(
             &*store,
             real_tx,
             &note_commitment,
+            note_id,
+            1_000,
             test_ger_envelope(real_tx),
             signer,
         )

--- a/src/service.rs
+++ b/src/service.rs
@@ -247,6 +247,20 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
+pub(crate) fn select_transaction_count(
+    accepted_nonce: u64,
+    tag: &str,
+    frontier: crate::store::PendingNonceFrontier,
+) -> u64 {
+    if matches!(tag, "" | "latest" | "safe" | "finalized" | "earliest") {
+        frontier
+            .lowest_pending
+            .map_or(accepted_nonce, |nonce| accepted_nonce.min(nonce))
+    } else {
+        accepted_nonce
+    }
+}
+
 async fn json_rpc_handler(service: ServiceState, request: JsonRpcExtractor) -> JrpcResult {
     let answer_id = request.get_answer_id();
     let method_name = request.method.clone();
@@ -391,35 +405,30 @@ async fn json_rpc_handler(service: ServiceState, request: JsonRpcExtractor) -> J
                 .nonce_get(addr)
                 .await
                 .map_err(|e| store_error(answer_id.clone(), e))?;
-            let mut returned_nonce = accepted_nonce;
 
             // RD-940 Decision 4 — honour the block tag.
             //
-            // `store.nonce_get` returns the **next-accepted** nonce because
-            // `eth_sendRawTransaction` advances it on accept (both legacy and
-            // worker paths). That value matches geth's `pending` semantics
-            // directly. For `latest` / `safe` / `finalized` / `earliest` the
-            // RPC must instead return the **next-committed** nonce, computed
-            // as `next-accepted - count(inflight non-terminal jobs from this
-            // signer)`.
+            // `store.nonce_get` is the next-accepted nonce (`pending`). For
+            // committed tags, use the oldest durable pending row as the
+            // boundary. This works in sync mode and survives a writer restart;
+            // the old DashMap subtraction lost both properties.
             //
             // claim-sponsor's `nonce_cache.go:35` LRU reads `latest`; without
             // this branch it sees queued/submitting txs leak into `latest`
-            // and races itself (Spec E). When the writer worker is disabled
-            // there are no inflight jobs so the two tags agree by
-            // construction.
+            // and races itself (Spec E).
             //
             // Empty / missing tag defaults to `latest` per the geth contract
             // (`eth_getTransactionCount` second-param convention).
             let treat_as_latest = matches!(tag, "" | "latest" | "safe" | "finalized" | "earliest");
-            let mut inflight_non_terminal = 0usize;
-            if treat_as_latest
-                && let Some(handle) = service.writer_handle.as_ref()
-                && let Ok(signer_addr) = addr.parse::<alloy::primitives::Address>()
-            {
-                inflight_non_terminal = handle.count_non_terminal_for_signer(&signer_addr);
-                returned_nonce = returned_nonce.saturating_sub(inflight_non_terminal as u64);
+            let mut pending_frontier = crate::store::PendingNonceFrontier::default();
+            if treat_as_latest {
+                pending_frontier = service
+                    .store
+                    .pending_nonce_frontier(addr)
+                    .await
+                    .map_err(|e| store_error(answer_id.clone(), e))?;
             }
+            let returned_nonce = select_transaction_count(accepted_nonce, tag, pending_frontier);
 
             tracing::info!(
                 target: "rpc::nonce_snoop",
@@ -430,7 +439,8 @@ async fn json_rpc_handler(service: ServiceState, request: JsonRpcExtractor) -> J
                     "tag": tag,
                     "treat_as_latest": treat_as_latest,
                     "accepted_nonce": accepted_nonce,
-                    "inflight_non_terminal": inflight_non_terminal,
+                    "durable_lowest_pending": pending_frontier.lowest_pending,
+                    "durable_lowest_unlinked": pending_frontier.lowest_unlinked,
                     "returned_nonce": returned_nonce,
                     "writer_enabled": service.enable_writer_worker,
                     "writer_handle_present": service.writer_handle.is_some(),

--- a/src/service.rs
+++ b/src/service.rs
@@ -442,7 +442,6 @@ async fn json_rpc_handler(service: ServiceState, request: JsonRpcExtractor) -> J
                     "durable_lowest_pending": pending_frontier.lowest_pending,
                     "durable_lowest_unlinked": pending_frontier.lowest_unlinked,
                     "returned_nonce": returned_nonce,
-                    "writer_enabled": service.enable_writer_worker,
                     "writer_handle_present": service.writer_handle.is_some(),
                 })
             );

--- a/src/service_estimate_gas.rs
+++ b/src/service_estimate_gas.rs
@@ -8,16 +8,11 @@
 //! propagated normally creates no transaction at all, and the manager simply
 //! retries the estimate later.
 //!
-//! This proxy used to answer every `eth_estimateGas` with a flat `0x0`,
-//! which admitted claims whose GER the proxy had not yet published; the
-//! branch then compensated with propagation sleeps inside the serialized
-//! Miden client (removed by this fix). Instead, mirror the EVM bridge:
-//! decode `claimAsset` calldata, compute the combined GER from the two exit
-//! roots, and return a deterministic `execution reverted:
-//! GlobalExitRootInvalid()` while the projected/published GER flag
-//! (`Store::is_ger_injected`) is false. The literal string
-//! `execution reverted` MUST stay in the message — bridge-service keys its
-//! retry classification on it.
+//! This is a compatibility shim, not a simulator: it only reads the landed
+//! projection and the local synchronized Miden bridge account. A spent claim
+//! returns `AlreadyClaimed()` before the GER check; otherwise an absent GER
+//! returns `GlobalExitRootInvalid()`. No transaction is executed or proved.
+//! The literal `execution reverted` prefix is load-bearing for ClaimTxManager.
 
 use crate::claim::claimAssetCall;
 use crate::hex::hex_decode_prefixed;
@@ -35,6 +30,9 @@ alloy_core::sol! {
     // Selector: 0x002f6fad.
     #[derive(Debug)]
     error GlobalExitRootInvalid();
+    // Selector: 0x646cf558.
+    #[derive(Debug)]
+    error AlreadyClaimed();
 }
 
 /// The JSON-RPC error code geth uses for `execution reverted` responses
@@ -52,6 +50,17 @@ pub(crate) fn global_exit_root_invalid_error() -> JsonRpcError {
         serde_json::Value::String(format!(
             "0x{}",
             alloy::hex::encode(GlobalExitRootInvalid::SELECTOR)
+        )),
+    )
+}
+
+pub(crate) fn already_claimed_error() -> JsonRpcError {
+    JsonRpcError::new(
+        JsonRpcErrorReason::ApplicationError(EXECUTION_REVERTED_CODE),
+        "execution reverted: AlreadyClaimed()".to_string(),
+        serde_json::Value::String(format!(
+            "0x{}",
+            alloy::hex::encode(AlreadyClaimed::SELECTOR)
         )),
     )
 }
@@ -96,26 +105,21 @@ pub(crate) async fn service_estimate_gas(
         && data.starts_with(&claimAssetCall::SELECTOR)
         && let Ok(call) = claimAssetCall::abi_decode(&data)
     {
-        // Same combined-GER computation and publication flag as the C6
-        // pre-admission gate in `eth_sendRawTransaction`
-        // (`is_ger_injected`, i.e. the SyntheticProjector has published
-        // the GER event — NOT merely `has_seen_ger`, which the
-        // L1InfoTreeIndexer pre-populates before the L2 inject exists).
         let combined = crate::ger::combined_ger(&call.mainnetExitRoot.0, &call.rollupExitRoot.0);
-        if !service
-            .store
-            .is_ger_injected(&combined)
-            .await
-            .map_err(|e| store_error(answer_id.clone(), e))?
-        {
+        let (claimed, ger_applied) =
+            crate::applied_state::claim_and_ger_applied(&service, call.globalIndex, &combined)
+                .await
+                .map_err(|error| store_error(answer_id.clone(), error))?;
+        if claimed {
+            ::metrics::counter!("rpc_estimate_gas_already_claimed_total").increment(1);
+            return Err(JsonRpcResponse::error(answer_id, already_claimed_error()));
+        }
+        if !ger_applied {
             ::metrics::counter!("rpc_estimate_gas_ger_not_ready_total").increment(1);
             tracing::info!(
                 global_index = %call.globalIndex,
-                mainnet_exit_root = %alloy::hex::encode(call.mainnetExitRoot.0),
-                rollup_exit_root = %alloy::hex::encode(call.rollupExitRoot.0),
                 combined_ger = %alloy::hex::encode(combined),
-                "eth_estimateGas(claimAsset): GER not yet published — reverting \
-                 GlobalExitRootInvalid() so the ClaimTxManager retries later"
+                "eth_estimateGas(claimAsset): GER is not applied; returning GlobalExitRootInvalid()"
             );
             return Err(JsonRpcResponse::error(
                 answer_id,
@@ -146,6 +150,13 @@ mod tests {
         assert_eq!(GlobalExitRootInvalid::SELECTOR, [0x00, 0x2f, 0x6f, 0xad]);
     }
 
+    #[test]
+    fn already_claimed_selector_is_646cf558() {
+        let hash = Keccak256::digest(b"AlreadyClaimed()");
+        assert_eq!(&hash[..4], &[0x64, 0x6c, 0xf5, 0x58]);
+        assert_eq!(AlreadyClaimed::SELECTOR, [0x64, 0x6c, 0xf5, 0x58]);
+    }
+
     fn claim_calldata(mainnet: [u8; 32], rollup: [u8; 32]) -> String {
         let calldata = claimAssetCall {
             smtProofLocalExitRoot: [FixedBytes::ZERO; 32],
@@ -174,11 +185,34 @@ mod tests {
         }
     }
 
-    /// Missing GER → deterministic `execution reverted:
-    /// GlobalExitRootInvalid()` with the 0x002f6fad selector in `data`, so
-    /// the official ClaimTxManager's pre-nonce `eth_estimateGas` probe fails
-    /// exactly as it would against the real EVM bridge and no transaction is
-    /// created (fail-fast/retry-later — no polling anywhere).
+    /// Applied claim wins over GER readiness and returns the exact AggKit shim shape.
+    #[tokio::test]
+    async fn estimate_gas_already_claimed_reverts_with_aggkit_shape() {
+        let service = create_test_service();
+        service
+            .store
+            .mark_claim_note_processed(
+                "already-applied".to_string(),
+                U256::from(7u64).to_be_bytes::<32>(),
+                1,
+            )
+            .await
+            .unwrap();
+        let request = estimate_request(&claim_calldata([0xAA; 32], [0xBB; 32]));
+
+        let response = service_estimate_gas(service, request)
+            .await
+            .expect_err("applied claim must revert during estimate");
+        let json = serde_json::to_value(response).unwrap();
+        assert_eq!(json["error"]["code"], 3);
+        assert_eq!(
+            json["error"]["message"],
+            "execution reverted: AlreadyClaimed()"
+        );
+        assert_eq!(json["error"]["data"], "0x646cf558");
+    }
+
+    /// Missing GER returns GlobalExitRootInvalid() with the pinned selector.
     #[tokio::test]
     async fn estimate_gas_claim_missing_ger_reverts_with_selector() {
         let service = create_test_service();

--- a/src/service_eth_call.rs
+++ b/src/service_eth_call.rs
@@ -6,6 +6,18 @@ use axum_jrpc::error::{JsonRpcError, JsonRpcErrorReason};
 use axum_jrpc::{JrpcResult, JsonRpcExtractor, JsonRpcResponse};
 use serde::Deserialize;
 
+const ABI_FALSE: &str = "0x0000000000000000000000000000000000000000000000000000000000000000";
+const ABI_TRUE: &str = "0x0000000000000000000000000000000000000000000000000000000000000001";
+const GLOBAL_EXIT_ROOT_MAP_SELECTOR: [u8; 4] = [0x25, 0x7b, 0x36, 0x32];
+const IS_CLAIMED_SELECTOR: [u8; 4] = [0xcc, 0x46, 0x16, 0x32];
+
+fn abi_u32(word: &[u8]) -> Option<u32> {
+    if word.len() != 32 || word[..28].iter().any(|byte| *byte != 0) {
+        return None;
+    }
+    Some(u32::from_be_bytes(word[28..32].try_into().ok()?))
+}
+
 pub(crate) async fn service_eth_call(
     service: ServiceState,
     request: JsonRpcExtractor,
@@ -42,32 +54,149 @@ pub(crate) async fn service_eth_call(
         }
 
         if data.starts_with(&networkIDCall::SELECTOR) {
-            let network_id = service.network_id;
-            let network_id_hex = format!("{:#066x}", network_id);
-            return Ok(JsonRpcResponse::success(answer_id, network_id_hex));
+            return Ok(JsonRpcResponse::success(
+                answer_id,
+                format!("{:#066x}", service.network_id),
+            ));
         }
 
-        // globalExitRootMap(bytes32) selector from PolygonZkEVMGlobalExitRootV2
-        const GLOBAL_EXIT_ROOT_MAP_SELECTOR: [u8; 4] = [0x25, 0x7b, 0x36, 0x32];
         if data.starts_with(&GLOBAL_EXIT_ROOT_MAP_SELECTOR) && data.len() >= 36 {
             let mut ger = [0u8; 32];
             ger.copy_from_slice(&data[4..36]);
-            if service
-                .store
-                .is_ger_injected(&ger)
+            let applied = crate::applied_state::ger_applied(&service, &ger)
                 .await
-                .map_err(|e| store_error(answer_id.clone(), e))?
-            {
-                return Ok(JsonRpcResponse::success(
+                .map_err(|error| store_error(answer_id.clone(), error))?;
+            return Ok(JsonRpcResponse::success(
+                answer_id,
+                if applied { ABI_TRUE } else { ABI_FALSE },
+            ));
+        }
+
+        if data.starts_with(&IS_CLAIMED_SELECTOR) {
+            if data.len() < 68 {
+                return Err(JsonRpcResponse::error(
                     answer_id,
-                    "0x0000000000000000000000000000000000000000000000000000000000000001",
+                    JsonRpcError::new(
+                        JsonRpcErrorReason::InvalidParams,
+                        "isClaimed requires two ABI-encoded uint32 arguments".to_string(),
+                        serde_json::Value::Null,
+                    ),
                 ));
             }
+            let (Some(leaf_index), Some(source)) = (abi_u32(&data[4..36]), abi_u32(&data[36..68]))
+            else {
+                return Err(JsonRpcResponse::error(
+                    answer_id,
+                    JsonRpcError::new(
+                        JsonRpcErrorReason::InvalidParams,
+                        "isClaimed arguments exceed uint32".to_string(),
+                        serde_json::Value::Null,
+                    ),
+                ));
+            };
+            let global_index = crate::applied_state::global_index_for_claim(leaf_index, source);
+            let applied = crate::applied_state::claim_applied(&service, global_index)
+                .await
+                .map_err(|error| store_error(answer_id.clone(), error))?;
+            return Ok(JsonRpcResponse::success(
+                answer_id,
+                if applied { ABI_TRUE } else { ABI_FALSE },
+            ));
         }
     }
 
-    Ok(JsonRpcResponse::success(
-        answer_id,
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-    ))
+    Ok(JsonRpcResponse::success(answer_id, ABI_FALSE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::create_test_service;
+    use axum_jrpc::Id;
+
+    fn eth_call_request(data: Vec<u8>) -> JsonRpcExtractor {
+        JsonRpcExtractor {
+            parsed: serde_json::json!([{
+                "to": "0x0000000000000000000000000000000000000001",
+                "data": format!("0x{}", alloy::hex::encode(data))
+            }, "latest"]),
+            method: "eth_call".to_string(),
+            id: Id::Num(1),
+        }
+    }
+
+    fn is_claimed_calldata(leaf: u32, source: u32) -> Vec<u8> {
+        let mut data = Vec::with_capacity(68);
+        data.extend(IS_CLAIMED_SELECTOR);
+        data.extend([0u8; 28]);
+        data.extend(leaf.to_be_bytes());
+        data.extend([0u8; 28]);
+        data.extend(source.to_be_bytes());
+        data
+    }
+
+    #[tokio::test]
+    async fn is_claimed_uses_required_mainnet_and_rollup_global_indices() {
+        for (leaf, source) in [(17u32, 0u32), (23u32, 9u32)] {
+            let service = create_test_service();
+            let gi = crate::applied_state::global_index_for_claim(leaf, source);
+            service
+                .store
+                .mark_claim_note_processed(
+                    format!("landed-{leaf}-{source}"),
+                    gi.to_be_bytes::<32>(),
+                    1,
+                )
+                .await
+                .unwrap();
+
+            let response =
+                service_eth_call(service, eth_call_request(is_claimed_calldata(leaf, source)))
+                    .await
+                    .unwrap();
+            let json = serde_json::to_value(response).unwrap();
+            assert_eq!(json["result"], ABI_TRUE);
+        }
+    }
+
+    #[tokio::test]
+    async fn is_claimed_ignores_in_flight_submission_locks() {
+        let service = create_test_service();
+        let leaf = 31u32;
+        let source = 4u32;
+        let gi = crate::applied_state::global_index_for_claim(leaf, source);
+        service.store.try_claim(gi).await.unwrap();
+
+        let response =
+            service_eth_call(service, eth_call_request(is_claimed_calldata(leaf, source)))
+                .await
+                .unwrap();
+        let json = serde_json::to_value(response).unwrap();
+        assert_eq!(json["result"], ABI_FALSE);
+    }
+
+    #[tokio::test]
+    async fn global_exit_root_map_reads_applied_state() {
+        let service = create_test_service();
+        let ger = [0xabu8; 32];
+        service
+            .store
+            .commit_ger_event_atomic(1, [0u8; 32], "0xger-applied", &ger, None, None, 0)
+            .await
+            .unwrap();
+        let mut calldata = Vec::with_capacity(36);
+        calldata.extend(GLOBAL_EXIT_ROOT_MAP_SELECTOR);
+        calldata.extend(ger);
+
+        let response = service_eth_call(service, eth_call_request(calldata))
+            .await
+            .unwrap();
+        let json = serde_json::to_value(response).unwrap();
+        assert_eq!(json["result"], ABI_TRUE);
+    }
+
+    #[test]
+    fn selector_is_pinned_to_aggkit_contract() {
+        assert_eq!(IS_CLAIMED_SELECTOR, [0xcc, 0x46, 0x16, 0x32]);
+    }
 }

--- a/src/service_get_txn_receipt.rs
+++ b/src/service_get_txn_receipt.rs
@@ -4,6 +4,83 @@ use alloy::primitives::TxHash;
 use alloy_rpc_types_eth::{Log, Receipt, ReceiptEnvelope, ReceiptWithBloom, TransactionReceipt};
 use std::str::FromStr;
 
+async fn reconcile_pending_duplicate(service: &ServiceState, txn_hash: TxHash) {
+    let Some(transaction) = service.store.txn_get(txn_hash).await.ok().flatten() else {
+        return;
+    };
+    if transaction.result.is_some() {
+        return;
+    }
+    let tx_key = format!("{txn_hash:#x}");
+    let Some(handoff) = service
+        .store
+        .get_note_handoff_for_tx(&tx_key)
+        .await
+        .ok()
+        .flatten()
+    else {
+        return;
+    };
+    let Some(note_id) = handoff.note_id else {
+        return;
+    };
+    let decoded = match crate::service_send_raw_txn::decode_envelope_write_call(
+        &transaction.envelope,
+    ) {
+        Ok(decoded) => decoded,
+        Err(error) => {
+            tracing::warn!(%txn_hash, error = %error, "cannot decode pending handoff; keeping receipt null");
+            return;
+        }
+    };
+    let outcome = match &decoded {
+        crate::writer_worker::DecodedWriteCall::Ger { ger_bytes } => {
+            crate::applied_state::reconcile_ger_handoff(service, *ger_bytes, note_id).await
+        }
+        crate::writer_worker::DecodedWriteCall::Claim { params } => {
+            crate::applied_state::reconcile_claim_handoff(service, params.globalIndex, note_id)
+                .await
+        }
+    };
+    let outcome = match outcome {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            tracing::warn!(%txn_hash, error = %error, "authoritative duplicate reconciliation is uncertain; keeping receipt null");
+            return;
+        }
+    };
+    let result = match (decoded, outcome) {
+        (
+            _,
+            crate::applied_state::ExactNoteOutcome::NotApplied
+            | crate::applied_state::ExactNoteOutcome::AppliedByExactNote
+            | crate::applied_state::ExactNoteOutcome::Uncertain,
+        ) => return,
+        (
+            crate::writer_worker::DecodedWriteCall::Ger { .. },
+            crate::applied_state::ExactNoteOutcome::AppliedElsewhere,
+        ) => Ok(()),
+        (
+            crate::writer_worker::DecodedWriteCall::Claim { .. },
+            crate::applied_state::ExactNoteOutcome::AppliedElsewhere,
+        ) => Err("execution reverted: AlreadyClaimed()".to_string()),
+    };
+    let block_num = match service.store.get_latest_block_number().await {
+        Ok(block_num) => block_num,
+        Err(error) => {
+            tracing::warn!(%txn_hash, error = %error, "cannot finalize confirmed duplicate; keeping receipt null");
+            return;
+        }
+    };
+    if let Err(error) = service
+        .store
+        .txn_commit_confirmed_duplicate(txn_hash, result, block_num)
+        .await
+    {
+        tracing::warn!(%txn_hash, error = %error, "failed to persist confirmed duplicate receipt; keeping receipt null");
+    }
+}
+
 // polycli polls receipts to get the eth_sendRawTransaction status
 // it logs cumulativeGasUsed and transactionHash
 // return null if the transaction is not yet included onto the blockchain, return status=0 for errors
@@ -12,6 +89,7 @@ pub async fn service_get_txn_receipt(
     txn_hash: String,
 ) -> anyhow::Result<Option<TransactionReceipt<ReceiptEnvelope<Log>>>> {
     let txn_hash = TxHash::from_str(&txn_hash)?;
+    reconcile_pending_duplicate(&service, txn_hash).await;
     let (status, block_num) = match service.store.txn_receipt(txn_hash).await? {
         Some((result, block_num)) => (result.is_ok(), block_num),
         None => {
@@ -201,6 +279,66 @@ mod tests {
         assert!(
             result.is_none(),
             "pre-commit receipt MUST be None — aggkit reads it as 'keep polling'"
+        );
+    }
+
+    #[tokio::test]
+    async fn applied_state_with_missing_exact_note_stays_pending() {
+        use alloy::consensus::{Signed, TxLegacy};
+        use alloy::primitives::{FixedBytes, Signature};
+        use alloy_core::sol_types::SolCall;
+
+        let service = create_test_service();
+        let ger = [0x5au8; 32];
+        service
+            .store
+            .commit_ger_event_atomic(1, [0u8; 32], "0xother-ger", &ger, None, None, 0)
+            .await
+            .unwrap();
+        let calldata = crate::ger::insertGlobalExitRootCall {
+            root: FixedBytes::from(ger),
+        }
+        .abi_encode();
+        let tx_hash = TxHash::from([0x5bu8; 32]);
+        let envelope = TxEnvelope::Legacy(Signed::new_unchecked(
+            TxLegacy {
+                input: calldata.into(),
+                ..Default::default()
+            },
+            Signature::test_signature(),
+            tx_hash,
+        ));
+        service
+            .store
+            .txn_begin(
+                tx_hash,
+                TxnEntry {
+                    id: None,
+                    envelope,
+                    signer: Address::from([0x5cu8; 20]),
+                    expires_at: Some(10),
+                    logs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        service
+            .store
+            .prepare_note_handoff(
+                &format!("{tx_hash:#x}"),
+                "commitment",
+                "missing-note-id",
+                10,
+            )
+            .await
+            .unwrap();
+
+        let receipt = service_get_txn_receipt(service, format!("{tx_hash:#x}"))
+            .await
+            .unwrap();
+        assert!(
+            receipt.is_none(),
+            "applied state without the exact NoteId is uncertain"
         );
     }
 

--- a/src/service_get_txn_receipt.rs
+++ b/src/service_get_txn_receipt.rs
@@ -15,6 +15,11 @@ pub async fn service_get_txn_receipt(
     let (status, block_num) = match service.store.txn_receipt(txn_hash).await? {
         Some((result, block_num)) => (result.is_ok(), block_num),
         None => {
+            // A known transaction without a terminal result is still pending.
+            // Synthetic-log fallback is only for hashes with no transaction row.
+            if service.store.txn_get(txn_hash).await?.is_some() {
+                return Ok(None);
+            }
             // Synthetic-log receipt fallback (receipts contract). A bridge-out
             // `BridgeEvent` (and a projected GER `UpdateHashChain`) has NO real txn
             // record: it was never an `eth_sendRawTransaction` — the
@@ -195,6 +200,21 @@ mod tests {
             .await
             .unwrap();
         // Deliberately NOT committing.
+        service
+            .store
+            .add_log(crate::log_synthesis::SyntheticLog {
+                address: Address::ZERO.to_string(),
+                topics: vec![],
+                data: "0x".to_string(),
+                block_number: 1,
+                block_hash: [0u8; 32],
+                transaction_hash: format!("{txn_hash:#x}"),
+                transaction_index: 0,
+                log_index: 0,
+                removed: false,
+            })
+            .await
+            .unwrap();
 
         let result = service_get_txn_receipt(service, txn_hash.to_string())
             .await

--- a/src/service_get_txn_receipt.rs
+++ b/src/service_get_txn_receipt.rs
@@ -4,83 +4,6 @@ use alloy::primitives::TxHash;
 use alloy_rpc_types_eth::{Log, Receipt, ReceiptEnvelope, ReceiptWithBloom, TransactionReceipt};
 use std::str::FromStr;
 
-async fn reconcile_pending_duplicate(service: &ServiceState, txn_hash: TxHash) {
-    let Some(transaction) = service.store.txn_get(txn_hash).await.ok().flatten() else {
-        return;
-    };
-    if transaction.result.is_some() {
-        return;
-    }
-    let tx_key = format!("{txn_hash:#x}");
-    let Some(handoff) = service
-        .store
-        .get_note_handoff_for_tx(&tx_key)
-        .await
-        .ok()
-        .flatten()
-    else {
-        return;
-    };
-    let Some(note_id) = handoff.note_id else {
-        return;
-    };
-    let decoded = match crate::service_send_raw_txn::decode_envelope_write_call(
-        &transaction.envelope,
-    ) {
-        Ok(decoded) => decoded,
-        Err(error) => {
-            tracing::warn!(%txn_hash, error = %error, "cannot decode pending handoff; keeping receipt null");
-            return;
-        }
-    };
-    let outcome = match &decoded {
-        crate::writer_worker::DecodedWriteCall::Ger { ger_bytes } => {
-            crate::applied_state::reconcile_ger_handoff(service, *ger_bytes, note_id).await
-        }
-        crate::writer_worker::DecodedWriteCall::Claim { params } => {
-            crate::applied_state::reconcile_claim_handoff(service, params.globalIndex, note_id)
-                .await
-        }
-    };
-    let outcome = match outcome {
-        Ok(outcome) => outcome,
-        Err(error) => {
-            tracing::warn!(%txn_hash, error = %error, "authoritative duplicate reconciliation is uncertain; keeping receipt null");
-            return;
-        }
-    };
-    let result = match (decoded, outcome) {
-        (
-            _,
-            crate::applied_state::ExactNoteOutcome::NotApplied
-            | crate::applied_state::ExactNoteOutcome::AppliedByExactNote
-            | crate::applied_state::ExactNoteOutcome::Uncertain,
-        ) => return,
-        (
-            crate::writer_worker::DecodedWriteCall::Ger { .. },
-            crate::applied_state::ExactNoteOutcome::AppliedElsewhere,
-        ) => Ok(()),
-        (
-            crate::writer_worker::DecodedWriteCall::Claim { .. },
-            crate::applied_state::ExactNoteOutcome::AppliedElsewhere,
-        ) => Err("execution reverted: AlreadyClaimed()".to_string()),
-    };
-    let block_num = match service.store.get_latest_block_number().await {
-        Ok(block_num) => block_num,
-        Err(error) => {
-            tracing::warn!(%txn_hash, error = %error, "cannot finalize confirmed duplicate; keeping receipt null");
-            return;
-        }
-    };
-    if let Err(error) = service
-        .store
-        .txn_commit_confirmed_duplicate(txn_hash, result, block_num)
-        .await
-    {
-        tracing::warn!(%txn_hash, error = %error, "failed to persist confirmed duplicate receipt; keeping receipt null");
-    }
-}
-
 // polycli polls receipts to get the eth_sendRawTransaction status
 // it logs cumulativeGasUsed and transactionHash
 // return null if the transaction is not yet included onto the blockchain, return status=0 for errors
@@ -89,7 +12,6 @@ pub async fn service_get_txn_receipt(
     txn_hash: String,
 ) -> anyhow::Result<Option<TransactionReceipt<ReceiptEnvelope<Log>>>> {
     let txn_hash = TxHash::from_str(&txn_hash)?;
-    reconcile_pending_duplicate(&service, txn_hash).await;
     let (status, block_num) = match service.store.txn_receipt(txn_hash).await? {
         Some((result, block_num)) => (result.is_ok(), block_num),
         None => {
@@ -251,6 +173,7 @@ mod tests {
     #[tokio::test]
     async fn rd940_specd_pending_receipt_is_none() {
         let service = create_test_service();
+        let miden = service.miden_client.clone();
         let txn_hash = TxHash::from([0x77u8; 32]);
         let txn_envelope = TxEnvelope::Legacy(alloy::consensus::Signed::new_unchecked(
             alloy::consensus::TxLegacy::default(),
@@ -280,15 +203,88 @@ mod tests {
             result.is_none(),
             "pre-commit receipt MUST be None — aggkit reads it as 'keep polling'"
         );
+        assert_eq!(
+            miden.test_call_count(),
+            0,
+            "receipt polling must perform no Miden-client request"
+        );
     }
 
     #[tokio::test]
-    async fn applied_state_with_missing_exact_note_stays_pending() {
+    async fn pending_receipt_returns_promptly_while_miden_writer_is_blocked() {
+        let store: std::sync::Arc<dyn crate::store::Store> =
+            std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let block_state = std::sync::Arc::new(crate::block_state::BlockState::new());
+        let (miden, release_writer) = crate::MidenClient::new_test_blocked();
+        let service = ServiceState::new(
+            miden,
+            crate::test_helpers::test_accounts_config(),
+            1,
+            1,
+            store,
+            block_state,
+        );
+        let txn_hash = TxHash::from([0x78u8; 32]);
+        let envelope = TxEnvelope::Legacy(alloy::consensus::Signed::new_unchecked(
+            alloy::consensus::TxLegacy::default(),
+            alloy::primitives::Signature::test_signature(),
+            txn_hash,
+        ));
+        service
+            .store
+            .txn_begin(
+                txn_hash,
+                TxnEntry {
+                    id: None,
+                    envelope,
+                    signer: Address::from([0x98u8; 20]),
+                    expires_at: None,
+                    logs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+
+        let writer_client = service.miden_client.clone();
+        let blocked_writer = tokio::spawn(async move {
+            writer_client
+                .with(|_client| Box::new(async { Ok::<(), anyhow::Error>(()) }))
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while service.miden_client.test_call_count() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("writer request must enter the serialized Miden lane");
+
+        let receipt = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            service_get_txn_receipt(service.clone(), format!("{txn_hash:#x}")),
+        )
+        .await
+        .expect("store-only receipt polling must not queue behind the Miden writer")
+        .unwrap();
+        assert!(receipt.is_none());
+        assert_eq!(
+            service.miden_client.test_call_count(),
+            1,
+            "receipt polling must not issue a second Miden-client request"
+        );
+
+        release_writer.send(()).unwrap();
+        blocked_writer.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn note_linked_pending_receipt_does_not_reconcile_inline() {
         use alloy::consensus::{Signed, TxLegacy};
         use alloy::primitives::{FixedBytes, Signature};
         use alloy_core::sol_types::SolCall;
 
         let service = create_test_service();
+        let miden = service.miden_client.clone();
         let ger = [0x5au8; 32];
         service
             .store
@@ -340,6 +336,7 @@ mod tests {
             receipt.is_none(),
             "applied state without the exact NoteId is uncertain"
         );
+        assert_eq!(miden.test_call_count(), 0);
     }
 
     /// Receipts contract — a tx that emitted a synthetic log (a projected

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -214,6 +214,47 @@ async fn record_local_immediate_reverted(
         .await
 }
 
+/// BLOCKER-2 (#55 review) — idempotent crash-gap nonce repair.
+///
+/// On the sync accept path the durable receipt write (`txn_begin` + `txn_commit`)
+/// and the per-signer `nonce_increment` are SEPARATE steps; a crash / store error
+/// BETWEEN them leaves the tx KNOWN (receipt persisted) but the signer's expected
+/// nonce STALE at that tx's nonce. Called from the RD-940 same-hash dedup path on a
+/// rebroadcast: if the expected nonce still equals `tx_nonce` — the crash-gap
+/// signature; a normally-advanced tx has `expected > tx.nonce`, and async mode
+/// advances at enqueue so likewise `expected > tx.nonce` — it advances the nonce
+/// exactly once, completing the interrupted accept, so the rebroadcast HEALS the
+/// nonce rather than serving stale forever.
+///
+/// Cheap unlocked pre-check first (the common rebroadcast is `expected > tx.nonce`
+/// → no lock taken); the per-signer lock + re-read make the advance atomic against a
+/// concurrent accept/repair. Returns `true` iff it advanced the nonce.
+pub(crate) async fn repair_commit_gap_nonce(
+    service: &ServiceState,
+    signer: Address,
+    signer_str: &str,
+    tx_nonce: u64,
+) -> anyhow::Result<bool> {
+    if service.store.nonce_get(signer_str).await? != tx_nonce {
+        return Ok(false);
+    }
+    let _lock = service.per_signer_locks.lock(signer).await;
+    if service.store.nonce_get(signer_str).await? != tx_nonce {
+        return Ok(false);
+    }
+    service.store.nonce_increment(signer_str).await?;
+    ::metrics::counter!("rpc_nonce_repaired_after_commit_gap_total").increment(1);
+    tracing::warn!(
+        target: "rpc::nonce_repair",
+        signer = %signer_str,
+        nonce = tx_nonce,
+        "healed a stale signer nonce on rebroadcast: a known tx's receipt was persisted but its \
+         nonce advance was lost to a crash in the commit gap; advanced the expected nonce to \
+         complete the interrupted accept (#55 BLOCKER-2)"
+    );
+    Ok(true)
+}
+
 /// Handle a `claimAsset` transaction: skip zero-amount or publish the claim.
 ///
 /// RD-940 Phase 1: this is the unified dispatcher for both the legacy sync
@@ -256,73 +297,18 @@ pub(crate) async fn worker_handle_claim_asset(
         return Ok(());
     }
 
-    // #55 — ACCEPT-AND-REVERT for an already-LANDED globalIndex (geth-faithful).
-    //
-    // Claims are permissionless: destination + amount are bound by the
-    // merkle-proven claimAsset calldata, so the sponsor (aggkit ClaimTxManager
-    // autoclaim) and a user (manual eth_sendRawTransaction) can BOTH target the
-    // same globalIndex, and dedup is keyed by globalIndex only (signer-agnostic).
-    // When a USER front-runs a gi the sponsor has already signed + persisted a
-    // monitored tx for, the sponsor later submits that (DIFFERENT-hash) tx. If we
-    // hard-reject it at the JSON-RPC layer ("already submitted"), the reject does
-    // NOT consume the sponsor's nonce: the proxy's expected-nonce and the
-    // sponsor's sequence permanently desync, ClaimTxManager re-broadcasts the
-    // pinned tx forever ("nonce mismatch"), every later sponsor claim queues
-    // behind it, and autoclaim dies un-healably (the monitored tx survives
-    // restarts).
-    //
-    // On real geth this never happens: the doomed claim MINES, reverts with
-    // `AlreadyClaimed`, and CONSUMES its nonce + gas, so ClaimTxManager marks it
-    // final and advances. Mirror that here: if a real ClaimEvent already exists
-    // for this globalIndex, ACCEPT the tx, write a durable REVERTED receipt
-    // (status 0x0, empty logs, NO new ClaimEvent), and return Ok so the caller
-    // CONSUMES the signer's nonce exactly like a normal accept — keeping the
-    // sponsor's sequence in lockstep.
-    //
-    // Scope / coexistence:
-    //   - This is reached ONLY after the RD-940 tx-hash dedup early-return (a
-    //     SAME-hash rebroadcast — including a resubmit of the REAL landed claim's
-    //     own tx — was already short-circuited to Ok(hash) upstream WITHOUT a new
-    //     receipt). So this fires only for a DIFFERENT tx (other signer/nonce)
-    //     targeting an already-landed gi.
-    //   - It is reached ONLY after the R4 nonce gate admitted the tx
-    //     (tx.nonce == expected). A future/stale-nonce landed claim never gets
-    //     here — it is waited/rejected by R4 first — so accept-and-revert can
-    //     NEVER paper over a real nonce gap.
-    //   - It runs BEFORE `acquire_claim_lock`: it neither takes nor releases the
-    //     claim lock, so the real landed claim's LANDED lock + ClaimEvent +
-    //     receipt are UNTOUCHED. `acquire_claim_lock`'s own LANDED hard-reject
-    //     stays as defense-in-depth for the narrow TOCTOU where a claim lands
-    //     between this check and the lock.
-    let gi_bytes: [u8; 32] = params.globalIndex.to_be_bytes::<32>();
-    if service
-        .store
-        .has_claim_event_for_global_index(&gi_bytes)
-        .await?
-    {
-        ::metrics::counter!("claim_landed_dedup_reverted_total").increment(1);
-        tracing::warn!(
-            global_index = %params.globalIndex,
-            eth_tx = %txn_hash,
-            signer = %signer,
-            "claim targets an already-landed globalIndex (a ClaimEvent already exists); \
-             accepting and writing a REVERTED receipt (status 0x0, no new event) so the \
-             submitter's nonce is consumed — geth-faithful AlreadyClaimed revert (#55). \
-             The real landed claim is untouched."
-        );
-        record_local_immediate_reverted(
-            service,
-            txn_hash,
-            txn_envelope,
-            signer,
-            format!(
-                "claim for globalIndex {} already landed (AlreadyClaimed); reverted (#55)",
-                params.globalIndex
-            ),
-        )
-        .await?;
-        return Ok(());
-    }
+    // NOTE (#55): the geth-faithful ACCEPT-AND-REVERT for an already-LANDED
+    // globalIndex is NOT a separate pre-check here. Detecting "landed" and
+    // deciding accept-and-revert are now ONE authoritative, atomic step inside
+    // `acquire_claim_lock` (its `ClaimLockOutcome::Landed`), below. A standalone
+    // pre-check would reopen a TOCTOU: it could observe "not landed", the real
+    // claim could LAND, and `acquire_claim_lock` would then hard-reject — the
+    // exact nonce-desync wedge #55 fixes. Routing landed→accept-and-revert
+    // through the lock's own classification closes that window (there is no
+    // interleaving in which a landed gi is hard-rejected). A landed gi
+    // necessarily passes RD-860 (its destination was resolvable when it landed;
+    // address mappings are monotonic) and C6 (its GER is injected; injection is
+    // monotonic), so those checks never fire for it before the lock.
 
     // RD-860 — swallow unresolvable-destination claims permanently. If the
     // destination address can't be resolved to a Miden AccountId, record the
@@ -394,17 +380,73 @@ pub(crate) async fn worker_handle_claim_asset(
     // See `ensure_claim_ger_published` for the full rationale.
     ensure_claim_ger_published(&service.store, &params).await?;
 
-    // Lock the claim index. All error paths after this MUST unclaim.
+    // Lock the claim index — the AUTHORITATIVE, atomic classification of this
+    // submission against the per-globalIndex lock + landed state. All error
+    // paths after an `Acquired` MUST unclaim.
     //
     // SOAK FINDING #1 (orphaned-claim wedge): a plain `try_claim` rejection here permanently
     // wedged a deposit if the proxy died between the lock write and the CLAIM landing on
     // Miden (chaos restart in the submit window): the persisted record survived, the R9
     // guard never fired, and every sponsor retry was rejected forever — starving all later
     // claims the sponsor owns. Dedup must mean "landed or genuinely in flight", not
-    // "submission was attempted once": on rejection, verify + recover via
-    // `acquire_claim_lock` (landed → hard reject; in flight (younger than TTL) → reject;
-    // orphaned (no ClaimEvent + TTL expired) → supersede the record and accept).
-    acquire_claim_lock(&service.store, params.globalIndex, claim_resubmit_ttl()).await?;
+    // "submission was attempted once".
+    match acquire_claim_lock(&service.store, params.globalIndex, claim_resubmit_ttl()).await? {
+        // #55 — geth-faithful ACCEPT-AND-REVERT for an already-LANDED globalIndex.
+        //
+        // Claims are permissionless: destination + amount are bound by the
+        // merkle-proven calldata, so the sponsor (aggkit ClaimTxManager autoclaim)
+        // and a user can BOTH target the same gi; dedup is keyed by globalIndex
+        // only (signer-agnostic). When a user front-runs a gi the sponsor already
+        // signed + persisted a monitored tx for, hard-rejecting the sponsor's
+        // later (different-hash) tx would NOT consume its nonce: its sequence and
+        // the proxy's expected-nonce desync, ClaimTxManager re-broadcasts forever
+        // ("nonce mismatch"), and autoclaim dies un-healably. On real geth the
+        // doomed claim MINES, reverts with AlreadyClaimed, and CONSUMES its nonce
+        // + gas. Mirror that: ACCEPT the tx, write a durable REVERTED receipt
+        // (status 0x0, empty logs, NO new ClaimEvent), and return Ok so the caller
+        // CONSUMES the signer's nonce exactly like a normal accept.
+        //
+        // `Landed` is decided INSIDE `acquire_claim_lock` at the lock boundary
+        // (the authoritative `has_claim_event_for_global_index`), so there is no
+        // pre-check→lock interleaving in which a landed gi is hard-rejected.
+        ClaimLockOutcome::Landed => {
+            ::metrics::counter!("claim_landed_dedup_reverted_total").increment(1);
+            tracing::warn!(
+                global_index = %params.globalIndex,
+                eth_tx = %txn_hash,
+                signer = %signer,
+                "claim targets an already-landed globalIndex (a ClaimEvent already exists); \
+                 accepting and writing a REVERTED receipt (status 0x0, no new event) so the \
+                 submitter's nonce is consumed — geth-faithful AlreadyClaimed revert (#55). \
+                 The real landed claim is untouched."
+            );
+            record_local_immediate_reverted(
+                service,
+                txn_hash,
+                txn_envelope,
+                signer,
+                format!(
+                    "claim for globalIndex {} already landed (AlreadyClaimed); reverted (#55)",
+                    params.globalIndex
+                ),
+            )
+            .await?;
+            return Ok(());
+        }
+        // A genuine concurrent submission for this gi is in flight (locked, no
+        // ClaimEvent yet, within TTL). Hard-reject — must not double-publish. In
+        // sync mode this returns Err WITHOUT the caller advancing the nonce (a
+        // genuine retry, nonce not consumed); once the in-flight claim LANDS, the
+        // retry re-enters and takes the `Landed` accept-and-revert arm above.
+        ClaimLockOutcome::InFlight => {
+            anyhow::bail!(
+                "claim already submitted for global_index {}",
+                params.globalIndex
+            );
+        }
+        // Fresh lock (or an orphaned record superseded) — proceed to publish.
+        ClaimLockOutcome::Acquired => {}
+    }
 
     // R9 — install a RAII drop guard so that even if the request future is
     // dropped (client disconnect mid-publish, panic, task cancellation), the
@@ -492,45 +534,87 @@ pub(crate) fn claim_resubmit_ttl() -> std::time::Duration {
     std::time::Duration::from_secs(secs)
 }
 
-/// Acquire the per-`global_index` claim submission lock, with orphaned-record recovery
-/// (SOAK FINDING #1). Semantics: dedup means "landed or genuinely in flight", never
-/// "submission was attempted once".
+/// Typed, AUTHORITATIVE outcome of [`acquire_claim_lock`]. Landed detection and the
+/// #55 accept-and-revert decision are ONE step here (no separate pre-check→lock
+/// window), so there is no interleaving in which a claim for an already-landed
+/// globalIndex is hard-rejected — the exact nonce-desync wedge #55 fixes.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ClaimLockOutcome {
+    /// The submission lock is now held by THIS caller (fresh index, or an orphaned
+    /// record superseded — SOAK FINDING #1). Proceed to publish; the caller MUST
+    /// arrange `unclaim` on any later failure (via `ClaimGuard`).
+    Acquired,
+    /// A genuine concurrent submission for the same gi is in flight (locked, no
+    /// ClaimEvent yet, record younger than `ttl`). The caller hard-rejects
+    /// ("already submitted") — no double publish, and no nonce is consumed.
+    InFlight,
+    /// A real `ClaimEvent` already exists for this globalIndex — the claim LANDED.
+    /// The caller routes this to #55 accept-and-revert (consume the nonce + write a
+    /// reverted receipt), NEVER a hard reject. Any lock this call transiently took
+    /// has been released before returning.
+    Landed,
+}
+
+/// Classify a claim submission against the per-`global_index` submission lock and the
+/// authoritative landed state, with orphaned-record recovery (SOAK FINDING #1).
 ///
-///   1. Fresh index → lock acquired (the normal path).
-///   2. Record exists + ClaimEvent recorded for the index → hard reject ("already
-///      submitted" stays an error — the claim LANDED; dedup holds forever).
-///   3. Record exists + no ClaimEvent + record younger than `ttl` → reject (a submission
-///      is genuinely in flight; no double-submit race).
-///   4. Record exists + no ClaimEvent + `ttl` expired → ORPHANED (the proxy died between
-///      the lock write and the CLAIM landing): atomically supersede the record
-///      (`Store::try_reclaim_expired` — single UPDATE, one winner under concurrency),
-///      warn + `claim_resubmission_recovered_total`, and accept the resubmission.
+/// This is the SINGLE authoritative step for landed detection: whatever the
+/// interleaving, an index whose `ClaimEvent` already exists is classified `Landed`
+/// (→ #55 accept-and-revert), never hard-rejected. Cases:
+///
+///   1. `try_claim` succeeds (fresh) + no ClaimEvent → `Acquired` (normal path).
+///   2. `try_claim` succeeds (fresh) + a ClaimEvent already exists (e.g. a restore
+///      wrote the event without a submission lock) → release the spurious lock and
+///      return `Landed` — never double-publish onto a landed gi.
+///   3. `try_claim` fails + a ClaimEvent exists → `Landed`. This is the closed
+///      TOCTOU: even if the claim LANDED after some earlier read, the landed
+///      classification is made here, at the lock decision, and routes to
+///      accept-and-revert rather than a hard reject.
+///   4. `try_claim` fails + no ClaimEvent + record younger than `ttl` → `InFlight`.
+///   5. `try_claim` fails + no ClaimEvent + `ttl` expired → ORPHANED: atomically
+///      supersede (`Store::try_reclaim_expired` — single UPDATE, one winner under
+///      concurrency), warn + `claim_resubmission_recovered_total`, return `Acquired`.
 pub(crate) async fn acquire_claim_lock(
     store: &std::sync::Arc<dyn crate::store::Store>,
     global_index: alloy::primitives::U256,
     ttl: std::time::Duration,
-) -> anyhow::Result<()> {
-    let Err(rejected) = store.try_claim(global_index).await else {
-        return Ok(()); // fresh index — the normal path
-    };
-    // LANDED check first: an index whose ClaimEvent exists is a hard dedup, always.
+) -> anyhow::Result<ClaimLockOutcome> {
     let gi_bytes: [u8; 32] = global_index.to_be_bytes::<32>();
-    if store.has_claim_event_for_global_index(&gi_bytes).await? {
-        return Err(rejected);
+    match store.try_claim(global_index).await {
+        Ok(()) => {
+            // Fresh lock acquired. Guard the rare "ClaimEvent exists but no lock"
+            // (e.g. a restore populated the event without a submission lock): if a
+            // ClaimEvent already exists, this is LANDED — release the lock we just
+            // took and route to accept-and-revert rather than double-publishing.
+            if store.has_claim_event_for_global_index(&gi_bytes).await? {
+                store.unclaim(&global_index).await?;
+                return Ok(ClaimLockOutcome::Landed);
+            }
+            Ok(ClaimLockOutcome::Acquired)
+        }
+        Err(_rejected) => {
+            // LANDED is authoritative and checked AT the lock decision — there is
+            // no separate pre-check window in which a landed gi could be routed to
+            // a hard reject.
+            if store.has_claim_event_for_global_index(&gi_bytes).await? {
+                return Ok(ClaimLockOutcome::Landed);
+            }
+            // Not landed. Atomically supersede IFF the record has out-lived the
+            // in-flight TTL; a fresher record means a submission is genuinely in
+            // flight — keep rejecting.
+            if !store.try_reclaim_expired(global_index, ttl).await? {
+                return Ok(ClaimLockOutcome::InFlight);
+            }
+            ::metrics::counter!("claim_resubmission_recovered_total").increment(1);
+            tracing::warn!(
+                global_index = %global_index,
+                ttl_secs = ttl.as_secs(),
+                "orphaned claim submission record for global_index {global_index} (submitted but \
+                 never landed — likely a crash mid-flight); accepting resubmission"
+            );
+            Ok(ClaimLockOutcome::Acquired)
+        }
     }
-    // Not landed. Atomically supersede IFF the record has out-lived the in-flight TTL;
-    // a fresher record means a submission is genuinely in flight — keep rejecting.
-    if !store.try_reclaim_expired(global_index, ttl).await? {
-        return Err(rejected);
-    }
-    ::metrics::counter!("claim_resubmission_recovered_total").increment(1);
-    tracing::warn!(
-        global_index = %global_index,
-        ttl_secs = ttl.as_secs(),
-        "orphaned claim submission record for global_index {global_index} (submitted but \
-         never landed — likely a crash mid-flight); accepting resubmission"
-    );
-    Ok(())
 }
 
 /// RAII guard that releases a `try_claim` lock if the holding future is dropped
@@ -732,6 +816,7 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
     let txn = unwrap_txn_envelope(txn_envelope.clone())?;
     let txn_hash = txn.hash;
     let signer = txn_envelope.recover_signer()?;
+    let signer_str = format!("{signer:#x}");
     let tx_nonce = envelope_nonce(&txn_envelope);
     let selector = calldata_selector(&txn.input);
     tracing::debug!(target: concat!(module_path!(), "::debug"), "raw transaction hash: {txn_hash}");
@@ -797,6 +882,18 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
             %txn_hash,
             "tx-hash dedup (committed): returning OK without re-running R4"
         );
+        // BLOCKER-2 (#55 review) — crash-gap nonce REPAIR. On the sync accept
+        // path the durable receipt write (`txn_begin` + `txn_commit`) and the
+        // per-signer `nonce_increment` are SEPARATE steps; a crash / store error
+        // BETWEEN them leaves this tx KNOWN (receipt persisted) while the
+        // signer's expected nonce stays STALE at this tx's nonce. Without repair
+        // this rebroadcast is served as success forever while the nonce never
+        // advances, and the signer's NEXT tx (nonce+1) fails the R4 gate — the
+        // exact wedge #55 fixes, reintroduced by a crash in the commit gap.
+        //
+        // Heal it idempotently via `repair_commit_gap_nonce` (extracted so both
+        // stores can regression-test the repair directly).
+        repair_commit_gap_nonce(&service, signer, &signer_str, tx_nonce).await?;
         return Ok(txn_hash);
     }
 
@@ -810,7 +907,6 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
     // nonce N, release the lock, wait briefly for N to be accepted, then
     // re-check. This is a small in-process txpool behavior; stale/replay nonces
     // still fail immediately, and missing gaps still fail after the bound.
-    let signer_str = format!("{signer:#x}");
     let future_nonce_wait_max = std::time::Duration::from_secs(30);
     let future_nonce_poll = std::time::Duration::from_millis(50);
     let future_nonce_wait_started = tokio::time::Instant::now();
@@ -1990,19 +2086,26 @@ mod tests {
 
         // "Crash": no ClaimEvent ever lands, and the record out-lives the TTL
         // (Duration::ZERO = instantly expired, keeps the test clock-free).
-        acquire_claim_lock(&store, gi, std::time::Duration::ZERO)
+        let outcome = acquire_claim_lock(&store, gi, std::time::Duration::ZERO)
             .await
-            .expect("orphaned record (no ClaimEvent, TTL expired) must accept resubmission");
+            .expect("orphaned record classification must not error");
+        assert_eq!(
+            outcome,
+            ClaimLockOutcome::Acquired,
+            "orphaned record (no ClaimEvent, TTL expired) must be superseded → Acquired"
+        );
         assert!(
             store.is_claimed(&gi).await.unwrap(),
             "recovery SUPERSEDES the record (lock re-held by the new submission), not deletes it"
         );
     }
 
-    /// Dedup must HOLD for a landed claim: record present + ClaimEvent recorded → still
-    /// rejected, even with the TTL long expired. "Already claimed" stays an error forever.
+    /// A LANDED claim is classified `Landed` (→ #55 accept-and-revert), NOT a hard
+    /// reject — even with the TTL long expired, the LANDED classification wins over
+    /// orphan recovery, for any submitter. (Pre-#55 this returned an "already
+    /// submitted" error; the accept-and-revert routing replaces that at the lock.)
     #[tokio::test]
-    async fn landed_claim_stays_hard_deduped() {
+    async fn landed_claim_classified_as_landed() {
         let store: std::sync::Arc<dyn crate::store::Store> =
             std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
         let gi = U256::from(77u64);
@@ -2024,12 +2127,14 @@ mod tests {
             .await
             .unwrap();
 
-        let err = acquire_claim_lock(&store, gi, std::time::Duration::ZERO)
+        let outcome = acquire_claim_lock(&store, gi, std::time::Duration::ZERO)
             .await
-            .expect_err("a LANDED claim must stay rejected even with the TTL expired");
-        assert!(
-            err.to_string().contains("already submitted"),
-            "landed dedup keeps the original rejection: {err:#}"
+            .expect("landed classification must not error");
+        assert_eq!(
+            outcome,
+            ClaimLockOutcome::Landed,
+            "a LANDED gi must classify as Landed (→ accept-and-revert), never a hard reject, \
+             even with the TTL expired"
         );
     }
 
@@ -2306,13 +2411,18 @@ mod tests {
             "accept-and-revert must not publish a second CLAIM to Miden"
         );
 
-        // The claim-lock PRIMITIVE is unchanged: a direct acquire_claim_lock on
-        // a LANDED gi still hard-rejects even with the TTL forced to zero — the
-        // LANDED check wins over orphan recovery, regardless of submitter.
-        let err = acquire_claim_lock(&store, gi, std::time::Duration::ZERO)
+        // The claim-lock classification: a direct acquire_claim_lock on a LANDED
+        // gi returns `Landed` even with the TTL forced to zero — the LANDED check
+        // wins over orphan recovery, regardless of submitter (routes to
+        // accept-and-revert, never a hard reject).
+        let outcome = acquire_claim_lock(&store, gi, std::time::Duration::ZERO)
             .await
-            .expect_err("LANDED must beat TTL-expiry recovery at the lock primitive");
-        assert!(err.to_string().contains("already submitted"));
+            .expect("landed classification must not error");
+        assert_eq!(
+            outcome,
+            ClaimLockOutcome::Landed,
+            "LANDED beats TTL-expiry recovery"
+        );
     }
 
     /// TTL takeover by a DIFFERENT signer — PINS CURRENT (deliberate) BEHAVIOR:
@@ -2869,8 +2979,188 @@ mod tests {
         let _ = shutdown.send(());
     }
 
+    /// BLOCKER 1 (landed-state TOCTOU) — deterministic race, at the lock boundary.
+    ///
+    /// Pre-fix a standalone `has_claim_event` pre-check ran BEFORE the lock: it
+    /// could read "not landed", the real claim could LAND, and `acquire_claim_lock`
+    /// would then hard-reject → the sponsor's nonce is NOT consumed → wedge. The
+    /// fix makes "landed" a TYPED, ATOMIC outcome of `acquire_claim_lock` itself.
+    ///
+    /// This models the exact interleaving deterministically: the same lock record
+    /// classifies `InFlight` while in flight (no ClaimEvent) and flips to `Landed`
+    /// the instant the ClaimEvent is recorded — the landed detection is atomic with
+    /// the lock decision, so there is NO interleaving in which a landed gi is
+    /// hard-rejected.
+    #[tokio::test]
+    async fn blocker1_landed_at_lock_boundary_flips_inflight_to_landed() {
+        let store: std::sync::Arc<dyn crate::store::Store> =
+            std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let gi = U256::from(0x550au64);
+        // Signer A's claim is IN FLIGHT: locked, NO ClaimEvent yet — the exact state
+        // a pre-check would read as "not landed".
+        store.try_claim(gi).await.expect("A locks gi");
+        assert_eq!(
+            acquire_claim_lock(&store, gi, claim_resubmit_ttl())
+                .await
+                .expect("classify must not error"),
+            ClaimLockOutcome::InFlight,
+            "in flight (no ClaimEvent) → InFlight — a pre-check here would read 'not landed'"
+        );
+
+        // The racing interleaving: A's claim LANDS (ClaimEvent recorded) in the
+        // window a pre-check-then-lock design would have left open.
+        store
+            .commit_manual_claim_event_atomic(
+                "toctou-note".into(),
+                "0x00000000000000000000000000000000000000aa",
+                5,
+                [0u8; 32],
+                "0x1111111111111111111111111111111111111111111111111111111111111111",
+                gi.to_be_bytes::<32>(),
+                0,
+                &[0u8; 20],
+                &[0u8; 20],
+                1_000,
+            )
+            .await
+            .unwrap();
+
+        // The SAME lock call now classifies `Landed` — routed to accept-and-revert,
+        // NEVER a hard reject. The TOCTOU window is closed.
+        assert_eq!(
+            acquire_claim_lock(&store, gi, claim_resubmit_ttl())
+                .await
+                .expect("classify must not error"),
+            ClaimLockOutcome::Landed,
+            "once landed, the lock classifies Landed (→ accept-and-revert), never hard-reject"
+        );
+    }
+
+    /// BLOCKER 1 — end-to-end: a landed-at-lock-boundary claim from a DIFFERENT
+    /// signer goes through the FULL RPC path and is accept-and-reverted (nonce
+    /// consumed, reverted receipt), never hard-rejected — no nonce desync.
+    #[tokio::test]
+    async fn blocker1_landed_at_lock_boundary_accept_and_reverts_e2e() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        seed_zero_ger(&store).await;
+        let gi = U256::from(0x550bu64);
+        // The landed state (locked + ClaimEvent) is present before B's submission
+        // classifies it — i.e. A's claim has LANDED by the time B reaches the lock.
+        land_claim_for(&store, gi).await;
+
+        let key_b = alloy::signers::local::PrivateKeySigner::random();
+        let addr_b = key_b.address();
+        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
+
+        let accepted = service_send_raw_txn(service.clone(), input_b)
+            .await
+            .expect("landed-at-lock-boundary must accept-and-revert, not hard-reject");
+        assert_eq!(accepted, tx_b);
+        assert_eq!(
+            store.nonce_get(&format!("{addr_b:#x}")).await.unwrap(),
+            1,
+            "nonce consumed — no desync (the wedge is unreachable)"
+        );
+        let (result, _blk) = store
+            .txn_receipt(tx_b)
+            .await
+            .unwrap()
+            .expect("reverted receipt written");
+        assert!(result.is_err(), "status 0x0 reverted");
+    }
+
+    /// BLOCKER 2 (sync-path crash/error atomicity) — deterministic crash-boundary.
+    ///
+    /// On the sync accept path the durable receipt write and the per-signer
+    /// `nonce_increment` are separate steps; a crash BETWEEN them leaves the tx
+    /// KNOWN (receipt persisted) but the nonce STALE. We simulate exactly that
+    /// durable state (persist the reverted receipt WITHOUT advancing the nonce),
+    /// then rebroadcast the same tx: the RD-940 same-hash dedup path REPAIRS the
+    /// nonce (advances it, completing the interrupted accept), and the signer's
+    /// NEXT tx (nonce+1) then passes R4 — the sponsor is NOT left wedged.
+    #[tokio::test]
+    async fn blocker2_crash_gap_rebroadcast_repairs_stale_nonce() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        seed_zero_ger(&store).await;
+
+        let key_b = alloy::signers::local::PrivateKeySigner::random();
+        let addr_b = key_b.address();
+        let signer_str = format!("{addr_b:#x}");
+        let gi = U256::from(0x550cu64);
+        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
+
+        // Reconstruct the envelope and persist the reverted receipt for B's tx at
+        // nonce 0 WITHOUT advancing the nonce — the exact durable state a crash in
+        // the record→nonce_increment gap leaves.
+        let payload = crate::hex::hex_decode_prefixed(&input_b).unwrap();
+        let mut slice = payload.as_slice();
+        let env = TxEnvelope::decode_2718(&mut slice).unwrap();
+        record_local_immediate_reverted(
+            &service,
+            tx_b,
+            env,
+            addr_b,
+            "simulated crash-gap reverted receipt".into(),
+        )
+        .await
+        .unwrap();
+        // Precondition: tx KNOWN, nonce STALE at 0.
+        assert!(
+            store.txn_get(tx_b).await.unwrap().is_some(),
+            "receipt persisted"
+        );
+        assert_eq!(
+            store.nonce_get(&signer_str).await.unwrap(),
+            0,
+            "nonce not yet advanced"
+        );
+
+        // REBROADCAST the same tx → dedup path detects expected(0) == tx.nonce(0)
+        // and repairs the nonce.
+        let res = service_send_raw_txn(service.clone(), input_b.clone())
+            .await
+            .expect("rebroadcast returns the known hash");
+        assert_eq!(res, tx_b);
+        assert_eq!(
+            store.nonce_get(&signer_str).await.unwrap(),
+            1,
+            "crash-gap nonce REPAIRED on rebroadcast — the interrupted accept completed"
+        );
+
+        // Idempotent: a further rebroadcast does NOT advance again (expected 1 != 0).
+        service_send_raw_txn(service.clone(), input_b)
+            .await
+            .expect("second rebroadcast still Ok");
+        assert_eq!(
+            store.nonce_get(&signer_str).await.unwrap(),
+            1,
+            "repair is idempotent — no double advance"
+        );
+
+        // The signer's NEXT tx (nonce 1) now passes R4 — NOT wedged. Use an
+        // unresolvable destination so it completes synchronously (RD-860 swallow).
+        let calldata_next = claim_calldata(
+            U256::from(0x550du64),
+            Address::from([0x99u8; 20]),
+            U256::from(1u64),
+        );
+        let (input_next, _) = encode_tx_signed_with_nonce(&key_b, calldata_next, 1);
+        service_send_raw_txn(service, input_next)
+            .await
+            .expect("next tx at nonce 1 must be accepted — the sponsor is not wedged");
+        assert_eq!(
+            store.nonce_get(&signer_str).await.unwrap(),
+            2,
+            "sequence stays in lockstep after crash-gap recovery"
+        );
+    }
+
     /// No double-submit race: a record YOUNGER than the TTL (a submission genuinely in
-    /// flight) keeps rejecting resubmissions even though no ClaimEvent exists yet.
+    /// flight, no ClaimEvent yet) classifies as `InFlight` — the caller hard-rejects.
     #[tokio::test]
     async fn in_flight_claim_within_ttl_still_rejected() {
         let store: std::sync::Arc<dyn crate::store::Store> =
@@ -2878,12 +3168,13 @@ mod tests {
         let gi = U256::from(88u64);
         store.try_claim(gi).await.unwrap();
 
-        let err = acquire_claim_lock(&store, gi, std::time::Duration::from_secs(3600))
+        let outcome = acquire_claim_lock(&store, gi, std::time::Duration::from_secs(3600))
             .await
-            .expect_err("an in-flight record (younger than the TTL) must keep rejecting");
-        assert!(
-            err.to_string().contains("already submitted"),
-            "in-flight dedup keeps the original rejection: {err:#}"
+            .expect("in-flight classification must not error");
+        assert_eq!(
+            outcome,
+            ClaimLockOutcome::InFlight,
+            "an in-flight record (younger than the TTL, no ClaimEvent) must classify InFlight"
         );
         assert!(store.is_claimed(&gi).await.unwrap(), "lock stays held");
     }

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -331,9 +331,9 @@ pub(crate) async fn repair_commit_gap_nonce(
 
 /// Handle a `claimAsset` transaction: skip zero-amount or publish the claim.
 ///
-/// This is the unified dispatcher for both the sync path and writer worker. It
-/// runs only after the signed envelope is durable and the nonce CAS has accepted
-/// the transaction. It never advances or reopens the nonce itself; any later
+/// This is the writer-worker dispatcher. It runs only after the signed envelope
+/// is durable and the nonce CAS has accepted the transaction. It never
+/// advances or reopens the nonce itself; any later
 /// failure becomes a status-0 receipt for the already-accepted hash.
 pub(crate) async fn worker_handle_claim_asset(
     service: &ServiceState,
@@ -566,8 +566,8 @@ impl Drop for AbortTaskOnDrop {
     }
 }
 
-/// #55 BLOCKER 1 — execute a WON admission (dispatch to the writer worker or the
-/// legacy sync path) and return the tx hash. Extracted so `service_send_raw_txn` can
+/// #55 BLOCKER 1 — execute a WON admission through the writer worker and return
+/// the tx hash. Extracted so `service_send_raw_txn` can
 /// wrap it with the reservation-lease RELEASE (success → future same-hash dedups;
 /// failure → the same tx may retry via lease takeover). Only ever called after the
 /// caller won the `(signer, nonce)` reservation.
@@ -712,12 +712,7 @@ async fn dispatch_after_reservation(
         return Ok(txn_hash);
     }
 
-    if service.enable_writer_worker {
-        let handle = service.writer_handle.as_ref().ok_or_else(|| {
-            anyhow::anyhow!(
-                "enable_writer_worker=true but no writer_handle plumbed into ServiceState"
-            )
-        })?;
+    if let Some(handle) = service.writer_handle.as_ref() {
         if handle.available_capacity() == 0 {
             return Err(crate::writer_worker::WriterQueueSaturatedError.into());
         }
@@ -741,41 +736,52 @@ async fn dispatch_after_reservation(
             }
         }
     } else {
-        durably_admit_and_advance_nonce(
-            service,
-            txn_hash,
-            &txn_envelope,
-            signer,
-            signer_str,
-            tx_nonce,
-        )
-        .await?;
-        let dispatch: anyhow::Result<()> = match decoded {
-            crate::writer_worker::DecodedWriteCall::Claim { params } => {
-                worker_handle_claim_asset(service, *params, txn_hash, txn_envelope, signer).await
+        #[cfg(not(test))]
+        anyhow::bail!("single writer handle missing from production ServiceState");
+
+        // Lower-level unit tests deliberately omit the background runtime so
+        // they can assert dispatch results synchronously. This path is not
+        // compiled into production.
+        #[cfg(test)]
+        {
+            durably_admit_and_advance_nonce(
+                service,
+                txn_hash,
+                &txn_envelope,
+                signer,
+                signer_str,
+                tx_nonce,
+            )
+            .await?;
+            let dispatch: anyhow::Result<()> = match decoded {
+                crate::writer_worker::DecodedWriteCall::Claim { params } => {
+                    worker_handle_claim_asset(service, *params, txn_hash, txn_envelope, signer)
+                        .await
+                }
+                crate::writer_worker::DecodedWriteCall::Ger { ger_bytes } => {
+                    worker_handle_ger_insert(service, ger_bytes, txn_hash, txn_envelope, signer)
+                        .await
+                }
+            };
+            if let Err(err) = dispatch {
+                // Once the durable row and nonce CAS commit, the transaction is accepted.
+                // Any later sync failure is represented as a status-0 receipt instead of
+                // reopening the nonce slot after an outcome-ambiguous external call.
+                let block_num = service.store.get_latest_block_number().await?;
+                let block_hash = service.block_state.get_block_hash(block_num);
+                service
+                    .store
+                    .txn_commit(
+                        txn_hash,
+                        Err(format!("sync dispatch failed: {err:#}")),
+                        block_num,
+                        block_hash,
+                    )
+                    .await?;
+                tracing::error!(%txn_hash, error = %err, "accepted sync transaction reverted");
             }
-            crate::writer_worker::DecodedWriteCall::Ger { ger_bytes } => {
-                worker_handle_ger_insert(service, ger_bytes, txn_hash, txn_envelope, signer).await
-            }
-        };
-        if let Err(err) = dispatch {
-            // Once the durable row and nonce CAS commit, the transaction is accepted.
-            // Any later sync failure is represented as a status-0 receipt instead of
-            // reopening the nonce slot after an outcome-ambiguous external call.
-            let block_num = service.store.get_latest_block_number().await?;
-            let block_hash = service.block_state.get_block_hash(block_num);
-            service
-                .store
-                .txn_commit(
-                    txn_hash,
-                    Err(format!("sync dispatch failed: {err:#}")),
-                    block_num,
-                    block_hash,
-                )
-                .await?;
-            tracing::error!(%txn_hash, error = %err, "accepted sync transaction reverted");
+            Ok(txn_hash)
         }
-        Ok(txn_hash)
     }
 }
 
@@ -1248,7 +1254,6 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
             "known_store_linked": known_store_linked,
             "known_store_prepared": handoff.as_ref().is_some_and(|handoff| handoff.state == crate::store::NoteHandoffState::Prepared),
             "known_durable_intent": known_durable_intent,
-            "writer_enabled": service.enable_writer_worker,
             "writer_handle_present": service.writer_handle.is_some(),
         })
     );
@@ -1275,15 +1280,14 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
     // Deterministic and side-effect-free rejection belongs before the signer
     // lock. Stateful checks repeat after reservation to close landing races.
     validate_before_nonce_reservation(&service, &decoded).await?;
-    if service.enable_writer_worker {
-        let handle = service.writer_handle.as_ref().ok_or_else(|| {
-            anyhow::anyhow!(
-                "enable_writer_worker=true but no writer_handle plumbed into ServiceState"
-            )
-        })?;
-        if handle.available_capacity() == 0 {
-            return Err(crate::writer_worker::WriterQueueSaturatedError.into());
-        }
+    if let Some(handle) = service.writer_handle.as_ref()
+        && handle.available_capacity() == 0
+    {
+        return Err(crate::writer_worker::WriterQueueSaturatedError.into());
+    }
+    #[cfg(not(test))]
+    if service.writer_handle.is_none() {
+        anyhow::bail!("single writer handle missing from production ServiceState");
     }
 
     // R4 follow-up — serialise the entire nonce-check + enqueue/handler
@@ -1345,7 +1349,7 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         }
         let durable_resume_nonce =
             known_durable_intent && expected_nonce == tx_nonce.saturating_add(1);
-        let can_wait_for_future_nonce = service.enable_writer_worker
+        let can_wait_for_future_nonce = service.writer_handle.is_some()
             && tx_nonce > expected_nonce
             && future_nonce_wait_started.elapsed() < future_nonce_wait_max;
         let nonce_action = if tx_nonce == expected_nonce || durable_resume_nonce {
@@ -1369,7 +1373,6 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
                 "durable_resume": durable_resume_nonce,
                 "action": nonce_action,
                 "future_nonce_wait_ms": future_nonce_wait_started.elapsed().as_millis(),
-                "writer_enabled": service.enable_writer_worker,
                 "writer_handle_present": service.writer_handle.is_some(),
             })
         );
@@ -1825,8 +1828,7 @@ mod tests {
         );
     }
 
-    /// PR #127 review point 3 — writer mode. Pre-fix, with
-    /// `enable_writer_worker = true` the C6 gate only ran inside the worker,
+    /// PR #127 review point 3. Pre-fix, the C6 gate only ran inside the worker,
     /// AFTER `try_enqueue` had consumed the nonce and admitted the tx hash
     /// into the inflight dedup cache. The gate must run on the REQUEST path:
     /// a claim whose GER is unpublished is rejected with no nonce consumed,
@@ -1835,7 +1837,6 @@ mod tests {
     #[tokio::test]
     async fn c6_writer_mode_missing_ger_rejected_before_enqueue_then_retryable() {
         let mut service = create_test_service();
-        service.enable_writer_worker = true;
         let (handle, _shutdown) = crate::writer_worker::WriterWorker::spawn(
             service.clone(),
             8,
@@ -1935,7 +1936,6 @@ mod tests {
     #[tokio::test]
     async fn c6_writer_mode_zero_amount_claim_not_ger_gated() {
         let mut service = create_test_service();
-        service.enable_writer_worker = true;
         let (handle, _shutdown) = crate::writer_worker::WriterWorker::spawn(
             service.clone(),
             8,
@@ -2344,7 +2344,6 @@ mod tests {
             64,
             std::time::Duration::from_secs(60),
         );
-        service.enable_writer_worker = true;
         service.writer_handle = Some(std::sync::Arc::new(handle));
 
         let calldata = insertGlobalExitRootCall {
@@ -3400,7 +3399,6 @@ mod tests {
             64,
             std::time::Duration::from_secs(60),
         );
-        service.enable_writer_worker = true;
         service.writer_handle = Some(std::sync::Arc::new(handle));
         seed_zero_ger(&store).await;
 
@@ -3436,7 +3434,6 @@ mod tests {
             64,
             std::time::Duration::from_secs(60),
         );
-        service.enable_writer_worker = true;
         service.writer_handle = Some(std::sync::Arc::new(handle));
         seed_zero_ger(&store).await;
 
@@ -4080,7 +4077,6 @@ mod tests {
             std::time::Duration::from_secs(60),
         );
         let handle = std::sync::Arc::new(handle);
-        service.enable_writer_worker = true;
         service.writer_handle = Some(handle.clone());
         let store = service.store.clone();
 
@@ -4110,7 +4106,6 @@ mod tests {
             std::time::Duration::from_secs(60),
         );
         let handle2 = std::sync::Arc::new(handle2);
-        service2.enable_writer_worker = true;
         service2.writer_handle = Some(handle2.clone());
 
         // Arm a one-shot CAS store failure.
@@ -4202,7 +4197,6 @@ mod tests {
             std::time::Duration::from_secs(60),
         );
         let handle = std::sync::Arc::new(handle);
-        service.enable_writer_worker = true;
         service.writer_handle = Some(handle.clone());
         let retried = service_send_raw_txn(service, input_hex).await.unwrap();
         assert_eq!(retried, tx_hash);
@@ -4322,7 +4316,6 @@ mod tests {
             64,
             std::time::Duration::from_secs(60),
         );
-        service.enable_writer_worker = true;
         service.writer_handle = Some(std::sync::Arc::new(handle));
         // gi LANDED; GER deliberately NOT seeded → C6 would reject "not observed yet".
         let gi = U256::from(0x55c3u64);

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -15,7 +15,7 @@ struct TransactionData {
     pub input: alloy::primitives::Bytes,
 }
 
-fn envelope_nonce(txn_envelope: &TxEnvelope) -> u64 {
+pub(crate) fn envelope_nonce(txn_envelope: &TxEnvelope) -> u64 {
     match txn_envelope {
         TxEnvelope::Eip1559(s) => s.tx().nonce,
         TxEnvelope::Eip2930(s) => s.tx().nonce,
@@ -140,7 +140,7 @@ async fn record_local_pending_tx(
 ) -> anyhow::Result<()> {
     service
         .store
-        .txn_begin(
+        .txn_begin_if_absent(
             tx_hash,
             TxnEntry {
                 id: None,
@@ -151,6 +151,7 @@ async fn record_local_pending_tx(
             },
         )
         .await
+        .map(|_| ())
 }
 
 async fn record_local_immediate_success(
@@ -286,15 +287,10 @@ pub(crate) async fn repair_commit_gap_nonce(
 
 /// Handle a `claimAsset` transaction: skip zero-amount or publish the claim.
 ///
-/// RD-940 Phase 1: this is the unified dispatcher for both the legacy sync
-/// path and the new writer-worker path. **It does NOT advance the per-signer
-/// nonce** — the caller in `service_send_raw_txn` does that once, after the
-/// dispatch (sync) or after a successful `try_enqueue` (worker), so the two
-/// paths agree on when nonce advances.
-///
-/// `_` suffix in `_signer_str_unused` calls below is a deliberate marker that
-/// this function used to own three `nonce_increment` calls — see git blame on
-/// the previous revision.
+/// This is the unified dispatcher for both the sync path and writer worker. It
+/// runs only after the signed envelope is durable and the nonce CAS has accepted
+/// the transaction. It never advances or reopens the nonce itself; any later
+/// failure becomes a status-0 receipt for the already-accepted hash.
 pub(crate) async fn worker_handle_claim_asset(
     service: &ServiceState,
     params: claimAssetCall,
@@ -338,7 +334,14 @@ pub(crate) async fn worker_handle_claim_asset(
     // `InFlight`, so no interleaving hard-rejects a landed gi.
     let tx_nonce = envelope_nonce(&txn_envelope);
     let signer_str = format!("{signer:#x}");
-    match acquire_claim_lock(&service.store, params.globalIndex, claim_resubmit_ttl()).await? {
+    let claim_fence = match acquire_claim_lock(
+        &service.store,
+        params.globalIndex,
+        txn_hash,
+        claim_resubmit_ttl(),
+    )
+    .await?
+    {
         // Geth-faithful accept-and-revert: ACCEPT, write a REVERTED receipt (status
         // 0x0, empty logs, NO new ClaimEvent) AND advance the nonce ATOMICALLY (one
         // store transaction — BLOCKER C), so the submitter's nonce is consumed like
@@ -358,10 +361,9 @@ pub(crate) async fn worker_handle_claim_asset(
             return Ok(());
         }
         // A genuine concurrent submission for this gi is in flight (locked, no
-        // ClaimEvent yet, within TTL). Hard-reject — must not double-publish. In
-        // sync mode this returns Err WITHOUT the caller advancing the nonce (a
-        // genuine retry, nonce not consumed); once the in-flight claim LANDS, the
-        // retry re-enters and takes the `Landed` accept-and-revert arm above.
+        // ClaimEvent yet, within TTL). Do not double-publish. Because this dispatcher
+        // runs after durable admission, the outer sync/worker path records status 0;
+        // a same-hash rebroadcast then deduplicates to that terminal receipt.
         ClaimLockOutcome::InFlight => {
             anyhow::bail!(
                 "claim already submitted for global_index {}",
@@ -369,13 +371,18 @@ pub(crate) async fn worker_handle_claim_asset(
             );
         }
         // Fresh lock (or an orphaned record superseded) — proceed to publish.
-        ClaimLockOutcome::Acquired => {}
-    }
+        ClaimLockOutcome::Acquired { fence } => fence,
+    };
 
-    // R9 — we now HOLD the per-globalIndex lock. Install a RAII drop guard so a
-    // cancelled / panicked / disconnected future releases it; every early return
-    // below (RD-860 swallow, C6 reject, publish failure) releases it explicitly.
-    let guard = ClaimGuard::new(service.store.clone(), params.globalIndex);
+    // R9 — install a fenced RAII guard. Cancellation or a pre-submit failure can
+    // release only this executing fence; after `mark_submitted_fenced`, release is
+    // fail-closed and neither this guard nor a stale owner can reopen the claim.
+    let guard = ClaimGuard::new(
+        service.store.clone(),
+        params.globalIndex,
+        txn_hash,
+        claim_fence,
+    );
 
     // RD-860 — swallow unresolvable-destination claims permanently. If the
     // destination address can't be resolved to a Miden AccountId, record the
@@ -450,8 +457,15 @@ pub(crate) async fn worker_handle_claim_asset(
         return Err(err);
     }
 
-    let result =
-        publish_and_record_claim(service, params.clone(), txn_hash, txn_envelope, signer).await;
+    let result = publish_and_record_claim(
+        service,
+        params.clone(),
+        txn_hash,
+        txn_envelope,
+        signer,
+        &guard,
+    )
+    .await;
     if let Err(err) = result {
         // Explicit release: the guard would also fire on drop, but doing it
         // here avoids the tokio::spawn round-trip on the error path.
@@ -479,14 +493,10 @@ pub(crate) async fn worker_handle_claim_asset(
 /// receipt or queued job is created, and the SAME signed transaction can be
 /// re-submitted after GER publication.
 ///
-/// This gate MUST run before every enqueue path, nonce increment, try_claim,
-/// txn_begin, or receipt creation:
-///   - sync path: `worker_handle_claim_asset` calls it before
-///     `acquire_claim_lock` (nonce advances only after the dispatch returns
-///     Ok);
-///   - writer path: `service_send_raw_txn` calls it on the REQUEST thread
-///     before `try_enqueue` (which would otherwise consume the nonce and
-///     admit the hash into the inflight dedup cache).
+/// This gate MUST run before durable admission, nonce CAS, or enqueue.
+/// `dispatch_after_reservation` does so on the request thread for both sync and
+/// writer modes. `worker_handle_claim_asset` repeats it after fenced acquisition
+/// as defense in depth against GER state changing while a queued job waits.
 ///
 /// `is_ger_injected` rather than `has_seen_ger`: the L1InfoTreeIndexer
 /// pre-populates ger_entries rows for L1 pairs it has indexed but that
@@ -530,7 +540,7 @@ pub(crate) fn claim_resubmit_ttl() -> std::time::Duration {
 }
 
 /// #55 BLOCKER 1 — how long a won `(signer, nonce)` admission lease is owned before
-/// another replica may take it over on expiry (crash recovery). Kept comfortably
+/// another replica presenting the SAME hash may take it over on expiry. Kept comfortably
 /// BELOW aggkit's re-broadcast envelope so a rebroadcast after an owner crash can
 /// take over promptly, yet above the slowest legitimate admission (a sync claim
 /// publish). Env-tunable via `NONCE_RESERVATION_LEASE_SECS`.
@@ -540,7 +550,7 @@ pub(crate) fn reservation_lease() -> std::time::Duration {
         .ok()
         .and_then(|v| v.trim().parse::<u64>().ok())
         .unwrap_or(DEFAULT_SECS);
-    std::time::Duration::from_secs(secs)
+    std::time::Duration::from_secs(secs.max(3))
 }
 
 /// #55 BLOCKER 1 — execute a WON admission (dispatch to the writer worker or the
@@ -548,6 +558,45 @@ pub(crate) fn reservation_lease() -> std::time::Duration {
 /// wrap it with the reservation-lease RELEASE (success → future same-hash dedups;
 /// failure → the same tx may retry via lease takeover). Only ever called after the
 /// caller won the `(signer, nonce)` reservation.
+async fn durably_admit_and_advance_nonce(
+    service: &ServiceState,
+    txn_hash: TxHash,
+    txn_envelope: &TxEnvelope,
+    signer: Address,
+    signer_str: &str,
+    tx_nonce: u64,
+) -> anyhow::Result<()> {
+    // The pending row is the durable queue intent. It is committed before the
+    // nonce CAS, so a crash can never consume a nonce while leaving no work to
+    // recover from the signed envelope.
+    service
+        .store
+        .txn_begin_if_absent(
+            txn_hash,
+            TxnEntry {
+                id: None,
+                envelope: txn_envelope.clone(),
+                signer,
+                expires_at: None,
+                logs: vec![],
+            },
+        )
+        .await?;
+    let advanced = service
+        .store
+        .nonce_advance_cas(signer_str, tx_nonce)
+        .await?;
+    if !advanced {
+        let current = service.store.nonce_get(signer_str).await?;
+        if current != tx_nonce.saturating_add(1) {
+            anyhow::bail!(
+                "lost nonce CAS for durable transaction {txn_hash:#x}: expected {tx_nonce}, current {current}"
+            );
+        }
+    }
+    Ok(())
+}
+
 async fn dispatch_after_reservation(
     service: &ServiceState,
     decoded: crate::writer_worker::DecodedWriteCall,
@@ -557,76 +606,67 @@ async fn dispatch_after_reservation(
     signer_str: &str,
     tx_nonce: u64,
 ) -> anyhow::Result<TxHash> {
+    // Cheap deterministic validation, landed classification, and retryable GER
+    // checks happen before durable acceptance in both sync and writer modes.
+    if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
+        && params.destinationNetwork != service.network_id
+    {
+        anyhow::bail!(
+            "claim targets destinationNetwork {} but this proxy only handles network {}",
+            params.destinationNetwork,
+            service.network_id
+        );
+    }
+    if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
+        && service
+            .store
+            .has_claim_event_for_global_index(&params.globalIndex.to_be_bytes::<32>())
+            .await?
+    {
+        accept_and_revert_landed_claim(
+            service,
+            params,
+            txn_hash,
+            txn_envelope,
+            signer,
+            signer_str,
+            tx_nonce,
+        )
+        .await?;
+        return Ok(txn_hash);
+    }
+    if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
+        && params.destinationNetwork == service.network_id
+        && !params.amount.is_zero()
+        && crate::address_mapper::resolve_address(
+            &*service.store,
+            params.destinationAddress,
+            &service.accounts.0,
+        )
+        .await
+        .is_ok()
+    {
+        ensure_claim_ger_published(&service.store, params).await?;
+    }
+
     if service.enable_writer_worker {
         let handle = service.writer_handle.as_ref().ok_or_else(|| {
             anyhow::anyhow!(
-                "enable_writer_worker=true but no writer_handle plumbed into ServiceState; \
-                 boot order bug — see main.rs writer spawn block"
+                "enable_writer_worker=true but no writer_handle plumbed into ServiceState"
             )
         })?;
-
-        // BLOCKER 3 — landed classification BEFORE C6 in WRITER mode too: an
-        // already-LANDED gi routes to accept-and-revert here (atomic reverted receipt
-        // + nonce, synchronous, no enqueue), regardless of GER state, so it never
-        // gets a C6 RPC error with no nonce consumption. The worker's
-        // `acquire_claim_lock` still catches a claim that LANDS after this check.
-        if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
-            && service
-                .store
-                .has_claim_event_for_global_index(&params.globalIndex.to_be_bytes::<32>())
-                .await?
-        {
-            accept_and_revert_landed_claim(
-                service,
-                params,
-                txn_hash,
-                txn_envelope,
-                signer,
-                signer_str,
-                tx_nonce,
-            )
-            .await?;
-            return Ok(txn_hash);
-        }
-
-        // C6 on the REQUEST path (PR #127 review point 3) — gate before enqueue so a
-        // GER-not-yet-published claim leaves nothing behind. Only claims that would
-        // reach C6 in the worker are gated (zero-amount + unresolvable destinations
-        // are swallowed earlier).
-        if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
-            && params.destinationNetwork == service.network_id
-            && !params.amount.is_zero()
-            && crate::address_mapper::resolve_address(
-                &*service.store,
-                params.destinationAddress,
-                &service.accounts.0,
-            )
-            .await
-            .is_ok()
-        {
-            ensure_claim_ger_published(&service.store, params).await?;
-        }
-
-        // BLOCKER B — order MUST be reserve → nonce_advance_cas → enqueue. If the
-        // CAS ran AFTER a successful `try_enqueue`, a CAS store error would leave the
-        // job LIVE (enqueued, will execute) with a STALE nonce, and the outer
-        // reservation would be marked `released_failure` — so an immediate same-hash
-        // retry could retake the lease and enqueue DUPLICATE work. Advancing the
-        // nonce FIRST means a CAS failure aborts admission with NO enqueued job and
-        // NO nonce change.
-        //
-        // To keep genuine backpressure retryable with the SAME nonce, fast-fail
-        // QueueFull BEFORE the CAS when the queue is already full (the common case);
-        // only a rare fill-in-the-gap TOCTOU (queue fills between this check and
-        // try_enqueue) consumes the nonce — the geth-like consumed-nonce semantics,
-        // never an enqueue-then-fail-the-nonce.
         if handle.available_capacity() == 0 {
             return Err(crate::writer_worker::WriterQueueSaturatedError.into());
         }
-        let _ = service
-            .store
-            .nonce_advance_cas(signer_str, tx_nonce)
-            .await?;
+        durably_admit_and_advance_nonce(
+            service,
+            txn_hash,
+            &txn_envelope,
+            signer,
+            signer_str,
+            tx_nonce,
+        )
+        .await?;
         let job = decoded.into_job(txn_envelope, signer, txn_hash);
         match handle.try_enqueue(job) {
             Ok(()) => Ok(txn_hash),
@@ -634,27 +674,44 @@ async fn dispatch_after_reservation(
                 Err(crate::writer_worker::WriterQueueSaturatedError.into())
             }
             Err(crate::writer_worker::TryEnqueueError::ShutDown) => {
-                anyhow::bail!(
-                    "writer worker has shut down — service is draining; retry against the next \
-                     replica"
-                );
+                anyhow::bail!("writer worker has shut down; retry the same signed transaction")
             }
         }
     } else {
-        // Legacy synchronous dispatch.
-        match decoded {
+        durably_admit_and_advance_nonce(
+            service,
+            txn_hash,
+            &txn_envelope,
+            signer,
+            signer_str,
+            tx_nonce,
+        )
+        .await?;
+        let dispatch: anyhow::Result<()> = match decoded {
             crate::writer_worker::DecodedWriteCall::Claim { params } => {
-                worker_handle_claim_asset(service, *params, txn_hash, txn_envelope, signer).await?;
+                worker_handle_claim_asset(service, *params, txn_hash, txn_envelope, signer).await
             }
             crate::writer_worker::DecodedWriteCall::Ger { ger_bytes } => {
-                worker_handle_ger_insert(service, ger_bytes, txn_hash, txn_envelope, signer)
-                    .await?;
+                worker_handle_ger_insert(service, ger_bytes, txn_hash, txn_envelope, signer).await
             }
+        };
+        if let Err(err) = dispatch {
+            // Once the durable row and nonce CAS commit, the transaction is accepted.
+            // Any later sync failure is represented as a status-0 receipt instead of
+            // reopening the nonce slot after an outcome-ambiguous external call.
+            let block_num = service.store.get_latest_block_number().await?;
+            let block_hash = service.block_state.get_block_hash(block_num);
+            service
+                .store
+                .txn_commit(
+                    txn_hash,
+                    Err(format!("sync dispatch failed: {err:#}")),
+                    block_num,
+                    block_hash,
+                )
+                .await?;
+            tracing::error!(%txn_hash, error = %err, "accepted sync transaction reverted");
         }
-        let _ = service
-            .store
-            .nonce_advance_cas(signer_str, tx_nonce)
-            .await?;
         Ok(txn_hash)
     }
 }
@@ -667,11 +724,11 @@ async fn dispatch_after_reservation(
 pub(crate) enum ClaimLockOutcome {
     /// The submission lock is now held by THIS caller (fresh index, or an orphaned
     /// record superseded — SOAK FINDING #1). Proceed to publish; the caller MUST
-    /// arrange `unclaim` on any later failure (via `ClaimGuard`).
-    Acquired,
+    /// arrange a fenced conditional release on any pre-submit failure (via `ClaimGuard`).
+    Acquired { fence: u64 },
     /// A genuine concurrent submission for the same gi is in flight (locked, no
-    /// ClaimEvent yet, record younger than `ttl`). The caller hard-rejects
-    /// ("already submitted") — no double publish, and no nonce is consumed.
+    /// ClaimEvent yet, record younger than `ttl`). Publication is denied so there
+    /// is no double submit; an already-accepted RPC hash is finalised status 0.
     InFlight,
     /// A real `ClaimEvent` already exists for this globalIndex — the claim LANDED.
     /// The caller routes this to #55 accept-and-revert (consume the nonce + write a
@@ -687,117 +744,140 @@ pub(crate) enum ClaimLockOutcome {
 /// interleaving, an index whose `ClaimEvent` already exists is classified `Landed`
 /// (→ #55 accept-and-revert), never hard-rejected. Cases:
 ///
-///   1. `try_claim` succeeds (fresh) + no ClaimEvent → `Acquired` (normal path).
-///   2. `try_claim` succeeds (fresh) + a ClaimEvent already exists (e.g. a restore
+///   1. `try_claim_fenced` succeeds (fresh) + no ClaimEvent → `Acquired` (normal path).
+///   2. `try_claim_fenced` succeeds (fresh) + a ClaimEvent already exists (e.g. a restore
 ///      wrote the event without a submission lock) → release the spurious lock and
 ///      return `Landed` — never double-publish onto a landed gi.
-///   3. `try_claim` fails + a ClaimEvent exists → `Landed`. This is the closed
+///   3. fenced acquisition conflicts + a ClaimEvent exists → `Landed`. This is the closed
 ///      TOCTOU: even if the claim LANDED after some earlier read, the landed
 ///      classification is made here, at the lock decision, and routes to
 ///      accept-and-revert rather than a hard reject.
-///   4. `try_claim` fails + no ClaimEvent + record younger than `ttl` → `InFlight`.
-///   5. `try_claim` fails + no ClaimEvent + `ttl` expired → ORPHANED: atomically
-///      supersede (`Store::try_reclaim_expired` — single UPDATE, one winner under
+///   4. fenced acquisition conflicts + no ClaimEvent + record younger than `ttl` → `InFlight`.
+///   5. fenced acquisition conflicts + no ClaimEvent + `ttl` expired → ORPHANED: atomically
+///      supersede (`Store::try_reclaim_claim_fenced` — single UPDATE, one winner under
 ///      concurrency), warn + `claim_resubmission_recovered_total`, return `Acquired`.
 pub(crate) async fn acquire_claim_lock(
     store: &std::sync::Arc<dyn crate::store::Store>,
     global_index: alloy::primitives::U256,
+    owner_tx_hash: TxHash,
     ttl: std::time::Duration,
 ) -> anyhow::Result<ClaimLockOutcome> {
     let gi_bytes: [u8; 32] = global_index.to_be_bytes::<32>();
-    match store.try_claim(global_index).await {
-        Ok(()) => {
-            // Fresh lock acquired. Guard the rare "ClaimEvent exists but no lock"
-            // (e.g. a restore populated the event without a submission lock): if a
-            // ClaimEvent already exists, this is LANDED — release the lock we just
-            // took and route to accept-and-revert rather than double-publishing.
-            if store.has_claim_event_for_global_index(&gi_bytes).await? {
-                store.unclaim(&global_index).await?;
-                return Ok(ClaimLockOutcome::Landed);
-            }
-            Ok(ClaimLockOutcome::Acquired)
+    if let Some(claim) = store
+        .try_claim_fenced(global_index, owner_tx_hash, ttl)
+        .await?
+    {
+        if store.has_claim_event_for_global_index(&gi_bytes).await? {
+            store
+                .unclaim_fenced(&global_index, owner_tx_hash, claim.fence)
+                .await?;
+            return Ok(ClaimLockOutcome::Landed);
         }
-        Err(_rejected) => {
-            // LANDED is authoritative and checked AT the lock decision — there is
-            // no separate pre-check window in which a landed gi could be routed to
-            // a hard reject.
-            if store.has_claim_event_for_global_index(&gi_bytes).await? {
-                return Ok(ClaimLockOutcome::Landed);
-            }
-            // Not landed at the first read. Atomically supersede IFF the record has
-            // out-lived the in-flight TTL; a fresher record means a submission is
-            // genuinely in flight.
-            if !store.try_reclaim_expired(global_index, ttl).await? {
-                // BLOCKER B — RE-READ the authoritative landed state AFTER failing
-                // to reclaim. The original claim may have committed its ClaimEvent
-                // in the window between the first `has_claim_event` read and the
-                // reclaim attempt; without this re-read that just-landed gi would
-                // classify `InFlight` and be hard-rejected WITHOUT consuming the
-                // nonce — the exact wedge. A gi that landed at ANY point up to here
-                // classifies `Landed` (→ accept-and-revert), never `InFlight`.
-                if store.has_claim_event_for_global_index(&gi_bytes).await? {
-                    return Ok(ClaimLockOutcome::Landed);
-                }
-                return Ok(ClaimLockOutcome::InFlight);
-            }
-            // BLOCKER 2 — the reclaim SUCCEEDED (an expired lock was superseded to
-            // us). But a claim that landed AFTER the first read yet still holds an
-            // expired-looking lock (a slow real claim: publish took > TTL, then its
-            // ClaimEvent committed) would be reclaimed here and misclassified
-            // `Acquired` → DUPLICATE PUBLISH. So RE-READ landed after the successful
-            // reclaim: if it landed, RELEASE the lock we just superseded and return
-            // `Landed` (→ accept-and-revert), never Acquired. A gi that landed at any
-            // point up to here is Landed. (Residual: an event landing strictly after
-            // this final read is caught only by the worker's own re-classification —
-            // see the report's single-store-transaction residual.)
-            if store.has_claim_event_for_global_index(&gi_bytes).await? {
-                store.unclaim(&global_index).await?;
-                return Ok(ClaimLockOutcome::Landed);
-            }
-            ::metrics::counter!("claim_resubmission_recovered_total").increment(1);
-            tracing::warn!(
-                global_index = %global_index,
-                ttl_secs = ttl.as_secs(),
-                "orphaned claim submission record for global_index {global_index} (submitted but \
-                 never landed — likely a crash mid-flight); accepting resubmission"
+        return Ok(ClaimLockOutcome::Acquired { fence: claim.fence });
+    }
+
+    if store.has_claim_event_for_global_index(&gi_bytes).await? {
+        return Ok(ClaimLockOutcome::Landed);
+    }
+    let Some(claim) = store
+        .try_reclaim_claim_fenced(global_index, owner_tx_hash, ttl)
+        .await?
+    else {
+        if store.has_claim_event_for_global_index(&gi_bytes).await? {
+            return Ok(ClaimLockOutcome::Landed);
+        }
+        return Ok(ClaimLockOutcome::InFlight);
+    };
+    if store.has_claim_event_for_global_index(&gi_bytes).await? {
+        store
+            .unclaim_fenced(&global_index, owner_tx_hash, claim.fence)
+            .await?;
+        return Ok(ClaimLockOutcome::Landed);
+    }
+    ::metrics::counter!("claim_resubmission_recovered_total").increment(1);
+    tracing::warn!(
+        global_index = %global_index,
+        ttl_secs = ttl.as_secs(),
+        fence = claim.fence,
+        "reclaimed an expired claim submission with a new ownership fence"
+    );
+    Ok(ClaimLockOutcome::Acquired { fence: claim.fence })
+}
+
+/// RAII guard that conditionally releases only its own executing claim fence if
+/// the holding future is dropped before `commit()` or `release_explicitly()`. On
+/// drop it schedules `unclaim_fenced` on the runtime; a stale owner cannot delete a
+/// successor fence, and a submitted claim remains fail-closed. Self-review R9.
+#[derive(Clone)]
+pub(crate) struct ClaimSubmissionFence {
+    store: std::sync::Arc<dyn crate::store::Store>,
+    global_index: alloy::primitives::U256,
+    owner_tx_hash: TxHash,
+    fence: u64,
+}
+
+impl ClaimSubmissionFence {
+    pub(crate) async fn mark_submitted(&self, note_commitment: &str) -> anyhow::Result<()> {
+        if !self
+            .store
+            .mark_claim_submitted_fenced(
+                self.global_index,
+                self.owner_tx_hash,
+                self.fence,
+                self.owner_tx_hash,
+                note_commitment,
+            )
+            .await?
+        {
+            anyhow::bail!(
+                "claim ownership fence lost before submission for global_index {}",
+                self.global_index
             );
-            Ok(ClaimLockOutcome::Acquired)
         }
+        Ok(())
     }
 }
 
-/// RAII guard that releases a `try_claim` lock if the holding future is dropped
-/// before either `commit()` (claim succeeded — keep the lock) or
-/// `release_explicitly()` (claim failed — release synchronously) is called.
-///
-/// On drop with neither call made, schedules a background `unclaim` via
-/// `tokio::spawn`. Guarantees that a cancelled / panicked / disconnected request
-/// future cannot leave a globalIndex permanently locked. Self-review R9.
 pub(crate) struct ClaimGuard {
     store: Option<std::sync::Arc<dyn crate::store::Store>>,
     global_index: alloy::primitives::U256,
+    owner_tx_hash: TxHash,
+    fence: u64,
 }
 
 impl ClaimGuard {
     fn new(
         store: std::sync::Arc<dyn crate::store::Store>,
         global_index: alloy::primitives::U256,
+        owner_tx_hash: TxHash,
+        fence: u64,
     ) -> Self {
         Self {
             store: Some(store),
             global_index,
+            owner_tx_hash,
+            fence,
         }
     }
 
-    /// Mark the lock as committed — the claim succeeded. Drop becomes a no-op.
+    fn submission_fence(&self) -> ClaimSubmissionFence {
+        ClaimSubmissionFence {
+            store: self.store.as_ref().expect("active claim guard").clone(),
+            global_index: self.global_index,
+            owner_tx_hash: self.owner_tx_hash,
+            fence: self.fence,
+        }
+    }
+
     fn commit(mut self) {
         self.store = None;
     }
 
-    /// Synchronously release the lock (caller awaits the unclaim).
     async fn release_explicitly(mut self) {
         if let Some(store) = self.store.take() {
-            let _ = store.unclaim(&self.global_index).await;
+            let _ = store
+                .unclaim_fenced(&self.global_index, self.owner_tx_hash, self.fence)
+                .await;
         }
     }
 }
@@ -806,30 +886,31 @@ impl Drop for ClaimGuard {
     fn drop(&mut self) {
         if let Some(store) = self.store.take() {
             let global_index = self.global_index;
-            // tokio::spawn requires a current runtime; in normal handler contexts
-            // it always exists. If we're somehow being dropped outside any
-            // runtime (e.g. a unit test that constructed the guard but never
-            // entered tokio), the spawn will panic — guard against that with
-            // try_handle.
+            let owner_tx_hash = self.owner_tx_hash;
+            let fence = self.fence;
             if let Ok(handle) = tokio::runtime::Handle::try_current() {
                 handle.spawn(async move {
-                    if let Err(e) = store.unclaim(&global_index).await {
-                        tracing::error!(
+                    match store
+                        .unclaim_fenced(&global_index, owner_tx_hash, fence)
+                        .await
+                    {
+                        Ok(true) => tracing::warn!(
                             target: "claim::guard",
-                            "R9 drop-guard failed to unclaim {global_index}: {e:#}"
-                        );
-                    } else {
-                        tracing::warn!(
+                            %global_index, fence,
+                            "released current fenced claim after cancellation"
+                        ),
+                        Ok(false) => tracing::debug!(
                             target: "claim::guard",
-                            "R9 drop-guard released claim {global_index} after future was cancelled"
-                        );
+                            %global_index, fence,
+                            "stale or submitted claim guard release was fenced out"
+                        ),
+                        Err(e) => tracing::error!(
+                            target: "claim::guard",
+                            %global_index, fence, error = %e,
+                            "failed to release fenced claim guard"
+                        ),
                     }
                 });
-            } else {
-                tracing::error!(
-                    target: "claim::guard",
-                    "R9 drop-guard ran outside tokio runtime; claim {global_index} may be leaked"
-                );
             }
         }
     }
@@ -837,14 +918,15 @@ impl Drop for ClaimGuard {
 
 /// Publish a CLAIM note and record the transaction in the store.
 ///
-/// Called after `try_claim` succeeds. The caller is responsible for calling
-/// `unclaim()` if this function returns an error.
+/// Called after fenced claim acquisition. The caller owns `ClaimGuard`, whose
+/// conditional release cannot delete a successor or a submitted claim.
 async fn publish_and_record_claim(
     service: &ServiceState,
     params: claimAssetCall,
     txn_hash: TxHash,
     txn_envelope: TxEnvelope,
     signer: Address,
+    guard: &ClaimGuard,
 ) -> anyhow::Result<()> {
     // ClaimEvent recording happens inside the MidenClient closure (cancellation-safe).
     let latest_block = service.store.get_latest_block_number().await?;
@@ -859,6 +941,7 @@ async fn publish_and_record_claim(
         signer,
         service.reject_zero_padding_addresses,
         Some(service.expected_mints.clone()),
+        guard.submission_fence(),
     )
     .await?;
     tracing::info!(
@@ -994,12 +1077,22 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         .writer_handle
         .as_ref()
         .is_some_and(|handle| handle.is_inflight(&txn_hash));
-    let known_store_tx = service
-        .store
-        .txn_get(txn_hash)
-        .await
-        .map(|entry| entry.is_some())
-        .unwrap_or(false);
+    let known_store_entry = service.store.txn_get(txn_hash).await?;
+    let known_store_tx = known_store_entry.is_some();
+    let known_store_linked = if known_store_tx {
+        service
+            .store
+            .get_note_link_for_tx(&format!("{txn_hash:#x}"))
+            .await?
+            .is_some()
+    } else {
+        false
+    };
+    // A pending row without a note handoff is the durable queue intent. It must
+    // be resumed after a crashed process loses its in-memory mpsc contents.
+    let known_durable_intent = known_store_entry
+        .as_ref()
+        .is_some_and(|entry| entry.result.is_none() && !known_store_linked);
     tracing::info!(
         target: "rpc::nonce_snoop",
         "{}",
@@ -1012,6 +1105,8 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
             "calldata_len": txn.input.len(),
             "known_inflight": known_inflight,
             "known_store_tx": known_store_tx,
+            "known_store_linked": known_store_linked,
+            "known_durable_intent": known_durable_intent,
             "writer_enabled": service.enable_writer_worker,
             "writer_handle_present": service.writer_handle.is_some(),
         })
@@ -1025,22 +1120,12 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         );
         return Ok(txn_hash);
     }
-    if known_store_tx {
+    if known_store_tx && !known_durable_intent {
         tracing::debug!(
             target: "rpc::dedup",
             %txn_hash,
-            "tx-hash dedup (committed): returning OK without re-running R4"
+            "tx-hash dedup (handed off or terminal): returning OK"
         );
-        // BLOCKER C/D (#55 review) — crash-gap nonce REPAIR via store-level CAS.
-        // On the sync accept path the durable receipt write and the nonce advance
-        // are SEPARATE steps; a crash / store error BETWEEN them leaves this tx
-        // KNOWN (receipt persisted) while the signer's expected nonce stays STALE
-        // at this tx's nonce. Without repair this rebroadcast is served as success
-        // forever while the nonce never advances, and the signer's NEXT tx
-        // (nonce+1) fails the R4 gate — the exact wedge #55 fixes, reintroduced by
-        // a crash in the commit gap. `repair_commit_gap_nonce` CAS-advances the
-        // nonce iff it is still stuck at tx_nonce (idempotent; cross-replica-safe;
-        // extracted so both stores regression-test it directly).
         repair_commit_gap_nonce(&service, &signer_str, tx_nonce).await?;
         return Ok(txn_hash);
     }
@@ -1067,10 +1152,12 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         // only on success and never compared the incoming `tx.nonce` against
         // the expected next value. That allowed replay and skipped sequencing.
         let expected_nonce = service.store.nonce_get(&signer_str).await?;
+        let durable_resume_nonce =
+            known_durable_intent && expected_nonce == tx_nonce.saturating_add(1);
         let can_wait_for_future_nonce = service.enable_writer_worker
             && tx_nonce > expected_nonce
             && future_nonce_wait_started.elapsed() < future_nonce_wait_max;
-        let nonce_action = if tx_nonce == expected_nonce {
+        let nonce_action = if tx_nonce == expected_nonce || durable_resume_nonce {
             "accept"
         } else if can_wait_for_future_nonce {
             "wait_future"
@@ -1087,6 +1174,7 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
                 "tx_nonce": tx_nonce,
                 "expected_nonce": expected_nonce,
                 "nonce_matches": tx_nonce == expected_nonce,
+                "durable_resume": durable_resume_nonce,
                 "action": nonce_action,
                 "future_nonce_wait_ms": future_nonce_wait_started.elapsed().as_millis(),
                 "writer_enabled": service.enable_writer_worker,
@@ -1094,7 +1182,7 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
             })
         );
 
-        if tx_nonce == expected_nonce {
+        if tx_nonce == expected_nonce || durable_resume_nonce {
             break lock;
         }
 
@@ -1213,6 +1301,30 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         }
     };
 
+    // Keep ownership live while sync publication or request-thread admission is
+    // running. Without renewal, a slow proof can outlive the lease and let a
+    // second replica execute the same hash concurrently.
+    let heartbeat_store = service.store.clone();
+    let heartbeat_signer = signer_str.clone();
+    let heartbeat_lease = reservation_lease();
+    let heartbeat_period = std::cmp::max(std::time::Duration::from_secs(1), heartbeat_lease / 3);
+    let reservation_heartbeat = tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(heartbeat_period).await;
+            match heartbeat_store
+                .renew_reservation(&heartbeat_signer, tx_nonce, txn_hash, heartbeat_lease)
+                .await
+            {
+                Ok(true) => {}
+                Ok(false) => break,
+                Err(err) => tracing::warn!(
+                    target: "rpc::reserve", %txn_hash, error = %err,
+                    "failed to renew nonce reservation; retrying until the lease expires"
+                ),
+            }
+        }
+    });
+
     // Execute the WON admission, then RELEASE the lease on the outcome: success →
     // `released_success` (a future same-hash submission dedups via OwnedBySame);
     // failure → `released_failure` (the SAME tx may retry via lease takeover). Only
@@ -1229,6 +1341,7 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         tx_nonce,
     )
     .await;
+    reservation_heartbeat.abort();
     if let Err(release_err) = service
         .store
         .release_reservation(
@@ -1705,8 +1818,14 @@ mod tests {
             .await
             .unwrap();
 
-        let result = service_send_raw_txn(service, input_hex).await;
-        assert!(result.is_err(), "publish_claim should fail with test stub");
+        let tx_hash = service_send_raw_txn(service, input_hex)
+            .await
+            .expect("post-accept publish failure returns the accepted hash");
+        let (receipt, _) = store.txn_receipt(tx_hash).await.unwrap().unwrap();
+        assert!(
+            receipt.is_err(),
+            "publish failure is represented as status 0x0"
+        );
 
         assert!(
             miden_client.test_was_called(),
@@ -2223,12 +2342,12 @@ mod tests {
 
         // "Crash": no ClaimEvent ever lands, and the record out-lives the TTL
         // (Duration::ZERO = instantly expired, keeps the test clock-free).
-        let outcome = acquire_claim_lock(&store, gi, std::time::Duration::ZERO)
+        let outcome = acquire_claim_lock(&store, gi, TxHash::ZERO, std::time::Duration::ZERO)
             .await
             .expect("orphaned record classification must not error");
         assert_eq!(
             outcome,
-            ClaimLockOutcome::Acquired,
+            ClaimLockOutcome::Acquired { fence: 1 },
             "orphaned record (no ClaimEvent, TTL expired) must be superseded → Acquired"
         );
         assert!(
@@ -2264,7 +2383,7 @@ mod tests {
             .await
             .unwrap();
 
-        let outcome = acquire_claim_lock(&store, gi, std::time::Duration::ZERO)
+        let outcome = acquire_claim_lock(&store, gi, TxHash::ZERO, std::time::Duration::ZERO)
             .await
             .expect("landed classification must not error");
         assert_eq!(
@@ -2443,22 +2562,15 @@ mod tests {
     }
 
     /// Signer-agnostic dedup, in-flight then landed. Signer A ("the sponsor")
-    /// has a submission genuinely in flight for gi=X (lock record present,
-    /// younger than the TTL, no ClaimEvent yet — created directly on the
-    /// store, exactly the state `service_send_raw_txn` holds between
-    /// `acquire_claim_lock` and publish completion). Signer B — a DIFFERENT
-    /// key — submits a full valid claimAsset for the SAME gi:
-    ///   1. IN FLIGHT (no ClaimEvent yet), within the TTL → rejected on the
-    ///      "already submitted" path, with ZERO side effects for B (no publish,
-    ///      no nonce advance, no tx). accept-and-revert does NOT fire here
-    ///      because the gi has not LANDED (no ClaimEvent).
-    ///   2. after A's claim LANDS (ClaimEvent recorded) → #55 accept-and-revert:
-    ///      B's full-RPC resubmission is ACCEPTED with a reverted (status 0x0)
-    ///      receipt (nonce consumed, NO new ClaimEvent, no Miden publish) — the
-    ///      geth-faithful AlreadyClaimed, so a cross-signer's nonce never
-    ///      desyncs. The claim-lock PRIMITIVE (`acquire_claim_lock`) is
-    ///      unchanged and still hard-rejects a LANDED gi — accept-and-revert
-    ///      lives in the RPC handler ABOVE the lock, not in the lock itself.
+    /// has a submission genuinely in flight for gi=X (a fresh fenced lock,
+    /// no ClaimEvent yet). Signer B — a DIFFERENT key — submits a full valid
+    /// claimAsset for the SAME gi:
+    ///   1. while A is IN FLIGHT, B crosses the durable acceptance boundary but
+    ///      cannot acquire the claim fence, so it receives a status-0 receipt;
+    ///      its nonce is consumed, with no Miden publish and no ClaimEvent.
+    ///   2. after A lands, B same-hash rebroadcast deduplicates to the existing
+    ///      status-0 receipt. A landed claim submitted under a fresh B nonce
+    ///      follows the same geth-faithful accept-and-revert path.
     #[tokio::test]
     async fn user_sponsor_double_submit_same_global_index() {
         let service = create_test_service();
@@ -2475,26 +2587,24 @@ mod tests {
         let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
         let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
 
-        let err = service_send_raw_txn(service.clone(), input_b.clone())
+        let accepted_inflight = service_send_raw_txn(service.clone(), input_b.clone())
             .await
-            .expect_err("a different signer's claim for an in-flight gi must be rejected");
-        assert!(
-            err.to_string().contains("already submitted"),
-            "must be the dedup rejection: {err:#}"
-        );
-        // The rejection must leave NO trace of B's attempt.
+            .expect("the structurally valid transaction is accepted then reverted");
+        assert_eq!(accepted_inflight, tx_b);
+        // The claim must not reach Miden while A is in flight.
         assert!(
             !miden.test_was_called(),
             "B must never reach the Miden publish while A is in flight"
         );
         assert_eq!(
             store.nonce_get(&format!("{addr_b:#x}")).await.unwrap(),
-            0,
-            "a rejected claim must not advance B's nonce"
+            1,
+            "accepted status-0 transaction consumes B nonce"
         );
+        let (failed, _) = store.txn_receipt(tx_b).await.unwrap().unwrap();
         assert!(
-            store.txn_get(tx_b).await.unwrap().is_none(),
-            "no tx entry may be recorded for B's rejected claim"
+            failed.is_err(),
+            "in-flight claim becomes a status-0 receipt"
         );
 
         // A's claim LANDS: a ClaimEvent now exists for gi.
@@ -2552,7 +2662,7 @@ mod tests {
         // gi returns `Landed` even with the TTL forced to zero — the LANDED check
         // wins over orphan recovery, regardless of submitter (routes to
         // accept-and-revert, never a hard reject).
-        let outcome = acquire_claim_lock(&store, gi, std::time::Duration::ZERO)
+        let outcome = acquire_claim_lock(&store, gi, TxHash::ZERO, std::time::Duration::ZERO)
             .await
             .expect("landed classification must not error");
         assert_eq!(
@@ -2598,14 +2708,13 @@ mod tests {
         let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
         let (input_b, _) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
 
-        let err = service_send_raw_txn(service, input_b)
+        let accepted = service_send_raw_txn(service, input_b)
             .await
-            .expect_err("the stub MidenClient cannot complete the publish");
-        // The orphaned record was superseded and B's claim PROCEEDED: the
-        // failure is the unit stub's publish failure, NOT the dedup rejection.
+            .expect("the orphaned record is reclaimed and the tx is accepted");
+        let (failed, _) = store.txn_receipt(accepted).await.unwrap().unwrap();
         assert!(
-            !err.to_string().contains("already submitted"),
-            "an orphaned (TTL-expired) record must not keep rejecting: {err:#}"
+            failed.is_err(),
+            "the stub publish failure becomes status 0x0"
         );
         assert!(
             miden.test_was_called(),
@@ -2712,15 +2821,15 @@ mod tests {
         let gi_real = U256::from(0x5005u64);
         assert_ne!(resolvable_dest(), addr_c);
         let calldata = claim_calldata(gi_real, resolvable_dest(), U256::from(1_000_000u64));
-        let (input_hex, _) = encode_tx_signed_with_nonce(&key_c, calldata, 0);
-        let err = service_send_raw_txn(service.clone(), input_hex)
+        let (input_hex, tx_real) = encode_tx_signed_with_nonce(&key_c, calldata, 0);
+        let accepted = service_send_raw_txn(service.clone(), input_hex)
             .await
-            .expect_err("the stub MidenClient cannot complete the publish");
-        let msg = err.to_string();
+            .expect("permissionless structurally valid claim is accepted");
+        assert_eq!(accepted, tx_real);
+        let (failed, _) = store.txn_receipt(tx_real).await.unwrap().unwrap();
         assert!(
-            !msg.contains("allow-list") && !msg.contains("already submitted"),
-            "someone-else's-deposit claim must not be rejected on any authorization \
-             or dedup path: {msg}"
+            failed.is_err(),
+            "the unit-stub publish failure becomes status 0x0"
         );
         assert!(
             miden.test_was_called(),
@@ -3147,7 +3256,7 @@ mod tests {
         // a pre-check would read as "not landed".
         store.try_claim(gi).await.expect("A locks gi");
         assert_eq!(
-            acquire_claim_lock(&store, gi, claim_resubmit_ttl())
+            acquire_claim_lock(&store, gi, TxHash::ZERO, claim_resubmit_ttl())
                 .await
                 .expect("classify must not error"),
             ClaimLockOutcome::InFlight,
@@ -3175,7 +3284,7 @@ mod tests {
         // The SAME lock call now classifies `Landed` — routed to accept-and-revert,
         // NEVER a hard reject. The TOCTOU window is closed.
         assert_eq!(
-            acquire_claim_lock(&store, gi, claim_resubmit_ttl())
+            acquire_claim_lock(&store, gi, TxHash::ZERO, claim_resubmit_ttl())
                 .await
                 .expect("classify must not error"),
             ClaimLockOutcome::Landed,
@@ -3402,9 +3511,14 @@ mod tests {
         // BLOCKER-B re-read (after the failed reclaim) observes it.
         concrete.test_land_gi_after_next_has_claim_miss(gi.to_be_bytes::<32>());
 
-        let outcome = acquire_claim_lock(&store, gi, std::time::Duration::from_secs(3600))
-            .await
-            .expect("classification must not error");
+        let outcome = acquire_claim_lock(
+            &store,
+            gi,
+            TxHash::ZERO,
+            std::time::Duration::from_secs(3600),
+        )
+        .await
+        .expect("classification must not error");
         assert_eq!(
             outcome,
             ClaimLockOutcome::Landed,
@@ -3534,7 +3648,8 @@ mod tests {
     /// SAME tx under a valid lease → OwnedBySame (dedup, another replica must not
     /// execute); a DIFFERENT tx → HeldByOther (hard reject); release-FAILURE lets the
     /// SAME tx take over (fence bumps); a fenced-out stale release is ignored;
-    /// release-SUCCESS makes the SAME tx dedup; an EXPIRED lease is taken over.
+    /// release-SUCCESS makes the SAME tx dedup; only the SAME tx can take over an
+    /// EXPIRED lease.
     #[tokio::test]
     async fn blocker_1_reserve_nonce_fenced_lifecycle() {
         use crate::store::NonceReservation;
@@ -3660,12 +3775,11 @@ mod tests {
         assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 0);
     }
 
-    /// BLOCKER A — state-FIRST takeover: a DIFFERENT tx may take over a slot whose
-    /// holder FAILED or whose lease EXPIRED (nonce NOT consumed), but is HARD-rejected
-    /// while the holder is executing under a valid lease or already released_success
-    /// (nonce consumed / in flight).
+    /// Crash outcomes are ambiguous: a nonce slot is permanently bound to the
+    /// first signed transaction, even after failure or lease expiry. Only that
+    /// exact hash may recover the durable intent.
     #[tokio::test]
-    async fn blocker_a_different_tx_takes_over_failed_or_expired_slot() {
+    async fn blocker_a_different_tx_never_takes_over_ambiguous_slot() {
         use crate::store::NonceReservation;
         let concrete = std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
         let store: std::sync::Arc<dyn crate::store::Store> = concrete.clone();
@@ -3674,71 +3788,45 @@ mod tests {
         let hb = TxHash::from([0xb2u8; 32]);
         let lease = std::time::Duration::from_secs(90);
 
-        // (1) released_FAILURE slot → a DIFFERENT tx takes over (fence bumps).
         let NonceReservation::Won { fence } =
             store.reserve_nonce(addr, 1, ha, lease).await.unwrap()
         else {
-            panic!("fresh must Win");
+            panic!("fresh must win");
         };
         store
             .release_reservation(addr, 1, ha, fence, false)
             .await
             .unwrap();
-        assert!(
-            matches!(
-                store.reserve_nonce(addr, 1, hb, lease).await.unwrap(),
-                NonceReservation::Won { .. }
-            ),
-            "a DIFFERENT tx must take over a released_failure slot (nonce not consumed)"
+        assert_eq!(
+            store.reserve_nonce(addr, 1, hb, lease).await.unwrap(),
+            NonceReservation::HeldByOther(ha),
+            "failure cannot authorize a replacement after an ambiguous external outcome"
         );
+        assert!(matches!(
+            store.reserve_nonce(addr, 1, ha, lease).await.unwrap(),
+            NonceReservation::Won { .. }
+        ));
 
-        // (2) EXPIRED lease → a DIFFERENT tx takes over.
         assert!(matches!(
             store.reserve_nonce(addr, 2, ha, lease).await.unwrap(),
             NonceReservation::Won { .. }
         ));
         concrete.test_expire_reservation_lease(addr, 2);
-        assert!(
-            matches!(
-                store.reserve_nonce(addr, 2, hb, lease).await.unwrap(),
-                NonceReservation::Won { .. }
-            ),
-            "a DIFFERENT tx must take over an EXPIRED slot (owner crashed, nonce not consumed)"
+        assert_eq!(
+            store.reserve_nonce(addr, 2, hb, lease).await.unwrap(),
+            NonceReservation::HeldByOther(ha),
+            "expiry is crash recovery for the same hash, never replacement permission"
         );
-
-        // (3) executing + VALID lease → a DIFFERENT tx is HARD-REJECTED (in flight).
         assert!(matches!(
-            store.reserve_nonce(addr, 3, ha, lease).await.unwrap(),
+            store.reserve_nonce(addr, 2, ha, lease).await.unwrap(),
             NonceReservation::Won { .. }
         ));
-        assert_eq!(
-            store.reserve_nonce(addr, 3, hb, lease).await.unwrap(),
-            NonceReservation::HeldByOther(ha),
-            "a valid/executing holder must still reject a different tx"
-        );
-
-        // (4) released_SUCCESS → a DIFFERENT tx is HARD-REJECTED (nonce consumed).
-        let NonceReservation::Won { fence: f4 } =
-            store.reserve_nonce(addr, 4, ha, lease).await.unwrap()
-        else {
-            panic!("fresh must Win");
-        };
-        store
-            .release_reservation(addr, 4, ha, f4, true)
-            .await
-            .unwrap();
-        assert_eq!(
-            store.reserve_nonce(addr, 4, hb, lease).await.unwrap(),
-            NonceReservation::HeldByOther(ha),
-            "a released_success holder (nonce consumed) must reject a different tx"
-        );
     }
 
-    /// BLOCKER B — writer mode advances the nonce (CAS) BEFORE enqueue. A nonce-CAS
-    /// store FAILURE must leave NO enqueued job and the nonce UNCHANGED; a successful
-    /// admission advances the nonce exactly once AND enqueues the job.
+    /// Writer admission persists the recoverable envelope before nonce CAS and enqueue.
+    /// A CAS error leaves a durable, unlinked intent and no live in-memory job.
     #[tokio::test]
-    async fn blocker_b_writer_cas_before_enqueue() {
+    async fn blocker_b_writer_durable_intent_precedes_nonce_cas() {
         // Happy path: exactly-once advance + job enqueued.
         let mut service = create_test_service();
         let (handle, shutdown) = crate::writer_worker::WriterWorker::spawn(
@@ -3787,6 +3875,9 @@ mod tests {
         }
         .abi_encode();
         let (input_hex2, signer2) = encode_legacy_tx(calldata2);
+        let raw = hex_decode_prefixed(&input_hex2).unwrap();
+        let envelope = TxEnvelope::decode_2718(&mut raw.as_slice()).unwrap();
+        let durable_hash = unwrap_txn_envelope(envelope).unwrap().hash;
         let err = service_send_raw_txn(service2, input_hex2)
             .await
             .expect_err("a nonce-CAS store failure must abort admission");
@@ -3804,7 +3895,128 @@ mod tests {
             0,
             "NO job may be enqueued when the CAS failed before enqueue"
         );
+        let intent = concrete.txn_get(durable_hash).await.unwrap().unwrap();
+        assert!(
+            intent.result.is_none(),
+            "durable admission remains retryable"
+        );
+        assert!(
+            concrete
+                .get_note_link_for_tx(&format!("{durable_hash:#x}"))
+                .await
+                .unwrap()
+                .is_none(),
+            "pre-dispatch durable intent is deliberately unlinked"
+        );
         let _ = shutdown2.send(());
+    }
+
+    /// A crash after nonce CAS but before mpsc enqueue is recovered from the
+    /// durable unlinked envelope without advancing twice.
+    #[tokio::test]
+    async fn writer_crash_after_nonce_cas_resumes_same_durable_hash() {
+        use crate::store::NonceReservation;
+        let concrete = std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let mut service = crate::test_helpers::create_test_service_with_store(concrete.clone());
+        let calldata = insertGlobalExitRootCall {
+            root: FixedBytes::from([0xc7u8; 32]),
+        }
+        .abi_encode();
+        let (input_hex, signer) = encode_legacy_tx(calldata);
+        let raw = hex_decode_prefixed(&input_hex).unwrap();
+        let envelope = TxEnvelope::decode_2718(&mut raw.as_slice()).unwrap();
+        let tx_hash = unwrap_txn_envelope(envelope.clone()).unwrap().hash;
+        let signer_str = format!("{signer:#x}");
+        let NonceReservation::Won { .. } = concrete
+            .reserve_nonce(&signer_str, 0, tx_hash, reservation_lease())
+            .await
+            .unwrap()
+        else {
+            panic!("fresh reservation must win");
+        };
+        durably_admit_and_advance_nonce(&service, tx_hash, &envelope, signer, &signer_str, 0)
+            .await
+            .unwrap();
+        assert_eq!(concrete.nonce_get(&signer_str).await.unwrap(), 1);
+        assert!(
+            concrete
+                .txn_get(tx_hash)
+                .await
+                .unwrap()
+                .unwrap()
+                .result
+                .is_none()
+        );
+
+        // Simulate process death: the durable row and nonce survived, the mpsc did
+        // not, and the reservation heartbeat stopped until its lease expired.
+        concrete.test_expire_reservation_lease(&signer_str, 0);
+        let (handle, shutdown) = crate::writer_worker::WriterWorker::spawn(
+            service.clone(),
+            64,
+            std::time::Duration::from_secs(60),
+        );
+        let handle = std::sync::Arc::new(handle);
+        service.enable_writer_worker = true;
+        service.writer_handle = Some(handle.clone());
+        let retried = service_send_raw_txn(service, input_hex).await.unwrap();
+        assert_eq!(retried, tx_hash);
+        assert_eq!(concrete.nonce_get(&signer_str).await.unwrap(), 1);
+        assert!(handle.is_inflight(&tx_hash));
+        let _ = shutdown.send(());
+    }
+
+    /// A stale claim owner cannot seal or release a successor after lease reclaim.
+    #[tokio::test]
+    async fn claim_reclaim_is_fenced_through_external_submission_boundary() {
+        let concrete = std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let store: std::sync::Arc<dyn crate::store::Store> = concrete.clone();
+        let gi = U256::from(0xf3ceu64);
+        let tx_a = TxHash::from([0xaau8; 32]);
+        let tx_b = TxHash::from([0xbbu8; 32]);
+        let ttl = std::time::Duration::from_secs(90);
+
+        let a = store
+            .try_claim_fenced(gi, tx_a, ttl)
+            .await
+            .unwrap()
+            .unwrap();
+        concrete.test_backdate_claim(gi, ttl + std::time::Duration::from_secs(1));
+        let b = store
+            .try_reclaim_claim_fenced(gi, tx_b, ttl)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(b.fence > a.fence);
+        assert!(
+            !store
+                .mark_claim_submitted_fenced(gi, tx_a, a.fence, tx_a, "stale-note")
+                .await
+                .unwrap()
+        );
+        assert!(!store.unclaim_fenced(&gi, tx_a, a.fence).await.unwrap());
+        assert!(
+            store
+                .mark_claim_submitted_fenced(gi, tx_b, b.fence, tx_b, "winner-note")
+                .await
+                .unwrap()
+        );
+        assert!(!store.unclaim_fenced(&gi, tx_b, b.fence).await.unwrap());
+        assert_eq!(
+            store
+                .get_note_link_for_tx(&format!("{tx_b:#x}"))
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("winner-note")
+        );
+        assert!(
+            store
+                .try_reclaim_claim_fenced(gi, tx_a, ttl)
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     /// BLOCKER 2 — the reclaim-SUCCESS window. A gi whose lock is EXPIRED but which
@@ -3826,7 +4038,7 @@ mod tests {
         // The claim LANDS on the first has_claim_event miss (so the re-read sees it).
         concrete.test_land_gi_after_next_has_claim_miss(gi.to_be_bytes::<32>());
 
-        let outcome = acquire_claim_lock(&store, gi, claim_resubmit_ttl())
+        let outcome = acquire_claim_lock(&store, gi, TxHash::ZERO, claim_resubmit_ttl())
             .await
             .expect("classification must not error");
         assert_eq!(
@@ -3923,6 +4135,10 @@ mod tests {
         let tx_pending = TxHash::from([0x42u8; 32]);
         store.txn_begin(tx_pending, entry()).await.unwrap();
         store
+            .record_tx_note_link(&format!("{tx_pending:#x}"), "real-note")
+            .await
+            .unwrap();
+        store
             .commit_reverted_receipt_and_advance_nonce(
                 tx_pending,
                 entry(),
@@ -3939,8 +4155,34 @@ mod tests {
             "a REAL pending receipt must stay pending (null), not be finalised to failed"
         );
 
-        // (c) ABSENT hash → the reverted receipt IS written (status 0x0).
-        let tx_new = TxHash::from([0x43u8; 32]);
+        // (c) An unlinked pending row is only a durable pre-admission intent and
+        // must be finalised to failed when the landed-claim race is detected.
+        let tx_intent = TxHash::from([0x43u8; 32]);
+        store.txn_begin_if_absent(tx_intent, entry()).await.unwrap();
+        store
+            .commit_reverted_receipt_and_advance_nonce(
+                tx_intent,
+                entry(),
+                "revert".into(),
+                9,
+                [0u8; 32],
+                &signer_str,
+                2,
+            )
+            .await
+            .unwrap();
+        let (r_intent, _) = store
+            .txn_receipt(tx_intent)
+            .await
+            .unwrap()
+            .expect("receipt");
+        assert!(
+            r_intent.is_err(),
+            "unlinked durable intent must become status 0x0"
+        );
+
+        // (d) ABSENT hash → the reverted receipt IS written (status 0x0).
+        let tx_new = TxHash::from([0x44u8; 32]);
         store
             .commit_reverted_receipt_and_advance_nonce(
                 tx_new,
@@ -3949,7 +4191,7 @@ mod tests {
                 9,
                 [0u8; 32],
                 &signer_str,
-                2,
+                3,
             )
             .await
             .unwrap();
@@ -3969,9 +4211,14 @@ mod tests {
         let gi = U256::from(88u64);
         store.try_claim(gi).await.unwrap();
 
-        let outcome = acquire_claim_lock(&store, gi, std::time::Duration::from_secs(3600))
-            .await
-            .expect("in-flight classification must not error");
+        let outcome = acquire_claim_lock(
+            &store,
+            gi,
+            TxHash::ZERO,
+            std::time::Duration::from_secs(3600),
+        )
+        .await
+        .expect("in-flight classification must not error");
         assert_eq!(
             outcome,
             ClaimLockOutcome::InFlight,

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -180,79 +180,108 @@ async fn record_local_success_at_block(
         .await
 }
 
-/// Write a durable REVERTED receipt (status `0x0`) for `tx_hash` at the current
-/// tip, with EMPTY logs. Used by the #55 "accept-and-revert" path: a claimAsset
-/// that targets an already-landed globalIndex is accepted (its nonce is
-/// consumed by the caller, exactly like a normal accept) but records a failed
-/// receipt instead of publishing a second CLAIM — the geth-faithful equivalent
-/// of the doomed tx MINING and reverting with `AlreadyClaimed`.
+/// #55 — geth-faithful ACCEPT-AND-REVERT for a claimAsset that targets an
+/// already-LANDED globalIndex. Increments the observability counter, then ATOMICALLY
+/// (one store transaction — BLOCKER C) persists a durable REVERTED receipt (status
+/// 0x0, EMPTY logs, NO ClaimEvent) AND CAS-advances the signer's nonce, so a crash
+/// can never leave a half state (no pending-forever receipt, no stale nonce).
 ///
-/// The receipt is shaped identically to the writer-worker's failure receipt
-/// (`writer_worker::write_failure_receipt`) — `txn_begin` (so `eth_getTransaction*`
-/// resolves the real tx + signer) followed by `txn_commit(Err(..))`, which
+/// The nonce CAS advances iff the current nonce == `tx_nonce` (the sync accept path,
+/// where the caller has not yet advanced it). In async-writer mode the enqueue
+/// already CAS-advanced it, so the CAS here is a no-op and only the receipt is
+/// written — the caller's/enqueue's own advance is authoritative. The receipt is
+/// shaped identically to the writer-worker's failure receipt, which
 /// `service_get_txn_receipt` renders as `status: 0x0` with every numeric field
 /// present (blockNumber/blockHash/transactionIndex/gasUsed/cumulativeGasUsed/
-/// effectiveGasPrice/from/to/logs=[]/logsBloom/type). aggkit's Go
-/// ethtxmanager/receipt unmarshaller then sees the monitored tx as MINED-but-
-/// failed and advances instead of re-broadcasting forever.
-///
-/// Crucially it emits NO ClaimEvent and NO synthetic log (the real landed
-/// claim's event is authoritative; getLogs immutability forbids a second event).
-async fn record_local_immediate_reverted(
+/// effectiveGasPrice/from/to/logs=[]/logsBloom/type), so aggkit's Go ethtxmanager
+/// sees the monitored tx as MINED-but-failed and advances instead of re-broadcasting.
+async fn accept_and_revert_landed_claim(
     service: &ServiceState,
+    params: &claimAssetCall,
     tx_hash: TxHash,
     txn_envelope: TxEnvelope,
     signer: Address,
-    reason: String,
+    signer_str: &str,
+    tx_nonce: u64,
 ) -> anyhow::Result<()> {
+    ::metrics::counter!("claim_landed_dedup_reverted_total").increment(1);
+    tracing::warn!(
+        global_index = %params.globalIndex,
+        eth_tx = %tx_hash,
+        signer = %signer,
+        "claim targets an already-landed globalIndex (a ClaimEvent already exists); \
+         accepting and writing a REVERTED receipt (status 0x0, no new event) + advancing \
+         the nonce ATOMICALLY so the submitter's nonce is consumed — geth-faithful \
+         AlreadyClaimed revert (#55). The real landed claim is untouched."
+    );
     let block_num = service.store.get_latest_block_number().await?;
-    record_local_pending_tx(service, tx_hash, txn_envelope, signer, None, vec![]).await?;
     let block_hash = service.block_state.get_block_hash(block_num);
-    service
+    let nonce_advanced = service
         .store
-        .txn_commit(tx_hash, Err(reason), block_num, block_hash)
-        .await
+        .commit_reverted_receipt_and_advance_nonce(
+            tx_hash,
+            TxnEntry {
+                id: None,
+                envelope: txn_envelope,
+                signer,
+                expires_at: None,
+                logs: vec![],
+            },
+            format!(
+                "claim for globalIndex {} already landed (AlreadyClaimed); reverted (#55)",
+                params.globalIndex
+            ),
+            block_num,
+            block_hash,
+            signer_str,
+            tx_nonce,
+        )
+        .await?;
+    tracing::debug!(
+        target: "rpc::accept_revert",
+        %tx_hash,
+        nonce = tx_nonce,
+        nonce_advanced,
+        "accept-and-revert committed atomically (receipt + nonce CAS)"
+    );
+    Ok(())
 }
 
-/// BLOCKER-2 (#55 review) — idempotent crash-gap nonce repair.
+/// #55 BLOCKER C/D — idempotent crash-gap nonce repair via store-level CAS.
 ///
-/// On the sync accept path the durable receipt write (`txn_begin` + `txn_commit`)
-/// and the per-signer `nonce_increment` are SEPARATE steps; a crash / store error
-/// BETWEEN them leaves the tx KNOWN (receipt persisted) but the signer's expected
-/// nonce STALE at that tx's nonce. Called from the RD-940 same-hash dedup path on a
-/// rebroadcast: if the expected nonce still equals `tx_nonce` — the crash-gap
-/// signature; a normally-advanced tx has `expected > tx.nonce`, and async mode
-/// advances at enqueue so likewise `expected > tx.nonce` — it advances the nonce
-/// exactly once, completing the interrupted accept, so the rebroadcast HEALS the
-/// nonce rather than serving stale forever.
+/// On the sync accept path the durable receipt write and the nonce advance are
+/// separate steps; a crash / store error BETWEEN them leaves the tx KNOWN (receipt
+/// persisted) but the signer's expected nonce STALE at that tx's nonce. Called from
+/// the RD-940 same-hash dedup path on a rebroadcast: the store-level
+/// `nonce_advance_cas(signer, tx_nonce)` advances the nonce EXACTLY ONCE iff it is
+/// still stuck at `tx_nonce` (the crash-gap signature — a normally-advanced tx has
+/// `expected > tx.nonce`, and async mode advances at enqueue so likewise), so the
+/// rebroadcast HEALS the nonce rather than serving stale forever.
 ///
-/// Cheap unlocked pre-check first (the common rebroadcast is `expected > tx.nonce`
-/// → no lock taken); the per-signer lock + re-read make the advance atomic against a
-/// concurrent accept/repair. Returns `true` iff it advanced the nonce.
+/// The CAS is atomic at the store level, so this is correct even when two replicas
+/// on a shared PostgreSQL race the same rebroadcast (BLOCKER D) — exactly one wins.
+/// Returns `true` iff it advanced the nonce.
 pub(crate) async fn repair_commit_gap_nonce(
     service: &ServiceState,
-    signer: Address,
     signer_str: &str,
     tx_nonce: u64,
 ) -> anyhow::Result<bool> {
-    if service.store.nonce_get(signer_str).await? != tx_nonce {
-        return Ok(false);
+    let advanced = service
+        .store
+        .nonce_advance_cas(signer_str, tx_nonce)
+        .await?;
+    if advanced {
+        ::metrics::counter!("rpc_nonce_repaired_after_commit_gap_total").increment(1);
+        tracing::warn!(
+            target: "rpc::nonce_repair",
+            signer = %signer_str,
+            nonce = tx_nonce,
+            "healed a stale signer nonce on rebroadcast: a known tx's receipt was persisted but \
+             its nonce advance was lost to a crash in the commit gap; CAS-advanced the expected \
+             nonce to complete the interrupted accept (#55 BLOCKER C/D)"
+        );
     }
-    let _lock = service.per_signer_locks.lock(signer).await;
-    if service.store.nonce_get(signer_str).await? != tx_nonce {
-        return Ok(false);
-    }
-    service.store.nonce_increment(signer_str).await?;
-    ::metrics::counter!("rpc_nonce_repaired_after_commit_gap_total").increment(1);
-    tracing::warn!(
-        target: "rpc::nonce_repair",
-        signer = %signer_str,
-        nonce = tx_nonce,
-        "healed a stale signer nonce on rebroadcast: a known tx's receipt was persisted but its \
-         nonce advance was lost to a crash in the commit gap; advanced the expected nonce to \
-         complete the interrupted accept (#55 BLOCKER-2)"
-    );
-    Ok(true)
+    Ok(advanced)
 }
 
 /// Handle a `claimAsset` transaction: skip zero-amount or publish the claim.
@@ -297,33 +326,69 @@ pub(crate) async fn worker_handle_claim_asset(
         return Ok(());
     }
 
-    // NOTE (#55): the geth-faithful ACCEPT-AND-REVERT for an already-LANDED
-    // globalIndex is NOT a separate pre-check here. Detecting "landed" and
-    // deciding accept-and-revert are now ONE authoritative, atomic step inside
-    // `acquire_claim_lock` (its `ClaimLockOutcome::Landed`), below. A standalone
-    // pre-check would reopen a TOCTOU: it could observe "not landed", the real
-    // claim could LAND, and `acquire_claim_lock` would then hard-reject — the
-    // exact nonce-desync wedge #55 fixes. Routing landed→accept-and-revert
-    // through the lock's own classification closes that window (there is no
-    // interleaving in which a landed gi is hard-rejected). A landed gi
-    // necessarily passes RD-860 (its destination was resolvable when it landed;
-    // address mappings are monotonic) and C6 (its GER is injected; injection is
-    // monotonic), so those checks never fire for it before the lock.
+    // #55 BLOCKER A — the AUTHORITATIVE landed classification runs FIRST, before
+    // RD-860 (unresolvable-destination) and C6 (GER-observed). A landed globalIndex
+    // must route to accept-and-revert regardless of destination-resolvability or
+    // GER-observed state, so nothing downstream can (1) take RD-860's SUCCESS path
+    // and emit a SECOND ClaimEvent for an already-claimed gi (double-emit), or
+    // (2) hard-reject on an unobserved GER WITHOUT consuming the nonce (wedge).
+    //
+    // `acquire_claim_lock` is the ONE atomic classification (BLOCKER B): a gi that
+    // landed at any point in the try_claim window classifies `Landed`, never
+    // `InFlight`, so no interleaving hard-rejects a landed gi.
+    let tx_nonce = envelope_nonce(&txn_envelope);
+    let signer_str = format!("{signer:#x}");
+    match acquire_claim_lock(&service.store, params.globalIndex, claim_resubmit_ttl()).await? {
+        // Geth-faithful accept-and-revert: ACCEPT, write a REVERTED receipt (status
+        // 0x0, empty logs, NO new ClaimEvent) AND advance the nonce ATOMICALLY (one
+        // store transaction — BLOCKER C), so the submitter's nonce is consumed like
+        // a normal accept and no crash can leave a half state. The real landed claim
+        // is untouched.
+        ClaimLockOutcome::Landed => {
+            accept_and_revert_landed_claim(
+                service,
+                &params,
+                txn_hash,
+                txn_envelope,
+                signer,
+                &signer_str,
+                tx_nonce,
+            )
+            .await?;
+            return Ok(());
+        }
+        // A genuine concurrent submission for this gi is in flight (locked, no
+        // ClaimEvent yet, within TTL). Hard-reject — must not double-publish. In
+        // sync mode this returns Err WITHOUT the caller advancing the nonce (a
+        // genuine retry, nonce not consumed); once the in-flight claim LANDS, the
+        // retry re-enters and takes the `Landed` accept-and-revert arm above.
+        ClaimLockOutcome::InFlight => {
+            anyhow::bail!(
+                "claim already submitted for global_index {}",
+                params.globalIndex
+            );
+        }
+        // Fresh lock (or an orphaned record superseded) — proceed to publish.
+        ClaimLockOutcome::Acquired => {}
+    }
+
+    // R9 — we now HOLD the per-globalIndex lock. Install a RAII drop guard so a
+    // cancelled / panicked / disconnected future releases it; every early return
+    // below (RD-860 swallow, C6 reject, publish failure) releases it explicitly.
+    let guard = ClaimGuard::new(service.store.clone(), params.globalIndex);
 
     // RD-860 — swallow unresolvable-destination claims permanently. If the
     // destination address can't be resolved to a Miden AccountId, record the
     // unclaimable entry, emit the synthetic ClaimEvent so aggkit marks the
-    // globalIndex complete and stops retrying, and return success to the
-    // caller. Funds remain locked on L1; an operator rescue endpoint (tier 2,
-    // future work) would let ops re-process by registering a destination
-    // mapping and replaying.
+    // globalIndex complete and stops retrying, RELEASE the lock, and return success.
+    // Funds remain locked on L1; an operator rescue endpoint (tier 2, future work)
+    // would let ops re-process by registering a destination mapping and replaying.
     //
-    // Ordering: this check runs BEFORE C6's GER pre-check because the
-    // unresolvable-destination state is permanent (no amount of GER
-    // propagation will change it), whereas a missing GER is transient. Doing
-    // RD-860 first means aggkit gets a single decisive swallow instead of
-    // grinding through GER-not-seen retries before eventually hitting the
-    // same swallow.
+    // This runs AFTER the landed classification (BLOCKER A): a LANDED gi already
+    // took the accept-and-revert arm above, so RD-860 can only fire for a FRESH gi
+    // and can never emit a second ClaimEvent for an already-claimed one. Ordering
+    // vs C6: RD-860 first because unresolvable-destination is permanent while a
+    // missing GER is transient.
     if let Err(err) = crate::address_mapper::resolve_address(
         &*service.store,
         params.destinationAddress,
@@ -369,91 +434,21 @@ pub(crate) async fn worker_handle_claim_asset(
         let event = crate::claim::ClaimEvent::from(params.clone());
         let log = <crate::claim::ClaimEvent as alloy::sol_types::SolEvent>::encode_log_data(&event);
         record_local_immediate_success(service, txn_hash, txn_envelope, signer, vec![log]).await?;
+        // The gi is now handled (unclaimable record + ClaimEvent); drop the lock so
+        // a resubmit classifies `Landed` (the ClaimEvent exists) → accept-and-revert.
+        guard.release_explicitly().await;
         return Ok(());
     }
 
-    // C6 — pre-admission GER publication gate, BEFORE acquiring the claim
-    // lock (and before any nonce/receipt side-effect on this path). In
-    // writer mode the SAME gate already ran on the request path before
-    // `try_enqueue`/`nonce_increment` (PR #127 review point 3); this second
-    // run is cheap defense-in-depth, not the primary admission decision.
+    // C6 — pre-publish GER publication gate. In writer mode the SAME gate already
+    // ran on the request path before `try_enqueue` (PR #127 review point 3); this
+    // second run is cheap defense-in-depth. On rejection RELEASE the lock (cheap
+    // retryable surface — the claim didn't publish) and return the retryable error.
     // See `ensure_claim_ger_published` for the full rationale.
-    ensure_claim_ger_published(&service.store, &params).await?;
-
-    // Lock the claim index — the AUTHORITATIVE, atomic classification of this
-    // submission against the per-globalIndex lock + landed state. All error
-    // paths after an `Acquired` MUST unclaim.
-    //
-    // SOAK FINDING #1 (orphaned-claim wedge): a plain `try_claim` rejection here permanently
-    // wedged a deposit if the proxy died between the lock write and the CLAIM landing on
-    // Miden (chaos restart in the submit window): the persisted record survived, the R9
-    // guard never fired, and every sponsor retry was rejected forever — starving all later
-    // claims the sponsor owns. Dedup must mean "landed or genuinely in flight", not
-    // "submission was attempted once".
-    match acquire_claim_lock(&service.store, params.globalIndex, claim_resubmit_ttl()).await? {
-        // #55 — geth-faithful ACCEPT-AND-REVERT for an already-LANDED globalIndex.
-        //
-        // Claims are permissionless: destination + amount are bound by the
-        // merkle-proven calldata, so the sponsor (aggkit ClaimTxManager autoclaim)
-        // and a user can BOTH target the same gi; dedup is keyed by globalIndex
-        // only (signer-agnostic). When a user front-runs a gi the sponsor already
-        // signed + persisted a monitored tx for, hard-rejecting the sponsor's
-        // later (different-hash) tx would NOT consume its nonce: its sequence and
-        // the proxy's expected-nonce desync, ClaimTxManager re-broadcasts forever
-        // ("nonce mismatch"), and autoclaim dies un-healably. On real geth the
-        // doomed claim MINES, reverts with AlreadyClaimed, and CONSUMES its nonce
-        // + gas. Mirror that: ACCEPT the tx, write a durable REVERTED receipt
-        // (status 0x0, empty logs, NO new ClaimEvent), and return Ok so the caller
-        // CONSUMES the signer's nonce exactly like a normal accept.
-        //
-        // `Landed` is decided INSIDE `acquire_claim_lock` at the lock boundary
-        // (the authoritative `has_claim_event_for_global_index`), so there is no
-        // pre-check→lock interleaving in which a landed gi is hard-rejected.
-        ClaimLockOutcome::Landed => {
-            ::metrics::counter!("claim_landed_dedup_reverted_total").increment(1);
-            tracing::warn!(
-                global_index = %params.globalIndex,
-                eth_tx = %txn_hash,
-                signer = %signer,
-                "claim targets an already-landed globalIndex (a ClaimEvent already exists); \
-                 accepting and writing a REVERTED receipt (status 0x0, no new event) so the \
-                 submitter's nonce is consumed — geth-faithful AlreadyClaimed revert (#55). \
-                 The real landed claim is untouched."
-            );
-            record_local_immediate_reverted(
-                service,
-                txn_hash,
-                txn_envelope,
-                signer,
-                format!(
-                    "claim for globalIndex {} already landed (AlreadyClaimed); reverted (#55)",
-                    params.globalIndex
-                ),
-            )
-            .await?;
-            return Ok(());
-        }
-        // A genuine concurrent submission for this gi is in flight (locked, no
-        // ClaimEvent yet, within TTL). Hard-reject — must not double-publish. In
-        // sync mode this returns Err WITHOUT the caller advancing the nonce (a
-        // genuine retry, nonce not consumed); once the in-flight claim LANDS, the
-        // retry re-enters and takes the `Landed` accept-and-revert arm above.
-        ClaimLockOutcome::InFlight => {
-            anyhow::bail!(
-                "claim already submitted for global_index {}",
-                params.globalIndex
-            );
-        }
-        // Fresh lock (or an orphaned record superseded) — proceed to publish.
-        ClaimLockOutcome::Acquired => {}
+    if let Err(err) = ensure_claim_ger_published(&service.store, &params).await {
+        guard.release_explicitly().await;
+        return Err(err);
     }
-
-    // R9 — install a RAII drop guard so that even if the request future is
-    // dropped (client disconnect mid-publish, panic, task cancellation), the
-    // claim lock is released. Without the guard, a malicious caller can
-    // permanently lock arbitrary globalIndex values by repeatedly disconnecting
-    // mid-flight during the multi-second proof/submit work inside `publish_claim`.
-    let guard = ClaimGuard::new(service.store.clone(), params.globalIndex);
 
     let result =
         publish_and_record_claim(service, params.clone(), txn_hash, txn_envelope, signer).await;
@@ -599,10 +594,20 @@ pub(crate) async fn acquire_claim_lock(
             if store.has_claim_event_for_global_index(&gi_bytes).await? {
                 return Ok(ClaimLockOutcome::Landed);
             }
-            // Not landed. Atomically supersede IFF the record has out-lived the
-            // in-flight TTL; a fresher record means a submission is genuinely in
-            // flight — keep rejecting.
+            // Not landed at the first read. Atomically supersede IFF the record has
+            // out-lived the in-flight TTL; a fresher record means a submission is
+            // genuinely in flight.
             if !store.try_reclaim_expired(global_index, ttl).await? {
+                // BLOCKER B — RE-READ the authoritative landed state AFTER failing
+                // to reclaim. The original claim may have committed its ClaimEvent
+                // in the window between the first `has_claim_event` read and the
+                // reclaim attempt; without this re-read that just-landed gi would
+                // classify `InFlight` and be hard-rejected WITHOUT consuming the
+                // nonce — the exact wedge. A gi that landed at ANY point up to here
+                // classifies `Landed` (→ accept-and-revert), never `InFlight`.
+                if store.has_claim_event_for_global_index(&gi_bytes).await? {
+                    return Ok(ClaimLockOutcome::Landed);
+                }
                 return Ok(ClaimLockOutcome::InFlight);
             }
             ::metrics::counter!("claim_resubmission_recovered_total").increment(1);
@@ -882,18 +887,17 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
             %txn_hash,
             "tx-hash dedup (committed): returning OK without re-running R4"
         );
-        // BLOCKER-2 (#55 review) — crash-gap nonce REPAIR. On the sync accept
-        // path the durable receipt write (`txn_begin` + `txn_commit`) and the
-        // per-signer `nonce_increment` are SEPARATE steps; a crash / store error
-        // BETWEEN them leaves this tx KNOWN (receipt persisted) while the
-        // signer's expected nonce stays STALE at this tx's nonce. Without repair
-        // this rebroadcast is served as success forever while the nonce never
-        // advances, and the signer's NEXT tx (nonce+1) fails the R4 gate — the
-        // exact wedge #55 fixes, reintroduced by a crash in the commit gap.
-        //
-        // Heal it idempotently via `repair_commit_gap_nonce` (extracted so both
-        // stores can regression-test the repair directly).
-        repair_commit_gap_nonce(&service, signer, &signer_str, tx_nonce).await?;
+        // BLOCKER C/D (#55 review) — crash-gap nonce REPAIR via store-level CAS.
+        // On the sync accept path the durable receipt write and the nonce advance
+        // are SEPARATE steps; a crash / store error BETWEEN them leaves this tx
+        // KNOWN (receipt persisted) while the signer's expected nonce stays STALE
+        // at this tx's nonce. Without repair this rebroadcast is served as success
+        // forever while the nonce never advances, and the signer's NEXT tx
+        // (nonce+1) fails the R4 gate — the exact wedge #55 fixes, reintroduced by
+        // a crash in the commit gap. `repair_commit_gap_nonce` CAS-advances the
+        // nonce iff it is still stuck at tx_nonce (idempotent; cross-replica-safe;
+        // extracted so both stores regression-test it directly).
+        repair_commit_gap_nonce(&service, &signer_str, tx_nonce).await?;
         return Ok(txn_hash);
     }
 
@@ -1079,7 +1083,15 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         let job = decoded.into_job(txn_envelope, signer, txn_hash);
         match handle.try_enqueue(job) {
             Ok(()) => {
-                service.store.nonce_increment(&signer_str).await?;
+                // BLOCKER D — advance via store-level CAS (advance only WHERE nonce
+                // == tx_nonce), so two replicas on a shared PostgreSQL can't both
+                // advance from the same expected value (N→N+2). A `false` return
+                // means another replica (or the worker's own accept-and-revert)
+                // already advanced it — the nonce ends advanced either way.
+                let _ = service
+                    .store
+                    .nonce_advance_cas(&signer_str, tx_nonce)
+                    .await?;
                 Ok(txn_hash)
             }
             Err(crate::writer_worker::TryEnqueueError::QueueFull) => {
@@ -1109,7 +1121,14 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
                     .await?;
             }
         }
-        service.store.nonce_increment(&signer_str).await?;
+        // BLOCKER D — advance via store-level CAS (advance only WHERE nonce ==
+        // tx_nonce), cross-replica-safe. A `false` return means the advance already
+        // happened (the accept-and-revert path advances the nonce atomically with
+        // its receipt, or a concurrent replica won) — the nonce ends advanced.
+        let _ = service
+            .store
+            .nonce_advance_cas(&signer_str, tx_nonce)
+            .await?;
         Ok(txn_hash)
     }
 }
@@ -1308,12 +1327,13 @@ mod tests {
         );
     }
 
-    /// Self-review C6 — repro+regression. A claim referencing a GER that
-    /// aggkit has not observed must be rejected BEFORE the lock is
-    /// acquired. Pre-fix the proxy locked the globalIndex, ran the 15s
-    /// GER-propagation wait, submitted to Miden, and only then saw the
-    /// on-chain `ERR_GER_NOT_FOUND` panic — wasted work + held lock for
-    /// the full round-trip.
+    /// Self-review C6 — repro+regression. A claim referencing a GER that aggkit
+    /// has not observed must be rejected retryably, and must leave the globalIndex
+    /// UNLOCKED afterwards (cheap retry surface — no lock held across the long
+    /// publish path). Post-#55-BLOCKER-A, the authoritative landed classification
+    /// runs first, so the lock is transiently acquired then RELEASED on the C6
+    /// rejection (`guard.release_explicitly`); the end state is still unclaimed, and
+    /// C6 is only a fast `is_ger_injected` read (no 15s wait) while the lock is held.
     #[tokio::test]
     async fn c6_claim_with_unseen_ger_rejected_before_lock() {
         let service = create_test_service();
@@ -1347,10 +1367,11 @@ mod tests {
         let msg = format!("{err}");
         assert!(msg.contains("not observed yet"), "unexpected: {msg}");
 
-        // The lock must NOT have been acquired (cheap retry surface).
+        // The lock must be RELEASED after the C6 rejection (transiently acquired
+        // then dropped) — the retry surface stays cheap (no lock left held).
         assert!(
             !store.is_claimed(&global_index).await.unwrap(),
-            "C6 must reject before acquiring the claim lock"
+            "C6 rejection must leave the globalIndex unlocked (lock released)"
         );
 
         // PR #127 review point 5 — pre-admission failure must leave NOTHING
@@ -3093,21 +3114,35 @@ mod tests {
         let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
         let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
 
-        // Reconstruct the envelope and persist the reverted receipt for B's tx at
-        // nonce 0 WITHOUT advancing the nonce — the exact durable state a crash in
-        // the record→nonce_increment gap leaves.
+        // Reconstruct the envelope and persist a COMMITTED (reverted) receipt for
+        // B's tx at nonce 0 WITHOUT advancing the nonce — the exact durable state a
+        // crash between the receipt commit and the nonce advance leaves.
         let payload = crate::hex::hex_decode_prefixed(&input_b).unwrap();
         let mut slice = payload.as_slice();
         let env = TxEnvelope::decode_2718(&mut slice).unwrap();
-        record_local_immediate_reverted(
-            &service,
-            tx_b,
-            env,
-            addr_b,
-            "simulated crash-gap reverted receipt".into(),
-        )
-        .await
-        .unwrap();
+        store
+            .txn_begin(
+                tx_b,
+                crate::store::TxnEntry {
+                    id: None,
+                    envelope: env,
+                    signer: addr_b,
+                    expires_at: None,
+                    logs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        let blk = store.get_latest_block_number().await.unwrap();
+        store
+            .txn_commit(
+                tx_b,
+                Err("simulated crash-gap reverted receipt".into()),
+                blk,
+                [0u8; 32],
+            )
+            .await
+            .unwrap();
         // Precondition: tx KNOWN, nonce STALE at 0.
         assert!(
             store.txn_get(tx_b).await.unwrap().is_some(),
@@ -3156,6 +3191,216 @@ mod tests {
             store.nonce_get(&signer_str).await.unwrap(),
             2,
             "sequence stays in lockstep after crash-gap recovery"
+        );
+    }
+
+    /// BLOCKER A — a claim for an already-LANDED gi whose destination is
+    /// UNRESOLVABLE must route to accept-and-revert (landed classification FIRST),
+    /// NOT take RD-860's success path and emit a SECOND ClaimEvent (double-emit).
+    #[tokio::test]
+    async fn blocker_a_landed_unresolvable_destination_accept_and_reverts_no_double_emit() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        seed_zero_ger(&store).await;
+        let gi = U256::from(0x55a1u64);
+        land_claim_for(&store, gi).await;
+        let events_before = count_claim_events(&store).await;
+
+        // B: SAME landed gi, but an UNRESOLVABLE destination (non-zero-padded, no
+        // mapping) — RD-860 would normally swallow + emit a ClaimEvent.
+        let key_b = alloy::signers::local::PrivateKeySigner::random();
+        let addr_b = key_b.address();
+        let calldata = claim_calldata(gi, Address::from([0x99u8; 20]), U256::from(1_000_000u64));
+        let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
+
+        let accepted = service_send_raw_txn(service.clone(), input_b).await.expect(
+            "landed gi + unresolvable dest must accept-and-revert (landed classified FIRST)",
+        );
+        assert_eq!(accepted, tx_b);
+        assert_eq!(
+            count_claim_events(&store).await,
+            events_before,
+            "RD-860 must NOT run for a landed gi — no SECOND ClaimEvent (double-emit)"
+        );
+        assert!(
+            store.get_unclaimable_claim(&gi).await.unwrap().is_none(),
+            "RD-860 must NOT record an unclaimable entry for a landed gi"
+        );
+        assert_eq!(store.nonce_get(&format!("{addr_b:#x}")).await.unwrap(), 1);
+        let (result, _blk) = store.txn_receipt(tx_b).await.unwrap().expect("receipt");
+        assert!(result.is_err(), "reverted (status 0x0)");
+    }
+
+    /// BLOCKER A — a claim for an already-LANDED gi whose GER is NOT observed must
+    /// route to accept-and-revert (landed classification FIRST), NOT hard-reject on
+    /// C6 WITHOUT consuming the nonce.
+    #[tokio::test]
+    async fn blocker_a_landed_unobserved_ger_accept_and_reverts_nonce_consumed() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        // Deliberately DO NOT seed the GER — C6 would reject "not observed yet".
+        let gi = U256::from(0x55a2u64);
+        land_claim_for(&store, gi).await;
+
+        let key_b = alloy::signers::local::PrivateKeySigner::random();
+        let addr_b = key_b.address();
+        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
+
+        let accepted = service_send_raw_txn(service.clone(), input_b)
+            .await
+            .expect("landed gi + unobserved GER must accept-and-revert (landed classified FIRST)");
+        assert_eq!(accepted, tx_b);
+        assert_eq!(
+            store.nonce_get(&format!("{addr_b:#x}")).await.unwrap(),
+            1,
+            "nonce CONSUMED (accept-and-revert), not a C6 hard-reject that leaves it stale"
+        );
+        let (result, _blk) = store.txn_receipt(tx_b).await.unwrap().expect("receipt");
+        assert!(result.is_err(), "reverted (status 0x0)");
+    }
+
+    /// BLOCKER B — atomic classification. Drive the exact interleaving: the claim
+    /// LANDS in the window between `acquire_claim_lock`'s first `has_claim_event`
+    /// read (miss) and the reclaim attempt. The re-read AFTER the failed reclaim
+    /// must classify `Landed` (→ accept-and-revert), NEVER `InFlight`.
+    #[tokio::test]
+    async fn blocker_b_lands_in_reclaim_window_classifies_landed() {
+        let concrete = std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let store: std::sync::Arc<dyn crate::store::Store> = concrete.clone();
+        let gi = U256::from(0x55b0u64);
+        // A genuine in-flight lock (fresh, within TTL, NO ClaimEvent yet): the first
+        // read misses and try_reclaim_expired returns false → would be InFlight.
+        store.try_claim(gi).await.unwrap();
+        // Arm the race: the FIRST has_claim_event miss lands the claim, so the
+        // BLOCKER-B re-read (after the failed reclaim) observes it.
+        concrete.test_land_gi_after_next_has_claim_miss(gi.to_be_bytes::<32>());
+
+        let outcome = acquire_claim_lock(&store, gi, std::time::Duration::from_secs(3600))
+            .await
+            .expect("classification must not error");
+        assert_eq!(
+            outcome,
+            ClaimLockOutcome::Landed,
+            "a gi that lands in the try_claim-Err → reclaim window must classify Landed, \
+             never InFlight (BLOCKER B re-read)"
+        );
+    }
+
+    /// BLOCKER C — the atomic store op `commit_reverted_receipt_and_advance_nonce`
+    /// commits the reverted receipt AND advances the nonce in ONE call (no half
+    /// state). Tested DIRECTLY on the store (not via the RPC path, whose caller-side
+    /// CAS would otherwise mask the method's own nonce advance): the method itself
+    /// must (a) write a COMMITTED reverted receipt — never a pending-forever row —
+    /// and (b) CAS-advance the nonce, returning whether it won; and be idempotent.
+    /// (The `test_pgstore_commit_reverted_receipt_and_advance_nonce` twin asserts
+    /// the same on PgStore.)
+    #[tokio::test]
+    async fn blocker_c_accept_and_revert_atomic_receipt_and_nonce() {
+        let store: std::sync::Arc<dyn crate::store::Store> =
+            std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let signer = Address::from([0x5cu8; 20]);
+        let signer_str = format!("{signer:#x}");
+        let tx_hash = TxHash::from([0x5du8; 32]);
+        let envelope = TxEnvelope::Legacy(alloy::consensus::Signed::new_unchecked(
+            alloy::consensus::TxLegacy::default(),
+            alloy::primitives::Signature::test_signature(),
+            tx_hash,
+        ));
+        assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 0);
+
+        // ONE atomic call: receipt committed-reverted + nonce CAS-advanced.
+        let advanced = store
+            .commit_reverted_receipt_and_advance_nonce(
+                tx_hash,
+                crate::store::TxnEntry {
+                    id: None,
+                    envelope: envelope.clone(),
+                    signer,
+                    expires_at: None,
+                    logs: vec![],
+                },
+                "landed (AlreadyClaimed) #55".into(),
+                7,
+                [0u8; 32],
+                &signer_str,
+                0,
+            )
+            .await
+            .unwrap();
+        assert!(
+            advanced,
+            "the nonce CAS must win on the sync accept path (expected == 0)"
+        );
+
+        // (a) receipt is COMMITTED (non-null → eth_getTransactionReceipt resolves)
+        // and reverted (status 0x0) — never a pending-forever row.
+        let (result, block) = store
+            .txn_receipt(tx_hash)
+            .await
+            .unwrap()
+            .expect("receipt is committed, never pending");
+        assert!(result.is_err(), "reverted status 0x0");
+        assert_eq!(block, 7);
+        // (b) nonce advanced ATOMICALLY with the receipt — no half state.
+        assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 1);
+
+        // Idempotent re-entry (expected 0 again): receipt re-affirmed, nonce NOT
+        // double-advanced (the CAS no-ops because the nonce already moved to 1).
+        let advanced_again = store
+            .commit_reverted_receipt_and_advance_nonce(
+                tx_hash,
+                crate::store::TxnEntry {
+                    id: None,
+                    envelope,
+                    signer,
+                    expires_at: None,
+                    logs: vec![],
+                },
+                "landed (AlreadyClaimed) #55".into(),
+                7,
+                [0u8; 32],
+                &signer_str,
+                0,
+            )
+            .await
+            .unwrap();
+        assert!(
+            !advanced_again,
+            "re-entry must not double-advance the nonce"
+        );
+        assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 1);
+        assert!(store.txn_receipt(tx_hash).await.unwrap().is_some());
+    }
+
+    /// BLOCKER D — store-level nonce CAS: two concurrent advances at expected N →
+    /// exactly ONE wins, the nonce ends at N+1 (never N+2 — the cross-replica skip).
+    #[tokio::test]
+    async fn blocker_d_nonce_cas_concurrent_advances_exactly_one_wins() {
+        let store: std::sync::Arc<dyn crate::store::Store> =
+            std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let addr = "0x00000000000000000000000000000000000000dd";
+        // Prime the nonce to N = 5 (two replicas both read expected 5).
+        for _ in 0..5 {
+            store.nonce_increment(addr).await.unwrap();
+        }
+        assert_eq!(store.nonce_get(addr).await.unwrap(), 5);
+
+        let s1 = store.clone();
+        let s2 = store.clone();
+        let h1 = tokio::spawn(async move { s1.nonce_advance_cas(addr, 5).await.unwrap() });
+        let h2 = tokio::spawn(async move { s2.nonce_advance_cas(addr, 5).await.unwrap() });
+        let (w1, w2) = (h1.await.unwrap(), h2.await.unwrap());
+
+        assert_eq!(
+            [w1, w2].iter().filter(|w| **w).count(),
+            1,
+            "exactly ONE CAS at expected=5 may win"
+        );
+        assert_eq!(
+            store.nonce_get(addr).await.unwrap(),
+            6,
+            "nonce advances to exactly N+1 (never N+2 — the cross-replica skip)"
         );
     }
 

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -610,6 +610,20 @@ pub(crate) async fn acquire_claim_lock(
                 }
                 return Ok(ClaimLockOutcome::InFlight);
             }
+            // BLOCKER 2 — the reclaim SUCCEEDED (an expired lock was superseded to
+            // us). But a claim that landed AFTER the first read yet still holds an
+            // expired-looking lock (a slow real claim: publish took > TTL, then its
+            // ClaimEvent committed) would be reclaimed here and misclassified
+            // `Acquired` → DUPLICATE PUBLISH. So RE-READ landed after the successful
+            // reclaim: if it landed, RELEASE the lock we just superseded and return
+            // `Landed` (→ accept-and-revert), never Acquired. A gi that landed at any
+            // point up to here is Landed. (Residual: an event landing strictly after
+            // this final read is caught only by the worker's own re-classification —
+            // see the report's single-store-transaction residual.)
+            if store.has_claim_event_for_global_index(&gi_bytes).await? {
+                store.unclaim(&global_index).await?;
+                return Ok(ClaimLockOutcome::Landed);
+            }
             ::metrics::counter!("claim_resubmission_recovered_total").increment(1);
             tracing::warn!(
                 global_index = %global_index,
@@ -1023,6 +1037,50 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         anyhow::bail!("unhandled txn method {params_encoded:?}");
     };
 
+    // ── #55 BLOCKER 1 — atomic (signer, nonce) reservation ──────────────
+    //
+    // Reserve the (signer, nonce) slot ATOMICALLY, BEFORE any queue/dispatch/receipt
+    // side effect. Two replicas on a shared PostgreSQL that each passed their
+    // process-local R4 for two DIFFERENT txs at the same (signer, nonce) both reach
+    // here; the store reservation lets exactly ONE win. The loser NEVER executes —
+    // no enqueue, no dispatch, no receipt. (This runs AFTER the R4 per-signer lock,
+    // which still serialises intra-process and provides the future-nonce wait; the
+    // reservation is the cross-replica uniqueness guarantee the process lock can't.)
+    match service
+        .store
+        .reserve_nonce(&signer_str, tx_nonce, txn_hash)
+        .await?
+    {
+        crate::store::NonceReservation::Won => {}
+        crate::store::NonceReservation::HeldBy(h) if h == txn_hash => {
+            // This exact tx already reserved the slot (its own earlier attempt — e.g.
+            // a retry after a RETRYABLE C6/GER rejection that left the reservation but
+            // no receipt — or an idempotent rebroadcast). PROCEED so a retryable
+            // failure can re-run admission and eventually execute. The upstream
+            // tx-hash dedup already short-circuited a tx that truly completed
+            // (receipt written / in-flight), so reaching here means re-execution is
+            // safe (and idempotent: a landed gi accept-reverts, a GER re-inserts).
+            tracing::debug!(
+                target: "rpc::reserve",
+                %txn_hash, nonce = tx_nonce,
+                "reservation held by this same tx — proceeding (retry/re-execute)"
+            );
+        }
+        crate::store::NonceReservation::HeldBy(other) => {
+            // A DIFFERENT tx already reserved this (signer, nonce) slot — this
+            // submission LOST and must NOT execute. Reject; the winner advances the
+            // nonce, so this loser's subsequent retries fail R4 as stale (nonce too
+            // low) and aggkit drops it — mirroring geth dropping the losing tx at an
+            // already-consumed nonce.
+            ::metrics::counter!("rpc_nonce_reservation_lost_total").increment(1);
+            anyhow::bail!(
+                "nonce {tx_nonce} for {signer_str} is already reserved by a different tx \
+                 {other:#x} (concurrent submission at the same nonce slot); this tx must not \
+                 execute"
+            );
+        }
+    }
+
     // ── Dispatch fork (RD-940) ──────────────────────────────────────────
     //
     // `enable_writer_worker` defaults to false — the legacy synchronous
@@ -1048,6 +1106,33 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
                  boot order bug — see main.rs writer spawn block"
             )
         })?;
+
+        // BLOCKER 3 — landed classification BEFORE C6 in WRITER mode too. The sync
+        // worker already classifies landed before RD-860/C6, but the REQUEST path
+        // ran C6 (`ensure_claim_ger_published`) before enqueue: an already-LANDED gi
+        // with a resolvable destination and an altered/unobserved GER would get a C6
+        // RPC error with NO nonce consumption — the wedge. So route an already-landed
+        // claim to accept-and-revert HERE (atomic reverted receipt + nonce, synchronous,
+        // no enqueue), regardless of GER state. The worker's `acquire_claim_lock` still
+        // catches a claim that LANDS after this check (its `Landed` arm accept-reverts).
+        if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
+            && service
+                .store
+                .has_claim_event_for_global_index(&params.globalIndex.to_be_bytes::<32>())
+                .await?
+        {
+            accept_and_revert_landed_claim(
+                &service,
+                params,
+                txn_hash,
+                txn_envelope,
+                signer,
+                &signer_str,
+                tx_nonce,
+            )
+            .await?;
+            return Ok(txn_hash);
+        }
 
         // C6 on the REQUEST path (PR #127 review point 3). Pre-fix, with the
         // writer enabled the gate only ran inside the worker — AFTER
@@ -2615,13 +2700,23 @@ mod tests {
         // completes under the stub): destination is a third party's EVM
         // address ≠ C. Accepted, ClaimEvent emitted, and the recorded signer
         // is C — the destination in the calldata is untouched by who signed.
+        //
+        // Fresh service so C's nonce-0 slot is a clean reservation: leg 1 already
+        // reserved (addr_c, 0) for its (different-calldata) tx — #55 BLOCKER 1
+        // correctly refuses a DIFFERENT tx at that same slot, so a genuinely new
+        // leg-2 scenario needs its own reservation namespace (a real sponsor would
+        // retry leg 1's SAME tx, not submit a different claim at the same nonce).
+        let mut service2 = create_test_service();
+        service2.allow_any_signer = false;
+        service2.allowed_signers = Some(vec![addr_c]);
+        let store = service2.store.clone();
+        seed_zero_ger(&store).await;
         let gi_swallow = U256::from(0x5006u64);
         let someone_else = Address::from([0x77u8; 20]);
         assert_ne!(someone_else, addr_c);
-        // Leg 1's publish failed, so C's nonce is still 0.
         let calldata = claim_calldata(gi_swallow, someone_else, U256::from(1_000_000u64));
         let (input_hex, tx_hash) = encode_tx_signed_with_nonce(&key_c, calldata, 0);
-        let accepted = service_send_raw_txn(service, input_hex)
+        let accepted = service_send_raw_txn(service2, input_hex)
             .await
             .expect("permissionless claim for someone else's deposit must be accepted");
         assert_eq!(accepted, tx_hash);
@@ -3401,6 +3496,224 @@ mod tests {
             store.nonce_get(addr).await.unwrap(),
             6,
             "nonce advances to exactly N+1 (never N+2 — the cross-replica skip)"
+        );
+    }
+
+    /// BLOCKER 1 — atomic (signer, nonce) reservation: the FIRST tx to reserve a
+    /// slot wins; a DIFFERENT tx at the same slot loses (HeldBy the winner); the
+    /// SAME tx re-reserving is idempotent (HeldBy itself); a different nonce is free.
+    #[tokio::test]
+    async fn blocker_1_reserve_nonce_first_wins_different_tx_loses() {
+        use crate::store::NonceReservation;
+        let store: std::sync::Arc<dyn crate::store::Store> =
+            std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let addr = "0x00000000000000000000000000000000000000dd";
+        let h1 = TxHash::from([0x11u8; 32]);
+        let h2 = TxHash::from([0x22u8; 32]);
+
+        assert_eq!(
+            store.reserve_nonce(addr, 5, h1).await.unwrap(),
+            NonceReservation::Won
+        );
+        // Same tx re-reserving → HeldBy(itself) (idempotent).
+        assert_eq!(
+            store.reserve_nonce(addr, 5, h1).await.unwrap(),
+            NonceReservation::HeldBy(h1)
+        );
+        // A DIFFERENT tx at the SAME slot → HeldBy(the winner h1) → it must not execute.
+        assert_eq!(
+            store.reserve_nonce(addr, 5, h2).await.unwrap(),
+            NonceReservation::HeldBy(h1)
+        );
+        // A different nonce is a free slot.
+        assert_eq!(
+            store.reserve_nonce(addr, 6, h2).await.unwrap(),
+            NonceReservation::Won
+        );
+    }
+
+    /// BLOCKER 1 — end-to-end: a submission whose (signer, nonce) slot was already
+    /// reserved by a DIFFERENT tx (another replica won) is REJECTED and does NOT
+    /// execute — no nonce advance, no receipt.
+    #[tokio::test]
+    async fn blocker_1_service_rejects_when_slot_reserved_by_another() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        let calldata = insertGlobalExitRootCall {
+            root: FixedBytes::from([0xE1u8; 32]),
+        }
+        .abi_encode();
+        let (input_hex, signer) = encode_legacy_tx(calldata); // nonce 0
+        let signer_str = format!("{signer:#x}");
+        // Simulate another replica having won the (signer, 0) slot with a different tx.
+        let other = TxHash::from([0xEEu8; 32]);
+        assert_eq!(
+            store.reserve_nonce(&signer_str, 0, other).await.unwrap(),
+            crate::store::NonceReservation::Won
+        );
+
+        let err = service_send_raw_txn(service, input_hex)
+            .await
+            .expect_err("must be rejected — the (signer, nonce) slot is reserved by another tx");
+        assert!(
+            err.to_string()
+                .contains("already reserved by a different tx"),
+            "unexpected: {err:#}"
+        );
+        // Did NOT execute: nonce not advanced.
+        assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 0);
+    }
+
+    /// BLOCKER 2 — the reclaim-SUCCESS window. A gi whose lock is EXPIRED but which
+    /// LANDED (its ClaimEvent committed after the first read) must classify `Landed`,
+    /// NOT `Acquired` (which would duplicate-publish). Driven deterministically: the
+    /// first `has_claim_event` read misses (arming the landing), the expired lock is
+    /// reclaimed, and the re-read AFTER the successful reclaim observes the landing.
+    #[tokio::test]
+    async fn blocker_2_landed_in_reclaim_success_window_classifies_landed() {
+        let concrete = std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let store: std::sync::Arc<dyn crate::store::Store> = concrete.clone();
+        let gi = U256::from(0x55b2u64);
+        store.try_claim(gi).await.unwrap();
+        // Lock is EXPIRED (backdated past the TTL) so try_reclaim_expired SUCCEEDS.
+        concrete.test_backdate_claim(
+            gi,
+            claim_resubmit_ttl() + std::time::Duration::from_secs(10),
+        );
+        // The claim LANDS on the first has_claim_event miss (so the re-read sees it).
+        concrete.test_land_gi_after_next_has_claim_miss(gi.to_be_bytes::<32>());
+
+        let outcome = acquire_claim_lock(&store, gi, claim_resubmit_ttl())
+            .await
+            .expect("classification must not error");
+        assert_eq!(
+            outcome,
+            ClaimLockOutcome::Landed,
+            "a gi that landed but has an expired lock must classify Landed via the \
+             reclaim-success re-read, never Acquired (no duplicate publish)"
+        );
+    }
+
+    /// BLOCKER 3 — writer mode: an already-LANDED gi with an UNOBSERVED GER must
+    /// accept-and-revert on the REQUEST path (before C6/enqueue), not get a C6 GER
+    /// rejection with no nonce consumption.
+    #[tokio::test]
+    async fn blocker_3_writer_mode_landed_before_c6() {
+        let mut service = create_test_service();
+        let store = service.store.clone();
+        let (handle, shutdown) = crate::writer_worker::WriterWorker::spawn(
+            service.clone(),
+            64,
+            std::time::Duration::from_secs(60),
+        );
+        service.enable_writer_worker = true;
+        service.writer_handle = Some(std::sync::Arc::new(handle));
+        // gi LANDED; GER deliberately NOT seeded → C6 would reject "not observed yet".
+        let gi = U256::from(0x55c3u64);
+        land_claim_for(&store, gi).await;
+
+        let key_b = alloy::signers::local::PrivateKeySigner::random();
+        let addr_b = key_b.address();
+        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
+
+        let accepted = service_send_raw_txn(service.clone(), input_b)
+            .await
+            .expect("writer-mode landed gi must accept-and-revert before C6, not reject on GER");
+        assert_eq!(accepted, tx_b);
+        assert_eq!(
+            store.nonce_get(&format!("{addr_b:#x}")).await.unwrap(),
+            1,
+            "nonce consumed via accept-and-revert (not a C6 hard-reject)"
+        );
+        let (result, _blk) = store.txn_receipt(tx_b).await.unwrap().expect("receipt");
+        assert!(result.is_err(), "reverted (status 0x0)");
+        let _ = shutdown.send(());
+    }
+
+    /// BLOCKER 4 — the conditional reverted-receipt write must NEVER overwrite a REAL
+    /// receipt (pending or successful) with status 0. Cross-replica: one path lands
+    /// the real claim; another later classifies Landed and calls accept-and-revert on
+    /// the same hash — the real outcome must survive.
+    #[tokio::test]
+    async fn blocker_4_reverted_receipt_does_not_overwrite_real_receipt() {
+        let store: std::sync::Arc<dyn crate::store::Store> =
+            std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let signer = Address::from([0x44u8; 20]);
+        let signer_str = format!("{signer:#x}");
+        let envelope = TxEnvelope::Legacy(alloy::consensus::Signed::new_unchecked(
+            alloy::consensus::TxLegacy::default(),
+            alloy::primitives::Signature::test_signature(),
+            TxHash::default(),
+        ));
+        let entry = || crate::store::TxnEntry {
+            id: None,
+            envelope: envelope.clone(),
+            signer,
+            expires_at: None,
+            logs: vec![],
+        };
+
+        // (a) SUCCESS receipt must not be overwritten to failed.
+        let tx_ok = TxHash::from([0x41u8; 32]);
+        store.txn_begin(tx_ok, entry()).await.unwrap();
+        store.txn_commit(tx_ok, Ok(()), 5, [0u8; 32]).await.unwrap();
+        store
+            .commit_reverted_receipt_and_advance_nonce(
+                tx_ok,
+                entry(),
+                "revert".into(),
+                9,
+                [0u8; 32],
+                &signer_str,
+                0,
+            )
+            .await
+            .unwrap();
+        let (r_ok, _) = store.txn_receipt(tx_ok).await.unwrap().expect("receipt");
+        assert!(
+            r_ok.is_ok(),
+            "a REAL success receipt must NOT be overwritten to failed"
+        );
+
+        // (b) PENDING receipt (begun, awaiting the projector) must not be finalised to failed.
+        let tx_pending = TxHash::from([0x42u8; 32]);
+        store.txn_begin(tx_pending, entry()).await.unwrap();
+        store
+            .commit_reverted_receipt_and_advance_nonce(
+                tx_pending,
+                entry(),
+                "revert".into(),
+                9,
+                [0u8; 32],
+                &signer_str,
+                1,
+            )
+            .await
+            .unwrap();
+        assert!(
+            store.txn_receipt(tx_pending).await.unwrap().is_none(),
+            "a REAL pending receipt must stay pending (null), not be finalised to failed"
+        );
+
+        // (c) ABSENT hash → the reverted receipt IS written (status 0x0).
+        let tx_new = TxHash::from([0x43u8; 32]);
+        store
+            .commit_reverted_receipt_and_advance_nonce(
+                tx_new,
+                entry(),
+                "revert".into(),
+                9,
+                [0u8; 32],
+                &signer_str,
+                2,
+            )
+            .await
+            .unwrap();
+        let (r_new, _) = store.txn_receipt(tx_new).await.unwrap().expect("receipt");
+        assert!(
+            r_new.is_err(),
+            "an absent hash gets the reverted (status 0x0) receipt"
         );
     }
 

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -2985,7 +2985,8 @@ mod tests {
         let gi_real = U256::from(0x5005u64);
         assert_ne!(resolvable_dest(), addr_c);
         let calldata = claim_calldata(gi_real, resolvable_dest(), U256::from(1_000_000u64));
-        let (input_hex, tx_real) = encode_tx_signed_with_nonce(&key_c, calldata, 0);
+        let nonce_real = store.nonce_get(&format!("{addr_c:#x}")).await.unwrap();
+        let (input_hex, tx_real) = encode_tx_signed_with_nonce(&key_c, calldata, nonce_real);
         let accepted = service_send_raw_txn(service.clone(), input_hex)
             .await
             .expect("permissionless structurally valid claim is accepted");
@@ -3019,7 +3020,8 @@ mod tests {
         let someone_else = Address::from([0x77u8; 20]);
         assert_ne!(someone_else, addr_c);
         let calldata = claim_calldata(gi_swallow, someone_else, U256::from(1_000_000u64));
-        let (input_hex, tx_hash) = encode_tx_signed_with_nonce(&key_c, calldata, 0);
+        let nonce_swallow = store.nonce_get(&format!("{addr_c:#x}")).await.unwrap();
+        let (input_hex, tx_hash) = encode_tx_signed_with_nonce(&key_c, calldata, nonce_swallow);
         let accepted = service_send_raw_txn(service2, input_hex)
             .await
             .expect("permissionless claim for someone else's deposit must be accepted");

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -30,6 +30,35 @@ fn calldata_selector(input: &alloy::primitives::Bytes) -> String {
     )
 }
 
+fn decode_write_call(
+    params_encoded: &alloy::primitives::Bytes,
+) -> anyhow::Result<crate::writer_worker::DecodedWriteCall> {
+    if params_encoded.starts_with(&claimAssetCall::SELECTOR) {
+        tracing::debug!("claimAsset call");
+        let params = claimAssetCall::abi_decode(params_encoded)?;
+        tracing::debug!(target: concat!(module_path!(), "::debug"), "claimAsset call params: {params:?}");
+        Ok(crate::writer_worker::DecodedWriteCall::Claim {
+            params: Box::new(params),
+        })
+    } else if params_encoded.starts_with(&insertGlobalExitRootCall::SELECTOR) {
+        tracing::debug!("insertGlobalExitRoot call");
+        let params = insertGlobalExitRootCall::abi_decode(params_encoded)?;
+        tracing::debug!(target: concat!(module_path!(), "::debug"), "insertGlobalExitRoot call params: {params:?}");
+        Ok(crate::writer_worker::DecodedWriteCall::Ger {
+            ger_bytes: params.root.0,
+        })
+    } else if params_encoded.starts_with(&updateExitRootCall::SELECTOR) {
+        tracing::debug!("updateExitRoot call");
+        let params = updateExitRootCall::abi_decode(params_encoded)?;
+        tracing::debug!(target: concat!(module_path!(), "::debug"), "updateExitRoot call params: {params:?}");
+        Ok(crate::writer_worker::DecodedWriteCall::Ger {
+            ger_bytes: ger::combined_ger(&params.newMainnetExitRoot.0, &params.newRollupExitRoot.0),
+        })
+    } else {
+        anyhow::bail!("unhandled txn method {params_encoded:?}")
+    }
+}
+
 fn unwrap_txn_envelope(txn_envelope: TxEnvelope) -> anyhow::Result<TransactionData> {
     let data = match txn_envelope {
         TxEnvelope::Eip1559(txn_signed) => {
@@ -1160,6 +1189,18 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
     let selector = calldata_selector(&txn.input);
     tracing::debug!(target: concat!(module_path!(), "::debug"), "raw transaction hash: {txn_hash}");
 
+    // Reject unauthorized signers before any store read or per-signer lock
+    // allocation. In fail-closed mode this keeps untrusted addresses from
+    // growing the lock registry or consuming database capacity.
+    if !service.allow_any_signer && !is_signer_allowed(service.allowed_signers.as_deref(), &signer)
+    {
+        ::metrics::counter!("rpc_unauthorized_signer_total").increment(1);
+        anyhow::bail!(
+            "signer {signer:#x} is not on the allow-list; configure --allowed-signers (or ALLOWED_SIGNERS), \
+             or set --insecure-allow-any-signer to explicitly opt into open mode"
+        );
+    }
+
     // RD-940 Decision 3 — tx-hash dedup early-return, BEFORE the R4 nonce check.
     //
     // aggkit's ethtxmanager re-broadcasts stuck txs within its
@@ -1218,7 +1259,7 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         .is_some_and(|handoff| handoff.state == crate::store::NoteHandoffState::Submitted);
     // A pending row without a note handoff is the durable queue intent. It must
     // be resumed after a crashed process loses its in-memory mpsc contents.
-    let known_durable_intent = known_store_entry
+    let mut known_durable_intent = known_store_entry
         .as_ref()
         .is_some_and(|entry| entry.result.is_none() && !known_store_linked);
     tracing::info!(
@@ -1259,6 +1300,21 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         return Ok(txn_hash);
     }
 
+    let decoded = decode_write_call(&txn.input)?;
+    // Deterministic and side-effect-free rejection belongs before the signer
+    // lock. Stateful checks repeat after reservation to close landing races.
+    validate_before_nonce_reservation(&service, &decoded).await?;
+    if service.enable_writer_worker {
+        let handle = service.writer_handle.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "enable_writer_worker=true but no writer_handle plumbed into ServiceState"
+            )
+        })?;
+        if handle.available_capacity() == 0 {
+            return Err(crate::writer_worker::WriterQueueSaturatedError.into());
+        }
+    }
+
     // R4 follow-up — serialise the entire nonce-check + enqueue/handler
     // critical section for this signer. Without the mutex, two concurrent
     // same-nonce txs both pass the equality check before either calls
@@ -1276,6 +1332,27 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
 
     let _lock = loop {
         let lock = service.per_signer_locks.lock(signer).await;
+
+        // Close the race between the optimistic dedup read above and this lock.
+        // A concurrent identical request may have admitted the hash while we
+        // waited; it must deduplicate here instead of failing as a stale nonce.
+        if service
+            .writer_handle
+            .as_ref()
+            .is_some_and(|handle| handle.is_inflight(&txn_hash))
+        {
+            return Ok(txn_hash);
+        }
+        if !known_durable_intent
+            && let Some(refreshed_entry) = service.store.txn_get(txn_hash).await?
+        {
+            let refreshed_handoff = service.store.get_note_handoff_for_tx(&tx_key).await?;
+            if refreshed_entry.result.is_some() || refreshed_handoff.is_some() {
+                repair_commit_gap_nonce(&service, &signer_str, tx_nonce).await?;
+                return Ok(txn_hash);
+            }
+            known_durable_intent = true;
+        }
 
         // R4 — nonce validation. Pre-fix the proxy advanced its tracked nonce
         // only on success and never compared the incoming `tx.nonce` against
@@ -1345,73 +1422,6 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
             "nonce mismatch for {signer_str}: tx.nonce = {tx_nonce}, expected {expected_nonce}; this guards against replay and out-of-order submission (R4)"
         );
     };
-
-    // R2 — signer allow-list. Without this, anyone who can hit the JSON-RPC port
-    // can sign and submit `claimAsset` / `insertGlobalExitRoot` / `updateExitRoot`
-    // calldata. The proxy then runs Miden tx work on the service account's behalf
-    // (auto-creates faucets, advances LET, marks GERs injected), letting an
-    // attacker burn fees, poison registries, or feed fabricated GERs to
-    // bridge-service. Reject any signer not in the configured allow-list.
-    // Audit C2 — `None` is fail-closed (no signer accepted); legacy open mode
-    // requires the explicit `allow_any_signer` opt-in.
-    if !service.allow_any_signer && !is_signer_allowed(service.allowed_signers.as_deref(), &signer)
-    {
-        ::metrics::counter!("rpc_unauthorized_signer_total").increment(1);
-        anyhow::bail!(
-            "signer {signer:#x} is not on the allow-list; configure --allowed-signers (or ALLOWED_SIGNERS), \
-             or set --insecure-allow-any-signer to explicitly opt into open mode"
-        );
-    }
-
-    // ── Method decode ───────────────────────────────────────────────────
-    //
-    // Decoding the selector + ABI on the request thread (rather than inside
-    // the worker) keeps malformed payloads from poisoning the queue and lets
-    // both the legacy sync path and the worker path share the same dispatch
-    // shape downstream. The `DecodedWriteCall` enum is defined in
-    // `writer_worker` so it can also serve as the wire shape for the v1.5
-    // durable-queue migration sketched in `docs/design/RD-940-async-writer.md`.
-    let params_encoded = &txn.input;
-    let decoded = if params_encoded.starts_with(&claimAssetCall::SELECTOR) {
-        tracing::debug!("claimAsset call");
-        let params = claimAssetCall::abi_decode(params_encoded)?;
-        tracing::debug!(target: concat!(module_path!(), "::debug"), "claimAsset call params: {params:?}");
-        crate::writer_worker::DecodedWriteCall::Claim {
-            params: Box::new(params),
-        }
-    } else if params_encoded.starts_with(&insertGlobalExitRootCall::SELECTOR) {
-        tracing::debug!("insertGlobalExitRoot call");
-        let params = insertGlobalExitRootCall::abi_decode(params_encoded)?;
-        tracing::debug!(target: concat!(module_path!(), "::debug"), "insertGlobalExitRoot call params: {params:?}");
-        let ger_bytes: [u8; 32] = params.root.0;
-        crate::writer_worker::DecodedWriteCall::Ger { ger_bytes }
-    } else if params_encoded.starts_with(&updateExitRootCall::SELECTOR) {
-        tracing::debug!("updateExitRoot call");
-        let params = updateExitRootCall::abi_decode(params_encoded)?;
-        tracing::debug!(target: concat!(module_path!(), "::debug"), "updateExitRoot call params: {params:?}");
-        let combined_ger =
-            ger::combined_ger(&params.newMainnetExitRoot.0, &params.newRollupExitRoot.0);
-        crate::writer_worker::DecodedWriteCall::Ger {
-            ger_bytes: combined_ger,
-        }
-    } else {
-        tracing::error!("unhandled txn method {params_encoded:?}");
-        anyhow::bail!("unhandled txn method {params_encoded:?}");
-    };
-
-    // All deterministic claim rejection happens before the permanent
-    // reservation row is created, so a corrected transaction may reuse nonce N.
-    validate_before_nonce_reservation(&service, &decoded).await?;
-    if service.enable_writer_worker {
-        let handle = service.writer_handle.as_ref().ok_or_else(|| {
-            anyhow::anyhow!(
-                "enable_writer_worker=true but no writer_handle plumbed into ServiceState"
-            )
-        })?;
-        if handle.available_capacity() == 0 {
-            return Err(crate::writer_worker::WriterQueueSaturatedError.into());
-        }
-    }
 
     // ── #55 BLOCKER 1 — atomic (signer, nonce) reservation ──────────────
     //
@@ -2418,6 +2428,45 @@ mod tests {
             store.nonce_get(&format!("{signer:#x}")).await.unwrap(),
             1,
             "dedup must not double-advance the nonce"
+        );
+    }
+
+    /// A duplicate can pass the optimistic dedup read while the original request
+    /// owns the signer lock. Recheck after lock acquisition so it returns the same
+    /// hash instead of observing the advanced nonce as stale.
+    #[tokio::test]
+    async fn concurrent_same_hash_rechecks_dedup_inside_signer_lock() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        let calldata = insertGlobalExitRootCall {
+            root: FixedBytes::from([0xCDu8; 32]),
+        }
+        .abi_encode();
+        let (input_hex, signer) = encode_legacy_tx(calldata);
+
+        // Hold the signer lock while both calls complete their initial empty-store
+        // dedup reads, forcing the race this regression covers.
+        let gate = service.per_signer_locks.lock(signer).await;
+        let first_service = service.clone();
+        let first_input = input_hex.clone();
+        let first =
+            tokio::spawn(async move { service_send_raw_txn(first_service, first_input).await });
+        let second_service = service.clone();
+        let second =
+            tokio::spawn(async move { service_send_raw_txn(second_service, input_hex).await });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        drop(gate);
+
+        let first = first.await.unwrap().expect("first submit must succeed");
+        let second = second
+            .await
+            .unwrap()
+            .expect("concurrent rebroadcast must deduplicate");
+        assert_eq!(first, second);
+        assert_eq!(
+            store.nonce_get(&format!("{signer:#x}")).await.unwrap(),
+            1,
+            "concurrent dedup must advance the nonce exactly once"
         );
     }
 

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -16,13 +16,7 @@ struct TransactionData {
 }
 
 pub(crate) fn envelope_nonce(txn_envelope: &TxEnvelope) -> u64 {
-    match txn_envelope {
-        TxEnvelope::Eip1559(s) => s.tx().nonce,
-        TxEnvelope::Eip2930(s) => s.tx().nonce,
-        TxEnvelope::Eip4844(s) => s.tx().tx().nonce,
-        TxEnvelope::Eip7702(s) => s.tx().nonce,
-        TxEnvelope::Legacy(s) => s.tx().nonce,
-    }
+    crate::store::envelope_nonce(txn_envelope)
 }
 
 fn calldata_selector(input: &alloy::primitives::Bytes) -> String {
@@ -124,6 +118,20 @@ async fn handle_ger_result(
             Ok(())
         }
         Err(err) => {
+            let tx_key = format!("{txn_hash:#x}");
+            if service
+                .store
+                .get_note_handoff_for_tx(&tx_key)
+                .await?
+                .is_some()
+            {
+                tracing::warn!(
+                    %txn_hash,
+                    error = %err,
+                    "GER outcome is ambiguous after durable note handoff; leaving receipt pending"
+                );
+                return Ok(());
+            }
             tracing::error!("insert_ger failed: {err:#?}");
             Err(err)
         }
@@ -553,6 +561,29 @@ pub(crate) fn reservation_lease() -> std::time::Duration {
     std::time::Duration::from_secs(secs.max(3))
 }
 
+/// A spawned lease-renewal task must never outlive the request that owns it.
+/// Tokio detaches a `JoinHandle` on drop, so an unguarded handle would keep an
+/// abandoned reservation alive forever after request cancellation.
+struct AbortTaskOnDrop(Option<tokio::task::JoinHandle<()>>);
+
+impl AbortTaskOnDrop {
+    fn new(handle: tokio::task::JoinHandle<()>) -> Self {
+        Self(Some(handle))
+    }
+
+    fn abort(&mut self) {
+        if let Some(handle) = self.0.take() {
+            handle.abort();
+        }
+    }
+}
+
+impl Drop for AbortTaskOnDrop {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
+
 /// #55 BLOCKER 1 — execute a WON admission (dispatch to the writer worker or the
 /// legacy sync path) and return the tx hash. Extracted so `service_send_raw_txn` can
 /// wrap it with the reservation-lease RELEASE (success → future same-hash dedups;
@@ -597,6 +628,47 @@ async fn durably_admit_and_advance_nonce(
     Ok(())
 }
 
+/// Run every deterministic / side-effect-free rejection before binding the
+/// `(signer, nonce)` reservation to a hash. A malformed claim can therefore be
+/// corrected and re-signed at the same nonce. Stateful checks are repeated by
+/// the dispatcher after reservation only to close a landed-claim race.
+async fn validate_before_nonce_reservation(
+    service: &ServiceState,
+    decoded: &crate::writer_worker::DecodedWriteCall,
+) -> anyhow::Result<()> {
+    let crate::writer_worker::DecodedWriteCall::Claim { params } = decoded else {
+        return Ok(());
+    };
+    if params.destinationNetwork != service.network_id {
+        anyhow::bail!(
+            "claim targets destinationNetwork {} but this proxy only handles network {}",
+            params.destinationNetwork,
+            service.network_id
+        );
+    }
+
+    // A landed claim must bypass C6 and be accepted-and-reverted.
+    if service
+        .store
+        .has_claim_event_for_global_index(&params.globalIndex.to_be_bytes::<32>())
+        .await?
+    {
+        return Ok(());
+    }
+    if !params.amount.is_zero()
+        && crate::address_mapper::resolve_address(
+            &*service.store,
+            params.destinationAddress,
+            &service.accounts.0,
+        )
+        .await
+        .is_ok()
+    {
+        ensure_claim_ger_published(&service.store, params).await?;
+    }
+    Ok(())
+}
+
 async fn dispatch_after_reservation(
     service: &ServiceState,
     decoded: crate::writer_worker::DecodedWriteCall,
@@ -606,17 +678,8 @@ async fn dispatch_after_reservation(
     signer_str: &str,
     tx_nonce: u64,
 ) -> anyhow::Result<TxHash> {
-    // Cheap deterministic validation, landed classification, and retryable GER
-    // checks happen before durable acceptance in both sync and writer modes.
-    if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
-        && params.destinationNetwork != service.network_id
-    {
-        anyhow::bail!(
-            "claim targets destinationNetwork {} but this proxy only handles network {}",
-            params.destinationNetwork,
-            service.network_id
-        );
-    }
+    // Landed classification is repeated after reservation to close the race
+    // with a claim that lands immediately after pre-validation.
     if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
         && service
             .store
@@ -817,20 +880,42 @@ pub(crate) struct ClaimSubmissionFence {
 }
 
 impl ClaimSubmissionFence {
-    pub(crate) async fn mark_submitted(&self, note_commitment: &str) -> anyhow::Result<()> {
+    pub(crate) async fn prepare(
+        &self,
+        note_commitment: &str,
+        note_id: &str,
+        expiration_block: u64,
+    ) -> anyhow::Result<()> {
         if !self
             .store
-            .mark_claim_submitted_fenced(
+            .prepare_claim_submission_fenced(
                 self.global_index,
                 self.owner_tx_hash,
                 self.fence,
                 self.owner_tx_hash,
                 note_commitment,
+                note_id,
+                expiration_block,
             )
             .await?
         {
             anyhow::bail!(
                 "claim ownership fence lost before submission for global_index {}",
+                self.global_index
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn confirm(&self, note_commitment: &str) -> anyhow::Result<()> {
+        let tx_key = format!("{:#x}", self.owner_tx_hash);
+        if !self
+            .store
+            .confirm_note_handoff(&tx_key, note_commitment)
+            .await?
+        {
+            anyhow::bail!(
+                "claim note handoff changed before commit confirmation for global_index {}",
                 self.global_index
             );
         }
@@ -943,13 +1028,35 @@ async fn publish_and_record_claim(
         Some(service.expected_mints.clone()),
         guard.submission_fence(),
     )
-    .await?;
-    tracing::info!(
-        eth_tx = %txn_hash,
-        miden_tx = %claim_result.txn_id,
-        "claim published; receipt pending until the projector finalises it on consumption"
-    );
-    Ok(())
+    .await;
+    match claim_result {
+        Ok(claim_result) => {
+            tracing::info!(
+                eth_tx = %txn_hash,
+                miden_tx = %claim_result.txn_id,
+                "claim published; receipt pending until the projector finalises it on consumption"
+            );
+            Ok(())
+        }
+        Err(err) => {
+            let tx_key = format!("{txn_hash:#x}");
+            if service
+                .store
+                .get_note_handoff_for_tx(&tx_key)
+                .await?
+                .is_some()
+            {
+                tracing::warn!(
+                    %txn_hash,
+                    error = %err,
+                    "claim outcome is ambiguous after durable note handoff; leaving receipt pending"
+                );
+                Ok(())
+            } else {
+                Err(err)
+            }
+        }
+    }
 }
 
 /// Unified GER-insert / updateExitRoot dispatcher used by both the legacy sync
@@ -1077,17 +1184,38 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         .writer_handle
         .as_ref()
         .is_some_and(|handle| handle.is_inflight(&txn_hash));
-    let known_store_entry = service.store.txn_get(txn_hash).await?;
-    let known_store_tx = known_store_entry.is_some();
-    let known_store_linked = if known_store_tx {
-        service
+    let tx_key = format!("{txn_hash:#x}");
+    let mut known_store_entry = service.store.txn_get(txn_hash).await?;
+    let mut handoff = service.store.get_note_handoff_for_tx(&tx_key).await?;
+    if let Some(prepared) = handoff
+        .as_ref()
+        .filter(|handoff| handoff.state == crate::store::NoteHandoffState::Prepared)
+    {
+        if service
             .store
-            .get_note_link_for_tx(&format!("{txn_hash:#x}"))
+            .clear_expired_prepared_note_handoff(&tx_key, &prepared.note_commitment)
             .await?
-            .is_some()
-    } else {
-        false
-    };
+        {
+            tracing::warn!(
+                %txn_hash,
+                "authoritative reconcile cursor passed prepared transaction expiration; retrying exact transaction"
+            );
+            handoff = None;
+            known_store_entry = service.store.txn_get(txn_hash).await?;
+        } else {
+            repair_commit_gap_nonce(&service, &signer_str, tx_nonce).await?;
+            tracing::debug!(
+                target: "rpc::dedup",
+                %txn_hash,
+                "prepared note handoff is still ambiguous; leaving receipt pending"
+            );
+            return Ok(txn_hash);
+        }
+    }
+    let known_store_tx = known_store_entry.is_some();
+    let known_store_linked = handoff
+        .as_ref()
+        .is_some_and(|handoff| handoff.state == crate::store::NoteHandoffState::Submitted);
     // A pending row without a note handoff is the durable queue intent. It must
     // be resumed after a crashed process loses its in-memory mpsc contents.
     let known_durable_intent = known_store_entry
@@ -1106,6 +1234,7 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
             "known_inflight": known_inflight,
             "known_store_tx": known_store_tx,
             "known_store_linked": known_store_linked,
+            "known_store_prepared": handoff.as_ref().is_some_and(|handoff| handoff.state == crate::store::NoteHandoffState::Prepared),
             "known_durable_intent": known_durable_intent,
             "writer_enabled": service.enable_writer_worker,
             "writer_handle_present": service.writer_handle.is_some(),
@@ -1152,6 +1281,20 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         // only on success and never compared the incoming `tx.nonce` against
         // the expected next value. That allowed replay and skipped sequencing.
         let expected_nonce = service.store.nonce_get(&signer_str).await?;
+        let durable_frontier = service.store.pending_nonce_frontier(&signer_str).await?;
+        if let Some(lower_nonce) = durable_frontier.lowest_unlinked
+            && lower_nonce < tx_nonce
+        {
+            let lower_is_live = service
+                .writer_handle
+                .as_ref()
+                .is_some_and(|handle| handle.has_non_terminal_nonce(&signer, lower_nonce));
+            if !lower_is_live {
+                anyhow::bail!(
+                    "cannot admit nonce {tx_nonce} for {signer_str}: durable transaction at lower nonce {lower_nonce} has not reached the Miden handoff; re-submit that exact signed transaction first"
+                );
+            }
+        }
         let durable_resume_nonce =
             known_durable_intent && expected_nonce == tx_nonce.saturating_add(1);
         let can_wait_for_future_nonce = service.enable_writer_worker
@@ -1173,6 +1316,7 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
                 "tx_hash": format!("{txn_hash:#x}"),
                 "tx_nonce": tx_nonce,
                 "expected_nonce": expected_nonce,
+                "durable_lowest_unlinked": durable_frontier.lowest_unlinked,
                 "nonce_matches": tx_nonce == expected_nonce,
                 "durable_resume": durable_resume_nonce,
                 "action": nonce_action,
@@ -1255,6 +1399,20 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         anyhow::bail!("unhandled txn method {params_encoded:?}");
     };
 
+    // All deterministic claim rejection happens before the permanent
+    // reservation row is created, so a corrected transaction may reuse nonce N.
+    validate_before_nonce_reservation(&service, &decoded).await?;
+    if service.enable_writer_worker {
+        let handle = service.writer_handle.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "enable_writer_worker=true but no writer_handle plumbed into ServiceState"
+            )
+        })?;
+        if handle.available_capacity() == 0 {
+            return Err(crate::writer_worker::WriterQueueSaturatedError.into());
+        }
+    }
+
     // ── #55 BLOCKER 1 — atomic (signer, nonce) reservation ──────────────
     //
     // Reserve the (signer, nonce) slot ATOMICALLY, BEFORE any queue/dispatch/receipt
@@ -1276,14 +1434,14 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
         crate::store::NonceReservation::Won { fence } => fence,
         crate::store::NonceReservation::OwnedBySame => {
             // The slot is currently owned+executing by THIS SAME tx under a valid
-            // lease (another replica is admitting it), or it already released-
-            // success. Do NOT execute — dedup-return the hash; the owner produces
-            // the receipt. This is the authoritative single-executor guarantee that
+            // lease (another replica is admitting it). Do NOT execute — dedup-return
+            // the hash; the owner produces the receipt. This is the authoritative
+            // single-executor guarantee that
             // the process-local dedup reads (which can miss cross-replica) cannot give.
             tracing::debug!(
                 target: "rpc::reserve",
                 %txn_hash, nonce = tx_nonce,
-                "reservation owned by this same tx (valid lease / released-success) — \
+                "reservation owned by this same tx under a valid executing lease — \
                  dedup-returning hash, NOT executing"
             );
             return Ok(txn_hash);
@@ -1308,7 +1466,7 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
     let heartbeat_signer = signer_str.clone();
     let heartbeat_lease = reservation_lease();
     let heartbeat_period = std::cmp::max(std::time::Duration::from_secs(1), heartbeat_lease / 3);
-    let reservation_heartbeat = tokio::spawn(async move {
+    let mut reservation_heartbeat = AbortTaskOnDrop::new(tokio::spawn(async move {
         loop {
             tokio::time::sleep(heartbeat_period).await;
             match heartbeat_store
@@ -1323,10 +1481,10 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
                 ),
             }
         }
-    });
+    }));
 
     // Execute the WON admission, then RELEASE the lease on the outcome: success →
-    // `released_success` (a future same-hash submission dedups via OwnedBySame);
+    // `released_success` (a future same-hash durable recovery may reacquire);
     // failure → `released_failure` (the SAME tx may retry via lease takeover). Only
     // the current fence owner may release, so a delayed crashed owner whose lease was
     // taken over cannot clobber the new owner's state. A crash before release leaves
@@ -2585,7 +2743,8 @@ mod tests {
         let key_b = alloy::signers::local::PrivateKeySigner::random();
         let addr_b = key_b.address();
         let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
-        let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
+        let nonce_b = store.nonce_get(&format!("{addr_b:#x}")).await.unwrap();
+        let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, nonce_b);
 
         let accepted_inflight = service_send_raw_txn(service.clone(), input_b.clone())
             .await
@@ -2706,7 +2865,11 @@ mod tests {
         // signer) submits the same gi through the FULL RPC path.
         let key_b = alloy::signers::local::PrivateKeySigner::random();
         let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
-        let (input_b, _) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
+        let nonce_b = store
+            .nonce_get(&format!("{:#x}", key_b.address()))
+            .await
+            .unwrap();
+        let (input_b, _) = encode_tx_signed_with_nonce(&key_b, calldata, nonce_b);
 
         let accepted = service_send_raw_txn(service, input_b)
             .await
@@ -2733,8 +2896,6 @@ mod tests {
         let user_key = alloy::signers::local::PrivateKeySigner::random();
         let user_addr = user_key.address();
         let gi = U256::from(0x4004u64);
-        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
-        let (input_hex, tx_hash) = encode_tx_signed_with_nonce(&user_key, calldata, 0);
 
         // (a) allow-list configured, signer NOT on it.
         let mut service = create_test_service();
@@ -2746,6 +2907,9 @@ mod tests {
         let store = service.store.clone();
         let miden = service.miden_client.clone();
         seed_zero_ger(&store).await;
+        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
+        let nonce = store.nonce_get(&format!("{user_addr:#x}")).await.unwrap();
+        let (input_hex, tx_hash) = encode_tx_signed_with_nonce(&user_key, calldata, nonce);
 
         let err = service_send_raw_txn(service, input_hex.clone())
             .await
@@ -3648,8 +3812,8 @@ mod tests {
     /// SAME tx under a valid lease → OwnedBySame (dedup, another replica must not
     /// execute); a DIFFERENT tx → HeldByOther (hard reject); release-FAILURE lets the
     /// SAME tx take over (fence bumps); a fenced-out stale release is ignored;
-    /// release-SUCCESS makes the SAME tx dedup; only the SAME tx can take over an
-    /// EXPIRED lease.
+    /// release-SUCCESS remains recoverable by the SAME durable tx; only that hash
+    /// can ever take over the slot.
     #[tokio::test]
     async fn blocker_1_reserve_nonce_fenced_lifecycle() {
         use crate::store::NonceReservation;
@@ -3703,15 +3867,16 @@ mod tests {
             "a fenced-out stale release must not flip the current owner's state"
         );
 
-        // release-SUCCESS (by the current owner) → the SAME tx now dedups.
+        // release-SUCCESS (by the current owner) → the SAME durable tx can
+        // resume after a restart loses the in-memory queue.
         store
             .release_reservation(addr, 5, h1, fence2, true)
             .await
             .unwrap();
-        assert_eq!(
+        assert!(matches!(
             store.reserve_nonce(addr, 5, h1, lease).await.unwrap(),
-            NonceReservation::OwnedBySame
-        );
+            NonceReservation::Won { fence } if fence > fence2
+        ));
 
         // A different nonce is a free slot.
         assert!(matches!(
@@ -3990,14 +4155,30 @@ mod tests {
         assert!(b.fence > a.fence);
         assert!(
             !store
-                .mark_claim_submitted_fenced(gi, tx_a, a.fence, tx_a, "stale-note")
+                .prepare_claim_submission_fenced(
+                    gi,
+                    tx_a,
+                    a.fence,
+                    tx_a,
+                    "stale-note",
+                    "stale-id",
+                    100,
+                )
                 .await
                 .unwrap()
         );
         assert!(!store.unclaim_fenced(&gi, tx_a, a.fence).await.unwrap());
         assert!(
             store
-                .mark_claim_submitted_fenced(gi, tx_b, b.fence, tx_b, "winner-note")
+                .prepare_claim_submission_fenced(
+                    gi,
+                    tx_b,
+                    b.fence,
+                    tx_b,
+                    "winner-note",
+                    "winner-id",
+                    100,
+                )
                 .await
                 .unwrap()
         );
@@ -4225,5 +4406,139 @@ mod tests {
             "an in-flight record (younger than the TTL, no ClaimEvent) must classify InFlight"
         );
         assert!(store.is_claimed(&gi).await.unwrap(), "lock stays held");
+    }
+
+    #[tokio::test]
+    async fn invalid_claim_does_not_bind_nonce_reservation() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        let key = alloy::signers::local::PrivateKeySigner::random();
+        let gi = U256::from(0xd001u64);
+
+        let mut bad =
+            claimAssetCall::abi_decode(&claim_calldata(gi, resolvable_dest(), U256::ZERO)).unwrap();
+        bad.destinationNetwork = service.network_id + 1;
+        let signer_key = format!("{:#x}", key.address());
+        let nonce = store.nonce_get(&signer_key).await.unwrap();
+        let (bad_raw, bad_hash) = encode_tx_signed_with_nonce(&key, bad.abi_encode(), nonce);
+        let err = service_send_raw_txn(service.clone(), bad_raw)
+            .await
+            .expect_err("wrong destination network must be rejected");
+        assert!(err.to_string().contains("destinationNetwork"));
+        assert!(store.txn_get(bad_hash).await.unwrap().is_none());
+
+        // A corrected, newly-signed hash at the same nonce is still admissible.
+        let (good_raw, good_hash) = encode_tx_signed_with_nonce(
+            &key,
+            claim_calldata(gi, resolvable_dest(), U256::ZERO),
+            store.nonce_get(&signer_key).await.unwrap(),
+        );
+        assert_eq!(
+            service_send_raw_txn(service, good_raw).await.unwrap(),
+            good_hash
+        );
+        assert_eq!(
+            store
+                .nonce_get(&format!("{:#x}", key.address()))
+                .await
+                .unwrap(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn durable_pending_floor_survives_restart_and_blocks_nonce_skip() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        let key = alloy::signers::local::PrivateKeySigner::random();
+        let signer = key.address();
+        let signer_str = format!("{signer:#x}");
+        let call0 = insertGlobalExitRootCall {
+            root: FixedBytes::from([0xd0; 32]),
+        }
+        .abi_encode();
+        let nonce0 = store.nonce_get(&signer_str).await.unwrap();
+        let (raw0, hash0) = encode_tx_signed_with_nonce(&key, call0, nonce0);
+        let payload0 = hex_decode_prefixed(&raw0).unwrap();
+        let envelope0 = TxEnvelope::decode_2718(&mut payload0.as_slice()).unwrap();
+
+        // Model a process kill after durable intent + nonce CAS, with no DashMap.
+        store
+            .txn_begin_if_absent(
+                hash0,
+                TxnEntry {
+                    id: None,
+                    envelope: envelope0,
+                    signer,
+                    expires_at: None,
+                    logs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        assert!(store.nonce_advance_cas(&signer_str, nonce0).await.unwrap());
+
+        let frontier = store.pending_nonce_frontier(&signer_str).await.unwrap();
+        assert_eq!(frontier.lowest_pending, Some(0));
+        assert_eq!(frontier.lowest_unlinked, Some(0));
+        assert_eq!(
+            crate::service::select_transaction_count(1, "latest", frontier),
+            0
+        );
+        assert_eq!(
+            crate::service::select_transaction_count(1, "pending", frontier),
+            1
+        );
+
+        let call1 = insertGlobalExitRootCall {
+            root: FixedBytes::from([0xd1; 32]),
+        }
+        .abi_encode();
+        let nonce1 = store.nonce_get(&signer_str).await.unwrap();
+        let (raw1, _) = encode_tx_signed_with_nonce(&key, call1, nonce1);
+        let err = service_send_raw_txn(service, raw1)
+            .await
+            .expect_err("nonce 1 must not skip recoverable durable nonce 0");
+        assert!(err.to_string().contains("lower nonce 0"));
+        assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn reservation_heartbeat_is_aborted_on_owner_drop() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let ticks = std::sync::Arc::new(AtomicUsize::new(0));
+        let task_ticks = ticks.clone();
+        let guard = AbortTaskOnDrop::new(tokio::spawn(async move {
+            loop {
+                task_ticks.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        }));
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        drop(guard);
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let after_abort = ticks.load(Ordering::SeqCst);
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert_eq!(ticks.load(Ordering::SeqCst), after_abort);
+    }
+
+    #[tokio::test]
+    async fn same_hash_claim_lease_is_immediately_reclaimable() {
+        let concrete = std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let store: std::sync::Arc<dyn crate::store::Store> = concrete.clone();
+        let gi = U256::from(0xd004u64);
+        let owner = TxHash::from([0xd4; 32]);
+        let ttl = std::time::Duration::from_secs(120);
+        store
+            .try_claim_fenced(gi, owner, ttl)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(matches!(
+            acquire_claim_lock(&store, gi, owner, ttl).await.unwrap(),
+            ClaimLockOutcome::Acquired { .. }
+        ));
     }
 }

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -30,7 +30,7 @@ fn calldata_selector(input: &alloy::primitives::Bytes) -> String {
     )
 }
 
-fn decode_write_call(
+pub(crate) fn decode_write_call(
     params_encoded: &alloy::primitives::Bytes,
 ) -> anyhow::Result<crate::writer_worker::DecodedWriteCall> {
     if params_encoded.starts_with(&claimAssetCall::SELECTOR) {
@@ -83,6 +83,13 @@ fn unwrap_txn_envelope(txn_envelope: TxEnvelope) -> anyhow::Result<TransactionDa
         }
     };
     Ok(data)
+}
+
+pub(crate) fn decode_envelope_write_call(
+    txn_envelope: &TxEnvelope,
+) -> anyhow::Result<crate::writer_worker::DecodedWriteCall> {
+    let transaction = unwrap_txn_envelope(txn_envelope.clone())?;
+    decode_write_call(&transaction.input)
 }
 
 async fn handle_ger_result(
@@ -484,16 +491,6 @@ pub(crate) async fn worker_handle_claim_asset(
         return Ok(());
     }
 
-    // C6 — pre-publish GER publication gate. In writer mode the SAME gate already
-    // ran on the request path before `try_enqueue` (PR #127 review point 3); this
-    // second run is cheap defense-in-depth. On rejection RELEASE the lock (cheap
-    // retryable surface — the claim didn't publish) and return the retryable error.
-    // See `ensure_claim_ger_published` for the full rationale.
-    if let Err(err) = ensure_claim_ger_published(&service.store, &params).await {
-        guard.release_explicitly().await;
-        return Err(err);
-    }
-
     let result = publish_and_record_claim(
         service,
         params.clone(),
@@ -515,50 +512,6 @@ pub(crate) async fn worker_handle_claim_asset(
     // the guard to forget so its Drop is a no-op.
     guard.commit();
 
-    Ok(())
-}
-
-/// C6 — the pre-admission GER publication gate (Cantina #21 / PR #127 review).
-///
-/// The CLAIM note's leaf proof is internally consistent (built from L1
-/// calldata), but on-chain the bridge MASM verifies it against the GER
-/// currently stored in the bridge account. Mirroring the real EVM bridge
-/// (`AgglayerBridge._verifyLeaf` reads `globalExitRootMap[combinedGER]` once
-/// and reverts `GlobalExitRootInvalid()` when zero — it never waits), a claim
-/// whose GER the proxy has not yet PUBLISHED is rejected fail-fast with a
-/// retryable error: no nonce is consumed, no globalIndex lock is taken, no
-/// receipt or queued job is created, and the SAME signed transaction can be
-/// re-submitted after GER publication.
-///
-/// This gate MUST run before durable admission, nonce CAS, or enqueue.
-/// `dispatch_after_reservation` does so on the request thread for both sync and
-/// writer modes. `worker_handle_claim_asset` repeats it after fenced acquisition
-/// as defense in depth against GER state changing while a queued job waits.
-///
-/// `is_ger_injected` rather than `has_seen_ger`: the L1InfoTreeIndexer
-/// pre-populates ger_entries rows for L1 pairs it has indexed but that
-/// haven't yet been injected/published on L2. C6 requires the GER event to be
-/// published on L2, not merely indexed; the `is_injected` flag captures that
-/// intent (it also holds while the #30 visibility barrier keeps the projector
-/// from publishing the consumption event). The final race/security gate stays
-/// on-chain: the CLAIM's FPI runs the MASM `assert_valid_ger` against the
-/// authoritative bridge-account storage and fails closed with
-/// `ERR_GER_NOT_FOUND` — C6 is scheduling/visibility policy, MASM is the hard
-/// safety boundary.
-pub(crate) async fn ensure_claim_ger_published(
-    store: &std::sync::Arc<dyn crate::store::Store>,
-    params: &claimAssetCall,
-) -> anyhow::Result<()> {
-    let combined = crate::ger::combined_ger(&params.mainnetExitRoot.0, &params.rollupExitRoot.0);
-    if !store.is_ger_injected(&combined).await? {
-        ::metrics::counter!("rpc_claim_ger_not_seen_total").increment(1);
-        anyhow::bail!(
-            "claim references a GER that aggkit has not observed yet \
-             (mainnet={}, rollup={}); retry after the GER is injected. C6.",
-            ::hex::encode(params.mainnetExitRoot.0),
-            ::hex::encode(params.rollupExitRoot.0)
-        );
-    }
     Ok(())
 }
 
@@ -657,10 +610,37 @@ async fn durably_admit_and_advance_nonce(
     Ok(())
 }
 
-/// Run every deterministic / side-effect-free rejection before binding the
-/// `(signer, nonce)` reservation to a hash. A malformed claim can therefore be
-/// corrected and re-signed at the same nonce. Stateful checks are repeated by
-/// the dispatcher after reservation only to close a landed-claim race.
+/// State-only compatibility gate for `claimAsset`. One bridge snapshot answers
+/// both questions in EVM order: already-claimed wins; otherwise a missing GER
+/// fails before nonce consumption. Returns true only for an applied claim.
+async fn claim_state_gate(service: &ServiceState, params: &claimAssetCall) -> anyhow::Result<bool> {
+    let combined = crate::ger::combined_ger(&params.mainnetExitRoot.0, &params.rollupExitRoot.0);
+    let (claimed, ger_applied) =
+        crate::applied_state::claim_and_ger_applied(service, params.globalIndex, &combined).await?;
+    if claimed {
+        return Ok(true);
+    }
+    if !params.amount.is_zero()
+        && crate::address_mapper::resolve_address(
+            &*service.store,
+            params.destinationAddress,
+            &service.accounts.0,
+        )
+        .await
+        .is_ok()
+        && !ger_applied
+    {
+        ::metrics::counter!("rpc_claim_ger_not_seen_total").increment(1);
+        anyhow::bail!(
+            "claim references a GER that aggkit has not observed yet or that is not applied on the Miden bridge \
+             (mainnet={}, rollup={}); retry after the GER is injected. C6.",
+            ::hex::encode(params.mainnetExitRoot.0),
+            ::hex::encode(params.rollupExitRoot.0)
+        );
+    }
+    Ok(false)
+}
+
 async fn validate_before_nonce_reservation(
     service: &ServiceState,
     decoded: &crate::writer_worker::DecodedWriteCall,
@@ -676,25 +656,8 @@ async fn validate_before_nonce_reservation(
         );
     }
 
-    // A landed claim must bypass C6 and be accepted-and-reverted.
-    if service
-        .store
-        .has_claim_event_for_global_index(&params.globalIndex.to_be_bytes::<32>())
-        .await?
-    {
-        return Ok(());
-    }
-    if !params.amount.is_zero()
-        && crate::address_mapper::resolve_address(
-            &*service.store,
-            params.destinationAddress,
-            &service.accounts.0,
-        )
-        .await
-        .is_ok()
-    {
-        ensure_claim_ger_published(&service.store, params).await?;
-    }
+    // One state-only bridge snapshot answers both compatibility questions.
+    let _already_claimed = claim_state_gate(service, params).await?;
     Ok(())
 }
 
@@ -707,13 +670,10 @@ async fn dispatch_after_reservation(
     signer_str: &str,
     tx_nonce: u64,
 ) -> anyhow::Result<TxHash> {
-    // Landed classification is repeated after reservation to close the race
-    // with a claim that lands immediately after pre-validation.
+    // Repeat the single state snapshot after reservation to close the landing
+    // race. The bridge maps are monotonic, so no third pre-publish read is needed.
     if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
-        && service
-            .store
-            .has_claim_event_for_global_index(&params.globalIndex.to_be_bytes::<32>())
-            .await?
+        && claim_state_gate(service, params).await?
     {
         accept_and_revert_landed_claim(
             service,
@@ -727,18 +687,29 @@ async fn dispatch_after_reservation(
         .await?;
         return Ok(txn_hash);
     }
-    if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
-        && params.destinationNetwork == service.network_id
-        && !params.amount.is_zero()
-        && crate::address_mapper::resolve_address(
-            &*service.store,
-            params.destinationAddress,
-            &service.accounts.0,
-        )
-        .await
-        .is_ok()
+
+    if let crate::writer_worker::DecodedWriteCall::Ger { ger_bytes } = &decoded
+        && crate::applied_state::ger_applied(service, ger_bytes).await?
     {
-        ensure_claim_ger_published(&service.store, params).await?;
+        durably_admit_and_advance_nonce(
+            service,
+            txn_hash,
+            &txn_envelope,
+            signer,
+            signer_str,
+            tx_nonce,
+        )
+        .await?;
+        handle_ger_result(
+            Ok(false),
+            txn_hash,
+            txn_envelope,
+            signer,
+            service,
+            *ger_bytes,
+        )
+        .await?;
+        return Ok(txn_hash);
     }
 
     if service.enable_writer_worker {
@@ -1671,6 +1642,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn already_registered_ger_returns_success_without_second_event() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        let ger = [0xacu8; 32];
+        store
+            .commit_ger_event_atomic(1, [0u8; 32], "0xoriginal-ger", &ger, None, None, 0)
+            .await
+            .unwrap();
+        let filter = crate::log_synthesis::LogFilter {
+            from_block: Some("0x0".to_string()),
+            to_block: Some("0xffff".to_string()),
+            ..Default::default()
+        };
+        let events_before = store
+            .get_logs(&filter, 0xffff)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|log| {
+                log.topics.first().map(String::as_str)
+                    == Some(crate::log_synthesis::UPDATE_HASH_CHAIN_VALUE_TOPIC)
+            })
+            .count();
+
+        let calldata = insertGlobalExitRootCall {
+            root: FixedBytes::from(ger),
+        }
+        .abi_encode();
+        let (raw, signer) = encode_legacy_tx(calldata);
+        let tx_hash = service_send_raw_txn(service.clone(), raw)
+            .await
+            .expect("already-registered GER must be accepted");
+        let receipt = crate::service_get_txn_receipt::service_get_txn_receipt(
+            service,
+            format!("{tx_hash:#x}"),
+        )
+        .await
+        .unwrap()
+        .expect("duplicate GER receipt must be terminal");
+        assert!(matches!(
+            receipt.inner.as_receipt().unwrap().status,
+            alloy::consensus::Eip658Value::Eip658(true)
+        ));
+        assert!(receipt.inner.as_receipt().unwrap().logs.is_empty());
+        assert_eq!(store.nonce_get(&format!("{signer:#x}")).await.unwrap(), 1);
+        let events_after = store
+            .get_logs(&filter, 0xffff)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|log| {
+                log.topics.first().map(String::as_str)
+                    == Some(crate::log_synthesis::UPDATE_HASH_CHAIN_VALUE_TOPIC)
+            })
+            .count();
+        assert_eq!(events_after, events_before, "duplicate GER emits no event");
+        assert!(store.is_ger_injected(&ger).await.unwrap());
+    }
+
+    #[tokio::test]
     async fn test_claim_asset_zero_amount_skipped() {
         let service = create_test_service();
         let store = service.store.clone();
@@ -1899,10 +1930,8 @@ mod tests {
         );
     }
 
-    /// Writer-mode C6 precedence mirror: claims the worker would swallow
-    /// WITHOUT reaching C6 (zero-amount genesis claims) must NOT be gated on
-    /// GER publication at admission — the gate only covers claims that would
-    /// actually reach `ensure_claim_ger_published` in the worker.
+    /// Zero-amount genesis claims do not require a GER. The combined state gate
+    /// still checks AlreadyClaimed first, then deliberately skips GER validation.
     #[tokio::test]
     async fn c6_writer_mode_zero_amount_claim_not_ger_gated() {
         let mut service = create_test_service();

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -2206,11 +2206,17 @@ mod tests {
     /// store, exactly the state `service_send_raw_txn` holds between
     /// `acquire_claim_lock` and publish completion). Signer B — a DIFFERENT
     /// key — submits a full valid claimAsset for the SAME gi:
-    ///   1. within the TTL → rejected on the "already submitted" path, with
-    ///      ZERO side effects for B (no publish, no nonce advance, no tx);
-    ///   2. after A's claim LANDS (ClaimEvent recorded) → B stays HARD
-    ///      rejected, even with the TTL treated as expired — landed dedup
-    ///      holds forever, for any signer.
+    ///   1. IN FLIGHT (no ClaimEvent yet), within the TTL → rejected on the
+    ///      "already submitted" path, with ZERO side effects for B (no publish,
+    ///      no nonce advance, no tx). accept-and-revert does NOT fire here
+    ///      because the gi has not LANDED (no ClaimEvent).
+    ///   2. after A's claim LANDS (ClaimEvent recorded) → #55 accept-and-revert:
+    ///      B's full-RPC resubmission is ACCEPTED with a reverted (status 0x0)
+    ///      receipt (nonce consumed, NO new ClaimEvent, no Miden publish) — the
+    ///      geth-faithful AlreadyClaimed, so a cross-signer's nonce never
+    ///      desyncs. The claim-lock PRIMITIVE (`acquire_claim_lock`) is
+    ///      unchanged and still hard-rejects a LANDED gi — accept-and-revert
+    ///      lives in the RPC handler ABOVE the lock, not in the lock itself.
     #[tokio::test]
     async fn user_sponsor_double_submit_same_global_index() {
         let service = create_test_service();
@@ -2266,19 +2272,46 @@ mod tests {
             .await
             .unwrap();
 
-        // B retries the same tx — still hard-rejected (LANDED beats everything).
-        let err = service_send_raw_txn(service, input_b)
+        // #55 — B retries the same tx. Now that gi has LANDED, B's full-RPC
+        // submission is ACCEPT-AND-REVERTED (geth-faithful AlreadyClaimed): it
+        // is ACCEPTED (nonce consumed) with a reverted (status 0x0) receipt and
+        // NO new ClaimEvent — instead of the old hard "already submitted"
+        // reject — so a cross-signer's nonce sequence never desyncs.
+        let claim_events_before = count_claim_events(&store).await;
+        let accepted = service_send_raw_txn(service, input_b)
             .await
-            .expect_err("a landed gi must stay rejected for any signer");
-        assert!(
-            err.to_string().contains("already submitted"),
-            "landed dedup keeps the original rejection: {err:#}"
+            .expect("a landed gi from a DIFFERENT tx is accept-and-reverted (#55), not rejected");
+        assert_eq!(accepted, tx_b, "accept-and-revert returns B's own tx hash");
+        assert_eq!(
+            store.nonce_get(&format!("{addr_b:#x}")).await.unwrap(),
+            1,
+            "accept-and-revert must CONSUME B's nonce, exactly like a normal accept"
         );
-        // ...and even with the TTL forced to zero (i.e. long expired), the
+        let (result, _blk) = store
+            .txn_receipt(tx_b)
+            .await
+            .unwrap()
+            .expect("accept-and-revert writes a durable receipt");
+        assert!(
+            result.is_err(),
+            "the accept-and-revert receipt is status 0x0 (reverted)"
+        );
+        assert_eq!(
+            count_claim_events(&store).await,
+            claim_events_before,
+            "accept-and-revert must NOT emit a second ClaimEvent"
+        );
+        assert!(
+            !miden.test_was_called(),
+            "accept-and-revert must not publish a second CLAIM to Miden"
+        );
+
+        // The claim-lock PRIMITIVE is unchanged: a direct acquire_claim_lock on
+        // a LANDED gi still hard-rejects even with the TTL forced to zero — the
         // LANDED check wins over orphan recovery, regardless of submitter.
         let err = acquire_claim_lock(&store, gi, std::time::Duration::ZERO)
             .await
-            .expect_err("LANDED must beat TTL-expiry recovery");
+            .expect_err("LANDED must beat TTL-expiry recovery at the lock primitive");
         assert!(err.to_string().contains("already submitted"));
     }
 
@@ -2531,9 +2564,9 @@ mod tests {
         let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
         let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
 
-        let accepted = service_send_raw_txn(service.clone(), input_b)
-            .await
-            .expect("a landed-gi claim from a different signer must be ACCEPTED (accept-and-revert)");
+        let accepted = service_send_raw_txn(service.clone(), input_b).await.expect(
+            "a landed-gi claim from a different signer must be ACCEPTED (accept-and-revert)",
+        );
         assert_eq!(accepted, tx_b, "must return B's own tx hash");
 
         // (1) B's nonce is CONSUMED — exactly like a normal accept.
@@ -2544,11 +2577,13 @@ mod tests {
         );
 
         // (2) A durable REVERTED receipt is retrievable, status 0x0, empty logs.
-        let receipt =
-            crate::service_get_txn_receipt::service_get_txn_receipt(service.clone(), format!("{tx_b:#x}"))
-                .await
-                .unwrap()
-                .expect("eth_getTransactionReceipt must return a non-null receipt");
+        let receipt = crate::service_get_txn_receipt::service_get_txn_receipt(
+            service.clone(),
+            format!("{tx_b:#x}"),
+        )
+        .await
+        .unwrap()
+        .expect("eth_getTransactionReceipt must return a non-null receipt");
         assert!(
             matches!(
                 receipt.inner.as_receipt().unwrap().status,
@@ -2564,7 +2599,10 @@ mod tests {
             receipt.from, addr_b,
             "receipt.from must be the submitting signer"
         );
-        assert_eq!(receipt.block_number, Some(store.get_latest_block_number().await.unwrap()));
+        assert_eq!(
+            receipt.block_number,
+            Some(store.get_latest_block_number().await.unwrap())
+        );
 
         // (3) NO new ClaimEvent was emitted — the real landed one is authoritative.
         assert_eq!(
@@ -2630,7 +2668,8 @@ mod tests {
         // the unit harness completes it synchronously via the RD-860 swallow).
         // The point is it PASSES the R4 nonce gate (nonce 1 == expected 1).
         let gi_y = U256::from(0x5503u64);
-        let calldata_y = claim_calldata(gi_y, Address::from([0x99u8; 20]), U256::from(1_000_000u64));
+        let calldata_y =
+            claim_calldata(gi_y, Address::from([0x99u8; 20]), U256::from(1_000_000u64));
         let (input_y, _tx_y) = encode_tx_signed_with_nonce(&key_s, calldata_y, 1);
         let res_y = service_send_raw_txn(service.clone(), input_y).await;
         assert!(
@@ -2724,7 +2763,9 @@ mod tests {
 
         let err = service_send_raw_txn(service.clone(), input_b)
             .await
-            .expect_err("a stale-nonce landed claim must be rejected by R4, not accept-and-reverted");
+            .expect_err(
+                "a stale-nonce landed claim must be rejected by R4, not accept-and-reverted",
+            );
         assert!(
             err.to_string().contains("nonce mismatch"),
             "must be the R4 nonce-mismatch rejection, not an accept: {err:#}"

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -529,6 +529,122 @@ pub(crate) fn claim_resubmit_ttl() -> std::time::Duration {
     std::time::Duration::from_secs(secs)
 }
 
+/// #55 BLOCKER 1 — how long a won `(signer, nonce)` admission lease is owned before
+/// another replica may take it over on expiry (crash recovery). Kept comfortably
+/// BELOW aggkit's re-broadcast envelope so a rebroadcast after an owner crash can
+/// take over promptly, yet above the slowest legitimate admission (a sync claim
+/// publish). Env-tunable via `NONCE_RESERVATION_LEASE_SECS`.
+pub(crate) fn reservation_lease() -> std::time::Duration {
+    const DEFAULT_SECS: u64 = 90;
+    let secs = std::env::var("NONCE_RESERVATION_LEASE_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_SECS);
+    std::time::Duration::from_secs(secs)
+}
+
+/// #55 BLOCKER 1 — execute a WON admission (dispatch to the writer worker or the
+/// legacy sync path) and return the tx hash. Extracted so `service_send_raw_txn` can
+/// wrap it with the reservation-lease RELEASE (success → future same-hash dedups;
+/// failure → the same tx may retry via lease takeover). Only ever called after the
+/// caller won the `(signer, nonce)` reservation.
+async fn dispatch_after_reservation(
+    service: &ServiceState,
+    decoded: crate::writer_worker::DecodedWriteCall,
+    txn_envelope: TxEnvelope,
+    signer: Address,
+    txn_hash: TxHash,
+    signer_str: &str,
+    tx_nonce: u64,
+) -> anyhow::Result<TxHash> {
+    if service.enable_writer_worker {
+        let handle = service.writer_handle.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "enable_writer_worker=true but no writer_handle plumbed into ServiceState; \
+                 boot order bug — see main.rs writer spawn block"
+            )
+        })?;
+
+        // BLOCKER 3 — landed classification BEFORE C6 in WRITER mode too: an
+        // already-LANDED gi routes to accept-and-revert here (atomic reverted receipt
+        // + nonce, synchronous, no enqueue), regardless of GER state, so it never
+        // gets a C6 RPC error with no nonce consumption. The worker's
+        // `acquire_claim_lock` still catches a claim that LANDS after this check.
+        if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
+            && service
+                .store
+                .has_claim_event_for_global_index(&params.globalIndex.to_be_bytes::<32>())
+                .await?
+        {
+            accept_and_revert_landed_claim(
+                service,
+                params,
+                txn_hash,
+                txn_envelope,
+                signer,
+                signer_str,
+                tx_nonce,
+            )
+            .await?;
+            return Ok(txn_hash);
+        }
+
+        // C6 on the REQUEST path (PR #127 review point 3) — gate before enqueue so a
+        // GER-not-yet-published claim leaves nothing behind. Only claims that would
+        // reach C6 in the worker are gated (zero-amount + unresolvable destinations
+        // are swallowed earlier).
+        if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
+            && params.destinationNetwork == service.network_id
+            && !params.amount.is_zero()
+            && crate::address_mapper::resolve_address(
+                &*service.store,
+                params.destinationAddress,
+                &service.accounts.0,
+            )
+            .await
+            .is_ok()
+        {
+            ensure_claim_ger_published(&service.store, params).await?;
+        }
+
+        let job = decoded.into_job(txn_envelope, signer, txn_hash);
+        match handle.try_enqueue(job) {
+            Ok(()) => {
+                let _ = service
+                    .store
+                    .nonce_advance_cas(signer_str, tx_nonce)
+                    .await?;
+                Ok(txn_hash)
+            }
+            Err(crate::writer_worker::TryEnqueueError::QueueFull) => {
+                Err(crate::writer_worker::WriterQueueSaturatedError.into())
+            }
+            Err(crate::writer_worker::TryEnqueueError::ShutDown) => {
+                anyhow::bail!(
+                    "writer worker has shut down — service is draining; retry against the next \
+                     replica"
+                );
+            }
+        }
+    } else {
+        // Legacy synchronous dispatch.
+        match decoded {
+            crate::writer_worker::DecodedWriteCall::Claim { params } => {
+                worker_handle_claim_asset(service, *params, txn_hash, txn_envelope, signer).await?;
+            }
+            crate::writer_worker::DecodedWriteCall::Ger { ger_bytes } => {
+                worker_handle_ger_insert(service, ger_bytes, txn_hash, txn_envelope, signer)
+                    .await?;
+            }
+        }
+        let _ = service
+            .store
+            .nonce_advance_cas(signer_str, tx_nonce)
+            .await?;
+        Ok(txn_hash)
+    }
+}
+
 /// Typed, AUTHORITATIVE outcome of [`acquire_claim_lock`]. Landed detection and the
 /// #55 accept-and-revert decision are ONE step here (no separate pre-check→lock
 /// window), so there is no interleaving in which a claim for an already-landed
@@ -1046,176 +1162,77 @@ pub async fn service_send_raw_txn(service: ServiceState, input: String) -> anyho
     // no enqueue, no dispatch, no receipt. (This runs AFTER the R4 per-signer lock,
     // which still serialises intra-process and provides the future-nonce wait; the
     // reservation is the cross-replica uniqueness guarantee the process lock can't.)
-    match service
+    // Reserve the (signer, nonce) admission LEASE atomically, BEFORE any
+    // queue/dispatch/receipt side effect. This is a FENCED-OWNERSHIP lifecycle,
+    // not a bare row: exactly one replica ever executes a given (signer, nonce),
+    // and a genuine retry after a failed/expired attempt is allowed via takeover.
+    let reservation_fence = match service
         .store
-        .reserve_nonce(&signer_str, tx_nonce, txn_hash)
+        .reserve_nonce(&signer_str, tx_nonce, txn_hash, reservation_lease())
         .await?
     {
-        crate::store::NonceReservation::Won => {}
-        crate::store::NonceReservation::HeldBy(h) if h == txn_hash => {
-            // This exact tx already reserved the slot (its own earlier attempt — e.g.
-            // a retry after a RETRYABLE C6/GER rejection that left the reservation but
-            // no receipt — or an idempotent rebroadcast). PROCEED so a retryable
-            // failure can re-run admission and eventually execute. The upstream
-            // tx-hash dedup already short-circuited a tx that truly completed
-            // (receipt written / in-flight), so reaching here means re-execution is
-            // safe (and idempotent: a landed gi accept-reverts, a GER re-inserts).
+        crate::store::NonceReservation::Won { fence } => fence,
+        crate::store::NonceReservation::OwnedBySame => {
+            // The slot is currently owned+executing by THIS SAME tx under a valid
+            // lease (another replica is admitting it), or it already released-
+            // success. Do NOT execute — dedup-return the hash; the owner produces
+            // the receipt. This is the authoritative single-executor guarantee that
+            // the process-local dedup reads (which can miss cross-replica) cannot give.
             tracing::debug!(
                 target: "rpc::reserve",
                 %txn_hash, nonce = tx_nonce,
-                "reservation held by this same tx — proceeding (retry/re-execute)"
+                "reservation owned by this same tx (valid lease / released-success) — \
+                 dedup-returning hash, NOT executing"
             );
-        }
-        crate::store::NonceReservation::HeldBy(other) => {
-            // A DIFFERENT tx already reserved this (signer, nonce) slot — this
-            // submission LOST and must NOT execute. Reject; the winner advances the
-            // nonce, so this loser's subsequent retries fail R4 as stale (nonce too
-            // low) and aggkit drops it — mirroring geth dropping the losing tx at an
-            // already-consumed nonce.
-            ::metrics::counter!("rpc_nonce_reservation_lost_total").increment(1);
-            anyhow::bail!(
-                "nonce {tx_nonce} for {signer_str} is already reserved by a different tx \
-                 {other:#x} (concurrent submission at the same nonce slot); this tx must not \
-                 execute"
-            );
-        }
-    }
-
-    // ── Dispatch fork (RD-940) ──────────────────────────────────────────
-    //
-    // `enable_writer_worker` defaults to false — the legacy synchronous
-    // branch below is byte-identical to pre-RD-940 behaviour for the
-    // claim and GER paths. When the flag is enabled and a writer handle
-    // is plumbed, requests are enqueued for asynchronous Miden submission
-    // and the HTTP future returns the tx-hash as soon as `try_enqueue`
-    // succeeds.
-    //
-    // Nonce-advance ordering matters under both branches:
-    //   - legacy: dispatch runs to completion → nonce_increment (current
-    //     behaviour preserved bit-for-bit)
-    //   - worker: try_enqueue → on Ok, nonce_increment; on QueueFull, the
-    //     nonce is intentionally **not** advanced so the caller retries
-    //     with the same nonce and -32005 doesn't burn a sequence slot
-    //
-    // Decision 3 (idempotent re-broadcast) and Decision 4
-    // (eth_getTransactionCount tag honouring) land in Phase 2.
-    if service.enable_writer_worker {
-        let handle = service.writer_handle.as_ref().ok_or_else(|| {
-            anyhow::anyhow!(
-                "enable_writer_worker=true but no writer_handle plumbed into ServiceState; \
-                 boot order bug — see main.rs writer spawn block"
-            )
-        })?;
-
-        // BLOCKER 3 — landed classification BEFORE C6 in WRITER mode too. The sync
-        // worker already classifies landed before RD-860/C6, but the REQUEST path
-        // ran C6 (`ensure_claim_ger_published`) before enqueue: an already-LANDED gi
-        // with a resolvable destination and an altered/unobserved GER would get a C6
-        // RPC error with NO nonce consumption — the wedge. So route an already-landed
-        // claim to accept-and-revert HERE (atomic reverted receipt + nonce, synchronous,
-        // no enqueue), regardless of GER state. The worker's `acquire_claim_lock` still
-        // catches a claim that LANDS after this check (its `Landed` arm accept-reverts).
-        if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
-            && service
-                .store
-                .has_claim_event_for_global_index(&params.globalIndex.to_be_bytes::<32>())
-                .await?
-        {
-            accept_and_revert_landed_claim(
-                &service,
-                params,
-                txn_hash,
-                txn_envelope,
-                signer,
-                &signer_str,
-                tx_nonce,
-            )
-            .await?;
             return Ok(txn_hash);
         }
+        crate::store::NonceReservation::HeldByOther(other) => {
+            // A DIFFERENT tx owns/owned this (signer, nonce) slot — this submission
+            // LOST and must NOT execute. Reject; the winner advances the nonce, so
+            // this loser's retries fail R4 as stale and aggkit drops it — mirroring
+            // geth dropping the losing tx at an already-consumed nonce.
+            ::metrics::counter!("rpc_nonce_reservation_lost_total").increment(1);
+            anyhow::bail!(
+                "nonce {tx_nonce} for {signer_str} is reserved by a different tx {other:#x} \
+                 (concurrent submission at the same nonce slot); this tx must not execute"
+            );
+        }
+    };
 
-        // C6 on the REQUEST path (PR #127 review point 3). Pre-fix, with the
-        // writer enabled the gate only ran inside the worker — AFTER
-        // `try_enqueue` had consumed the nonce and admitted the tx hash into
-        // the inflight dedup cache, so a GER-not-yet-published claim burned a
-        // sequence slot and its re-broadcast short-circuited as a "known"
-        // hash. Run the gate here, before any side-effect, so pre-admission
-        // failure leaves NOTHING behind: no tx hash/receipt, no nonce, no
-        // globalIndex lock, no queued job — the same signed transaction (same
-        // nonce) is accepted verbatim once the GER is published.
-        //
-        // Only claims that would actually reach C6 in the worker are gated,
-        // mirroring `worker_handle_claim_asset`'s short-circuit precedence:
-        // wrong-network claims hard-fail in the worker regardless of GER,
-        // zero-amount claims are swallowed as immediate successes, and
-        // unresolvable destinations are swallowed permanently (RD-860 runs
-        // BEFORE C6 because that state is permanent while a missing GER is
-        // transient).
-        if let crate::writer_worker::DecodedWriteCall::Claim { params } = &decoded
-            && params.destinationNetwork == service.network_id
-            && !params.amount.is_zero()
-            && crate::address_mapper::resolve_address(
-                &*service.store,
-                params.destinationAddress,
-                &service.accounts.0,
-            )
-            .await
-            .is_ok()
-        {
-            ensure_claim_ger_published(&service.store, params).await?;
-        }
-
-        let job = decoded.into_job(txn_envelope, signer, txn_hash);
-        match handle.try_enqueue(job) {
-            Ok(()) => {
-                // BLOCKER D — advance via store-level CAS (advance only WHERE nonce
-                // == tx_nonce), so two replicas on a shared PostgreSQL can't both
-                // advance from the same expected value (N→N+2). A `false` return
-                // means another replica (or the worker's own accept-and-revert)
-                // already advanced it — the nonce ends advanced either way.
-                let _ = service
-                    .store
-                    .nonce_advance_cas(&signer_str, tx_nonce)
-                    .await?;
-                Ok(txn_hash)
-            }
-            Err(crate::writer_worker::TryEnqueueError::QueueFull) => {
-                // The downcast on this typed error in `service.rs`
-                // promotes the JSON-RPC error code to -32005 (geth's
-                // LimitExceeded), letting aggkit's ethtxmanager retry
-                // transparently. The metric was already incremented in
-                // try_enqueue.
-                Err(crate::writer_worker::WriterQueueSaturatedError.into())
-            }
-            Err(crate::writer_worker::TryEnqueueError::ShutDown) => {
-                anyhow::bail!(
-                    "writer worker has shut down — service is draining; retry against the next \
-                     replica"
-                );
-            }
-        }
-    } else {
-        // Legacy synchronous dispatch — unchanged behaviour.
-        match decoded {
-            crate::writer_worker::DecodedWriteCall::Claim { params } => {
-                worker_handle_claim_asset(&service, *params, txn_hash, txn_envelope, signer)
-                    .await?;
-            }
-            crate::writer_worker::DecodedWriteCall::Ger { ger_bytes } => {
-                worker_handle_ger_insert(&service, ger_bytes, txn_hash, txn_envelope, signer)
-                    .await?;
-            }
-        }
-        // BLOCKER D — advance via store-level CAS (advance only WHERE nonce ==
-        // tx_nonce), cross-replica-safe. A `false` return means the advance already
-        // happened (the accept-and-revert path advances the nonce atomically with
-        // its receipt, or a concurrent replica won) — the nonce ends advanced.
-        let _ = service
-            .store
-            .nonce_advance_cas(&signer_str, tx_nonce)
-            .await?;
-        Ok(txn_hash)
+    // Execute the WON admission, then RELEASE the lease on the outcome: success →
+    // `released_success` (a future same-hash submission dedups via OwnedBySame);
+    // failure → `released_failure` (the SAME tx may retry via lease takeover). Only
+    // the current fence owner may release, so a delayed crashed owner whose lease was
+    // taken over cannot clobber the new owner's state. A crash before release leaves
+    // the lease to EXPIRE and be taken over. This is the durable admission lifecycle.
+    let admission = dispatch_after_reservation(
+        &service,
+        decoded,
+        txn_envelope,
+        signer,
+        txn_hash,
+        &signer_str,
+        tx_nonce,
+    )
+    .await;
+    if let Err(release_err) = service
+        .store
+        .release_reservation(
+            &signer_str,
+            tx_nonce,
+            txn_hash,
+            reservation_fence,
+            admission.is_ok(),
+        )
+        .await
+    {
+        tracing::warn!(
+            target: "rpc::reserve",
+            %txn_hash, nonce = tx_nonce, err = %release_err,
+            "failed to release the nonce reservation lease; it will expire and be taken over"
+        );
     }
+    admission
 }
 
 #[cfg(test)]
@@ -3499,36 +3516,99 @@ mod tests {
         );
     }
 
-    /// BLOCKER 1 — atomic (signer, nonce) reservation: the FIRST tx to reserve a
-    /// slot wins; a DIFFERENT tx at the same slot loses (HeldBy the winner); the
-    /// SAME tx re-reserving is idempotent (HeldBy itself); a different nonce is free.
+    /// BLOCKER 1 — the fenced admission-lease LIFECYCLE: fresh → Won(fence); the
+    /// SAME tx under a valid lease → OwnedBySame (dedup, another replica must not
+    /// execute); a DIFFERENT tx → HeldByOther (hard reject); release-FAILURE lets the
+    /// SAME tx take over (fence bumps); a fenced-out stale release is ignored;
+    /// release-SUCCESS makes the SAME tx dedup; an EXPIRED lease is taken over.
     #[tokio::test]
-    async fn blocker_1_reserve_nonce_first_wins_different_tx_loses() {
+    async fn blocker_1_reserve_nonce_fenced_lifecycle() {
         use crate::store::NonceReservation;
-        let store: std::sync::Arc<dyn crate::store::Store> =
-            std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let concrete = std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let store: std::sync::Arc<dyn crate::store::Store> = concrete.clone();
         let addr = "0x00000000000000000000000000000000000000dd";
         let h1 = TxHash::from([0x11u8; 32]);
         let h2 = TxHash::from([0x22u8; 32]);
+        let lease = std::time::Duration::from_secs(90);
 
+        // Fresh → Won(fence 1).
+        let NonceReservation::Won { fence } =
+            store.reserve_nonce(addr, 5, h1, lease).await.unwrap()
+        else {
+            panic!("fresh slot must be Won");
+        };
+        assert_eq!(fence, 1);
+        // Same tx, VALID lease → OwnedBySame (another replica must NOT execute).
         assert_eq!(
-            store.reserve_nonce(addr, 5, h1).await.unwrap(),
-            NonceReservation::Won
+            store.reserve_nonce(addr, 5, h1, lease).await.unwrap(),
+            NonceReservation::OwnedBySame
         );
-        // Same tx re-reserving → HeldBy(itself) (idempotent).
+        // A DIFFERENT tx at the same slot → HeldByOther(the winner) → hard reject.
         assert_eq!(
-            store.reserve_nonce(addr, 5, h1).await.unwrap(),
-            NonceReservation::HeldBy(h1)
+            store.reserve_nonce(addr, 5, h2, lease).await.unwrap(),
+            NonceReservation::HeldByOther(h1)
         );
-        // A DIFFERENT tx at the SAME slot → HeldBy(the winner h1) → it must not execute.
+
+        // release-FAILURE → the SAME tx may TAKE OVER (fence bumps).
+        store
+            .release_reservation(addr, 5, h1, fence, false)
+            .await
+            .unwrap();
+        let NonceReservation::Won { fence: fence2 } =
+            store.reserve_nonce(addr, 5, h1, lease).await.unwrap()
+        else {
+            panic!("after release-failure the same tx must retake ownership");
+        };
+        assert!(fence2 > fence, "takeover must bump the fence");
+        // A STALE prior owner (old fence) is fenced out — its release-FAILURE must be
+        // IGNORED. Without the fence guard it would flip the CURRENT owner's lease to
+        // released_failure and let a spurious takeover in; with it, the current owner
+        // (fence2) still holds the slot.
+        store
+            .release_reservation(addr, 5, h1, fence, false)
+            .await
+            .unwrap();
         assert_eq!(
-            store.reserve_nonce(addr, 5, h2).await.unwrap(),
-            NonceReservation::HeldBy(h1)
+            store.reserve_nonce(addr, 5, h1, lease).await.unwrap(),
+            NonceReservation::OwnedBySame,
+            "a fenced-out stale release must not flip the current owner's state"
         );
+
+        // release-SUCCESS (by the current owner) → the SAME tx now dedups.
+        store
+            .release_reservation(addr, 5, h1, fence2, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.reserve_nonce(addr, 5, h1, lease).await.unwrap(),
+            NonceReservation::OwnedBySame
+        );
+
         // A different nonce is a free slot.
+        assert!(matches!(
+            store.reserve_nonce(addr, 6, h2, lease).await.unwrap(),
+            NonceReservation::Won { .. }
+        ));
+
+        // Lease-EXPIRY takeover (crash recovery): valid lease dedups; once expired
+        // the SAME tx takes over.
+        let addr2 = "0x00000000000000000000000000000000000000ee";
+        let h3 = TxHash::from([0x33u8; 32]);
+        assert!(matches!(
+            store.reserve_nonce(addr2, 0, h3, lease).await.unwrap(),
+            NonceReservation::Won { .. }
+        ));
         assert_eq!(
-            store.reserve_nonce(addr, 6, h2).await.unwrap(),
-            NonceReservation::Won
+            store.reserve_nonce(addr2, 0, h3, lease).await.unwrap(),
+            NonceReservation::OwnedBySame
+        );
+        concrete.test_expire_reservation_lease(addr2, 0);
+        assert!(
+            matches!(
+                store.reserve_nonce(addr2, 0, h3, lease).await.unwrap(),
+                NonceReservation::Won { .. }
+            ),
+            "an EXPIRED lease must be taken over by the same tx (crash recovery)"
         );
     }
 
@@ -3547,17 +3627,19 @@ mod tests {
         let signer_str = format!("{signer:#x}");
         // Simulate another replica having won the (signer, 0) slot with a different tx.
         let other = TxHash::from([0xEEu8; 32]);
-        assert_eq!(
-            store.reserve_nonce(&signer_str, 0, other).await.unwrap(),
-            crate::store::NonceReservation::Won
-        );
+        assert!(matches!(
+            store
+                .reserve_nonce(&signer_str, 0, other, reservation_lease())
+                .await
+                .unwrap(),
+            crate::store::NonceReservation::Won { .. }
+        ));
 
         let err = service_send_raw_txn(service, input_hex)
             .await
             .expect_err("must be rejected — the (signer, nonce) slot is reserved by another tx");
         assert!(
-            err.to_string()
-                .contains("already reserved by a different tx"),
+            err.to_string().contains("reserved by a different tx"),
             "unexpected: {err:#}"
         );
         // Did NOT execute: nonce not advanced.

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -607,15 +607,29 @@ async fn dispatch_after_reservation(
             ensure_claim_ger_published(&service.store, params).await?;
         }
 
+        // BLOCKER B — order MUST be reserve → nonce_advance_cas → enqueue. If the
+        // CAS ran AFTER a successful `try_enqueue`, a CAS store error would leave the
+        // job LIVE (enqueued, will execute) with a STALE nonce, and the outer
+        // reservation would be marked `released_failure` — so an immediate same-hash
+        // retry could retake the lease and enqueue DUPLICATE work. Advancing the
+        // nonce FIRST means a CAS failure aborts admission with NO enqueued job and
+        // NO nonce change.
+        //
+        // To keep genuine backpressure retryable with the SAME nonce, fast-fail
+        // QueueFull BEFORE the CAS when the queue is already full (the common case);
+        // only a rare fill-in-the-gap TOCTOU (queue fills between this check and
+        // try_enqueue) consumes the nonce — the geth-like consumed-nonce semantics,
+        // never an enqueue-then-fail-the-nonce.
+        if handle.available_capacity() == 0 {
+            return Err(crate::writer_worker::WriterQueueSaturatedError.into());
+        }
+        let _ = service
+            .store
+            .nonce_advance_cas(signer_str, tx_nonce)
+            .await?;
         let job = decoded.into_job(txn_envelope, signer, txn_hash);
         match handle.try_enqueue(job) {
-            Ok(()) => {
-                let _ = service
-                    .store
-                    .nonce_advance_cas(signer_str, tx_nonce)
-                    .await?;
-                Ok(txn_hash)
-            }
+            Ok(()) => Ok(txn_hash),
             Err(crate::writer_worker::TryEnqueueError::QueueFull) => {
                 Err(crate::writer_worker::WriterQueueSaturatedError.into())
             }
@@ -3644,6 +3658,153 @@ mod tests {
         );
         // Did NOT execute: nonce not advanced.
         assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 0);
+    }
+
+    /// BLOCKER A — state-FIRST takeover: a DIFFERENT tx may take over a slot whose
+    /// holder FAILED or whose lease EXPIRED (nonce NOT consumed), but is HARD-rejected
+    /// while the holder is executing under a valid lease or already released_success
+    /// (nonce consumed / in flight).
+    #[tokio::test]
+    async fn blocker_a_different_tx_takes_over_failed_or_expired_slot() {
+        use crate::store::NonceReservation;
+        let concrete = std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let store: std::sync::Arc<dyn crate::store::Store> = concrete.clone();
+        let addr = "0x00000000000000000000000000000000000000aa";
+        let ha = TxHash::from([0xa1u8; 32]);
+        let hb = TxHash::from([0xb2u8; 32]);
+        let lease = std::time::Duration::from_secs(90);
+
+        // (1) released_FAILURE slot → a DIFFERENT tx takes over (fence bumps).
+        let NonceReservation::Won { fence } =
+            store.reserve_nonce(addr, 1, ha, lease).await.unwrap()
+        else {
+            panic!("fresh must Win");
+        };
+        store
+            .release_reservation(addr, 1, ha, fence, false)
+            .await
+            .unwrap();
+        assert!(
+            matches!(
+                store.reserve_nonce(addr, 1, hb, lease).await.unwrap(),
+                NonceReservation::Won { .. }
+            ),
+            "a DIFFERENT tx must take over a released_failure slot (nonce not consumed)"
+        );
+
+        // (2) EXPIRED lease → a DIFFERENT tx takes over.
+        assert!(matches!(
+            store.reserve_nonce(addr, 2, ha, lease).await.unwrap(),
+            NonceReservation::Won { .. }
+        ));
+        concrete.test_expire_reservation_lease(addr, 2);
+        assert!(
+            matches!(
+                store.reserve_nonce(addr, 2, hb, lease).await.unwrap(),
+                NonceReservation::Won { .. }
+            ),
+            "a DIFFERENT tx must take over an EXPIRED slot (owner crashed, nonce not consumed)"
+        );
+
+        // (3) executing + VALID lease → a DIFFERENT tx is HARD-REJECTED (in flight).
+        assert!(matches!(
+            store.reserve_nonce(addr, 3, ha, lease).await.unwrap(),
+            NonceReservation::Won { .. }
+        ));
+        assert_eq!(
+            store.reserve_nonce(addr, 3, hb, lease).await.unwrap(),
+            NonceReservation::HeldByOther(ha),
+            "a valid/executing holder must still reject a different tx"
+        );
+
+        // (4) released_SUCCESS → a DIFFERENT tx is HARD-REJECTED (nonce consumed).
+        let NonceReservation::Won { fence: f4 } =
+            store.reserve_nonce(addr, 4, ha, lease).await.unwrap()
+        else {
+            panic!("fresh must Win");
+        };
+        store
+            .release_reservation(addr, 4, ha, f4, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.reserve_nonce(addr, 4, hb, lease).await.unwrap(),
+            NonceReservation::HeldByOther(ha),
+            "a released_success holder (nonce consumed) must reject a different tx"
+        );
+    }
+
+    /// BLOCKER B — writer mode advances the nonce (CAS) BEFORE enqueue. A nonce-CAS
+    /// store FAILURE must leave NO enqueued job and the nonce UNCHANGED; a successful
+    /// admission advances the nonce exactly once AND enqueues the job.
+    #[tokio::test]
+    async fn blocker_b_writer_cas_before_enqueue() {
+        // Happy path: exactly-once advance + job enqueued.
+        let mut service = create_test_service();
+        let (handle, shutdown) = crate::writer_worker::WriterWorker::spawn(
+            service.clone(),
+            64,
+            std::time::Duration::from_secs(60),
+        );
+        let handle = std::sync::Arc::new(handle);
+        service.enable_writer_worker = true;
+        service.writer_handle = Some(handle.clone());
+        let store = service.store.clone();
+
+        let calldata = insertGlobalExitRootCall {
+            root: FixedBytes::from([0xB1u8; 32]),
+        }
+        .abi_encode();
+        let (input_hex, signer) = encode_legacy_tx(calldata);
+        let signer_str = format!("{signer:#x}");
+        let tx_hash = service_send_raw_txn(service, input_hex)
+            .await
+            .expect("enqueue must succeed");
+        assert_eq!(
+            store.nonce_get(&signer_str).await.unwrap(),
+            1,
+            "a won CAS advances the nonce exactly once"
+        );
+        assert!(handle.is_inflight(&tx_hash), "the job must be enqueued");
+        let _ = shutdown.send(());
+
+        // CAS-FAILURE path: no enqueued job, nonce unchanged.
+        let concrete = std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let mut service2 = crate::test_helpers::create_test_service_with_store(concrete.clone());
+        let (handle2, shutdown2) = crate::writer_worker::WriterWorker::spawn(
+            service2.clone(),
+            64,
+            std::time::Duration::from_secs(60),
+        );
+        let handle2 = std::sync::Arc::new(handle2);
+        service2.enable_writer_worker = true;
+        service2.writer_handle = Some(handle2.clone());
+
+        // Arm a one-shot CAS store failure.
+        concrete.test_fail_next_nonce_cas();
+        let calldata2 = insertGlobalExitRootCall {
+            root: FixedBytes::from([0xB2u8; 32]),
+        }
+        .abi_encode();
+        let (input_hex2, signer2) = encode_legacy_tx(calldata2);
+        let err = service_send_raw_txn(service2, input_hex2)
+            .await
+            .expect_err("a nonce-CAS store failure must abort admission");
+        assert!(
+            err.to_string().contains("simulated nonce_advance_cas"),
+            "unexpected: {err:#}"
+        );
+        assert_eq!(
+            concrete.nonce_get(&format!("{signer2:#x}")).await.unwrap(),
+            0,
+            "the nonce must be UNCHANGED after a pre-enqueue CAS failure"
+        );
+        assert_eq!(
+            handle2.inflight_len(),
+            0,
+            "NO job may be enqueued when the CAS failed before enqueue"
+        );
+        let _ = shutdown2.send(());
     }
 
     /// BLOCKER 2 — the reclaim-SUCCESS window. A gi whose lock is EXPIRED but which

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -148,6 +148,40 @@ async fn record_local_success_at_block(
         .await
 }
 
+/// Write a durable REVERTED receipt (status `0x0`) for `tx_hash` at the current
+/// tip, with EMPTY logs. Used by the #55 "accept-and-revert" path: a claimAsset
+/// that targets an already-landed globalIndex is accepted (its nonce is
+/// consumed by the caller, exactly like a normal accept) but records a failed
+/// receipt instead of publishing a second CLAIM — the geth-faithful equivalent
+/// of the doomed tx MINING and reverting with `AlreadyClaimed`.
+///
+/// The receipt is shaped identically to the writer-worker's failure receipt
+/// (`writer_worker::write_failure_receipt`) — `txn_begin` (so `eth_getTransaction*`
+/// resolves the real tx + signer) followed by `txn_commit(Err(..))`, which
+/// `service_get_txn_receipt` renders as `status: 0x0` with every numeric field
+/// present (blockNumber/blockHash/transactionIndex/gasUsed/cumulativeGasUsed/
+/// effectiveGasPrice/from/to/logs=[]/logsBloom/type). aggkit's Go
+/// ethtxmanager/receipt unmarshaller then sees the monitored tx as MINED-but-
+/// failed and advances instead of re-broadcasting forever.
+///
+/// Crucially it emits NO ClaimEvent and NO synthetic log (the real landed
+/// claim's event is authoritative; getLogs immutability forbids a second event).
+async fn record_local_immediate_reverted(
+    service: &ServiceState,
+    tx_hash: TxHash,
+    txn_envelope: TxEnvelope,
+    signer: Address,
+    reason: String,
+) -> anyhow::Result<()> {
+    let block_num = service.store.get_latest_block_number().await?;
+    record_local_pending_tx(service, tx_hash, txn_envelope, signer, None, vec![]).await?;
+    let block_hash = service.block_state.get_block_hash(block_num);
+    service
+        .store
+        .txn_commit(tx_hash, Err(reason), block_num, block_hash)
+        .await
+}
+
 /// Handle a `claimAsset` transaction: skip zero-amount or publish the claim.
 ///
 /// RD-940 Phase 1: this is the unified dispatcher for both the legacy sync
@@ -187,6 +221,74 @@ pub(crate) async fn worker_handle_claim_asset(
     if params.amount.is_zero() {
         tracing::info!("skipping zero-amount claim (genesis batch)");
         record_local_immediate_success(service, txn_hash, txn_envelope, signer, vec![]).await?;
+        return Ok(());
+    }
+
+    // #55 — ACCEPT-AND-REVERT for an already-LANDED globalIndex (geth-faithful).
+    //
+    // Claims are permissionless: destination + amount are bound by the
+    // merkle-proven claimAsset calldata, so the sponsor (aggkit ClaimTxManager
+    // autoclaim) and a user (manual eth_sendRawTransaction) can BOTH target the
+    // same globalIndex, and dedup is keyed by globalIndex only (signer-agnostic).
+    // When a USER front-runs a gi the sponsor has already signed + persisted a
+    // monitored tx for, the sponsor later submits that (DIFFERENT-hash) tx. If we
+    // hard-reject it at the JSON-RPC layer ("already submitted"), the reject does
+    // NOT consume the sponsor's nonce: the proxy's expected-nonce and the
+    // sponsor's sequence permanently desync, ClaimTxManager re-broadcasts the
+    // pinned tx forever ("nonce mismatch"), every later sponsor claim queues
+    // behind it, and autoclaim dies un-healably (the monitored tx survives
+    // restarts).
+    //
+    // On real geth this never happens: the doomed claim MINES, reverts with
+    // `AlreadyClaimed`, and CONSUMES its nonce + gas, so ClaimTxManager marks it
+    // final and advances. Mirror that here: if a real ClaimEvent already exists
+    // for this globalIndex, ACCEPT the tx, write a durable REVERTED receipt
+    // (status 0x0, empty logs, NO new ClaimEvent), and return Ok so the caller
+    // CONSUMES the signer's nonce exactly like a normal accept — keeping the
+    // sponsor's sequence in lockstep.
+    //
+    // Scope / coexistence:
+    //   - This is reached ONLY after the RD-940 tx-hash dedup early-return (a
+    //     SAME-hash rebroadcast — including a resubmit of the REAL landed claim's
+    //     own tx — was already short-circuited to Ok(hash) upstream WITHOUT a new
+    //     receipt). So this fires only for a DIFFERENT tx (other signer/nonce)
+    //     targeting an already-landed gi.
+    //   - It is reached ONLY after the R4 nonce gate admitted the tx
+    //     (tx.nonce == expected). A future/stale-nonce landed claim never gets
+    //     here — it is waited/rejected by R4 first — so accept-and-revert can
+    //     NEVER paper over a real nonce gap.
+    //   - It runs BEFORE `acquire_claim_lock`: it neither takes nor releases the
+    //     claim lock, so the real landed claim's LANDED lock + ClaimEvent +
+    //     receipt are UNTOUCHED. `acquire_claim_lock`'s own LANDED hard-reject
+    //     stays as defense-in-depth for the narrow TOCTOU where a claim lands
+    //     between this check and the lock.
+    let gi_bytes: [u8; 32] = params.globalIndex.to_be_bytes::<32>();
+    if service
+        .store
+        .has_claim_event_for_global_index(&gi_bytes)
+        .await?
+    {
+        ::metrics::counter!("claim_landed_dedup_reverted_total").increment(1);
+        tracing::warn!(
+            global_index = %params.globalIndex,
+            eth_tx = %txn_hash,
+            signer = %signer,
+            "claim targets an already-landed globalIndex (a ClaimEvent already exists); \
+             accepting and writing a REVERTED receipt (status 0x0, no new event) so the \
+             submitter's nonce is consumed — geth-faithful AlreadyClaimed revert (#55). \
+             The real landed claim is untouched."
+        );
+        record_local_immediate_reverted(
+            service,
+            txn_hash,
+            txn_envelope,
+            signer,
+            format!(
+                "claim for globalIndex {} already landed (AlreadyClaimed); reverted (#55)",
+                params.globalIndex
+            ),
+        )
+        .await?;
         return Ok(());
     }
 
@@ -2116,6 +2218,355 @@ mod tests {
             rec.destination_address, someone_else,
             "funds are bound to the calldata's destination regardless of submitter"
         );
+    }
+
+    // ── #55 ACCEPT-AND-REVERT tests ─────────────────────────────────────
+    //
+    // A claimAsset targeting an already-LANDED globalIndex (a real ClaimEvent
+    // exists) from a DIFFERENT tx must be ACCEPTED with a reverted (status 0x0)
+    // receipt so the submitter's nonce is consumed — the geth-faithful
+    // AlreadyClaimed revert. This is what keeps the aggkit sponsor's nonce
+    // sequence in lockstep after a user front-runs a gi (#55).
+
+    /// Land a claim for `gi` directly on the store (lock + ClaimEvent), exactly
+    /// the state left behind by signer A's successful claim.
+    async fn land_claim_for(store: &std::sync::Arc<dyn crate::store::Store>, gi: U256) {
+        store.try_claim(gi).await.expect("A's submission locks gi");
+        store
+            .commit_manual_claim_event_atomic(
+                "accept-revert-landed-note".into(),
+                "0x00000000000000000000000000000000000000aa",
+                5,
+                [0u8; 32],
+                "0x1111111111111111111111111111111111111111111111111111111111111111",
+                gi.to_be_bytes::<32>(),
+                0,
+                &[0u8; 20],
+                &[0u8; 20],
+                1_000,
+            )
+            .await
+            .expect("landing A's ClaimEvent");
+    }
+
+    /// Test 1 — landed globalIndex + matching nonce + DIFFERENT signer →
+    /// ACCEPTED, hash returned, signer nonce consumed, a status-0x0 receipt is
+    /// retrievable via `eth_getTransactionReceipt` with EMPTY logs, NO new
+    /// ClaimEvent, and the real landed claim is untouched.
+    #[tokio::test]
+    async fn landed_gi_different_signer_accept_and_reverts() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        let miden = service.miden_client.clone();
+        seed_zero_ger(&store).await;
+
+        let gi = U256::from(0x5501u64);
+        land_claim_for(&store, gi).await;
+        assert_eq!(count_claim_events(&store).await, 1, "A's ClaimEvent landed");
+
+        // Signer B — a DIFFERENT key — submits a full valid claim for the SAME
+        // gi at its expected nonce (0). Its hash is not in the store, so the
+        // RD-940 tx-hash dedup does not fire; it reaches the accept-and-revert.
+        let key_b = alloy::signers::local::PrivateKeySigner::random();
+        let addr_b = key_b.address();
+        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
+
+        let accepted = service_send_raw_txn(service.clone(), input_b)
+            .await
+            .expect("a landed-gi claim from a different signer must be ACCEPTED (accept-and-revert)");
+        assert_eq!(accepted, tx_b, "must return B's own tx hash");
+
+        // (1) B's nonce is CONSUMED — exactly like a normal accept.
+        assert_eq!(
+            store.nonce_get(&format!("{addr_b:#x}")).await.unwrap(),
+            1,
+            "accept-and-revert must consume the signer's nonce"
+        );
+
+        // (2) A durable REVERTED receipt is retrievable, status 0x0, empty logs.
+        let receipt =
+            crate::service_get_txn_receipt::service_get_txn_receipt(service.clone(), format!("{tx_b:#x}"))
+                .await
+                .unwrap()
+                .expect("eth_getTransactionReceipt must return a non-null receipt");
+        assert!(
+            matches!(
+                receipt.inner.as_receipt().unwrap().status,
+                alloy::consensus::Eip658Value::Eip658(false)
+            ),
+            "receipt status must be 0x0 (reverted)"
+        );
+        assert!(
+            receipt.inner.as_receipt().unwrap().logs.is_empty(),
+            "the reverted receipt must carry EMPTY logs (no second event)"
+        );
+        assert_eq!(
+            receipt.from, addr_b,
+            "receipt.from must be the submitting signer"
+        );
+        assert_eq!(receipt.block_number, Some(store.get_latest_block_number().await.unwrap()));
+
+        // (3) NO new ClaimEvent was emitted — the real landed one is authoritative.
+        assert_eq!(
+            count_claim_events(&store).await,
+            1,
+            "accept-and-revert must NOT emit a second ClaimEvent"
+        );
+
+        // (4) B never reached the Miden publish, and the real claim's lock stands.
+        assert!(
+            !miden.test_was_called(),
+            "accept-and-revert must not publish a second CLAIM to Miden"
+        );
+        assert!(
+            store.is_claimed(&gi).await.unwrap(),
+            "the real landed claim's lock is untouched"
+        );
+        assert!(
+            store
+                .has_claim_event_for_global_index(&gi.to_be_bytes::<32>())
+                .await
+                .unwrap(),
+            "the real landed claim's ClaimEvent is untouched"
+        );
+    }
+
+    /// Test 2 — THE ANTI-WEDGE SEQUENCE (the core #55 regression). Signer S
+    /// submits gi=X (already landed) at nonce N → accepted+reverted, its
+    /// expected nonce advances to N+1; S then submits gi=Y (a normal,
+    /// not-yet-landed claim) at nonce N+1 → accepted normally. No desync / wedge.
+    ///
+    /// Without accept-and-revert the first tx would HARD-REJECT without
+    /// consuming the nonce, S's expected nonce would stay N, and the second tx
+    /// (nonce N+1) would fail the R4 gate with "nonce mismatch" forever — the
+    /// permanent autoclaim wedge. See the mutation-check note in the PR report.
+    #[tokio::test]
+    async fn anti_wedge_sequence_landed_then_normal_stays_in_lockstep() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        seed_zero_ger(&store).await;
+
+        // The sponsor key S.
+        let key_s = alloy::signers::local::PrivateKeySigner::random();
+        let addr_s = key_s.address();
+
+        // gi=X is already landed (a user front-ran it).
+        let gi_x = U256::from(0x5502u64);
+        land_claim_for(&store, gi_x).await;
+
+        // S submits its (persisted) monitored tx for gi=X at nonce 0.
+        let calldata_x = claim_calldata(gi_x, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_x, _tx_x) = encode_tx_signed_with_nonce(&key_s, calldata_x, 0);
+        service_send_raw_txn(service.clone(), input_x)
+            .await
+            .expect("landed gi=X must be accept-and-reverted, not rejected");
+        assert_eq!(
+            store.nonce_get(&format!("{addr_s:#x}")).await.unwrap(),
+            1,
+            "S's expected nonce must advance to 1 after accept-and-revert"
+        );
+
+        // S's NEXT claim gi=Y at nonce 1 — a normal claim (unresolvable dest so
+        // the unit harness completes it synchronously via the RD-860 swallow).
+        // The point is it PASSES the R4 nonce gate (nonce 1 == expected 1).
+        let gi_y = U256::from(0x5503u64);
+        let calldata_y = claim_calldata(gi_y, Address::from([0x99u8; 20]), U256::from(1_000_000u64));
+        let (input_y, _tx_y) = encode_tx_signed_with_nonce(&key_s, calldata_y, 1);
+        let res_y = service_send_raw_txn(service.clone(), input_y).await;
+        assert!(
+            res_y.is_ok(),
+            "S's next claim at nonce 1 must be accepted (NO wedge): {res_y:?}"
+        );
+        assert!(
+            !format!("{:?}", res_y).contains("nonce mismatch"),
+            "the sequence must not produce a nonce-mismatch wedge"
+        );
+        assert_eq!(
+            store.nonce_get(&format!("{addr_s:#x}")).await.unwrap(),
+            2,
+            "S's nonce advances to 2 — perfectly in lockstep, no desync"
+        );
+    }
+
+    /// Test 3 — RD-940 idempotent rebroadcast in the accept-and-revert context:
+    /// resubmitting the SAME tx-hash (the aggkit ethtxmanager re-broadcast) must
+    /// return the same hash via the tx-hash dedup and must NOT create a second /
+    /// new receipt or advance the nonce again.
+    #[tokio::test]
+    async fn accept_and_revert_rebroadcast_same_hash_no_duplicate_receipt() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        seed_zero_ger(&store).await;
+
+        let gi = U256::from(0x5504u64);
+        land_claim_for(&store, gi).await;
+
+        let key_b = alloy::signers::local::PrivateKeySigner::random();
+        let addr_b = key_b.address();
+        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
+
+        // First submission → accept-and-revert (reverted receipt written).
+        let first = service_send_raw_txn(service.clone(), input_b.clone())
+            .await
+            .expect("first submit accept-and-reverts");
+        assert_eq!(first, tx_b);
+        assert_eq!(store.nonce_get(&format!("{addr_b:#x}")).await.unwrap(), 1);
+        let (r1, _b1) = store
+            .txn_receipt(tx_b)
+            .await
+            .unwrap()
+            .expect("a receipt exists after accept-and-revert");
+        assert!(r1.is_err(), "the receipt is a revert (status 0x0)");
+
+        // Re-broadcast the SAME wire bytes → RD-940 tx-hash dedup returns the
+        // same hash WITHOUT a new accept-and-revert (nonce unchanged, still one
+        // receipt, still exactly one ClaimEvent).
+        let second = service_send_raw_txn(service.clone(), input_b)
+            .await
+            .expect("re-broadcast must dedup to the same hash");
+        assert_eq!(second, tx_b, "dedup returns the original hash");
+        assert_eq!(
+            store.nonce_get(&format!("{addr_b:#x}")).await.unwrap(),
+            1,
+            "a same-hash rebroadcast must NOT advance the nonce again"
+        );
+        assert_eq!(
+            count_claim_events(&store).await,
+            1,
+            "no second ClaimEvent from the rebroadcast"
+        );
+    }
+
+    /// Test 4a — a landed-gi claim whose nonce is STALE must still be rejected by
+    /// the R4 gate (NOT accept-and-reverted). accept-and-revert must never paper
+    /// over a real nonce gap.
+    #[tokio::test]
+    async fn landed_gi_stale_nonce_still_rejected_not_reverted() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        seed_zero_ger(&store).await;
+
+        let gi = U256::from(0x5505u64);
+        land_claim_for(&store, gi).await;
+
+        let key_b = alloy::signers::local::PrivateKeySigner::random();
+        let addr_b = key_b.address();
+        // Advance B's tracked nonce so a nonce-0 tx is stale.
+        for _ in 0..5 {
+            store
+                .nonce_increment(&format!("{addr_b:#x}"))
+                .await
+                .unwrap();
+        }
+        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
+
+        let err = service_send_raw_txn(service.clone(), input_b)
+            .await
+            .expect_err("a stale-nonce landed claim must be rejected by R4, not accept-and-reverted");
+        assert!(
+            err.to_string().contains("nonce mismatch"),
+            "must be the R4 nonce-mismatch rejection, not an accept: {err:#}"
+        );
+        // No receipt was written (it was rejected, not accept-and-reverted).
+        assert!(
+            store.txn_receipt(tx_b).await.unwrap().is_none(),
+            "a rejected stale-nonce claim must NOT leave a receipt"
+        );
+    }
+
+    /// Test 4b — a landed-gi claim whose nonce is in the FUTURE (writer-worker
+    /// mode) must take the normal R4 retryable future-nonce WAIT, not
+    /// accept-and-revert immediately. Proves accept-and-revert only fires for a
+    /// tx the R4 gate would otherwise admit (nonce == expected).
+    #[tokio::test]
+    async fn landed_gi_future_nonce_waits_not_reverted() {
+        let mut service = create_test_service();
+        let store = service.store.clone();
+        let (handle, shutdown) = crate::writer_worker::WriterWorker::spawn(
+            service.clone(),
+            64,
+            std::time::Duration::from_secs(60),
+        );
+        service.enable_writer_worker = true;
+        service.writer_handle = Some(std::sync::Arc::new(handle));
+        seed_zero_ger(&store).await;
+
+        let gi = U256::from(0x5506u64);
+        land_claim_for(&store, gi).await;
+
+        // Submit at nonce 1 while expected is 0 → future nonce → must WAIT.
+        let key_b = alloy::signers::local::PrivateKeySigner::random();
+        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_b, _tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 1);
+
+        let svc = service.clone();
+        let pending = tokio::spawn(async move { service_send_raw_txn(svc, input_b).await });
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        assert!(
+            !pending.is_finished(),
+            "a future-nonce landed claim must WAIT on R4, not short-circuit to accept-and-revert"
+        );
+        pending.abort();
+        let _ = shutdown.send(());
+    }
+
+    /// Test 5 — async-writer-mode variant of Test 1: a landed-gi claim from a
+    /// DIFFERENT signer, enqueued to the writer worker, is accept-and-reverted
+    /// by the worker (reverted receipt, no second ClaimEvent), and the nonce is
+    /// consumed at enqueue time (RD-940 flow).
+    #[tokio::test]
+    async fn landed_gi_accept_and_revert_async_writer_mode() {
+        let mut service = create_test_service();
+        let store = service.store.clone();
+        let (handle, shutdown) = crate::writer_worker::WriterWorker::spawn(
+            service.clone(),
+            64,
+            std::time::Duration::from_secs(60),
+        );
+        service.enable_writer_worker = true;
+        service.writer_handle = Some(std::sync::Arc::new(handle));
+        seed_zero_ger(&store).await;
+
+        let gi = U256::from(0x5507u64);
+        land_claim_for(&store, gi).await;
+        assert_eq!(count_claim_events(&store).await, 1);
+
+        let key_b = alloy::signers::local::PrivateKeySigner::random();
+        let addr_b = key_b.address();
+        let calldata = claim_calldata(gi, resolvable_dest(), U256::from(1_000_000u64));
+        let (input_b, tx_b) = encode_tx_signed_with_nonce(&key_b, calldata, 0);
+
+        let accepted = service_send_raw_txn(service.clone(), input_b)
+            .await
+            .expect("enqueue must return the tx hash");
+        assert_eq!(accepted, tx_b);
+        // Nonce consumed at enqueue (RD-940 flow).
+        assert_eq!(store.nonce_get(&format!("{addr_b:#x}")).await.unwrap(), 1);
+
+        // Poll for the worker to write the reverted receipt.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            if let Some((result, _b)) = store.txn_receipt(tx_b).await.unwrap() {
+                assert!(
+                    result.is_err(),
+                    "the async accept-and-revert receipt must be status 0x0"
+                );
+                break;
+            }
+            if std::time::Instant::now() > deadline {
+                panic!("worker did not write the reverted receipt within 10s");
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            count_claim_events(&store).await,
+            1,
+            "async accept-and-revert must NOT emit a second ClaimEvent"
+        );
+        let _ = shutdown.send(());
     }
 
     /// No double-submit race: a record YOUNGER than the TTL (a submission genuinely in

--- a/src/service_state.rs
+++ b/src/service_state.rs
@@ -122,21 +122,10 @@ pub struct ServiceState {
     /// call. `None` when talking to the node directly; `Some(...)` when fronted by a
     /// gateway that rate-limits unauthenticated traffic. Redact if you ever log this.
     pub miden_api_key: Option<String>,
-    /// RD-940 async writer-worker dispatch toggle. When `false` (the default
-    /// until Phase 7 of the RD-940 rollout), `eth_sendRawTransaction` runs the
-    /// existing synchronous handler unchanged. When `true`, requests are
-    /// validated on the request thread and the actual Miden submission is
-    /// enqueued to the single writer-worker task. See
-    /// `docs/design/RD-940-async-writer.md` for the full design.
-    pub enable_writer_worker: bool,
-    /// RD-940 writer-worker producer handle. `None` when
-    /// `enable_writer_worker = false` *or* when the flag is set but the
-    /// worker failed to spawn at startup (logged-but-non-fatal — the sync
-    /// path remains usable as the fallback). `Some(handle)` is the live
-    /// `try_enqueue` surface plumbed into `service_send_raw_txn` and the
-    /// upcoming Phase 4 `eth_getTransactionByHash` in-flight reader. The
-    /// `Arc` shares the underlying channel + in-flight DashMap across every
-    /// `ServiceState::clone()` the dispatcher hands out.
+    /// Single writer-worker producer handle. Production startup always sets
+    /// this before serving RPC traffic. It remains optional only so lower-level
+    /// unit tests can construct a state without starting a background runtime.
+    /// The `Arc` shares the bounded channel and in-flight map across requests.
     pub writer_handle: Option<Arc<crate::writer_worker::WriterWorkerHandle>>,
 }
 
@@ -183,7 +172,6 @@ impl ServiceState {
             reject_zero_padding_addresses: false,
             expected_mints,
             miden_api_key: None,
-            enable_writer_worker: false,
             writer_handle: None,
         }
     }

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -23,6 +23,22 @@ struct TxnReceipt {
     logs: Vec<LogData>,
 }
 
+/// #55 BLOCKER 1 — in-memory fenced admission-lease reservation row.
+#[derive(Clone)]
+struct Reservation {
+    tx_hash: TxHash,
+    state: ReservationState,
+    lease_expires_at: std::time::Instant,
+    fence: u64,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ReservationState {
+    Executing,
+    ReleasedSuccess,
+    ReleasedFailure,
+}
+
 pub struct InMemoryStore {
     // Block number
     latest_block_number: RwLock<u64>,
@@ -45,9 +61,8 @@ pub struct InMemoryStore {
     // Nonces
     nonces: RwLock<HashMap<String, u64>>,
 
-    // #55 BLOCKER 1 — (signer, nonce) → tx_hash reservations. Insert-if-absent;
-    // the first tx to reserve a (signer, nonce) slot wins and executes.
-    nonce_reservations: RwLock<HashMap<(String, u64), TxHash>>,
+    // #55 BLOCKER 1 — (signer, nonce) → fenced admission-lease reservations.
+    nonce_reservations: RwLock<HashMap<(String, u64), Reservation>>,
 
     // Claims — value = when `try_claim` acquired the lock (as read from
     // `claim_clock_now`), so orphaned records (crash between the lock write and
@@ -206,6 +221,19 @@ impl InMemoryStore {
     #[cfg(test)]
     pub fn test_land_gi_after_next_has_claim_miss(&self, global_index: [u8; 32]) {
         *self.test_land_after_next_has_claim_miss.write() = Some(global_index);
+    }
+
+    /// Test hook (#55 BLOCKER 1): force the admission lease for `(addr, nonce)` to
+    /// have already EXPIRED, so the next `reserve_nonce` by the SAME tx takes over
+    /// (crash-recovery path). Panics if there is no reservation (test-authoring bug).
+    #[cfg(test)]
+    pub fn test_expire_reservation_lease(&self, addr: &str, nonce: u64) {
+        let key = (addr.to_lowercase(), nonce);
+        let mut reservations = self.nonce_reservations.write();
+        let r = reservations
+            .get_mut(&key)
+            .expect("test_expire_reservation_lease: no reservation for (addr, nonce)");
+        r.lease_expires_at = std::time::Instant::now() - std::time::Duration::from_secs(1);
     }
 
     /// Emit a synthetic BridgeEvent log. Private helper for the atomic B2AGG
@@ -744,16 +772,72 @@ impl Store for InMemoryStore {
         addr: &str,
         nonce: u64,
         tx_hash: TxHash,
+        lease: std::time::Duration,
     ) -> anyhow::Result<crate::store::NonceReservation> {
+        use crate::store::NonceReservation;
         let key = (addr.to_lowercase(), nonce);
+        let now = std::time::Instant::now();
         let mut reservations = self.nonce_reservations.write();
         match reservations.get(&key) {
-            Some(existing) => Ok(crate::store::NonceReservation::HeldBy(*existing)),
             None => {
-                reservations.insert(key, tx_hash);
-                Ok(crate::store::NonceReservation::Won)
+                reservations.insert(
+                    key,
+                    Reservation {
+                        tx_hash,
+                        state: ReservationState::Executing,
+                        lease_expires_at: now + lease,
+                        fence: 1,
+                    },
+                );
+                Ok(NonceReservation::Won { fence: 1 })
+            }
+            Some(r) if r.tx_hash != tx_hash => Ok(NonceReservation::HeldByOther(r.tx_hash)),
+            Some(r) => {
+                // Same tx. Owned+executing under a valid lease, or released_success →
+                // dedup. Expired lease or released_failure → takeover (fence++).
+                let takeover = matches!(r.state, ReservationState::ReleasedFailure)
+                    || (r.state == ReservationState::Executing && r.lease_expires_at <= now);
+                if takeover {
+                    let fence = r.fence + 1;
+                    reservations.insert(
+                        key,
+                        Reservation {
+                            tx_hash,
+                            state: ReservationState::Executing,
+                            lease_expires_at: now + lease,
+                            fence,
+                        },
+                    );
+                    Ok(NonceReservation::Won { fence })
+                } else {
+                    Ok(NonceReservation::OwnedBySame)
+                }
             }
         }
+    }
+
+    async fn release_reservation(
+        &self,
+        addr: &str,
+        nonce: u64,
+        tx_hash: TxHash,
+        fence: u64,
+        success: bool,
+    ) -> anyhow::Result<()> {
+        let key = (addr.to_lowercase(), nonce);
+        let mut reservations = self.nonce_reservations.write();
+        if let Some(r) = reservations.get_mut(&key)
+            && r.tx_hash == tx_hash
+            && r.fence == fence
+            && r.state == ReservationState::Executing
+        {
+            r.state = if success {
+                ReservationState::ReleasedSuccess
+            } else {
+                ReservationState::ReleasedFailure
+            };
+        }
+        Ok(())
     }
 
     async fn commit_reverted_receipt_and_advance_nonce(

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -427,6 +427,34 @@ impl Store for InMemoryStore {
             }))
     }
 
+    async fn pending_note_handoff_txs(
+        &self,
+        after: Option<TxHash>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<TxHash>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let txns = self.transactions.lock();
+        let links = self.tx_note_links.read();
+        let mut pending: Vec<TxHash> = txns
+            .iter()
+            .filter(|(tx_hash, txn)| {
+                txn.result.is_none()
+                    && links
+                        .get(&format!("{tx_hash:#x}"))
+                        .is_some_and(|link| link.note_id.is_some())
+            })
+            .map(|(tx_hash, _)| *tx_hash)
+            .collect();
+        pending.sort_unstable();
+        Ok(pending
+            .into_iter()
+            .filter(|tx_hash| after.is_none_or(|after| *tx_hash > after))
+            .take(limit)
+            .collect())
+    }
+
     async fn prepare_note_handoff(
         &self,
         tx_hash: &str,

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -76,6 +76,14 @@ pub struct InMemoryStore {
     // consume B2AGG `deposit_counter` slots — see commit_manual_claim_event_atomic).
     claim_watcher_processed: RwLock<HashMap<String, [u8; 32]>>,
 
+    /// Test hook (#55 BLOCKER B): when set to `Some(gi)`, the next
+    /// `has_claim_event_for_global_index(gi)` call that would report NO event
+    /// instead LANDS the claim (records a watcher ClaimEvent) as a side effect and
+    /// still reports the miss — so the FOLLOWING call observes it. Deterministically
+    /// models "the racing claim commits its ClaimEvent between `acquire_claim_lock`'s
+    /// two landed reads." Always `None` in production (zero behavioural impact).
+    test_land_after_next_has_claim_miss: RwLock<Option<[u8; 32]>>,
+
     // Faucet registry
     faucets: RwLock<Vec<FaucetEntry>>,
 
@@ -139,6 +147,7 @@ impl InMemoryStore {
             processed_notes: RwLock::new(HashMap::new()),
             deposit_counter: RwLock::new(0),
             claim_watcher_processed: RwLock::new(HashMap::new()),
+            test_land_after_next_has_claim_miss: RwLock::new(None),
             faucets: RwLock::new(Vec::new()),
             monitor_burn_serials: RwLock::new(HashSet::new()),
             monitor_twin_notes: RwLock::new(HashMap::new()),
@@ -183,6 +192,15 @@ impl InMemoryStore {
             "test_backdate_claim: no claim record for global_index {global_index}"
         );
         *self.claim_clock_skew.write() += age;
+    }
+
+    /// Test hook (#55 BLOCKER B): arm the store so the NEXT
+    /// `has_claim_event_for_global_index(gi)` that finds no event lands the claim as
+    /// a side effect (see the field doc). Used to deterministically drive the
+    /// try_claim-Err → reclaim-fail → re-read-landed interleaving.
+    #[cfg(test)]
+    pub fn test_land_gi_after_next_has_claim_miss(&self, global_index: [u8; 32]) {
+        *self.test_land_after_next_has_claim_miss.write() = Some(global_index);
     }
 
     /// Emit a synthetic BridgeEvent log. Private helper for the atomic B2AGG
@@ -704,6 +722,57 @@ impl Store for InMemoryStore {
         Ok(prev)
     }
 
+    async fn nonce_advance_cas(&self, addr: &str, expected: u64) -> anyhow::Result<bool> {
+        let key = addr.to_lowercase();
+        let mut nonces = self.nonces.write();
+        let cur = nonces.entry(key).or_insert(0);
+        if *cur == expected {
+            *cur = expected + 1;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    async fn commit_reverted_receipt_and_advance_nonce(
+        &self,
+        tx_hash: TxHash,
+        entry: TxnEntry,
+        reason: String,
+        block_num: u64,
+        _block_hash: [u8; 32],
+        addr: &str,
+        expected_nonce: u64,
+    ) -> anyhow::Result<bool> {
+        // BLOCKER C — receipt + nonce in one atomic step: hold BOTH the
+        // transactions and nonces locks so a reader can never observe the
+        // receipt committed with the nonce not yet advanced (or vice versa).
+        // The row is inserted already committed-`failed` (empty logs, no
+        // synthetic ClaimEvent), so there is no pending window.
+        let mut txns = self.transactions.lock();
+        let mut nonces = self.nonces.write();
+        let receipt = TxnReceipt {
+            id: entry.id,
+            envelope: entry.envelope,
+            signer: entry.signer,
+            expires_at: entry.expires_at,
+            result: Some(Err(reason)),
+            block_num,
+            logs: vec![],
+        };
+        // Idempotent on tx_hash: a rebroadcast/re-entry re-affirms the same
+        // committed-reverted row rather than erroring.
+        let _ = txns.put(tx_hash, receipt);
+        let cur = nonces.entry(addr.to_lowercase()).or_insert(0);
+        let advanced = if *cur == expected_nonce {
+            *cur = expected_nonce + 1;
+            true
+        } else {
+            false
+        };
+        Ok(advanced)
+    }
+
     // ── Claims ───────────────────────────────────────────────────
 
     async fn try_claim(&self, global_index: U256) -> anyhow::Result<()> {
@@ -943,6 +1012,19 @@ impl Store for InMemoryStore {
                 {
                     return Ok(true);
                 }
+            }
+        }
+        drop(logs);
+        // Test hook (BLOCKER B): this call found NO event. If armed for this gi, LAND
+        // it now so the NEXT call observes it, and still report this miss.
+        {
+            let mut armed = self.test_land_after_next_has_claim_miss.write();
+            if armed.as_ref() == Some(global_index) {
+                *armed = None;
+                drop(armed);
+                self.claim_watcher_processed
+                    .write()
+                    .insert("blockerB-race-land".to_string(), *global_index);
             }
         }
         Ok(false)

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -958,6 +958,24 @@ impl Store for InMemoryStore {
         Ok(())
     }
 
+    async fn txn_commit_confirmed_duplicate(
+        &self,
+        tx_hash: TxHash,
+        result: Result<(), String>,
+        block_num: u64,
+    ) -> anyhow::Result<()> {
+        let mut txns = self.transactions.lock();
+        let Some(receipt) = txns.get_mut(&tx_hash) else {
+            anyhow::bail!("Store: transaction {tx_hash} not found");
+        };
+        if receipt.result.is_none() {
+            receipt.result = Some(result);
+            receipt.block_num = block_num;
+            receipt.logs.clear();
+        }
+        Ok(())
+    }
+
     async fn txn_receipt(
         &self,
         tx_hash: TxHash,
@@ -2671,6 +2689,65 @@ mod tests {
                 .0
                 .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn confirmed_duplicate_finalizes_linked_pending_without_event() {
+        use alloy::consensus::{Signed, TxLegacy};
+        use alloy::primitives::Signature;
+
+        let store = InMemoryStore::new();
+        let tx_hash = TxHash::from([0x79u8; 32]);
+        let tx_key = format!("{tx_hash:#x}");
+        let envelope = alloy::consensus::TxEnvelope::Legacy(Signed::new_unchecked(
+            TxLegacy::default(),
+            Signature::test_signature(),
+            tx_hash,
+        ));
+        store
+            .txn_begin(
+                tx_hash,
+                TxnEntry {
+                    id: None,
+                    envelope,
+                    signer: Address::ZERO,
+                    expires_at: Some(10),
+                    logs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .prepare_note_handoff(&tx_key, "commitment", "note-id", 10)
+            .await
+            .unwrap();
+        store
+            .txn_commit(tx_hash, Err("raw Miden error".into()), 10, [0; 32])
+            .await
+            .unwrap();
+        assert!(store.txn_receipt(tx_hash).await.unwrap().is_none());
+
+        store
+            .txn_commit_confirmed_duplicate(
+                tx_hash,
+                Err("execution reverted: AlreadyClaimed()".into()),
+                11,
+            )
+            .await
+            .unwrap();
+        let (result, block) = store.txn_receipt(tx_hash).await.unwrap().unwrap();
+        assert!(result.is_err());
+        assert_eq!(block, 11);
+        assert!(
+            store
+                .txn_get(tx_hash)
+                .await
+                .unwrap()
+                .unwrap()
+                .logs
+                .is_empty()
+        );
+        assert!(store.get_logs_for_tx(&tx_key).await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -435,8 +435,8 @@ impl Store for InMemoryStore {
         if limit == 0 {
             return Ok(Vec::new());
         }
-        let txns = self.transactions.lock();
         let links = self.tx_note_links.read();
+        let txns = self.transactions.lock();
         let mut pending: Vec<TxHash> = txns
             .iter()
             .filter(|(tx_hash, txn)| {
@@ -1040,8 +1040,8 @@ impl Store for InMemoryStore {
 
     async fn pending_nonce_frontier(&self, addr: &str) -> anyhow::Result<PendingNonceFrontier> {
         let addr = addr.to_lowercase();
-        let txns = self.transactions.lock();
         let links = self.tx_note_links.read();
+        let txns = self.transactions.lock();
         let mut frontier = PendingNonceFrontier::default();
         for (tx_hash, receipt) in txns.iter() {
             if receipt.result.is_some() || format!("{:#x}", receipt.signer).to_lowercase() != addr {

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -64,6 +64,10 @@ pub struct InMemoryStore {
     // #55 BLOCKER 1 — (signer, nonce) → fenced admission-lease reservations.
     nonce_reservations: RwLock<HashMap<(String, u64), Reservation>>,
 
+    // #55 BLOCKER B test hook: when true, the NEXT `nonce_advance_cas` returns a
+    // store error (simulating a DB failure on the CAS). Always false in production.
+    test_fail_next_nonce_cas: std::sync::atomic::AtomicBool,
+
     // Claims — value = when `try_claim` acquired the lock (as read from
     // `claim_clock_now`), so orphaned records (crash between the lock write and
     // the CLAIM landing) can be superseded after a TTL (`try_reclaim_expired`,
@@ -158,6 +162,7 @@ impl InMemoryStore {
             transactions: Mutex::new(LruCache::new(NonZeroUsize::new(10_000).unwrap())),
             nonces: RwLock::new(HashMap::new()),
             nonce_reservations: RwLock::new(HashMap::new()),
+            test_fail_next_nonce_cas: std::sync::atomic::AtomicBool::new(false),
             claimed: RwLock::new(HashMap::new()),
             #[cfg(test)]
             claim_clock_skew: RwLock::new(std::time::Duration::ZERO),
@@ -221,6 +226,14 @@ impl InMemoryStore {
     #[cfg(test)]
     pub fn test_land_gi_after_next_has_claim_miss(&self, global_index: [u8; 32]) {
         *self.test_land_after_next_has_claim_miss.write() = Some(global_index);
+    }
+
+    /// Test hook (#55 BLOCKER B): arm the store so the NEXT `nonce_advance_cas`
+    /// returns a store error, simulating a DB failure on the nonce CAS.
+    #[cfg(test)]
+    pub fn test_fail_next_nonce_cas(&self) {
+        self.test_fail_next_nonce_cas
+            .store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
     /// Test hook (#55 BLOCKER 1): force the admission lease for `(addr, nonce)` to
@@ -756,6 +769,13 @@ impl Store for InMemoryStore {
     }
 
     async fn nonce_advance_cas(&self, addr: &str, expected: u64) -> anyhow::Result<bool> {
+        // BLOCKER B test hook — one-shot simulated CAS store failure.
+        if self
+            .test_fail_next_nonce_cas
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+        {
+            anyhow::bail!("simulated nonce_advance_cas store failure (test hook)");
+        }
         let key = addr.to_lowercase();
         let mut nonces = self.nonces.write();
         let cur = nonces.entry(key).or_insert(0);
@@ -778,7 +798,8 @@ impl Store for InMemoryStore {
         let key = (addr.to_lowercase(), nonce);
         let now = std::time::Instant::now();
         let mut reservations = self.nonce_reservations.write();
-        match reservations.get(&key) {
+        let existing = reservations.get(&key).cloned();
+        match existing {
             None => {
                 reservations.insert(
                     key,
@@ -791,10 +812,12 @@ impl Store for InMemoryStore {
                 );
                 Ok(NonceReservation::Won { fence: 1 })
             }
-            Some(r) if r.tx_hash != tx_hash => Ok(NonceReservation::HeldByOther(r.tx_hash)),
             Some(r) => {
-                // Same tx. Owned+executing under a valid lease, or released_success →
-                // dedup. Expired lease or released_failure → takeover (fence++).
+                // STATE-FIRST (BLOCKER A): a holder that FAILED or whose lease EXPIRED
+                // consumed NO nonce, so the slot is free for takeover by ANY tx — the
+                // SAME tx (retry) OR a DIFFERENT tx. A holder that is executing under a
+                // valid lease, or already released_success, has consumed the nonce / is
+                // in flight, so a DIFFERENT tx hard-rejects and the SAME tx dedups.
                 let takeover = matches!(r.state, ReservationState::ReleasedFailure)
                     || (r.state == ReservationState::Executing && r.lease_expires_at <= now);
                 if takeover {
@@ -809,8 +832,10 @@ impl Store for InMemoryStore {
                         },
                     );
                     Ok(NonceReservation::Won { fence })
-                } else {
+                } else if r.tx_hash == tx_hash {
                     Ok(NonceReservation::OwnedBySame)
+                } else {
+                    Ok(NonceReservation::HeldByOther(r.tx_hash))
                 }
             }
         }

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -45,6 +45,10 @@ pub struct InMemoryStore {
     // Nonces
     nonces: RwLock<HashMap<String, u64>>,
 
+    // #55 BLOCKER 1 — (signer, nonce) → tx_hash reservations. Insert-if-absent;
+    // the first tx to reserve a (signer, nonce) slot wins and executes.
+    nonce_reservations: RwLock<HashMap<(String, u64), TxHash>>,
+
     // Claims — value = when `try_claim` acquired the lock (as read from
     // `claim_clock_now`), so orphaned records (crash between the lock write and
     // the CLAIM landing) can be superseded after a TTL (`try_reclaim_expired`,
@@ -138,6 +142,7 @@ impl InMemoryStore {
             injected_gers: RwLock::new(HashSet::new()),
             transactions: Mutex::new(LruCache::new(NonZeroUsize::new(10_000).unwrap())),
             nonces: RwLock::new(HashMap::new()),
+            nonce_reservations: RwLock::new(HashMap::new()),
             claimed: RwLock::new(HashMap::new()),
             #[cfg(test)]
             claim_clock_skew: RwLock::new(std::time::Duration::ZERO),
@@ -734,6 +739,23 @@ impl Store for InMemoryStore {
         }
     }
 
+    async fn reserve_nonce(
+        &self,
+        addr: &str,
+        nonce: u64,
+        tx_hash: TxHash,
+    ) -> anyhow::Result<crate::store::NonceReservation> {
+        let key = (addr.to_lowercase(), nonce);
+        let mut reservations = self.nonce_reservations.write();
+        match reservations.get(&key) {
+            Some(existing) => Ok(crate::store::NonceReservation::HeldBy(*existing)),
+            None => {
+                reservations.insert(key, tx_hash);
+                Ok(crate::store::NonceReservation::Won)
+            }
+        }
+    }
+
     async fn commit_reverted_receipt_and_advance_nonce(
         &self,
         tx_hash: TxHash,
@@ -751,18 +773,31 @@ impl Store for InMemoryStore {
         // synthetic ClaimEvent), so there is no pending window.
         let mut txns = self.transactions.lock();
         let mut nonces = self.nonces.write();
-        let receipt = TxnReceipt {
-            id: entry.id,
-            envelope: entry.envelope,
-            signer: entry.signer,
-            expires_at: entry.expires_at,
-            result: Some(Err(reason)),
-            block_num,
-            logs: vec![],
+        // BLOCKER 4 — CONDITIONAL: never overwrite a REAL receipt. If this hash
+        // already has a pending (result None → a real claim awaiting the projector)
+        // or successful (Some(Ok) → a landed real claim) receipt, DO NOT rewrite it
+        // to status 0. A cross-replica accept-and-revert on the same hash must
+        // converge to the real outcome, not suppress a real success/pending. Only
+        // write the reverted receipt when the hash is absent or already `failed`
+        // (idempotent re-affirm).
+        let may_write = match txns.peek(&tx_hash).map(|r| &r.result) {
+            None => true,                // absent
+            Some(None) => false,         // pending real receipt — keep it
+            Some(Some(Ok(()))) => false, // successful real receipt — keep it
+            Some(Some(Err(_))) => true,  // already failed — re-affirm
         };
-        // Idempotent on tx_hash: a rebroadcast/re-entry re-affirms the same
-        // committed-reverted row rather than erroring.
-        let _ = txns.put(tx_hash, receipt);
+        if may_write {
+            let receipt = TxnReceipt {
+                id: entry.id,
+                envelope: entry.envelope,
+                signer: entry.signer,
+                expires_at: entry.expires_at,
+                result: Some(Err(reason)),
+                block_num,
+                logs: vec![],
+            };
+            let _ = txns.put(tx_hash, receipt);
+        }
         let cur = nonces.entry(addr.to_lowercase()).or_insert(0);
         let advanced = if *cur == expected_nonce {
             *cur = expected_nonce + 1;

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1,7 +1,8 @@
 //! In-memory Store implementation — wraps HashMap/RwLock data structures.
 
 use super::{
-    ClaimFence, FaucetEntry, Store, TxnData, TxnEntry, UnbridgeableBridgeOut, UnclaimableClaim,
+    ClaimFence, FaucetEntry, NoteHandoff, NoteHandoffState, PendingNonceFrontier, Store, TxnData,
+    TxnEntry, UnbridgeableBridgeOut, UnclaimableClaim,
 };
 use crate::log_synthesis::{
     GerEntry, L2_GLOBAL_EXIT_ROOT_ADDRESS, LogFilter, SyntheticLog, UPDATE_HASH_CHAIN_VALUE_TOPIC,
@@ -44,7 +45,9 @@ enum ReservationState {
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ClaimState {
     Executing,
+    Prepared,
     Submitted,
+    Landed,
 }
 
 #[derive(Clone)]
@@ -54,6 +57,14 @@ struct ClaimRecord {
     acquired_at: std::time::Instant,
     lease_expires_at: Option<std::time::Instant>,
     fence: u64,
+}
+
+#[derive(Clone)]
+struct NoteHandoffRecord {
+    note_commitment: String,
+    note_id: Option<String>,
+    state: NoteHandoffState,
+    expiration_block: Option<u64>,
 }
 
 pub struct InMemoryStore {
@@ -121,7 +132,8 @@ pub struct InMemoryStore {
     /// instead LANDS the claim (records a watcher ClaimEvent) as a side effect and
     /// still reports the miss — so the FOLLOWING call observes it. Deterministically
     /// models "the racing claim commits its ClaimEvent between `acquire_claim_lock`'s
-    /// two landed reads." Always `None` in production (zero behavioural impact).
+    /// two landed reads."
+    #[cfg(test)]
     test_land_after_next_has_claim_miss: RwLock<Option<[u8; 32]>>,
 
     // Faucet registry
@@ -150,7 +162,7 @@ pub struct InMemoryStore {
     // Receipts map (synthetic-indexer redesign, Phase 2b substrate) —
     // first-write-wins evm_tx_hash -> note_commitment, with the reverse index
     // mirrored alongside it. UNUSED in Phase 2a. See Store::record_tx_note_link.
-    tx_note_links: RwLock<HashMap<String, String>>,
+    tx_note_links: RwLock<HashMap<String, NoteHandoffRecord>>,
     note_tx_links: RwLock<HashMap<String, String>>,
 }
 
@@ -189,6 +201,7 @@ impl InMemoryStore {
             processed_notes: RwLock::new(HashMap::new()),
             deposit_counter: RwLock::new(0),
             claim_watcher_processed: RwLock::new(HashMap::new()),
+            #[cfg(test)]
             test_land_after_next_has_claim_miss: RwLock::new(None),
             faucets: RwLock::new(Vec::new()),
             monitor_burn_serials: RwLock::new(HashSet::new()),
@@ -372,7 +385,15 @@ impl Store for InMemoryStore {
         if fwd.contains_key(tx_hash) {
             return Ok(());
         }
-        fwd.insert(tx_hash.to_string(), note_commitment.to_string());
+        fwd.insert(
+            tx_hash.to_string(),
+            NoteHandoffRecord {
+                note_commitment: note_commitment.to_string(),
+                note_id: None,
+                state: NoteHandoffState::Submitted,
+                expiration_block: None,
+            },
+        );
         drop(fwd);
         self.note_tx_links
             .write()
@@ -382,11 +403,188 @@ impl Store for InMemoryStore {
     }
 
     async fn get_note_link_for_tx(&self, tx_hash: &str) -> anyhow::Result<Option<String>> {
-        Ok(self.tx_note_links.read().get(tx_hash).cloned())
+        Ok(self
+            .tx_note_links
+            .read()
+            .get(tx_hash)
+            .map(|record| record.note_commitment.clone()))
     }
 
     async fn get_tx_for_note(&self, note_commitment: &str) -> anyhow::Result<Option<String>> {
         Ok(self.note_tx_links.read().get(note_commitment).cloned())
+    }
+
+    async fn get_note_handoff_for_tx(&self, tx_hash: &str) -> anyhow::Result<Option<NoteHandoff>> {
+        Ok(self
+            .tx_note_links
+            .read()
+            .get(tx_hash)
+            .map(|record| NoteHandoff {
+                note_commitment: record.note_commitment.clone(),
+                note_id: record.note_id.clone(),
+                state: record.state,
+                expiration_block: record.expiration_block,
+            }))
+    }
+
+    async fn prepare_note_handoff(
+        &self,
+        tx_hash: &str,
+        note_commitment: &str,
+        note_id: &str,
+        expiration_block: u64,
+    ) -> anyhow::Result<()> {
+        let mut links = self.tx_note_links.write();
+        if let Some(existing) = links.get(tx_hash) {
+            if existing.note_commitment != note_commitment
+                || existing.note_id.as_deref() != Some(note_id)
+            {
+                anyhow::bail!("transaction {tx_hash} is already linked to a different note");
+            }
+            return Ok(());
+        }
+        links.insert(
+            tx_hash.to_string(),
+            NoteHandoffRecord {
+                note_commitment: note_commitment.to_string(),
+                note_id: Some(note_id.to_string()),
+                state: NoteHandoffState::Prepared,
+                expiration_block: Some(expiration_block),
+            },
+        );
+        self.note_tx_links
+            .write()
+            .entry(note_commitment.to_string())
+            .or_insert_with(|| tx_hash.to_string());
+        Ok(())
+    }
+
+    async fn confirm_note_handoff(
+        &self,
+        tx_hash: &str,
+        note_commitment: &str,
+    ) -> anyhow::Result<bool> {
+        let mut links = self.tx_note_links.write();
+        let mut claimed = self.claimed.write();
+        let Some(record) = links.get_mut(tx_hash) else {
+            return Ok(false);
+        };
+        if record.note_commitment != note_commitment {
+            return Ok(false);
+        }
+        record.state = NoteHandoffState::Submitted;
+        record.expiration_block = None;
+        if let Ok(owner) = tx_hash.parse::<TxHash>() {
+            for claim in claimed.values_mut() {
+                if claim.owner_tx_hash == Some(owner) && claim.state == ClaimState::Prepared {
+                    claim.state = ClaimState::Submitted;
+                    claim.lease_expires_at = None;
+                }
+            }
+        }
+        Ok(true)
+    }
+
+    async fn confirm_note_handoff_by_commitment(
+        &self,
+        note_commitment: &str,
+    ) -> anyhow::Result<Option<String>> {
+        let preferred = self.note_tx_links.read().get(note_commitment).cloned();
+        let mut links = self.tx_note_links.write();
+        let mut matching: Vec<String> = links
+            .iter()
+            .filter(|(_, link)| link.note_commitment == note_commitment)
+            .map(|(tx_hash, _)| tx_hash.clone())
+            .collect();
+        if matching.is_empty() {
+            return Ok(None);
+        }
+        matching.sort();
+        let mut claimed = self.claimed.write();
+        for tx_hash in &matching {
+            let link = links.get_mut(tx_hash).expect("matching link exists");
+            link.state = NoteHandoffState::Submitted;
+            link.expiration_block = None;
+            if let Ok(owner) = tx_hash.parse::<TxHash>() {
+                for claim in claimed.values_mut() {
+                    if claim.owner_tx_hash == Some(owner) && claim.state == ClaimState::Prepared {
+                        claim.state = ClaimState::Submitted;
+                        claim.lease_expires_at = None;
+                    }
+                }
+            }
+        }
+        Ok(Some(preferred.unwrap_or_else(|| matching[0].clone())))
+    }
+
+    async fn confirm_prepared_note_handoffs(&self, note_ids: &[String]) -> anyhow::Result<u64> {
+        let ids: HashSet<&str> = note_ids.iter().map(String::as_str).collect();
+        let matches: Vec<(String, String)> = self
+            .tx_note_links
+            .read()
+            .iter()
+            .filter(|(_, link)| {
+                link.state == NoteHandoffState::Prepared
+                    && link.note_id.as_deref().is_some_and(|id| ids.contains(id))
+            })
+            .map(|(tx_hash, link)| (tx_hash.clone(), link.note_commitment.clone()))
+            .collect();
+        let mut confirmed = 0;
+        for (tx_hash, commitment) in matches {
+            confirmed += u64::from(self.confirm_note_handoff(&tx_hash, &commitment).await?);
+        }
+        Ok(confirmed)
+    }
+
+    async fn clear_expired_prepared_note_handoff(
+        &self,
+        tx_hash: &str,
+        note_commitment: &str,
+    ) -> anyhow::Result<bool> {
+        let cursor = *self.reconcile_cursor.read();
+        let mut links = self.tx_note_links.write();
+        let mut claimed = self.claimed.write();
+        let Some(record) = links.get(tx_hash) else {
+            return Ok(false);
+        };
+        if record.state != NoteHandoffState::Prepared
+            || record.note_commitment != note_commitment
+            || record
+                .expiration_block
+                .is_none_or(|expiration| cursor <= expiration)
+        {
+            return Ok(false);
+        }
+        if let Ok(owner) = tx_hash.parse::<TxHash>() {
+            let matching_claim = claimed.iter().find_map(|(gi, claim)| {
+                (claim.owner_tx_hash == Some(owner)).then_some((*gi, claim.state))
+            });
+            match matching_claim {
+                Some((gi, ClaimState::Prepared)) => {
+                    claimed.remove(&gi);
+                }
+                Some((_gi, ClaimState::Landed)) => return Ok(false),
+                None => {}
+                Some(_) => return Ok(false),
+            }
+        }
+        links.remove(tx_hash);
+        if self
+            .note_tx_links
+            .read()
+            .get(note_commitment)
+            .is_some_and(|v| v == tx_hash)
+        {
+            self.note_tx_links.write().remove(note_commitment);
+        }
+        if let Ok(hash) = tx_hash.parse::<TxHash>()
+            && let Some(receipt) = self.transactions.lock().get_mut(&hash)
+            && receipt.result.as_ref().is_some_and(Result::is_err)
+        {
+            receipt.result = None;
+            receipt.block_num = 0;
+        }
+        Ok(true)
     }
 
     // ── Logs ─────────────────────────────────────────────────────
@@ -562,16 +760,30 @@ impl Store for InMemoryStore {
         rollup_exit_root: Option<[u8; 32]>,
         timestamp: u64,
     ) -> anyhow::Result<()> {
-        self.mark_ger_seen(
-            global_exit_root,
-            GerEntry {
-                mainnet_exit_root,
-                rollup_exit_root,
-                block_number,
-                timestamp,
-            },
-        )
-        .await?;
+        // Observing the exact note is authoritative confirmation of the
+        // pre-submit handoff. Hold this guard through the in-memory commit so a
+        // recovery clear cannot interleave with event publication.
+        let mut links = self.tx_note_links.write();
+        if let Some(link) = links.get_mut(&tx_hash.to_lowercase()) {
+            link.state = NoteHandoffState::Submitted;
+            link.expiration_block = None;
+        }
+
+        {
+            let mut seen = self.seen_gers.write();
+            if !seen.contains_key(global_exit_root) {
+                seen.insert(
+                    *global_exit_root,
+                    GerEntry {
+                        mainnet_exit_root,
+                        rollup_exit_root,
+                        block_number,
+                        timestamp,
+                    },
+                );
+                *self.latest_ger.write() = Some(*global_exit_root);
+            }
+        }
 
         // Audit H2 — idempotent chain roll + log emission. A retry (e.g. after a
         // crash) used to roll the hash chain and emit a duplicate synthetic log
@@ -607,11 +819,33 @@ impl Store for InMemoryStore {
                 log_index: 0,
                 removed: false,
             };
-            self.add_log(log).await?;
+            let mut log = log;
+            let mut counter = self.log_counter.write();
+            log.log_index = *counter;
+            *counter += 1;
+            drop(counter);
+            self.logs_by_block
+                .write()
+                .entry(block_number)
+                .or_default()
+                .push(log.clone());
+            self.logs_by_tx
+                .write()
+                .entry(tx_hash.to_lowercase())
+                .or_default()
+                .push(log.clone());
+            self.pending_events.write().push(log);
         }
 
         // Always set is_injected = TRUE (idempotent).
         self.injected_gers.write().insert(*global_exit_root);
+        if let Ok(hash) = tx_hash.parse::<TxHash>()
+            && let Some(receipt) = self.transactions.lock().get_mut(&hash)
+        {
+            receipt.result = Some(Ok(()));
+            receipt.block_num = block_number;
+        }
+        drop(links);
         Ok(())
     }
 
@@ -671,7 +905,13 @@ impl Store for InMemoryStore {
         block_num: u64,
         block_hash: [u8; 32],
     ) -> anyhow::Result<()> {
+        // Once an exact handoff exists, an error is ambiguous until commit,
+        // observation, or expiration reconciliation. Never expose status 0.
         let logs_to_add = {
+            let links = self.tx_note_links.read();
+            if result.is_err() && links.contains_key(&format!("{tx_hash:#x}")) {
+                return Ok(());
+            }
             let mut txns = self.transactions.lock();
             let Some(receipt) = txns.get_mut(&tx_hash) else {
                 anyhow::bail!("Store: transaction {tx_hash} not found");
@@ -750,6 +990,35 @@ impl Store for InMemoryStore {
             block_num: receipt.block_num,
             logs: receipt.logs.clone(),
         }))
+    }
+
+    async fn pending_nonce_frontier(&self, addr: &str) -> anyhow::Result<PendingNonceFrontier> {
+        let addr = addr.to_lowercase();
+        let txns = self.transactions.lock();
+        let links = self.tx_note_links.read();
+        let mut frontier = PendingNonceFrontier::default();
+        for (tx_hash, receipt) in txns.iter() {
+            if receipt.result.is_some() || format!("{:#x}", receipt.signer).to_lowercase() != addr {
+                continue;
+            }
+            let nonce = super::envelope_nonce(&receipt.envelope);
+            frontier.lowest_pending = Some(
+                frontier
+                    .lowest_pending
+                    .map_or(nonce, |current| current.min(nonce)),
+            );
+            if !links
+                .get(&format!("{tx_hash:#x}"))
+                .is_some_and(|link| link.state == NoteHandoffState::Submitted)
+            {
+                frontier.lowest_unlinked = Some(
+                    frontier
+                        .lowest_unlinked
+                        .map_or(nonce, |current| current.min(nonce)),
+                );
+            }
+        }
+        Ok(frontier)
     }
 
     async fn txn_pending_by_miden_id(&self, id: TransactionId) -> anyhow::Result<Option<TxHash>> {
@@ -863,8 +1132,10 @@ impl Store for InMemoryStore {
                 // failed or expired attempt may have crossed an external side-effect
                 // boundary, so a different replacement can never take it over.
                 let takeover = r.tx_hash == tx_hash
-                    && (matches!(r.state, ReservationState::ReleasedFailure)
-                        || r.lease_expires_at <= now);
+                    && (matches!(
+                        r.state,
+                        ReservationState::ReleasedFailure | ReservationState::ReleasedSuccess
+                    ) || r.lease_expires_at <= now);
                 if takeover {
                     let fence = r.fence + 1;
                     reservations.insert(
@@ -945,6 +1216,7 @@ impl Store for InMemoryStore {
         // receipt committed with the nonce not yet advanced (or vice versa).
         // The row is inserted already committed-`failed` (empty logs, no
         // synthetic ClaimEvent), so there is no pending window.
+        let links = self.tx_note_links.read();
         let mut txns = self.transactions.lock();
         let mut nonces = self.nonces.write();
         // BLOCKER 4 — CONDITIONAL: never overwrite a REAL receipt. If this hash
@@ -956,10 +1228,7 @@ impl Store for InMemoryStore {
         // (idempotent re-affirm).
         let may_write = match txns.peek(&tx_hash).map(|r| &r.result) {
             None => true, // absent
-            Some(None) => !self
-                .tx_note_links
-                .read()
-                .contains_key(&format!("{tx_hash:#x}")),
+            Some(None) => !links.contains_key(&format!("{tx_hash:#x}")),
             // linked pending receipt is a real external handoff; an unlinked pending
             // row is only the durable pre-admission intent and may be reverted
             Some(Some(Ok(()))) => false, // successful real receipt — keep it
@@ -1029,7 +1298,9 @@ impl Store for InMemoryStore {
             .is_some_and(|deadline| deadline <= now)
             || (record.lease_expires_at.is_none()
                 && now.saturating_duration_since(record.acquired_at) >= lease);
-        if record.state != ClaimState::Executing || !expired {
+        if record.state != ClaimState::Executing
+            || (record.owner_tx_hash != Some(owner_tx_hash) && !expired)
+        {
             return Ok(None);
         }
         record.owner_tx_hash = Some(owner_tx_hash);
@@ -1041,16 +1312,27 @@ impl Store for InMemoryStore {
         }))
     }
 
-    async fn mark_claim_submitted_fenced(
+    async fn prepare_claim_submission_fenced(
         &self,
         global_index: U256,
         owner_tx_hash: TxHash,
         fence: u64,
         tx_hash: TxHash,
         note_commitment: &str,
+        note_id: &str,
+        expiration_block: u64,
     ) -> anyhow::Result<bool> {
         let now = self.claim_clock_now();
         let tx_key = format!("{tx_hash:#x}");
+        let mut links = self.tx_note_links.write();
+        if let Some(existing) = links.get(&tx_key) {
+            if existing.note_commitment != note_commitment
+                || existing.note_id.as_deref() != Some(note_id)
+            {
+                anyhow::bail!("transaction {tx_key} is already linked to a different claim note");
+            }
+            return Ok(false);
+        }
         let mut claimed = self.claimed.write();
         let Some(record) = claimed.get_mut(&global_index) else {
             return Ok(false);
@@ -1064,17 +1346,17 @@ impl Store for InMemoryStore {
         {
             return Ok(false);
         }
-        if let Some(existing) = self.tx_note_links.read().get(&tx_key)
-            && existing != note_commitment
-        {
-            anyhow::bail!("transaction {tx_key} is already linked to a different claim note");
-        }
-        record.state = ClaimState::Submitted;
+        links.insert(
+            tx_key.clone(),
+            NoteHandoffRecord {
+                note_commitment: note_commitment.to_string(),
+                note_id: Some(note_id.to_string()),
+                state: NoteHandoffState::Prepared,
+                expiration_block: Some(expiration_block),
+            },
+        );
+        record.state = ClaimState::Prepared;
         record.lease_expires_at = None;
-        self.tx_note_links
-            .write()
-            .entry(tx_key.clone())
-            .or_insert_with(|| note_commitment.to_string());
         self.note_tx_links
             .write()
             .entry(note_commitment.to_string())
@@ -1356,6 +1638,7 @@ impl Store for InMemoryStore {
         drop(logs);
         // Test hook (BLOCKER B): this call found NO event. If armed for this gi, LAND
         // it now so the NEXT call observes it, and still report this miss.
+        #[cfg(test)]
         {
             let mut armed = self.test_land_after_next_has_claim_miss.write();
             if armed.as_ref() == Some(global_index) {
@@ -1367,6 +1650,104 @@ impl Store for InMemoryStore {
             }
         }
         Ok(false)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn commit_manual_claim_event_atomic(
+        &self,
+        note_id: String,
+        bridge_address: &str,
+        block_number: u64,
+        block_hash: [u8; 32],
+        tx_hash: &str,
+        global_index: [u8; 32],
+        origin_network: u32,
+        origin_address: &[u8; 20],
+        destination_address: &[u8; 20],
+        amount: u64,
+    ) -> anyhow::Result<()> {
+        // Link -> claim is the global handoff lock order. A ClaimEvent is the
+        // terminal claim fence even on replay, so a publisher whose final read
+        // raced this commit cannot subsequently prepare under an executing row.
+        let mut links = self.tx_note_links.write();
+        if let Some(link) = links.get_mut(&tx_hash.to_lowercase()) {
+            link.state = NoteHandoffState::Submitted;
+            link.expiration_block = None;
+        }
+        let gi = U256::from_be_bytes(global_index);
+        let mut claimed = self.claimed.write();
+        match claimed.entry(gi) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let claim = entry.get_mut();
+                claim.state = ClaimState::Landed;
+                claim.lease_expires_at = None;
+                claim.fence += 1;
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(ClaimRecord {
+                    owner_tx_hash: None,
+                    state: ClaimState::Landed,
+                    acquired_at: self.claim_clock_now(),
+                    lease_expires_at: None,
+                    fence: 1,
+                });
+            }
+        }
+
+        let mut processed = self.claim_watcher_processed.write();
+        let inserted = match processed.entry(note_id) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(global_index);
+                true
+            }
+            std::collections::hash_map::Entry::Occupied(_) => false,
+        };
+
+        // Finalise a real linked receipt under the same in-process critical
+        // section. Derived hashes simply have no transaction row.
+        if let Ok(hash) = tx_hash.parse::<TxHash>()
+            && let Some(receipt) = self.transactions.lock().get_mut(&hash)
+        {
+            receipt.result = Some(Ok(()));
+            receipt.block_num = block_number;
+        }
+
+        if !inserted {
+            return Ok(());
+        }
+
+        let mut log = SyntheticLog {
+            address: bridge_address.to_string(),
+            topics: vec![crate::log_synthesis::CLAIM_EVENT_TOPIC.to_string()],
+            data: crate::log_synthesis::encode_claim_event_data_u64(
+                &global_index,
+                origin_network,
+                origin_address,
+                destination_address,
+                amount,
+            ),
+            block_number,
+            block_hash,
+            transaction_hash: tx_hash.to_lowercase(),
+            transaction_index: 0,
+            log_index: 0,
+            removed: false,
+        };
+        let mut counter = self.log_counter.write();
+        log.log_index = *counter;
+        *counter += 1;
+        self.logs_by_block
+            .write()
+            .entry(block_number)
+            .or_default()
+            .push(log.clone());
+        self.logs_by_tx
+            .write()
+            .entry(tx_hash.to_lowercase())
+            .or_default()
+            .push(log.clone());
+        self.pending_events.write().push(log);
+        Ok(())
     }
 
     // ── Faucet registry ──────────────────────────────────────────
@@ -1655,6 +2036,88 @@ mod tests {
         assert_eq!(
             store.get_tx_for_note("note_c").await.unwrap(),
             Some("0xtx2".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn prepared_handoff_clears_only_after_authoritative_expiration() {
+        let store = InMemoryStore::new();
+        let tx = "0xprepared";
+        store
+            .prepare_note_handoff(tx, "commitment", "note-id", 10)
+            .await
+            .unwrap();
+
+        store.set_reconcile_cursor(10).await.unwrap();
+        assert!(
+            !store
+                .clear_expired_prepared_note_handoff(tx, "commitment")
+                .await
+                .unwrap()
+        );
+        store.set_reconcile_cursor(11).await.unwrap();
+        assert!(
+            store
+                .clear_expired_prepared_note_handoff(tx, "commitment")
+                .await
+                .unwrap()
+        );
+        assert!(store.get_note_handoff_for_tx(tx).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn exact_observation_confirms_all_matching_handoffs_with_stable_attribution() {
+        let store = InMemoryStore::new();
+        store
+            .prepare_note_handoff("0xtx2", "same-note", "note-id-2", 10)
+            .await
+            .unwrap();
+        store
+            .prepare_note_handoff("0xtx1", "same-note", "note-id-1", 10)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store
+                .confirm_note_handoff_by_commitment("same-note")
+                .await
+                .unwrap(),
+            Some("0xtx2".to_string()),
+            "the first-associated tx remains the projector attribution"
+        );
+        for tx in ["0xtx1", "0xtx2"] {
+            assert_eq!(
+                store
+                    .get_note_handoff_for_tx(tx)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .state,
+                NoteHandoffState::Submitted
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn raw_note_id_confirmation_prevents_expiration_clear() {
+        let store = InMemoryStore::new();
+        store
+            .prepare_note_handoff("0xtx", "commitment", "exact-note-id", 10)
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .confirm_prepared_note_handoffs(&["exact-note-id".to_string()])
+                .await
+                .unwrap(),
+            1
+        );
+        store.set_reconcile_cursor(11).await.unwrap();
+        assert!(
+            !store
+                .clear_expired_prepared_note_handoff("0xtx", "commitment")
+                .await
+                .unwrap()
         );
     }
 
@@ -2149,6 +2612,65 @@ mod tests {
         );
         // And it must not have invented a receipt.
         assert!(store.txn_receipt(tx_hash).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn handoff_blocks_failure_receipt_until_authoritative_clear() {
+        use alloy::consensus::{Signed, TxLegacy};
+        use alloy::primitives::Signature;
+
+        let store = InMemoryStore::new();
+        let tx_hash = TxHash::from([0x78u8; 32]);
+        let tx_key = format!("{tx_hash:#x}");
+        let envelope = alloy::consensus::TxEnvelope::Legacy(Signed::new_unchecked(
+            TxLegacy::default(),
+            Signature::test_signature(),
+            tx_hash,
+        ));
+        store
+            .txn_begin(
+                tx_hash,
+                TxnEntry {
+                    id: None,
+                    envelope,
+                    signer: Address::ZERO,
+                    expires_at: Some(10),
+                    logs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .prepare_note_handoff(&tx_key, "commitment", "note-id", 10)
+            .await
+            .unwrap();
+
+        store
+            .txn_commit(tx_hash, Err("ambiguous".into()), 10, [0; 32])
+            .await
+            .unwrap();
+        assert!(store.txn_receipt(tx_hash).await.unwrap().is_none());
+
+        store.set_reconcile_cursor(11).await.unwrap();
+        assert!(
+            store
+                .clear_expired_prepared_note_handoff(&tx_key, "commitment")
+                .await
+                .unwrap()
+        );
+        store
+            .txn_commit(tx_hash, Err("definitive".into()), 11, [0; 32])
+            .await
+            .unwrap();
+        assert!(
+            store
+                .txn_receipt(tx_hash)
+                .await
+                .unwrap()
+                .unwrap()
+                .0
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1,6 +1,8 @@
 //! In-memory Store implementation — wraps HashMap/RwLock data structures.
 
-use super::{FaucetEntry, Store, TxnData, TxnEntry, UnbridgeableBridgeOut, UnclaimableClaim};
+use super::{
+    ClaimFence, FaucetEntry, Store, TxnData, TxnEntry, UnbridgeableBridgeOut, UnclaimableClaim,
+};
 use crate::log_synthesis::{
     GerEntry, L2_GLOBAL_EXIT_ROOT_ADDRESS, LogFilter, SyntheticLog, UPDATE_HASH_CHAIN_VALUE_TOPIC,
 };
@@ -39,6 +41,21 @@ enum ReservationState {
     ReleasedFailure,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ClaimState {
+    Executing,
+    Submitted,
+}
+
+#[derive(Clone)]
+struct ClaimRecord {
+    owner_tx_hash: Option<TxHash>,
+    state: ClaimState,
+    acquired_at: std::time::Instant,
+    lease_expires_at: Option<std::time::Instant>,
+    fence: u64,
+}
+
 pub struct InMemoryStore {
     // Block number
     latest_block_number: RwLock<u64>,
@@ -72,7 +89,7 @@ pub struct InMemoryStore {
     // `claim_clock_now`), so orphaned records (crash between the lock write and
     // the CLAIM landing) can be superseded after a TTL (`try_reclaim_expired`,
     // SOAK FINDING #1).
-    claimed: RwLock<HashMap<U256, std::time::Instant>>,
+    claimed: RwLock<HashMap<U256, ClaimRecord>>,
 
     // Test-only skew for the claim-lock clock. `test_backdate_claim` ages
     // records by moving this clock FORWARD instead of subtracting from the
@@ -618,6 +635,35 @@ impl Store for InMemoryStore {
         Ok(())
     }
 
+    async fn txn_begin_if_absent(&self, tx_hash: TxHash, entry: TxnEntry) -> anyhow::Result<bool> {
+        let mut txns = self.transactions.lock();
+        if let Some(receipt) = txns.get_mut(&tx_hash) {
+            if receipt.result.is_none() {
+                if entry.id.is_some() {
+                    receipt.id = entry.id;
+                }
+                if entry.expires_at.is_some() {
+                    receipt.expires_at = entry.expires_at;
+                }
+                if !entry.logs.is_empty() {
+                    receipt.logs = entry.logs;
+                }
+            }
+            return Ok(false);
+        }
+        let receipt = TxnReceipt {
+            id: entry.id,
+            envelope: entry.envelope,
+            signer: entry.signer,
+            expires_at: entry.expires_at,
+            result: None,
+            block_num: 0,
+            logs: entry.logs,
+        };
+        let _ = txns.put(tx_hash, receipt);
+        Ok(true)
+    }
+
     async fn txn_commit(
         &self,
         tx_hash: TxHash,
@@ -813,13 +859,12 @@ impl Store for InMemoryStore {
                 Ok(NonceReservation::Won { fence: 1 })
             }
             Some(r) => {
-                // STATE-FIRST (BLOCKER A): a holder that FAILED or whose lease EXPIRED
-                // consumed NO nonce, so the slot is free for takeover by ANY tx — the
-                // SAME tx (retry) OR a DIFFERENT tx. A holder that is executing under a
-                // valid lease, or already released_success, has consumed the nonce / is
-                // in flight, so a DIFFERENT tx hard-rejects and the SAME tx dedups.
-                let takeover = matches!(r.state, ReservationState::ReleasedFailure)
-                    || (r.state == ReservationState::Executing && r.lease_expires_at <= now);
+                // A nonce slot is permanently bound to its first tx hash. Even a
+                // failed or expired attempt may have crossed an external side-effect
+                // boundary, so a different replacement can never take it over.
+                let takeover = r.tx_hash == tx_hash
+                    && (matches!(r.state, ReservationState::ReleasedFailure)
+                        || r.lease_expires_at <= now);
                 if takeover {
                     let fence = r.fence + 1;
                     reservations.insert(
@@ -841,6 +886,25 @@ impl Store for InMemoryStore {
         }
     }
 
+    async fn renew_reservation(
+        &self,
+        addr: &str,
+        nonce: u64,
+        tx_hash: TxHash,
+        lease: std::time::Duration,
+    ) -> anyhow::Result<bool> {
+        let key = (addr.to_lowercase(), nonce);
+        let mut reservations = self.nonce_reservations.write();
+        if let Some(r) = reservations.get_mut(&key)
+            && r.tx_hash == tx_hash
+            && !matches!(r.state, ReservationState::ReleasedFailure)
+        {
+            r.lease_expires_at = std::time::Instant::now() + lease;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
     async fn release_reservation(
         &self,
         addr: &str,
@@ -859,6 +923,7 @@ impl Store for InMemoryStore {
             r.state = if success {
                 ReservationState::ReleasedSuccess
             } else {
+                r.lease_expires_at = std::time::Instant::now();
                 ReservationState::ReleasedFailure
             };
         }
@@ -890,8 +955,13 @@ impl Store for InMemoryStore {
         // write the reverted receipt when the hash is absent or already `failed`
         // (idempotent re-affirm).
         let may_write = match txns.peek(&tx_hash).map(|r| &r.result) {
-            None => true,                // absent
-            Some(None) => false,         // pending real receipt — keep it
+            None => true, // absent
+            Some(None) => !self
+                .tx_note_links
+                .read()
+                .contains_key(&format!("{tx_hash:#x}")),
+            // linked pending receipt is a real external handoff; an unlinked pending
+            // row is only the durable pre-admission intent and may be reverted
             Some(Some(Ok(()))) => false, // successful real receipt — keep it
             Some(Some(Err(_))) => true,  // already failed — re-affirm
         };
@@ -919,12 +989,133 @@ impl Store for InMemoryStore {
 
     // ── Claims ───────────────────────────────────────────────────
 
+    async fn try_claim_fenced(
+        &self,
+        global_index: U256,
+        owner_tx_hash: TxHash,
+        lease: std::time::Duration,
+    ) -> anyhow::Result<Option<ClaimFence>> {
+        let now = self.claim_clock_now();
+        let mut claimed = self.claimed.write();
+        if claimed.contains_key(&global_index) {
+            return Ok(None);
+        }
+        claimed.insert(
+            global_index,
+            ClaimRecord {
+                owner_tx_hash: Some(owner_tx_hash),
+                state: ClaimState::Executing,
+                acquired_at: now,
+                lease_expires_at: Some(now + lease),
+                fence: 1,
+            },
+        );
+        Ok(Some(ClaimFence { fence: 1 }))
+    }
+
+    async fn try_reclaim_claim_fenced(
+        &self,
+        global_index: U256,
+        owner_tx_hash: TxHash,
+        lease: std::time::Duration,
+    ) -> anyhow::Result<Option<ClaimFence>> {
+        let now = self.claim_clock_now();
+        let mut claimed = self.claimed.write();
+        let Some(record) = claimed.get_mut(&global_index) else {
+            return Ok(None);
+        };
+        let expired = record
+            .lease_expires_at
+            .is_some_and(|deadline| deadline <= now)
+            || (record.lease_expires_at.is_none()
+                && now.saturating_duration_since(record.acquired_at) >= lease);
+        if record.state != ClaimState::Executing || !expired {
+            return Ok(None);
+        }
+        record.owner_tx_hash = Some(owner_tx_hash);
+        record.acquired_at = now;
+        record.lease_expires_at = Some(now + lease);
+        record.fence += 1;
+        Ok(Some(ClaimFence {
+            fence: record.fence,
+        }))
+    }
+
+    async fn mark_claim_submitted_fenced(
+        &self,
+        global_index: U256,
+        owner_tx_hash: TxHash,
+        fence: u64,
+        tx_hash: TxHash,
+        note_commitment: &str,
+    ) -> anyhow::Result<bool> {
+        let now = self.claim_clock_now();
+        let tx_key = format!("{tx_hash:#x}");
+        let mut claimed = self.claimed.write();
+        let Some(record) = claimed.get_mut(&global_index) else {
+            return Ok(false);
+        };
+        if record.owner_tx_hash != Some(owner_tx_hash)
+            || record.fence != fence
+            || record.state != ClaimState::Executing
+            || record
+                .lease_expires_at
+                .is_none_or(|deadline| deadline <= now)
+        {
+            return Ok(false);
+        }
+        if let Some(existing) = self.tx_note_links.read().get(&tx_key)
+            && existing != note_commitment
+        {
+            anyhow::bail!("transaction {tx_key} is already linked to a different claim note");
+        }
+        record.state = ClaimState::Submitted;
+        record.lease_expires_at = None;
+        self.tx_note_links
+            .write()
+            .entry(tx_key.clone())
+            .or_insert_with(|| note_commitment.to_string());
+        self.note_tx_links
+            .write()
+            .entry(note_commitment.to_string())
+            .or_insert(tx_key);
+        Ok(true)
+    }
+
+    async fn unclaim_fenced(
+        &self,
+        global_index: &U256,
+        owner_tx_hash: TxHash,
+        fence: u64,
+    ) -> anyhow::Result<bool> {
+        let mut claimed = self.claimed.write();
+        let removable = claimed.get(global_index).is_some_and(|record| {
+            record.owner_tx_hash == Some(owner_tx_hash)
+                && record.fence == fence
+                && record.state == ClaimState::Executing
+        });
+        if removable {
+            claimed.remove(global_index);
+        }
+        Ok(removable)
+    }
+
     async fn try_claim(&self, global_index: U256) -> anyhow::Result<()> {
         let mut claimed = self.claimed.write();
         if claimed.contains_key(&global_index) {
             anyhow::bail!("claim already submitted for global_index {global_index}");
         }
-        claimed.insert(global_index, self.claim_clock_now());
+        let now = self.claim_clock_now();
+        claimed.insert(
+            global_index,
+            ClaimRecord {
+                owner_tx_hash: None,
+                state: ClaimState::Executing,
+                acquired_at: now,
+                lease_expires_at: None,
+                fence: 0,
+            },
+        );
         Ok(())
     }
 
@@ -938,8 +1129,12 @@ impl Store for InMemoryStore {
         let now = self.claim_clock_now();
         let mut claimed = self.claimed.write();
         match claimed.get_mut(&global_index) {
-            Some(acquired_at) if now.saturating_duration_since(*acquired_at) >= ttl => {
-                *acquired_at = now;
+            Some(record)
+                if record.owner_tx_hash.is_none()
+                    && record.state == ClaimState::Executing
+                    && now.saturating_duration_since(record.acquired_at) >= ttl =>
+            {
+                record.acquired_at = now;
                 Ok(true)
             }
             _ => Ok(false),

--- a/src/store/migrator.rs
+++ b/src/store/migrator.rs
@@ -90,6 +90,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "011_nonce_reservations.sql",
         include_str!("../../migrations/011_nonce_reservations.sql"),
     ),
+    (
+        "012_submission_handoffs.sql",
+        include_str!("../../migrations/012_submission_handoffs.sql"),
+    ),
 ];
 
 /// Postgres advisory-lock key. Arbitrary 64-bit int; just needs to be

--- a/src/store/migrator.rs
+++ b/src/store/migrator.rs
@@ -86,6 +86,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "010_reconcile_cursor.sql",
         include_str!("../../migrations/010_reconcile_cursor.sql"),
     ),
+    (
+        "011_nonce_reservations.sql",
+        include_str!("../../migrations/011_nonce_reservations.sql"),
+    ),
 ];
 
 /// Postgres advisory-lock key. Arbitrary 64-bit int; just needs to be

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -437,6 +437,15 @@ pub trait Store: Send + Sync + 'static {
     }
     /// Return the durable prepared/submitted state for an exact note handoff.
     async fn get_note_handoff_for_tx(&self, tx_hash: &str) -> anyhow::Result<Option<NoteHandoff>>;
+    /// Return at most `limit` terminal-less transactions with an exact durable
+    /// note handoff whose hash sorts after `after`. The background projector
+    /// uses this bounded cursor query to reconcile confirmed duplicates fairly;
+    /// receipt polling never calls it.
+    async fn pending_note_handoff_txs(
+        &self,
+        after: Option<TxHash>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<TxHash>>;
     /// Persist an exact note identity immediately before the external submit.
     async fn prepare_note_handoff(
         &self,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -118,16 +118,23 @@ pub struct TxnEntry {
     pub logs: Vec<LogData>,
 }
 
-/// Outcome of [`Store::reserve_nonce`] — the atomic `(signer, nonce)` slot claim
-/// (#55 BLOCKER 1).
+/// Outcome of [`Store::reserve_nonce`] — the atomic, FENCED `(signer, nonce)`
+/// admission-lease claim (#55 BLOCKER 1).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NonceReservation {
-    /// THIS call inserted the reservation — this tx owns the slot and may execute.
-    Won,
-    /// The slot was already reserved; the winner's tx hash is carried. If it equals
-    /// this tx's own hash the reservation is idempotent (a rebroadcast / re-entry);
-    /// otherwise a DIFFERENT tx won the race and this submission must be rejected.
-    HeldBy(TxHash),
+    /// This call WON ownership of the admission lease — fresh, or a takeover of an
+    /// EXPIRED lease / a `released_failure` prior attempt by the same tx. This
+    /// replica (and ONLY this replica) may execute; the `fence` token must be
+    /// passed to [`Store::release_reservation`] so a delayed prior owner cannot
+    /// clobber this owner's release.
+    Won { fence: u64 },
+    /// The slot is currently owned+executing by the SAME tx under a VALID lease
+    /// (another replica is admitting it), or it already `released_success`. Do NOT
+    /// execute — dedup-return the hash; the owner produces the receipt.
+    OwnedBySame,
+    /// A DIFFERENT tx owns/owned this slot. Hard reject — this submission must not
+    /// execute.
+    HeldByOther(TxHash),
 }
 
 /// Record of a claim we dropped because the destination could not be resolved to a
@@ -480,17 +487,41 @@ pub trait Store: Send + Sync + 'static {
     /// (which may be this same tx — an idempotent re-reservation — or a DIFFERENT
     /// tx that raced and won).
     ///
-    /// MUST be atomic at the store level (single `INSERT … ON CONFLICT DO NOTHING`
-    /// + read of the winner / lock-guarded map insert), so that two replicas on a
-    /// shared PostgreSQL that each pass their process-local R4 for two DIFFERENT
-    /// txs at the same `(signer, nonce)` cannot BOTH be told they won — exactly one
-    /// wins and executes; the loser must be rejected without any side effect.
+    /// MUST be atomic at the store level (postgres: `SELECT … FOR UPDATE` +
+    /// conditional INSERT/UPDATE in ONE transaction; memory: one lock), so that two
+    /// replicas that each pass their process-local R4 for the same `(signer,
+    /// nonce)` are resolved deterministically:
+    ///   * a DIFFERENT tx → [`NonceReservation::HeldByOther`] (hard reject);
+    ///   * the SAME tx while the owner's lease is VALID (executing) or already
+    ///     `released_success` → [`NonceReservation::OwnedBySame`] (dedup, do NOT
+    ///     execute — the owner produces the receipt);
+    ///   * the SAME tx after the lease EXPIRED or a `released_failure` → takeover:
+    ///     [`NonceReservation::Won`] with a bumped fence (retry admission).
+    /// `lease` is how long the winner owns admission before another replica may
+    /// take over on expiry (crash recovery).
     async fn reserve_nonce(
         &self,
         addr: &str,
         nonce: u64,
         tx_hash: TxHash,
+        lease: std::time::Duration,
     ) -> anyhow::Result<NonceReservation>;
+
+    /// #55 BLOCKER 1 — release the admission lease won by [`Store::reserve_nonce`].
+    /// Transitions the reservation to `released_success` (admission completed — the
+    /// SAME tx henceforth dedups) or `released_failure` (admission failed — the SAME
+    /// tx may retry via takeover). FENCED: only applies while the row is still
+    /// `executing` under the given `fence` token, so a delayed prior owner whose
+    /// lease expired and was taken over (fence bumped) CANNOT clobber the new
+    /// owner's state. A no-op if already released or fenced out.
+    async fn release_reservation(
+        &self,
+        addr: &str,
+        nonce: u64,
+        tx_hash: TxHash,
+        fence: u64,
+        success: bool,
+    ) -> anyhow::Result<()>;
 
     /// #55 BLOCKER D — COMPARE-AND-SWAP nonce advance. Advance the stored nonce to
     /// `expected + 1` **iff** the current stored value equals `expected` (a fresh

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -129,8 +129,8 @@ pub enum NonceReservation {
     /// clobber this owner's release.
     Won { fence: u64 },
     /// The slot is currently owned+executing by the SAME tx under a VALID lease
-    /// (another replica is admitting it), or it already `released_success`. Do NOT
-    /// execute — dedup-return the hash; the owner produces the receipt.
+    /// (another replica is admitting it). Do NOT execute — dedup-return the hash;
+    /// the owner produces the receipt.
     OwnedBySame,
     /// A DIFFERENT tx owns/owned this slot. Hard reject — this submission must not
     /// execute.
@@ -141,6 +141,25 @@ pub enum NonceReservation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ClaimFence {
     pub fence: u64,
+}
+
+/// Durable state of the exact Miden note associated with an Ethereum write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoteHandoffState {
+    /// The exact note identity is durable, but inclusion has not been observed.
+    Prepared,
+    /// The transaction committed or the exact note was later observed.
+    Submitted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoteHandoff {
+    pub note_commitment: String,
+    pub note_id: Option<String>,
+    pub state: NoteHandoffState,
+    /// The executed Miden transaction's expiration block. Present for prepared
+    /// rows; a missing value is treated fail-closed and is never cleared.
+    pub expiration_block: Option<u64>,
 }
 
 /// Record of a claim we dropped because the destination could not be resolved to a
@@ -274,6 +293,28 @@ pub struct TxnData {
     pub logs: Vec<LogData>,
 }
 
+/// Durable pending-nonce frontier for one recovered signer.
+///
+/// `lowest_pending` is the committed-nonce boundary used by
+/// `eth_getTransactionCount(..., "latest")`. `lowest_unlinked` is the oldest
+/// accepted transaction that has not crossed the Miden note-handoff boundary;
+/// later nonces must not be admitted ahead of it after a process restart.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PendingNonceFrontier {
+    pub lowest_pending: Option<u64>,
+    pub lowest_unlinked: Option<u64>,
+}
+
+pub(crate) fn envelope_nonce(envelope: &TxEnvelope) -> u64 {
+    match envelope {
+        TxEnvelope::Eip1559(s) => s.tx().nonce,
+        TxEnvelope::Eip2930(s) => s.tx().nonce,
+        TxEnvelope::Eip4844(s) => s.tx().tx().nonce,
+        TxEnvelope::Eip7702(s) => s.tx().nonce,
+        TxEnvelope::Legacy(s) => s.tx().nonce,
+    }
+}
+
 impl TxnData {
     /// Build an `alloy::rpc::types::Transaction` for JSON-RPC responses.
     pub fn to_rpc_transaction(
@@ -394,6 +435,38 @@ pub trait Store: Send + Sync + 'static {
     async fn get_tx_for_note(&self, _note_commitment: &str) -> anyhow::Result<Option<String>> {
         Ok(None)
     }
+    /// Return the durable prepared/submitted state for an exact note handoff.
+    async fn get_note_handoff_for_tx(&self, tx_hash: &str) -> anyhow::Result<Option<NoteHandoff>>;
+    /// Persist an exact note identity immediately before the external submit.
+    async fn prepare_note_handoff(
+        &self,
+        tx_hash: &str,
+        note_commitment: &str,
+        note_id: &str,
+        expiration_block: u64,
+    ) -> anyhow::Result<()>;
+    /// Confirm Miden acceptance (or later exact-note observation).
+    async fn confirm_note_handoff(
+        &self,
+        tx_hash: &str,
+        note_commitment: &str,
+    ) -> anyhow::Result<bool>;
+    /// Confirm a prepared handoff from an observed note details commitment and
+    /// return its real Ethereum transaction hash.
+    async fn confirm_note_handoff_by_commitment(
+        &self,
+        note_commitment: &str,
+    ) -> anyhow::Result<Option<String>>;
+    /// Confirm prepared handoffs directly from a reconciler window's raw note
+    /// IDs, before body import/fetch and cursor advancement.
+    async fn confirm_prepared_note_handoffs(&self, note_ids: &[String]) -> anyhow::Result<u64>;
+    /// Clear only the same exact prepared handoff after an authoritative sync is
+    /// strictly past its Miden expiration block. Returns true when retry may proceed.
+    async fn clear_expired_prepared_note_handoff(
+        &self,
+        tx_hash: &str,
+        note_commitment: &str,
+    ) -> anyhow::Result<bool>;
 
     // === Synthetic logs ===
     async fn add_log(&self, log: SyntheticLog) -> anyhow::Result<()>;
@@ -475,6 +548,9 @@ pub trait Store: Send + Sync + 'static {
         tx_hash: TxHash,
     ) -> anyhow::Result<Option<(Result<(), String>, u64)>>;
     async fn txn_get(&self, tx_hash: TxHash) -> anyhow::Result<Option<TxnData>>;
+    /// Return the durable pending-nonce boundary for `addr`. Unlike the writer
+    /// DashMap, this survives restart and covers both sync and async admission.
+    async fn pending_nonce_frontier(&self, addr: &str) -> anyhow::Result<PendingNonceFrontier>;
     async fn txn_pending_by_miden_id(&self, id: TransactionId) -> anyhow::Result<Option<TxHash>>;
     async fn txn_commit_pending(
         &self,
@@ -491,20 +567,19 @@ pub trait Store: Send + Sync + 'static {
 
     /// #55 BLOCKER 1 — atomic `(signer, nonce)` reservation. Insert-if-absent keyed
     /// on `(addr, nonce)`; the winner's `tx_hash` is durable. Returns
-    /// [`NonceReservation::Won`] iff THIS call inserted the row (this tx owns the
-    /// slot), or [`NonceReservation::HeldBy`] with the winner's hash otherwise
-    /// (which may be this same tx — an idempotent re-reservation — or a DIFFERENT
-    /// tx that raced and won).
+    /// [`NonceReservation::Won`] iff this call owns the lease, otherwise
+    /// [`NonceReservation::OwnedBySame`] for the same hash or
+    /// [`NonceReservation::HeldByOther`] for a different winner.
     ///
     /// MUST be atomic at the store level (postgres: `SELECT … FOR UPDATE` +
     /// conditional INSERT/UPDATE in ONE transaction; memory: one lock), so that two
     /// replicas that each pass their process-local R4 for the same `(signer,
     /// nonce)` are resolved deterministically:
     ///   * a DIFFERENT tx → [`NonceReservation::HeldByOther`] (hard reject);
-    ///   * the SAME tx while the owner's lease is VALID (executing) or already
-    ///     `released_success` → [`NonceReservation::OwnedBySame`] (dedup, do NOT
-    ///     execute — the owner produces the receipt);
-    ///   * the SAME tx after the lease EXPIRED or a `released_failure` → takeover:
+    ///   * the SAME tx while the owner's lease is VALID and `executing` →
+    ///     [`NonceReservation::OwnedBySame`] (dedup, do NOT execute);
+    ///   * the SAME tx after lease expiry, `released_failure`, or
+    ///     `released_success` → takeover:
     ///     [`NonceReservation::Won`] with a bumped fence (retry admission).
     /// `lease` is how long the winner owns admission before another replica
     /// presenting the SAME hash may take over on expiry (crash recovery). The
@@ -526,8 +601,8 @@ pub trait Store: Send + Sync + 'static {
         lease: std::time::Duration,
     ) -> anyhow::Result<bool>;
 
-    /// Fenced completion of a won admission. Success retains its recovery lease;
-    /// failure becomes immediately retryable by the same hash only.
+    /// Fenced completion of a won admission. Either terminal state remains bound
+    /// to this hash and is immediately reclaimable by that exact durable retry.
     async fn release_reservation(
         &self,
         addr: &str,
@@ -588,14 +663,18 @@ pub trait Store: Send + Sync + 'static {
         owner_tx_hash: TxHash,
         lease: std::time::Duration,
     ) -> anyhow::Result<Option<ClaimFence>>;
-    /// Seal the current fence before the first external submission side effect.
-    async fn mark_claim_submitted_fenced(
+    /// Atomically seal the current fence and persist an exact prepared note
+    /// identity before the first external submission side effect.
+    #[allow(clippy::too_many_arguments)]
+    async fn prepare_claim_submission_fenced(
         &self,
         global_index: U256,
         owner_tx_hash: TxHash,
         fence: u64,
         tx_hash: TxHash,
         note_commitment: &str,
+        note_id: &str,
+        expiration_block: u64,
     ) -> anyhow::Result<bool>;
     /// Release only the current executing owner; stale owners cannot delete successors.
     async fn unclaim_fenced(
@@ -826,17 +905,14 @@ pub trait Store: Send + Sync + 'static {
         global_index: &[u8; 32],
     ) -> anyhow::Result<bool>;
 
-    /// Atomic commit for a watcher-synthesised ClaimEvent. Combines:
-    ///   1. `mark_claim_note_processed`
-    ///   2. `add_claim_event` (synthetic log emission)
-    ///   3. `set_latest_block_number` (cursor advance)
+    /// Atomic commit for a watcher-synthesised ClaimEvent. In one all-or-nothing
+    /// operation this marks the note processed, emits the synthetic log, and
+    /// finalises a linked pending transaction (when `tx_hash` names one).
     ///
-    /// PgStore overrides with a single SERIALIZABLE postgres txn; the default
-    /// impl below chains the three primitives sequentially, which is fine for
-    /// `InMemoryStore` where every primitive is an in-process lock. The
-    /// race-safe ordering (log THEN cursor) is the same invariant
-    /// `the projector B2AGG commit` and `the projector GER commit` enforce — see
-    /// the canonical comment at `src/bridge_out.rs::on_post_sync`.
+    /// The synthetic block tip is deliberately *not* advanced here. A block may
+    /// contain more notes; `SyntheticProjector` seals the block only after every
+    /// note has been projected. There is no default implementation so each store
+    /// must preserve the event/receipt atomicity contract.
     #[allow(clippy::too_many_arguments)]
     async fn commit_manual_claim_event_atomic(
         &self,
@@ -850,24 +926,7 @@ pub trait Store: Send + Sync + 'static {
         origin_address: &[u8; 20],
         destination_address: &[u8; 20],
         amount: u64,
-    ) -> anyhow::Result<()> {
-        self.mark_claim_note_processed(note_id, global_index, block_number)
-            .await?;
-        self.add_claim_event(
-            bridge_address,
-            block_number,
-            block_hash,
-            tx_hash,
-            &global_index,
-            origin_network,
-            origin_address,
-            destination_address,
-            amount,
-        )
-        .await?;
-        self.set_latest_block_number(block_number).await?;
-        Ok(())
-    }
+    ) -> anyhow::Result<()>;
 
     // === Faucet registry ===
     /// Register or update a faucet entry (upsert by faucet_id).

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -137,6 +137,12 @@ pub enum NonceReservation {
     HeldByOther(TxHash),
 }
 
+/// Fenced ownership token for an in-progress claim submission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClaimFence {
+    pub fence: u64,
+}
+
 /// Record of a claim we dropped because the destination could not be resolved to a
 /// Miden AccountId. See RD-860: storing these lets operators inspect the backlog and
 /// audit what happened to a user's funds when support asks about a specific deposit.
@@ -454,6 +460,9 @@ pub trait Store: Send + Sync + 'static {
 
     // === Transactions ===
     async fn txn_begin(&self, tx_hash: TxHash, entry: TxnEntry) -> anyhow::Result<()>;
+    /// Durably admit a transaction before advancing its nonce. Idempotent for the
+    /// same tx hash; returns true when this call inserted the pending row.
+    async fn txn_begin_if_absent(&self, tx_hash: TxHash, entry: TxnEntry) -> anyhow::Result<bool>;
     async fn txn_commit(
         &self,
         tx_hash: TxHash,
@@ -497,8 +506,9 @@ pub trait Store: Send + Sync + 'static {
     ///     execute — the owner produces the receipt);
     ///   * the SAME tx after the lease EXPIRED or a `released_failure` → takeover:
     ///     [`NonceReservation::Won`] with a bumped fence (retry admission).
-    /// `lease` is how long the winner owns admission before another replica may
-    /// take over on expiry (crash recovery).
+    /// `lease` is how long the winner owns admission before another replica
+    /// presenting the SAME hash may take over on expiry (crash recovery). The
+    /// slot remains permanently bound to its first hash.
     async fn reserve_nonce(
         &self,
         addr: &str,
@@ -507,13 +517,17 @@ pub trait Store: Send + Sync + 'static {
         lease: std::time::Duration,
     ) -> anyhow::Result<NonceReservation>;
 
-    /// #55 BLOCKER 1 — release the admission lease won by [`Store::reserve_nonce`].
-    /// Transitions the reservation to `released_success` (admission completed — the
-    /// SAME tx henceforth dedups) or `released_failure` (admission failed — the SAME
-    /// tx may retry via takeover). FENCED: only applies while the row is still
-    /// `executing` under the given `fence` token, so a delayed prior owner whose
-    /// lease expired and was taken over (fence bumped) CANNOT clobber the new
-    /// owner's state. A no-op if already released or fenced out.
+    /// Extend the lease for the same durable transaction while it is queued or running.
+    async fn renew_reservation(
+        &self,
+        addr: &str,
+        nonce: u64,
+        tx_hash: TxHash,
+        lease: std::time::Duration,
+    ) -> anyhow::Result<bool>;
+
+    /// Fenced completion of a won admission. Success retains its recovery lease;
+    /// failure becomes immediately retryable by the same hash only.
     async fn release_reservation(
         &self,
         addr: &str,
@@ -560,6 +574,37 @@ pub trait Store: Send + Sync + 'static {
     ) -> anyhow::Result<bool>;
 
     // === Claims ===
+    /// Acquire a new claim lease. A conflict returns None.
+    async fn try_claim_fenced(
+        &self,
+        global_index: U256,
+        owner_tx_hash: TxHash,
+        lease: std::time::Duration,
+    ) -> anyhow::Result<Option<ClaimFence>>;
+    /// Reclaim only an expired executing lease and bump its fence.
+    async fn try_reclaim_claim_fenced(
+        &self,
+        global_index: U256,
+        owner_tx_hash: TxHash,
+        lease: std::time::Duration,
+    ) -> anyhow::Result<Option<ClaimFence>>;
+    /// Seal the current fence before the first external submission side effect.
+    async fn mark_claim_submitted_fenced(
+        &self,
+        global_index: U256,
+        owner_tx_hash: TxHash,
+        fence: u64,
+        tx_hash: TxHash,
+        note_commitment: &str,
+    ) -> anyhow::Result<bool>;
+    /// Release only the current executing owner; stale owners cannot delete successors.
+    async fn unclaim_fenced(
+        &self,
+        global_index: &U256,
+        owner_tx_hash: TxHash,
+        fence: u64,
+    ) -> anyhow::Result<bool>;
+
     async fn try_claim(&self, global_index: U256) -> anyhow::Result<()>;
     async fn unclaim(&self, global_index: &U256) -> anyhow::Result<()>;
     async fn is_claimed(&self, global_index: &U256) -> anyhow::Result<bool>;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -118,6 +118,18 @@ pub struct TxnEntry {
     pub logs: Vec<LogData>,
 }
 
+/// Outcome of [`Store::reserve_nonce`] — the atomic `(signer, nonce)` slot claim
+/// (#55 BLOCKER 1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NonceReservation {
+    /// THIS call inserted the reservation — this tx owns the slot and may execute.
+    Won,
+    /// The slot was already reserved; the winner's tx hash is carried. If it equals
+    /// this tx's own hash the reservation is idempotent (a rebroadcast / re-entry);
+    /// otherwise a DIFFERENT tx won the race and this submission must be rejected.
+    HeldBy(TxHash),
+}
+
 /// Record of a claim we dropped because the destination could not be resolved to a
 /// Miden AccountId. See RD-860: storing these lets operators inspect the backlog and
 /// audit what happened to a user's funds when support asks about a specific deposit.
@@ -460,6 +472,25 @@ pub trait Store: Send + Sync + 'static {
     async fn nonce_get(&self, addr: &str) -> anyhow::Result<u64>;
     /// Increment nonce, returning the value **before** increment.
     async fn nonce_increment(&self, addr: &str) -> anyhow::Result<u64>;
+
+    /// #55 BLOCKER 1 — atomic `(signer, nonce)` reservation. Insert-if-absent keyed
+    /// on `(addr, nonce)`; the winner's `tx_hash` is durable. Returns
+    /// [`NonceReservation::Won`] iff THIS call inserted the row (this tx owns the
+    /// slot), or [`NonceReservation::HeldBy`] with the winner's hash otherwise
+    /// (which may be this same tx — an idempotent re-reservation — or a DIFFERENT
+    /// tx that raced and won).
+    ///
+    /// MUST be atomic at the store level (single `INSERT … ON CONFLICT DO NOTHING`
+    /// + read of the winner / lock-guarded map insert), so that two replicas on a
+    /// shared PostgreSQL that each pass their process-local R4 for two DIFFERENT
+    /// txs at the same `(signer, nonce)` cannot BOTH be told they won — exactly one
+    /// wins and executes; the loser must be rejected without any side effect.
+    async fn reserve_nonce(
+        &self,
+        addr: &str,
+        nonce: u64,
+        tx_hash: TxHash,
+    ) -> anyhow::Result<NonceReservation>;
 
     /// #55 BLOCKER D — COMPARE-AND-SWAP nonce advance. Advance the stored nonce to
     /// `expected + 1` **iff** the current stored value equals `expected` (a fresh

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -543,6 +543,15 @@ pub trait Store: Send + Sync + 'static {
         block_num: u64,
         block_hash: [u8; 32],
     ) -> anyhow::Result<()>;
+    /// Finalize a note-linked pending transaction only after bridge state and its
+    /// exact NoteId prove another transaction applied the operation. This emits no
+    /// event and must not overwrite an existing terminal receipt.
+    async fn txn_commit_confirmed_duplicate(
+        &self,
+        tx_hash: TxHash,
+        result: Result<(), String>,
+        block_num: u64,
+    ) -> anyhow::Result<()>;
     async fn txn_receipt(
         &self,
         tx_hash: TxHash,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -461,6 +461,42 @@ pub trait Store: Send + Sync + 'static {
     /// Increment nonce, returning the value **before** increment.
     async fn nonce_increment(&self, addr: &str) -> anyhow::Result<u64>;
 
+    /// #55 BLOCKER D — COMPARE-AND-SWAP nonce advance. Advance the stored nonce to
+    /// `expected + 1` **iff** the current stored value equals `expected` (a fresh
+    /// address is treated as nonce 0). Returns `true` iff it won the CAS (advanced).
+    ///
+    /// MUST be atomic at the store level (single conditional UPDATE / lock-guarded
+    /// CAS), so that under a shared PostgreSQL with rolling replicas two replicas
+    /// that both read expected nonce `N` cannot BOTH advance (`N → N+2`, skipping a
+    /// nonce → wedge). The process-local `per_signer_lock` only serialises within
+    /// one replica; this CAS is the cross-replica guarantee. Used on the accept
+    /// path (in place of the unconditional `nonce_increment`) and by the crash-gap
+    /// repair.
+    async fn nonce_advance_cas(&self, addr: &str, expected: u64) -> anyhow::Result<bool>;
+
+    /// #55 BLOCKER C — atomically persist a REVERTED receipt (status 0x0, EMPTY
+    /// logs, no ClaimEvent) for `tx_hash` **and** CAS-advance the signer's nonce, in
+    /// ONE store transaction, so a crash can never leave a half state — no
+    /// pending-forever receipt (the row is written already committed-`failed`, never
+    /// a separate `txn_begin`→`txn_commit`) and no stale nonce.
+    ///
+    /// The nonce CAS advances iff the current nonce == `expected_nonce` (the sync
+    /// accept path, where the nonce has not yet advanced). In async-writer mode the
+    /// enqueue already CAS-advanced it, so this CAS is a no-op and only the receipt
+    /// is written. Idempotent on `tx_hash` (a rebroadcast/re-entry re-affirms the
+    /// same committed-reverted row). Returns whether the nonce advanced here.
+    #[allow(clippy::too_many_arguments)]
+    async fn commit_reverted_receipt_and_advance_nonce(
+        &self,
+        tx_hash: TxHash,
+        entry: TxnEntry,
+        reason: String,
+        block_num: u64,
+        block_hash: [u8; 32],
+        addr: &str,
+        expected_nonce: u64,
+    ) -> anyhow::Result<bool>;
+
     // === Claims ===
     async fn try_claim(&self, global_index: U256) -> anyhow::Result<()>;
     async fn unclaim(&self, global_index: &U256) -> anyhow::Result<()>;

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -259,6 +259,39 @@ impl Store for PgStore {
         .transpose()
     }
 
+    async fn pending_note_handoff_txs(
+        &self,
+        after: Option<TxHash>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<TxHash>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let client = self.pool.get().await?;
+        let after = after.map(|tx_hash| format!("{tx_hash:#x}"));
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let rows = client
+            .query(
+                "SELECT t.tx_hash
+                 FROM transactions t
+                 INNER JOIN tx_note_links l ON l.tx_hash = t.tx_hash
+                 WHERE t.status = 'pending' AND l.note_id IS NOT NULL
+                   AND ($1::TEXT IS NULL OR t.tx_hash > $1)
+                 ORDER BY t.tx_hash ASC
+                 LIMIT $2",
+                &[&after, &limit],
+            )
+            .await?;
+        rows.into_iter()
+            .map(|row| {
+                let hash: String = row.get(0);
+                hash.parse::<TxHash>().map_err(|error| {
+                    anyhow::anyhow!("invalid pending transaction hash {hash}: {error}")
+                })
+            })
+            .collect()
+    }
+
     async fn prepare_note_handoff(
         &self,
         tx_hash: &str,

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1130,35 +1130,101 @@ impl Store for PgStore {
         addr: &str,
         nonce: u64,
         tx_hash: TxHash,
+        lease: std::time::Duration,
     ) -> anyhow::Result<crate::store::NonceReservation> {
-        let client = self.pool.get().await?;
+        use crate::store::NonceReservation;
+        let mut client = self.pool.get().await?;
         let key = addr.to_lowercase();
         let hash_str = format!("{tx_hash:#x}");
-        // Insert-if-absent; RETURNING yields a row IFF THIS statement inserted (won
-        // the atomic race — postgres serialises concurrent inserts on the PK). A
-        // conflict (no returned row) means the slot is already held; read the
-        // durable winner (the row never changes once inserted). So exactly one
-        // replica is ever told `Won`, even for two replicas submitting the same hash.
-        let inserted = client
+        let lease_secs = lease.as_secs().max(1) as f64;
+
+        // ONE transaction: lock the slot row (FOR UPDATE), then decide + write.
+        // Serialises concurrent replicas on the (signer, nonce) row so exactly one
+        // is ever told `Won`.
+        let tx = client.transaction().await?;
+        let existing = tx
             .query_opt(
-                "INSERT INTO nonce_reservations (signer, nonce, tx_hash) VALUES ($1, $2, $3)
-                 ON CONFLICT (signer, nonce) DO NOTHING
-                 RETURNING tx_hash",
-                &[&key, &(nonce as i64), &hash_str],
-            )
-            .await?;
-        if inserted.is_some() {
-            return Ok(crate::store::NonceReservation::Won);
-        }
-        let row = client
-            .query_one(
-                "SELECT tx_hash FROM nonce_reservations WHERE signer = $1 AND nonce = $2",
+                "SELECT tx_hash, state, (lease_expires_at <= now()) AS expired, fence_token
+                 FROM nonce_reservations WHERE signer = $1 AND nonce = $2 FOR UPDATE",
                 &[&key, &(nonce as i64)],
             )
             .await?;
-        let winner: String = row.get(0);
-        let other = <TxHash as std::str::FromStr>::from_str(&winner).unwrap_or_default();
-        Ok(crate::store::NonceReservation::HeldBy(other))
+        let outcome = match existing {
+            None => {
+                tx.execute(
+                    "INSERT INTO nonce_reservations (signer, nonce, tx_hash, state, lease_expires_at, fence_token)
+                     VALUES ($1, $2, $3, 'executing', now() + ($4 || ' seconds')::interval, 1)",
+                    &[&key, &(nonce as i64), &hash_str, &lease_secs.to_string()],
+                )
+                .await?;
+                NonceReservation::Won { fence: 1 }
+            }
+            Some(row) => {
+                let row_hash: String = row.get(0);
+                if !row_hash.eq_ignore_ascii_case(&hash_str) {
+                    let other =
+                        <TxHash as std::str::FromStr>::from_str(&row_hash).unwrap_or_default();
+                    NonceReservation::HeldByOther(other)
+                } else {
+                    let state: String = row.get(1);
+                    let expired: bool = row.get(2);
+                    let fence: i64 = row.get(3);
+                    let takeover = state == "released_failure" || (state == "executing" && expired);
+                    if takeover {
+                        let new_fence = fence + 1;
+                        tx.execute(
+                            "UPDATE nonce_reservations SET state = 'executing',
+                             lease_expires_at = now() + ($3 || ' seconds')::interval,
+                             fence_token = $4
+                             WHERE signer = $1 AND nonce = $2",
+                            &[&key, &(nonce as i64), &lease_secs.to_string(), &new_fence],
+                        )
+                        .await?;
+                        NonceReservation::Won {
+                            fence: new_fence as u64,
+                        }
+                    } else {
+                        NonceReservation::OwnedBySame
+                    }
+                }
+            }
+        };
+        tx.commit().await?;
+        Ok(outcome)
+    }
+
+    async fn release_reservation(
+        &self,
+        addr: &str,
+        nonce: u64,
+        tx_hash: TxHash,
+        fence: u64,
+        success: bool,
+    ) -> anyhow::Result<()> {
+        let client = self.pool.get().await?;
+        let key = addr.to_lowercase();
+        let hash_str = format!("{tx_hash:#x}");
+        let new_state = if success {
+            "released_success"
+        } else {
+            "released_failure"
+        };
+        // FENCED: only the current fence owner still in `executing` may release.
+        client
+            .execute(
+                "UPDATE nonce_reservations SET state = $5, lease_expires_at = now()
+                 WHERE signer = $1 AND nonce = $2 AND tx_hash = $3 AND fence_token = $4
+                   AND state = 'executing'",
+                &[
+                    &key,
+                    &(nonce as i64),
+                    &hash_str,
+                    &(fence as i64),
+                    &new_state,
+                ],
+            )
+            .await?;
+        Ok(())
     }
 
     async fn commit_reverted_receipt_and_advance_nonce(

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -4,8 +4,9 @@
 //! with the schema from `migrations/001_initial.sql` applied.
 
 use super::{
-    ClaimFence, FaucetEntry, Store, TxnData, TxnEntry, UnbridgeableBridgeOut,
-    UnbridgeableBridgeOutReason, UnclaimableClaim, UnclaimableReason,
+    ClaimFence, FaucetEntry, NoteHandoff, NoteHandoffState, PendingNonceFrontier, Store, TxnData,
+    TxnEntry, UnbridgeableBridgeOut, UnbridgeableBridgeOutReason, UnclaimableClaim,
+    UnclaimableReason,
 };
 use crate::bridge_address::get_bridge_address;
 use crate::log_synthesis::{
@@ -230,6 +231,228 @@ impl Store for PgStore {
             )
             .await?;
         Ok(row.map(|r| r.get::<_, String>(0)))
+    }
+
+    async fn get_note_handoff_for_tx(&self, tx_hash: &str) -> anyhow::Result<Option<NoteHandoff>> {
+        let client = self.pool.get().await?;
+        let row = client
+            .query_opt(
+                "SELECT note_commitment, note_id, handoff_state, prepared_expiration_block
+                 FROM tx_note_links WHERE tx_hash = $1",
+                &[&tx_hash],
+            )
+            .await?;
+        row.map(|row| {
+            let state: String = row.get(2);
+            let state = match state.as_str() {
+                "prepared" => NoteHandoffState::Prepared,
+                "submitted" => NoteHandoffState::Submitted,
+                other => anyhow::bail!("unknown note handoff state {other:?} for {tx_hash}"),
+            };
+            Ok(NoteHandoff {
+                note_commitment: row.get(0),
+                note_id: row.get(1),
+                state,
+                expiration_block: row.get::<_, Option<i64>>(3).map(|v| v as u64),
+            })
+        })
+        .transpose()
+    }
+
+    async fn prepare_note_handoff(
+        &self,
+        tx_hash: &str,
+        note_commitment: &str,
+        note_id: &str,
+        expiration_block: u64,
+    ) -> anyhow::Result<()> {
+        let client = self.pool.get().await?;
+        client
+            .execute(
+                "INSERT INTO tx_note_links
+                    (tx_hash, note_commitment, note_id, handoff_state, prepared_expiration_block)
+                 VALUES ($1, $2, $3, 'prepared', $4)
+                 ON CONFLICT (tx_hash) DO NOTHING",
+                &[
+                    &tx_hash,
+                    &note_commitment,
+                    &note_id,
+                    &(expiration_block as i64),
+                ],
+            )
+            .await?;
+        let row = client
+            .query_one(
+                "SELECT note_commitment, note_id FROM tx_note_links WHERE tx_hash = $1",
+                &[&tx_hash],
+            )
+            .await?;
+        let existing_commitment: String = row.get(0);
+        let existing_note_id: Option<String> = row.get(1);
+        if existing_commitment != note_commitment || existing_note_id.as_deref() != Some(note_id) {
+            anyhow::bail!("transaction {tx_hash} is already linked to a different note");
+        }
+        Ok(())
+    }
+
+    async fn confirm_note_handoff(
+        &self,
+        tx_hash: &str,
+        note_commitment: &str,
+    ) -> anyhow::Result<bool> {
+        let mut client = self.pool.get().await?;
+        let txn = client.transaction().await?;
+        let updated = txn
+            .execute(
+                "UPDATE tx_note_links
+                 SET handoff_state = 'submitted', prepared_expiration_block = NULL
+                 WHERE tx_hash = $1 AND note_commitment = $2",
+                &[&tx_hash, &note_commitment],
+            )
+            .await?;
+        if updated == 1 {
+            txn.execute(
+                "UPDATE claimed_indices
+                 SET claim_state = 'submitted', lease_expires_at = NULL
+                 WHERE owner_tx_hash = $1 AND claim_state = 'prepared'",
+                &[&tx_hash],
+            )
+            .await?;
+        }
+        txn.commit().await?;
+        Ok(updated == 1)
+    }
+
+    async fn confirm_note_handoff_by_commitment(
+        &self,
+        note_commitment: &str,
+    ) -> anyhow::Result<Option<String>> {
+        let mut client = self.pool.get().await?;
+        let txn = client.transaction().await?;
+        let rows = txn
+            .query(
+                "SELECT tx_hash FROM tx_note_links
+                 WHERE note_commitment = $1
+                 ORDER BY created_at ASC, tx_hash ASC
+                 FOR UPDATE",
+                &[&note_commitment],
+            )
+            .await?;
+        if rows.is_empty() {
+            txn.commit().await?;
+            return Ok(None);
+        }
+        txn.execute(
+            "UPDATE tx_note_links
+             SET handoff_state = 'submitted', prepared_expiration_block = NULL
+             WHERE note_commitment = $1",
+            &[&note_commitment],
+        )
+        .await?;
+        for row in &rows {
+            let tx_hash: String = row.get(0);
+            txn.execute(
+                "UPDATE claimed_indices
+                 SET claim_state = 'submitted', lease_expires_at = NULL
+                 WHERE owner_tx_hash = $1 AND claim_state = 'prepared'",
+                &[&tx_hash],
+            )
+            .await?;
+        }
+        let first_tx_hash: String = rows[0].get(0);
+        txn.commit().await?;
+        Ok(Some(first_tx_hash))
+    }
+
+    async fn confirm_prepared_note_handoffs(&self, note_ids: &[String]) -> anyhow::Result<u64> {
+        if note_ids.is_empty() {
+            return Ok(0);
+        }
+        let mut client = self.pool.get().await?;
+        let txn = client.transaction().await?;
+        let rows = txn
+            .query(
+                "UPDATE tx_note_links
+                 SET handoff_state = 'submitted', prepared_expiration_block = NULL
+                 WHERE handoff_state = 'prepared' AND note_id = ANY($1)
+                 RETURNING tx_hash",
+                &[&note_ids],
+            )
+            .await?;
+        for row in &rows {
+            let tx_hash: String = row.get(0);
+            txn.execute(
+                "UPDATE claimed_indices
+                 SET claim_state = 'submitted', lease_expires_at = NULL
+                 WHERE owner_tx_hash = $1 AND claim_state = 'prepared'",
+                &[&tx_hash],
+            )
+            .await?;
+        }
+        txn.commit().await?;
+        Ok(rows.len() as u64)
+    }
+
+    async fn clear_expired_prepared_note_handoff(
+        &self,
+        tx_hash: &str,
+        note_commitment: &str,
+    ) -> anyhow::Result<bool> {
+        let mut client = self.pool.get().await?;
+        let txn = client.transaction().await?;
+        let deleted = txn
+            .execute(
+                "DELETE FROM tx_note_links l
+                 USING service_state s
+                 WHERE l.tx_hash = $1 AND l.note_commitment = $2
+                   AND l.handoff_state = 'prepared'
+                   AND l.prepared_expiration_block IS NOT NULL
+                   AND s.id = 1 AND s.reconcile_cursor > l.prepared_expiration_block",
+                &[&tx_hash, &note_commitment],
+            )
+            .await?;
+        if deleted != 1 {
+            txn.rollback().await?;
+            return Ok(false);
+        }
+        let row = txn
+            .query_opt(
+                "SELECT claim_state FROM claimed_indices WHERE owner_tx_hash = $1 FOR UPDATE",
+                &[&tx_hash],
+            )
+            .await?;
+        if let Some(row) = row {
+            let state: String = row.get(0);
+            match state.as_str() {
+                "prepared" => {
+                    txn.execute(
+                        "DELETE FROM claimed_indices
+                         WHERE owner_tx_hash = $1 AND claim_state = 'prepared'",
+                        &[&tx_hash],
+                    )
+                    .await?;
+                }
+                // A landed claim is an authoritative fence. Rolling the link
+                // back would reopen attribution and permit a duplicate claim.
+                "landed" => {
+                    txn.rollback().await?;
+                    return Ok(false);
+                }
+                _ => {
+                    txn.rollback().await?;
+                    return Ok(false);
+                }
+            }
+        }
+        txn.execute(
+            "UPDATE transactions
+             SET status = 'pending', error_message = NULL, block_number = 0, updated_at = now()
+             WHERE tx_hash = $1 AND status = 'failed'",
+            &[&tx_hash],
+        )
+        .await?;
+        txn.commit().await?;
+        Ok(true)
     }
 
     // ── Logs ─────────────────────────────────────────────────────
@@ -596,6 +819,17 @@ impl Store for PgStore {
     ) -> anyhow::Result<()> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
+        let tx_hash_key = tx_hash.to_lowercase();
+
+        // Exact note observation confirms the handoff in the same transaction
+        // as the event and receipt. This runs even on an idempotent replay.
+        txn.execute(
+            "UPDATE tx_note_links
+             SET handoff_state = 'submitted', prepared_expiration_block = NULL
+             WHERE lower(tx_hash) = $1",
+            &[&tx_hash_key],
+        )
+        .await?;
 
         let mainnet: Option<Vec<u8>> = mainnet_exit_root.map(|root| root.to_vec());
         let rollup: Option<Vec<u8>> = rollup_exit_root.map(|root| root.to_vec());
@@ -617,7 +851,6 @@ impl Store for PgStore {
         // Canonicalize tx_hash to lowercase to match the store's convention
         // (get_logs_for_tx / memory.rs) so a mixed-case retry still matches the
         // stored lowercase row instead of double-emitting.
-        let tx_hash_key = tx_hash.to_lowercase();
         let already_emitted = txn
             .query_opt(
                 "SELECT 1 FROM synthetic_logs WHERE lower(transaction_hash) = $1 LIMIT 1",
@@ -689,6 +922,17 @@ impl Store for PgStore {
                 &(block_number as i64),
                 &(timestamp as i64),
             ],
+        )
+        .await?;
+
+        // A real linked GER hash has a pending transaction row. Finalise it in
+        // the same commit as the injected flag/log so a crash cannot expose the
+        // GER event while its receipt remains null. Derived hashes have no row.
+        txn.execute(
+            "UPDATE transactions SET status = 'success', error_message = NULL,
+                    block_number = $1, updated_at = now()
+             WHERE lower(tx_hash) = $2",
+            &[&(block_number as i64), &tx_hash_key],
         )
         .await?;
 
@@ -834,7 +1078,12 @@ impl Store for PgStore {
 
         let updated = tx
             .execute(
-                "UPDATE transactions SET status = $1, error_message = $2, block_number = $3, updated_at = now() WHERE tx_hash = $4",
+                "UPDATE transactions
+                 SET status = $1, error_message = $2, block_number = $3, updated_at = now()
+                 WHERE tx_hash = $4
+                   AND ($1 <> 'failed' OR NOT EXISTS (
+                       SELECT 1 FROM tx_note_links WHERE tx_note_links.tx_hash = $4
+                   ))",
                 &[
                     &status,
                     &error_msg as &(dyn ToSql + Sync),
@@ -857,6 +1106,21 @@ impl Store for PgStore {
         // continue), so erroring here is safe and makes the two stores
         // behave identically. Bailing before `tx.commit()` rolls the whole
         // transaction back — no partial log/counter writes escape.
+        if updated == 0 && result.is_err() {
+            let protected = tx
+                .query_opt(
+                    "SELECT 1 FROM transactions t
+                     JOIN tx_note_links l ON l.tx_hash = t.tx_hash
+                     WHERE t.tx_hash = $1",
+                    &[&hash_str],
+                )
+                .await?
+                .is_some();
+            if protected {
+                tx.commit().await?;
+                return Ok(());
+            }
+        }
         if updated == 0 {
             anyhow::bail!("PgStore: transaction {tx_hash} not found");
         }
@@ -1075,6 +1339,45 @@ impl Store for PgStore {
         }))
     }
 
+    async fn pending_nonce_frontier(&self, addr: &str) -> anyhow::Result<PendingNonceFrontier> {
+        use alloy::eips::Decodable2718;
+
+        let client = self.pool.get().await?;
+        let rows = client
+            .query(
+                "SELECT t.envelope_bytes,
+                        (l.tx_hash IS NULL OR l.handoff_state <> 'submitted') AS unlinked
+                 FROM transactions t
+                 LEFT JOIN tx_note_links l ON l.tx_hash = t.tx_hash
+                 WHERE lower(t.signer) = lower($1) AND t.status = 'pending'",
+                &[&addr],
+            )
+            .await?;
+        let mut frontier = PendingNonceFrontier::default();
+        for row in rows {
+            let bytes: &[u8] = row.get(0);
+            let envelope = TxEnvelope::decode_2718(&mut &bytes[..]).map_err(|err| {
+                anyhow::anyhow!(
+                    "pending transaction for signer {addr} has an undecodable envelope: {err}"
+                )
+            })?;
+            let nonce = super::envelope_nonce(&envelope);
+            frontier.lowest_pending = Some(
+                frontier
+                    .lowest_pending
+                    .map_or(nonce, |current| current.min(nonce)),
+            );
+            if row.get::<_, bool>(1) {
+                frontier.lowest_unlinked = Some(
+                    frontier
+                        .lowest_unlinked
+                        .map_or(nonce, |current| current.min(nonce)),
+                );
+            }
+        }
+        Ok(frontier)
+    }
+
     async fn txn_pending_by_miden_id(&self, id: TransactionId) -> anyhow::Result<Option<TxHash>> {
         let client = self.pool.get().await?;
         let id_str = id.to_hex();
@@ -1227,7 +1530,8 @@ impl Store for PgStore {
                 // Expiry only permits recovery by that exact signed transaction; a
                 // replacement is unsafe because the prior external outcome may be ambiguous.
                 let same_tx = row_hash.eq_ignore_ascii_case(&hash_str);
-                let takeover = same_tx && (state == "released_failure" || expired);
+                let takeover = same_tx
+                    && (state == "released_failure" || state == "released_success" || expired);
                 if takeover {
                     let new_fence = fence + 1;
                     tx.execute(
@@ -1362,7 +1666,8 @@ impl Store for PgStore {
              ON CONFLICT (tx_hash) DO UPDATE SET status = 'failed', error_message = $6, block_number = $7, updated_at = now()
              WHERE transactions.status = 'failed' OR
                (transactions.status = 'pending' AND NOT EXISTS (
-                   SELECT 1 FROM tx_note_links WHERE tx_note_links.tx_hash = transactions.tx_hash
+                   SELECT 1 FROM tx_note_links
+                   WHERE tx_note_links.tx_hash = transactions.tx_hash
                ))",
             &[
                 &hash_str,
@@ -1431,7 +1736,7 @@ impl Store for PgStore {
             "UPDATE claimed_indices SET owner_tx_hash = $2, fence_token = fence_token + 1,
                 created_at = now(), lease_expires_at = now() + ($3 || ' seconds')::interval
              WHERE global_index = $1 AND claim_state = 'executing'
-               AND (lease_expires_at <= now() OR
+               AND (owner_tx_hash = $2 OR lease_expires_at <= now() OR
                     (lease_expires_at IS NULL AND created_at <= now() - ($3 || ' seconds')::interval))
              RETURNING fence_token",
             &[&key, &owner, &lease_secs.to_string()],
@@ -1441,45 +1746,55 @@ impl Store for PgStore {
         }))
     }
 
-    async fn mark_claim_submitted_fenced(
+    async fn prepare_claim_submission_fenced(
         &self,
         global_index: U256,
         owner_tx_hash: TxHash,
         fence: u64,
         tx_hash: TxHash,
         note_commitment: &str,
+        note_id: &str,
+        expiration_block: u64,
     ) -> anyhow::Result<bool> {
         let mut client = self.pool.get().await?;
         let key = format!("{global_index:#x}");
         let owner = format!("{owner_tx_hash:#x}");
         let tx_hash = format!("{tx_hash:#x}");
         let tx = client.transaction().await?;
+        tx.execute(
+            "INSERT INTO tx_note_links
+                (tx_hash, note_commitment, note_id, handoff_state, prepared_expiration_block)
+             VALUES ($1, $2, $3, 'prepared', $4)
+             ON CONFLICT (tx_hash) DO NOTHING",
+            &[
+                &tx_hash,
+                &note_commitment,
+                &note_id,
+                &(expiration_block as i64),
+            ],
+        )
+        .await?;
+        let row = tx
+            .query_one(
+                "SELECT note_commitment, note_id FROM tx_note_links WHERE tx_hash = $1",
+                &[&tx_hash],
+            )
+            .await?;
+        let existing: String = row.get(0);
+        let existing_note_id: Option<String> = row.get(1);
+        if existing != note_commitment || existing_note_id.as_deref() != Some(note_id) {
+            anyhow::bail!("transaction {tx_hash} is already linked to a different claim note");
+        }
         let updated = tx
             .execute(
-                "UPDATE claimed_indices SET claim_state = 'submitted', lease_expires_at = NULL
-             WHERE global_index = $1 AND owner_tx_hash = $2 AND fence_token = $3
-               AND claim_state = 'executing' AND lease_expires_at > now()",
+                "UPDATE claimed_indices SET claim_state = 'prepared', lease_expires_at = NULL
+                 WHERE global_index = $1 AND owner_tx_hash = $2 AND fence_token = $3
+                   AND claim_state = 'executing' AND lease_expires_at > now()",
                 &[&key, &owner, &(fence as i64)],
             )
             .await?;
         if updated != 1 {
             return Ok(false);
-        }
-        tx.execute(
-            "INSERT INTO tx_note_links (tx_hash, note_commitment) VALUES ($1, $2)
-             ON CONFLICT (tx_hash) DO NOTHING",
-            &[&tx_hash, &note_commitment],
-        )
-        .await?;
-        let row = tx
-            .query_one(
-                "SELECT note_commitment FROM tx_note_links WHERE tx_hash = $1",
-                &[&tx_hash],
-            )
-            .await?;
-        let existing: String = row.get(0);
-        if existing != note_commitment {
-            anyhow::bail!("transaction {tx_hash} is already linked to a different claim note");
         }
         tx.commit().await?;
         Ok(true)
@@ -1970,9 +2285,9 @@ impl Store for PgStore {
         Ok(!rpc_rows.is_empty())
     }
 
-    /// Atomic commit for a watcher-synthesised ClaimEvent. Single PG txn folding
-    /// the three writes the default impl chains separately. Mirrors the design
-    /// of `the projector B2AGG commit` and `the projector GER commit`.
+    /// Atomic commit for a watcher-synthesised ClaimEvent and its linked receipt.
+    /// The block tip is sealed by `SyntheticProjector` after the whole block, not
+    /// by an individual note projection.
     #[allow(clippy::too_many_arguments)]
     async fn commit_manual_claim_event_atomic(
         &self,
@@ -1989,60 +2304,85 @@ impl Store for PgStore {
     ) -> anyhow::Result<()> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
+        let tx_hash_key = tx_hash.to_lowercase();
 
-        // 1. Mark the CLAIM note processed (idempotent — second observation no-ops).
+        // Link -> claim is the global handoff lock order. Observation is
+        // terminal even on replay, and fences out a publisher that raced the
+        // projector after its final landed-state read.
         txn.execute(
-            "INSERT INTO claim_watcher_processed (note_id, global_index, block_number)
+            "UPDATE tx_note_links
+             SET handoff_state = 'submitted', prepared_expiration_block = NULL
+             WHERE lower(tx_hash) = $1",
+            &[&tx_hash_key],
+        )
+        .await?;
+        let global_index_key = format!("{:#x}", U256::from_be_bytes(global_index));
+        txn.execute(
+            "INSERT INTO claimed_indices
+                 (global_index, owner_tx_hash, fence_token, claim_state, lease_expires_at)
+             VALUES ($1, NULL, 1, 'landed', NULL)
+             ON CONFLICT (global_index) DO UPDATE
+             SET claim_state = 'landed', lease_expires_at = NULL,
+                 fence_token = claimed_indices.fence_token + 1",
+            &[&global_index_key],
+        )
+        .await?;
+
+        // 1. Mark the note processed. Exactly one concurrent projector emits the
+        // log; a retry still repairs the linked receipt below.
+        let inserted = txn
+            .execute(
+                "INSERT INTO claim_watcher_processed (note_id, global_index, block_number)
              VALUES ($1, $2, $3)
              ON CONFLICT (note_id) DO NOTHING",
-            &[&note_id, &global_index.as_slice(), &(block_number as i64)],
-        )
-        .await?;
+                &[&note_id, &global_index.as_slice(), &(block_number as i64)],
+            )
+            .await?
+            == 1;
 
-        // 2. Allocate a log_index.
-        let row = txn
-            .query_one(
-                "UPDATE service_state SET log_counter = log_counter + 1, updated_at = now() WHERE id = 1 RETURNING log_counter - 1",
-                &[],
+        if inserted {
+            let row = txn
+                .query_one(
+                    "UPDATE service_state SET log_counter = log_counter + 1, updated_at = now() WHERE id = 1 RETURNING log_counter - 1",
+                    &[],
+                )
+                .await?;
+            let log_index: i64 = row.get(0);
+            let data = crate::log_synthesis::encode_claim_event_data_u64(
+                &global_index,
+                origin_network,
+                origin_address,
+                destination_address,
+                amount,
+            );
+            let topics_owned: [String; 1] = [crate::log_synthesis::CLAIM_EVENT_TOPIC.to_string()];
+            let topics: Vec<&str> = topics_owned.iter().map(|s| s.as_str()).collect();
+            txn.execute(
+                "INSERT INTO synthetic_logs (log_index, address, topics, data, block_number, block_hash, transaction_hash, transaction_index, removed)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                &[
+                    &log_index,
+                    &bridge_address,
+                    &topics,
+                    &data,
+                    &(block_number as i64),
+                    &block_hash.as_slice(),
+                    &tx_hash_key,
+                    &0_i64,
+                    &false,
+                ],
             )
             .await?;
-        let log_index: i64 = row.get(0);
+        }
 
-        // 3. Encode + insert the synthetic ClaimEvent log. Encoding is the
-        //    same path `add_claim_event` would take — keep it inline to keep
-        //    the bundle in one connection / one transaction.
-        let data = crate::log_synthesis::encode_claim_event_data_u64(
-            &global_index,
-            origin_network,
-            origin_address,
-            destination_address,
-            amount,
-        );
-        let topics_owned: [String; 1] = [crate::log_synthesis::CLAIM_EVENT_TOPIC.to_string()];
-        let topics: Vec<&str> = topics_owned.iter().map(|s| s.as_str()).collect();
+        // A real linked hash has a pending `transactions` row; a derived hash
+        // does not, so this idempotent update naturally becomes a no-op. Keeping
+        // it in this transaction prevents a visible ClaimEvent/null-receipt gap.
         txn.execute(
-            "INSERT INTO synthetic_logs (log_index, address, topics, data, block_number, block_hash, transaction_hash, transaction_index, removed)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
-            &[
-                &log_index,
-                &bridge_address,
-                &topics,
-                &data,
-                &(block_number as i64),
-                &block_hash.as_slice(),
-                &tx_hash,
-                &0_i64,
-                &false,
-            ],
-        )
-        .await?;
-
-        // 4. Advance the cursor — write log THEN advance, so any reader who
-        //    sees latest >= N also sees the log at N. The same invariant
-        //    `bridge_out.rs::on_post_sync` documents at line 555.
-        txn.execute(
-            "UPDATE service_state SET latest_block_number = $1, updated_at = now() WHERE id = 1",
-            &[&(block_number as i64)],
+            "UPDATE transactions SET status = 'success', error_message = NULL,
+                    block_number = $1, updated_at = now()
+             WHERE lower(tx_hash) = lower($2)",
+            &[&(block_number as i64), &tx_hash_key],
         )
         .await?;
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1204,6 +1204,45 @@ impl Store for PgStore {
         Ok(())
     }
 
+    async fn txn_commit_confirmed_duplicate(
+        &self,
+        tx_hash: TxHash,
+        result: Result<(), String>,
+        block_num: u64,
+    ) -> anyhow::Result<()> {
+        let mut client = self.pool.get().await?;
+        let tx = client.transaction().await?;
+        let hash = format!("{tx_hash:#x}");
+        let (status, error_message) = match &result {
+            Ok(()) => ("success", None),
+            Err(message) => ("failed", Some(message.as_str())),
+        };
+        let updated = tx
+            .execute(
+                "UPDATE transactions SET status = $1, error_message = $2, block_number = $3, updated_at = now() WHERE tx_hash = $4 AND status = $5",
+                &[
+                    &status,
+                    &error_message as &(dyn ToSql + Sync),
+                    &(block_num as i64),
+                    &hash,
+                    &"pending",
+                ],
+            )
+            .await?;
+        if updated == 1 {
+            tx.execute("DELETE FROM transaction_logs WHERE tx_hash = $1", &[&hash])
+                .await?;
+        } else if tx
+            .query_opt("SELECT 1 FROM transactions WHERE tx_hash = $1", &[&hash])
+            .await?
+            .is_none()
+        {
+            anyhow::bail!("PgStore: transaction {tx_hash} not found");
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
     async fn txn_receipt(
         &self,
         tx_hash: TxHash,

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1161,31 +1161,47 @@ impl Store for PgStore {
             }
             Some(row) => {
                 let row_hash: String = row.get(0);
-                if !row_hash.eq_ignore_ascii_case(&hash_str) {
-                    let other =
-                        <TxHash as std::str::FromStr>::from_str(&row_hash).unwrap_or_default();
-                    NonceReservation::HeldByOther(other)
-                } else {
-                    let state: String = row.get(1);
-                    let expired: bool = row.get(2);
-                    let fence: i64 = row.get(3);
-                    let takeover = state == "released_failure" || (state == "executing" && expired);
-                    if takeover {
-                        let new_fence = fence + 1;
-                        tx.execute(
-                            "UPDATE nonce_reservations SET state = 'executing',
-                             lease_expires_at = now() + ($3 || ' seconds')::interval,
-                             fence_token = $4
-                             WHERE signer = $1 AND nonce = $2",
-                            &[&key, &(nonce as i64), &lease_secs.to_string(), &new_fence],
-                        )
-                        .await?;
-                        NonceReservation::Won {
-                            fence: new_fence as u64,
-                        }
-                    } else {
-                        NonceReservation::OwnedBySame
+                let state: String = row.get(1);
+                let expired: bool = row.get(2);
+                let fence: i64 = row.get(3);
+                // STATE-FIRST (BLOCKER A): a holder that FAILED or whose lease EXPIRED
+                // consumed NO nonce, so the slot is free for takeover by ANY tx (the
+                // SAME tx retrying OR a DIFFERENT tx). Executing-under-valid-lease or
+                // released_success means the nonce is consumed / in flight → a
+                // DIFFERENT tx hard-rejects, the SAME tx dedups.
+                let takeover = state == "released_failure" || (state == "executing" && expired);
+                if takeover {
+                    let new_fence = fence + 1;
+                    tx.execute(
+                        "UPDATE nonce_reservations SET tx_hash = $5, state = 'executing',
+                         lease_expires_at = now() + ($3 || ' seconds')::interval,
+                         fence_token = $4
+                         WHERE signer = $1 AND nonce = $2",
+                        &[
+                            &key,
+                            &(nonce as i64),
+                            &lease_secs.to_string(),
+                            &new_fence,
+                            &hash_str,
+                        ],
+                    )
+                    .await?;
+                    NonceReservation::Won {
+                        fence: new_fence as u64,
                     }
+                } else if row_hash.eq_ignore_ascii_case(&hash_str) {
+                    NonceReservation::OwnedBySame
+                } else {
+                    // NIT — propagate a parse error WITH context instead of
+                    // substituting the zero hash.
+                    let other =
+                        <TxHash as std::str::FromStr>::from_str(&row_hash).map_err(|e| {
+                            anyhow::anyhow!(
+                                "nonce_reservations row for signer {key} nonce {nonce} has an \
+                             unparsable tx_hash {row_hash:?}: {e}"
+                            )
+                        })?;
+                    NonceReservation::HeldByOther(other)
                 }
             }
         };

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1098,6 +1098,89 @@ impl Store for PgStore {
         Ok(row.get::<_, i64>(0) as u64)
     }
 
+    async fn nonce_advance_cas(&self, addr: &str, expected: u64) -> anyhow::Result<bool> {
+        let client = self.pool.get().await?;
+        let key = addr.to_lowercase();
+        // BLOCKER D — atomic conditional advance. A fresh address (no row) is
+        // nonce 0: for `expected == 0` create/advance to 1 only while the current
+        // value is still 0; otherwise advance only WHERE the stored nonce equals
+        // `expected`. Postgres row-locking on the conflict/UPDATE serialises
+        // concurrent replicas, so exactly one wins the CAS.
+        let n = if expected == 0 {
+            client
+                .execute(
+                    "INSERT INTO nonces (address, nonce) VALUES ($1, 1)
+                     ON CONFLICT (address) DO UPDATE SET nonce = 1 WHERE nonces.nonce = 0",
+                    &[&key],
+                )
+                .await?
+        } else {
+            client
+                .execute(
+                    "UPDATE nonces SET nonce = nonce + 1 WHERE address = $1 AND nonce = $2",
+                    &[&key, &(expected as i64)],
+                )
+                .await?
+        };
+        Ok(n == 1)
+    }
+
+    async fn commit_reverted_receipt_and_advance_nonce(
+        &self,
+        tx_hash: TxHash,
+        entry: TxnEntry,
+        reason: String,
+        block_num: u64,
+        _block_hash: [u8; 32],
+        addr: &str,
+        expected_nonce: u64,
+    ) -> anyhow::Result<bool> {
+        let mut client = self.pool.get().await?;
+        let hash_str = format!("{tx_hash:#x}");
+        let miden_id = entry.id.map(|id| id.to_hex());
+        let signer_str = format!("{:#x}", entry.signer);
+        let mut envelope_bytes = Vec::new();
+        entry.envelope.encode_2718(&mut envelope_bytes);
+        let key = addr.to_lowercase();
+
+        // BLOCKER C — receipt + nonce in ONE transaction. The tx row is inserted
+        // already committed-`failed` (status 0x0, no attached logs → no ClaimEvent),
+        // so there is no `txn_begin`→`txn_commit` pending window a crash could freeze
+        // forever. Idempotent on tx_hash (a re-entry re-affirms the reverted row).
+        let tx = client.transaction().await?;
+        tx.execute(
+            "INSERT INTO transactions (tx_hash, miden_tx_id, envelope_bytes, signer, expires_at, status, error_message, block_number)
+             VALUES ($1, $2, $3, $4, $5, 'failed', $6, $7)
+             ON CONFLICT (tx_hash) DO UPDATE SET status = 'failed', error_message = $6, block_number = $7, updated_at = now()",
+            &[
+                &hash_str,
+                &miden_id as &(dyn ToSql + Sync),
+                &envelope_bytes,
+                &signer_str,
+                &entry.expires_at.map(|v| v as i64) as &(dyn ToSql + Sync),
+                &reason,
+                &(block_num as i64),
+            ],
+        )
+        .await?;
+        let n = if expected_nonce == 0 {
+            tx.execute(
+                "INSERT INTO nonces (address, nonce) VALUES ($1, 1)
+                 ON CONFLICT (address) DO UPDATE SET nonce = 1 WHERE nonces.nonce = 0",
+                &[&key],
+            )
+            .await?
+        } else {
+            tx.execute(
+                "UPDATE nonces SET nonce = nonce + 1 WHERE address = $1 AND nonce = $2",
+                &[&key, &(expected_nonce as i64)],
+            )
+            .await?
+        };
+        tx.commit().await?;
+        Ok(n == 1)
+    }
+
     // ── Claims ───────────────────────────────────────────────────
 
     async fn try_claim(&self, global_index: U256) -> anyhow::Result<()> {

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1125,6 +1125,42 @@ impl Store for PgStore {
         Ok(n == 1)
     }
 
+    async fn reserve_nonce(
+        &self,
+        addr: &str,
+        nonce: u64,
+        tx_hash: TxHash,
+    ) -> anyhow::Result<crate::store::NonceReservation> {
+        let client = self.pool.get().await?;
+        let key = addr.to_lowercase();
+        let hash_str = format!("{tx_hash:#x}");
+        // Insert-if-absent; RETURNING yields a row IFF THIS statement inserted (won
+        // the atomic race — postgres serialises concurrent inserts on the PK). A
+        // conflict (no returned row) means the slot is already held; read the
+        // durable winner (the row never changes once inserted). So exactly one
+        // replica is ever told `Won`, even for two replicas submitting the same hash.
+        let inserted = client
+            .query_opt(
+                "INSERT INTO nonce_reservations (signer, nonce, tx_hash) VALUES ($1, $2, $3)
+                 ON CONFLICT (signer, nonce) DO NOTHING
+                 RETURNING tx_hash",
+                &[&key, &(nonce as i64), &hash_str],
+            )
+            .await?;
+        if inserted.is_some() {
+            return Ok(crate::store::NonceReservation::Won);
+        }
+        let row = client
+            .query_one(
+                "SELECT tx_hash FROM nonce_reservations WHERE signer = $1 AND nonce = $2",
+                &[&key, &(nonce as i64)],
+            )
+            .await?;
+        let winner: String = row.get(0);
+        let other = <TxHash as std::str::FromStr>::from_str(&winner).unwrap_or_default();
+        Ok(crate::store::NonceReservation::HeldBy(other))
+    }
+
     async fn commit_reverted_receipt_and_advance_nonce(
         &self,
         tx_hash: TxHash,
@@ -1146,12 +1182,21 @@ impl Store for PgStore {
         // BLOCKER C — receipt + nonce in ONE transaction. The tx row is inserted
         // already committed-`failed` (status 0x0, no attached logs → no ClaimEvent),
         // so there is no `txn_begin`→`txn_commit` pending window a crash could freeze
-        // forever. Idempotent on tx_hash (a re-entry re-affirms the reverted row).
+        // forever.
+        //
+        // BLOCKER 4 — CONDITIONAL upsert: `ON CONFLICT ... WHERE transactions.status
+        // = 'failed'` so a REAL receipt is NEVER overwritten to status 0. If a
+        // cross-replica path already materialised the real claim under this hash
+        // (status 'pending' → awaiting the projector, or 'success' → landed), the
+        // conflicting UPDATE's WHERE fails → the real receipt survives and both
+        // replicas converge to the real outcome. Absent → insert; already 'failed' →
+        // idempotently re-affirm.
         let tx = client.transaction().await?;
         tx.execute(
             "INSERT INTO transactions (tx_hash, miden_tx_id, envelope_bytes, signer, expires_at, status, error_message, block_number)
              VALUES ($1, $2, $3, $4, $5, 'failed', $6, $7)
-             ON CONFLICT (tx_hash) DO UPDATE SET status = 'failed', error_message = $6, block_number = $7, updated_at = now()",
+             ON CONFLICT (tx_hash) DO UPDATE SET status = 'failed', error_message = $6, block_number = $7, updated_at = now()
+             WHERE transactions.status = 'failed'",
             &[
                 &hash_str,
                 &miden_id as &(dyn ToSql + Sync),

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -4,8 +4,8 @@
 //! with the schema from `migrations/001_initial.sql` applied.
 
 use super::{
-    FaucetEntry, Store, TxnData, TxnEntry, UnbridgeableBridgeOut, UnbridgeableBridgeOutReason,
-    UnclaimableClaim, UnclaimableReason,
+    ClaimFence, FaucetEntry, Store, TxnData, TxnEntry, UnbridgeableBridgeOut,
+    UnbridgeableBridgeOutReason, UnclaimableClaim, UnclaimableReason,
 };
 use crate::bridge_address::get_bridge_address;
 use crate::log_synthesis::{
@@ -740,6 +740,65 @@ impl Store for PgStore {
         Ok(())
     }
 
+    async fn txn_begin_if_absent(&self, tx_hash: TxHash, entry: TxnEntry) -> anyhow::Result<bool> {
+        let mut client = self.pool.get().await?;
+        let hash_str = format!("{tx_hash:#x}");
+        let miden_id = entry.id.map(|id| id.to_hex());
+        let signer_str = format!("{:#x}", entry.signer);
+        let mut envelope_bytes = Vec::new();
+        entry.envelope.encode_2718(&mut envelope_bytes);
+        let tx = client.transaction().await?;
+        let inserted = tx.execute(
+            "INSERT INTO transactions (tx_hash, miden_tx_id, envelope_bytes, signer, expires_at, status, block_number)
+             VALUES ($1, $2, $3, $4, $5, 'pending', 0) ON CONFLICT (tx_hash) DO NOTHING",
+            &[
+                &hash_str,
+                &miden_id as &(dyn ToSql + Sync),
+                &envelope_bytes,
+                &signer_str,
+                &entry.expires_at.map(|v| v as i64) as &(dyn ToSql + Sync),
+            ],
+        ).await? == 1;
+        let pending = if !inserted {
+            tx.execute(
+                "UPDATE transactions SET
+                    miden_tx_id = COALESCE($2, miden_tx_id),
+                    expires_at = COALESCE($3, expires_at), updated_at = now()
+                 WHERE tx_hash = $1 AND status = 'pending'",
+                &[
+                    &hash_str,
+                    &miden_id as &(dyn ToSql + Sync),
+                    &entry.expires_at.map(|v| v as i64) as &(dyn ToSql + Sync),
+                ],
+            )
+            .await?
+                == 1
+        } else {
+            true
+        };
+        if pending && !entry.logs.is_empty() {
+            tx.execute(
+                "DELETE FROM transaction_logs WHERE tx_hash = $1",
+                &[&hash_str],
+            )
+            .await?;
+            for log_data in &entry.logs {
+                let topics_bytes: Vec<Vec<u8>> = log_data
+                    .topics()
+                    .iter()
+                    .map(|t| t.as_slice().to_vec())
+                    .collect();
+                tx.execute(
+                    "INSERT INTO transaction_logs (tx_hash, topics, data) VALUES ($1, $2, $3)",
+                    &[&hash_str, &topics_bytes, &log_data.data.as_ref()],
+                )
+                .await?;
+            }
+        }
+        tx.commit().await?;
+        Ok(inserted)
+    }
+
     async fn txn_commit(
         &self,
         tx_hash: TxHash,
@@ -1164,12 +1223,11 @@ impl Store for PgStore {
                 let state: String = row.get(1);
                 let expired: bool = row.get(2);
                 let fence: i64 = row.get(3);
-                // STATE-FIRST (BLOCKER A): a holder that FAILED or whose lease EXPIRED
-                // consumed NO nonce, so the slot is free for takeover by ANY tx (the
-                // SAME tx retrying OR a DIFFERENT tx). Executing-under-valid-lease or
-                // released_success means the nonce is consumed / in flight → a
-                // DIFFERENT tx hard-rejects, the SAME tx dedups.
-                let takeover = state == "released_failure" || (state == "executing" && expired);
+                // A nonce slot is permanently bound to its first transaction hash.
+                // Expiry only permits recovery by that exact signed transaction; a
+                // replacement is unsafe because the prior external outcome may be ambiguous.
+                let same_tx = row_hash.eq_ignore_ascii_case(&hash_str);
+                let takeover = same_tx && (state == "released_failure" || expired);
                 if takeover {
                     let new_fence = fence + 1;
                     tx.execute(
@@ -1209,6 +1267,29 @@ impl Store for PgStore {
         Ok(outcome)
     }
 
+    async fn renew_reservation(
+        &self,
+        addr: &str,
+        nonce: u64,
+        tx_hash: TxHash,
+        lease: std::time::Duration,
+    ) -> anyhow::Result<bool> {
+        let client = self.pool.get().await?;
+        let key = addr.to_lowercase();
+        let hash_str = format!("{tx_hash:#x}");
+        let lease_secs = lease.as_secs().max(1) as f64;
+        let updated = client
+            .execute(
+                "UPDATE nonce_reservations
+             SET lease_expires_at = now() + ($4 || ' seconds')::interval
+             WHERE signer = $1 AND nonce = $2 AND tx_hash = $3
+               AND state <> 'released_failure'",
+                &[&key, &(nonce as i64), &hash_str, &lease_secs.to_string()],
+            )
+            .await?;
+        Ok(updated == 1)
+    }
+
     async fn release_reservation(
         &self,
         addr: &str,
@@ -1228,7 +1309,8 @@ impl Store for PgStore {
         // FENCED: only the current fence owner still in `executing` may release.
         client
             .execute(
-                "UPDATE nonce_reservations SET state = $5, lease_expires_at = now()
+                "UPDATE nonce_reservations SET state = $5,
+                    lease_expires_at = CASE WHEN $5 = 'released_failure' THEN now() ELSE lease_expires_at END
                  WHERE signer = $1 AND nonce = $2 AND tx_hash = $3 AND fence_token = $4
                    AND state = 'executing'",
                 &[
@@ -1278,7 +1360,10 @@ impl Store for PgStore {
             "INSERT INTO transactions (tx_hash, miden_tx_id, envelope_bytes, signer, expires_at, status, error_message, block_number)
              VALUES ($1, $2, $3, $4, $5, 'failed', $6, $7)
              ON CONFLICT (tx_hash) DO UPDATE SET status = 'failed', error_message = $6, block_number = $7, updated_at = now()
-             WHERE transactions.status = 'failed'",
+             WHERE transactions.status = 'failed' OR
+               (transactions.status = 'pending' AND NOT EXISTS (
+                   SELECT 1 FROM tx_note_links WHERE tx_note_links.tx_hash = transactions.tx_hash
+               ))",
             &[
                 &hash_str,
                 &miden_id as &(dyn ToSql + Sync),
@@ -1310,12 +1395,121 @@ impl Store for PgStore {
 
     // ── Claims ───────────────────────────────────────────────────
 
+    async fn try_claim_fenced(
+        &self,
+        global_index: U256,
+        owner_tx_hash: TxHash,
+        lease: std::time::Duration,
+    ) -> anyhow::Result<Option<ClaimFence>> {
+        let client = self.pool.get().await?;
+        let key = format!("{global_index:#x}");
+        let owner = format!("{owner_tx_hash:#x}");
+        let lease_secs = lease.as_secs_f64();
+        let inserted = client
+            .execute(
+                "INSERT INTO claimed_indices
+                (global_index, owner_tx_hash, fence_token, claim_state, lease_expires_at)
+             VALUES ($1, $2, 1, 'executing', now() + ($3 || ' seconds')::interval)
+             ON CONFLICT (global_index) DO NOTHING",
+                &[&key, &owner, &lease_secs.to_string()],
+            )
+            .await?;
+        Ok((inserted == 1).then_some(ClaimFence { fence: 1 }))
+    }
+
+    async fn try_reclaim_claim_fenced(
+        &self,
+        global_index: U256,
+        owner_tx_hash: TxHash,
+        lease: std::time::Duration,
+    ) -> anyhow::Result<Option<ClaimFence>> {
+        let client = self.pool.get().await?;
+        let key = format!("{global_index:#x}");
+        let owner = format!("{owner_tx_hash:#x}");
+        let lease_secs = lease.as_secs_f64();
+        let row = client.query_opt(
+            "UPDATE claimed_indices SET owner_tx_hash = $2, fence_token = fence_token + 1,
+                created_at = now(), lease_expires_at = now() + ($3 || ' seconds')::interval
+             WHERE global_index = $1 AND claim_state = 'executing'
+               AND (lease_expires_at <= now() OR
+                    (lease_expires_at IS NULL AND created_at <= now() - ($3 || ' seconds')::interval))
+             RETURNING fence_token",
+            &[&key, &owner, &lease_secs.to_string()],
+        ).await?;
+        Ok(row.map(|row| ClaimFence {
+            fence: row.get::<_, i64>(0) as u64,
+        }))
+    }
+
+    async fn mark_claim_submitted_fenced(
+        &self,
+        global_index: U256,
+        owner_tx_hash: TxHash,
+        fence: u64,
+        tx_hash: TxHash,
+        note_commitment: &str,
+    ) -> anyhow::Result<bool> {
+        let mut client = self.pool.get().await?;
+        let key = format!("{global_index:#x}");
+        let owner = format!("{owner_tx_hash:#x}");
+        let tx_hash = format!("{tx_hash:#x}");
+        let tx = client.transaction().await?;
+        let updated = tx
+            .execute(
+                "UPDATE claimed_indices SET claim_state = 'submitted', lease_expires_at = NULL
+             WHERE global_index = $1 AND owner_tx_hash = $2 AND fence_token = $3
+               AND claim_state = 'executing' AND lease_expires_at > now()",
+                &[&key, &owner, &(fence as i64)],
+            )
+            .await?;
+        if updated != 1 {
+            return Ok(false);
+        }
+        tx.execute(
+            "INSERT INTO tx_note_links (tx_hash, note_commitment) VALUES ($1, $2)
+             ON CONFLICT (tx_hash) DO NOTHING",
+            &[&tx_hash, &note_commitment],
+        )
+        .await?;
+        let row = tx
+            .query_one(
+                "SELECT note_commitment FROM tx_note_links WHERE tx_hash = $1",
+                &[&tx_hash],
+            )
+            .await?;
+        let existing: String = row.get(0);
+        if existing != note_commitment {
+            anyhow::bail!("transaction {tx_hash} is already linked to a different claim note");
+        }
+        tx.commit().await?;
+        Ok(true)
+    }
+
+    async fn unclaim_fenced(
+        &self,
+        global_index: &U256,
+        owner_tx_hash: TxHash,
+        fence: u64,
+    ) -> anyhow::Result<bool> {
+        let client = self.pool.get().await?;
+        let key = format!("{global_index:#x}");
+        let owner = format!("{owner_tx_hash:#x}");
+        let deleted = client
+            .execute(
+                "DELETE FROM claimed_indices WHERE global_index = $1
+             AND owner_tx_hash = $2 AND fence_token = $3 AND claim_state = 'executing'",
+                &[&key, &owner, &(fence as i64)],
+            )
+            .await?;
+        Ok(deleted == 1)
+    }
+
     async fn try_claim(&self, global_index: U256) -> anyhow::Result<()> {
         let client = self.pool.get().await?;
         let key = format!("{global_index:#x}");
         let result = client
             .execute(
-                "INSERT INTO claimed_indices (global_index) VALUES ($1)",
+                "INSERT INTO claimed_indices (global_index, claim_state) VALUES ($1, 'executing')",
                 &[&key],
             )
             .await;
@@ -1340,6 +1534,7 @@ impl Store for PgStore {
             .execute(
                 "UPDATE claimed_indices SET created_at = now()
                  WHERE global_index = $1
+                   AND owner_tx_hash IS NULL AND claim_state = 'executing'
                    AND created_at <= now() - make_interval(secs => $2)",
                 &[&key, &ttl.as_secs_f64()],
             )
@@ -1352,7 +1547,7 @@ impl Store for PgStore {
         let key = format!("{global_index:#x}");
         client
             .execute(
-                "DELETE FROM claimed_indices WHERE global_index = $1",
+                "DELETE FROM claimed_indices WHERE global_index = $1 AND owner_tx_hash IS NULL",
                 &[&key],
             )
             .await?;

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -1452,3 +1452,157 @@ fn rand_u64() -> u64 {
         .unwrap_or(0)
         ^ (std::process::id() as u64).wrapping_mul(2_654_435_761)
 }
+
+// ── #55 accept-and-revert — BLOCKER 1 & 2 regressions on the real store ──────
+//
+// PG-gated (skip when DATABASE_URL is unset; run in the postgres-feature CI).
+// The service-level routing logic (`acquire_claim_lock` typed outcome, the
+// crash-gap nonce repair) is exercised against a genuine PgStore so the atomic
+// landed classification and the nonce-repair primitive are proven on BOTH stores.
+
+/// BLOCKER 1 — `acquire_claim_lock` classifies a claim submission atomically on
+/// PgStore: fresh → Acquired; locked+no-event(in TTL) → InFlight; locked+ClaimEvent
+/// → Landed (the authoritative landed detection that closes the TOCTOU); orphaned
+/// (locked+no-event, TTL expired) → Acquired. LANDED beats TTL-expiry recovery.
+#[tokio::test]
+async fn test_pgstore_acquire_claim_lock_outcomes() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    let store: std::sync::Arc<dyn Store> = std::sync::Arc::new(store);
+    use crate::service_send_raw_txn::{ClaimLockOutcome, acquire_claim_lock};
+    let ttl = std::time::Duration::from_secs(3600);
+
+    let base = rand_u64();
+    let gi_fresh = U256::from(base.wrapping_add(1));
+    let gi_inflight = U256::from(base.wrapping_add(2));
+    let gi_landed = U256::from(base.wrapping_add(3));
+    let gi_orphan = U256::from(base.wrapping_add(4));
+
+    // 1. Fresh index → Acquired.
+    assert_eq!(
+        acquire_claim_lock(&store, gi_fresh, ttl).await.unwrap(),
+        ClaimLockOutcome::Acquired
+    );
+
+    // 2. Locked, no ClaimEvent, within TTL → InFlight.
+    store.try_claim(gi_inflight).await.unwrap();
+    assert_eq!(
+        acquire_claim_lock(&store, gi_inflight, ttl).await.unwrap(),
+        ClaimLockOutcome::InFlight
+    );
+
+    // 3. Locked + ClaimEvent → Landed (BLOCKER 1: atomic landed classification).
+    store.try_claim(gi_landed).await.unwrap();
+    store
+        .commit_manual_claim_event_atomic(
+            format!("pg-landed-note-{base}"),
+            "0xbridge",
+            base % 1_000_000,
+            [0u8; 32],
+            "0xwatchertx",
+            gi_landed.to_be_bytes::<32>(),
+            0,
+            &[0u8; 20],
+            &[0u8; 20],
+            1234,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        acquire_claim_lock(&store, gi_landed, ttl).await.unwrap(),
+        ClaimLockOutcome::Landed
+    );
+    // LANDED beats TTL-expiry recovery.
+    assert_eq!(
+        acquire_claim_lock(&store, gi_landed, std::time::Duration::ZERO)
+            .await
+            .unwrap(),
+        ClaimLockOutcome::Landed
+    );
+
+    // 4. Orphaned (locked, no ClaimEvent, TTL expired) → Acquired (superseded).
+    store.try_claim(gi_orphan).await.unwrap();
+    assert_eq!(
+        acquire_claim_lock(&store, gi_orphan, std::time::Duration::ZERO)
+            .await
+            .unwrap(),
+        ClaimLockOutcome::Acquired
+    );
+}
+
+/// BLOCKER 2 — the crash-gap nonce repair on PgStore, via a PgStore-backed
+/// service. Simulate the exact durable state a crash between the receipt write and
+/// `nonce_increment` leaves (a known tx row, but a STALE expected nonce), then run
+/// the repair: the nonce advances exactly once (idempotent), so a rebroadcast heals
+/// the nonce rather than serving stale forever — the sponsor is not wedged.
+#[tokio::test]
+async fn test_pgstore_crash_gap_nonce_repair() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    let store: std::sync::Arc<dyn Store> = std::sync::Arc::new(store);
+    let service = crate::test_helpers::create_test_service_with_store(store.clone());
+
+    let signer = Address::from([0x5au8; 20]);
+    let signer_str = format!("{signer:#x}");
+    let tx_hash = TxHash::from([0x5bu8; 32]);
+
+    // Precondition: expected nonce starts at 0.
+    assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 0);
+    // Simulate the crash-gap durable state: a KNOWN tx (receipt persisted) at nonce
+    // 0, with the nonce NOT advanced.
+    store
+        .txn_begin(tx_hash, dummy_txn_entry_for(signer))
+        .await
+        .unwrap();
+    store
+        .txn_commit(tx_hash, Err("crash-gap".into()), 0, [0u8; 32])
+        .await
+        .unwrap();
+    assert!(store.txn_get(tx_hash).await.unwrap().is_some());
+    assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 0);
+
+    // The repair (crash-gap signature: expected == tx.nonce == 0) advances once.
+    let repaired =
+        crate::service_send_raw_txn::repair_commit_gap_nonce(&service, signer, &signer_str, 0)
+            .await
+            .unwrap();
+    assert!(repaired, "the crash-gap must be repaired");
+    assert_eq!(
+        store.nonce_get(&signer_str).await.unwrap(),
+        1,
+        "crash-gap nonce advanced to complete the interrupted accept"
+    );
+
+    // Idempotent: a further repair for the same tx.nonce is a no-op (expected 1 != 0).
+    let repaired_again =
+        crate::service_send_raw_txn::repair_commit_gap_nonce(&service, signer, &signer_str, 0)
+            .await
+            .unwrap();
+    assert!(!repaired_again, "repair must be idempotent");
+    assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 1);
+
+    // A normally-advanced tx (expected 1 > tx.nonce 0) is never repaired.
+    assert!(
+        !crate::service_send_raw_txn::repair_commit_gap_nonce(&service, signer, &signer_str, 0)
+            .await
+            .unwrap()
+    );
+}
+
+/// A TxnEntry carrying a real signer for the crash-gap fixture.
+fn dummy_txn_entry_for(signer: Address) -> TxnEntry {
+    let tx = TxEip1559::default();
+    TxnEntry {
+        id: None,
+        envelope: TxEnvelope::Eip1559(alloy::consensus::Signed::new_unchecked(
+            tx,
+            Signature::test_signature(),
+            TxHash::default(),
+        )),
+        signer,
+        expires_at: None,
+        logs: vec![],
+    }
+}

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -450,6 +450,46 @@ async fn test_pgstore_txn_commit_missing_row_errors() {
     assert!(err.to_string().contains("not found"));
 }
 
+#[tokio::test]
+async fn test_pgstore_confirmed_duplicate_finalizes_linked_pending() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    let mut hash_bytes = [0xdeu8; 32];
+    hash_bytes[16..].copy_from_slice(
+        &std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            .to_be_bytes(),
+    );
+    let tx_hash = TxHash::from(hash_bytes);
+    let tx_key = format!("{tx_hash:#x}");
+    store.txn_begin(tx_hash, dummy_txn_entry()).await.unwrap();
+    store
+        .prepare_note_handoff(&tx_key, "confirmed-duplicate-commitment", "note-id", 10)
+        .await
+        .unwrap();
+    store
+        .txn_commit(tx_hash, Err("raw Miden error".into()), 10, [0; 32])
+        .await
+        .unwrap();
+    assert!(store.txn_receipt(tx_hash).await.unwrap().is_none());
+
+    store
+        .txn_commit_confirmed_duplicate(
+            tx_hash,
+            Err("execution reverted: AlreadyClaimed()".into()),
+            11,
+        )
+        .await
+        .unwrap();
+    let (result, block) = store.txn_receipt(tx_hash).await.unwrap().unwrap();
+    assert!(result.is_err());
+    assert_eq!(block, 11);
+    assert!(store.get_logs_for_tx(&tx_key).await.unwrap().is_empty());
+}
+
 // ── Nonces ───────────────────────────────────────────────────
 
 #[tokio::test]

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -1564,10 +1564,9 @@ async fn test_pgstore_crash_gap_nonce_repair() {
     assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 0);
 
     // The repair (crash-gap signature: expected == tx.nonce == 0) advances once.
-    let repaired =
-        crate::service_send_raw_txn::repair_commit_gap_nonce(&service, signer, &signer_str, 0)
-            .await
-            .unwrap();
+    let repaired = crate::service_send_raw_txn::repair_commit_gap_nonce(&service, &signer_str, 0)
+        .await
+        .unwrap();
     assert!(repaired, "the crash-gap must be repaired");
     assert_eq!(
         store.nonce_get(&signer_str).await.unwrap(),
@@ -1577,7 +1576,7 @@ async fn test_pgstore_crash_gap_nonce_repair() {
 
     // Idempotent: a further repair for the same tx.nonce is a no-op (expected 1 != 0).
     let repaired_again =
-        crate::service_send_raw_txn::repair_commit_gap_nonce(&service, signer, &signer_str, 0)
+        crate::service_send_raw_txn::repair_commit_gap_nonce(&service, &signer_str, 0)
             .await
             .unwrap();
     assert!(!repaired_again, "repair must be idempotent");
@@ -1585,7 +1584,7 @@ async fn test_pgstore_crash_gap_nonce_repair() {
 
     // A normally-advanced tx (expected 1 > tx.nonce 0) is never repaired.
     assert!(
-        !crate::service_send_raw_txn::repair_commit_gap_nonce(&service, signer, &signer_str, 0)
+        !crate::service_send_raw_txn::repair_commit_gap_nonce(&service, &signer_str, 0)
             .await
             .unwrap()
     );
@@ -1605,4 +1604,89 @@ fn dummy_txn_entry_for(signer: Address) -> TxnEntry {
         expires_at: None,
         logs: vec![],
     }
+}
+
+/// BLOCKER D — `nonce_advance_cas` on PgStore: advances only WHERE the stored nonce
+/// equals `expected`, returning whether it won. Fresh address is nonce 0.
+#[tokio::test]
+async fn test_pgstore_nonce_advance_cas() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    let addr = format!("0x{:040x}", rand_u64() as u128);
+
+    // Fresh (no row = 0): CAS(0) wins → 1; a second CAS(0) loses (now 1).
+    assert!(store.nonce_advance_cas(&addr, 0).await.unwrap());
+    assert_eq!(store.nonce_get(&addr).await.unwrap(), 1);
+    assert!(!store.nonce_advance_cas(&addr, 0).await.unwrap());
+    assert_eq!(store.nonce_get(&addr).await.unwrap(), 1);
+
+    // CAS at the wrong expected loses; at the right expected wins.
+    assert!(!store.nonce_advance_cas(&addr, 5).await.unwrap());
+    assert!(store.nonce_advance_cas(&addr, 1).await.unwrap());
+    assert_eq!(store.nonce_get(&addr).await.unwrap(), 2);
+}
+
+/// BLOCKER C — `commit_reverted_receipt_and_advance_nonce` on PgStore: one
+/// transaction writes a COMMITTED reverted receipt (never pending) AND CAS-advances
+/// the nonce; idempotent on tx_hash, and the CAS is a no-op once the nonce moved.
+#[tokio::test]
+async fn test_pgstore_commit_reverted_receipt_and_advance_nonce() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    let base = rand_u64();
+    let signer = Address::from([(base % 251) as u8 + 1; 20]);
+    let signer_str = format!("{signer:#x}");
+    let tx_hash = TxHash::from([(base % 241) as u8 + 2; 32]);
+
+    assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 0);
+
+    // First call: receipt committed-reverted + nonce CAS-advanced (expected 0 → 1).
+    let advanced = store
+        .commit_reverted_receipt_and_advance_nonce(
+            tx_hash,
+            dummy_txn_entry_for(signer),
+            "landed (AlreadyClaimed) #55".into(),
+            7,
+            [0u8; 32],
+            &signer_str,
+            0,
+        )
+        .await
+        .unwrap();
+    assert!(
+        advanced,
+        "the nonce CAS wins on the sync accept path (expected == 0)"
+    );
+    // Receipt is COMMITTED (non-null) and reverted (status 0x0).
+    let (result, block) = store
+        .txn_receipt(tx_hash)
+        .await
+        .unwrap()
+        .expect("receipt is committed, never pending");
+    assert!(result.is_err(), "status 0x0 reverted");
+    assert_eq!(block, 7);
+    assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 1);
+
+    // Idempotent re-entry (expected 0 again): receipt re-affirmed, nonce NOT
+    // double-advanced (the CAS no-ops because the nonce already moved to 1).
+    let advanced_again = store
+        .commit_reverted_receipt_and_advance_nonce(
+            tx_hash,
+            dummy_txn_entry_for(signer),
+            "landed (AlreadyClaimed) #55".into(),
+            7,
+            [0u8; 32],
+            &signer_str,
+            0,
+        )
+        .await
+        .unwrap();
+    assert!(
+        !advanced_again,
+        "re-entry must not double-advance the nonce"
+    );
+    assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 1);
+    assert!(store.txn_receipt(tx_hash).await.unwrap().is_some());
 }

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -1481,14 +1481,18 @@ async fn test_pgstore_acquire_claim_lock_outcomes() {
 
     // 1. Fresh index → Acquired.
     assert_eq!(
-        acquire_claim_lock(&store, gi_fresh, ttl).await.unwrap(),
-        ClaimLockOutcome::Acquired
+        acquire_claim_lock(&store, gi_fresh, TxHash::ZERO, ttl)
+            .await
+            .unwrap(),
+        ClaimLockOutcome::Acquired { fence: 1 }
     );
 
     // 2. Locked, no ClaimEvent, within TTL → InFlight.
     store.try_claim(gi_inflight).await.unwrap();
     assert_eq!(
-        acquire_claim_lock(&store, gi_inflight, ttl).await.unwrap(),
+        acquire_claim_lock(&store, gi_inflight, TxHash::ZERO, ttl)
+            .await
+            .unwrap(),
         ClaimLockOutcome::InFlight
     );
 
@@ -1510,12 +1514,14 @@ async fn test_pgstore_acquire_claim_lock_outcomes() {
         .await
         .unwrap();
     assert_eq!(
-        acquire_claim_lock(&store, gi_landed, ttl).await.unwrap(),
+        acquire_claim_lock(&store, gi_landed, TxHash::ZERO, ttl)
+            .await
+            .unwrap(),
         ClaimLockOutcome::Landed
     );
     // LANDED beats TTL-expiry recovery.
     assert_eq!(
-        acquire_claim_lock(&store, gi_landed, std::time::Duration::ZERO)
+        acquire_claim_lock(&store, gi_landed, TxHash::ZERO, std::time::Duration::ZERO)
             .await
             .unwrap(),
         ClaimLockOutcome::Landed
@@ -1524,10 +1530,10 @@ async fn test_pgstore_acquire_claim_lock_outcomes() {
     // 4. Orphaned (locked, no ClaimEvent, TTL expired) → Acquired (superseded).
     store.try_claim(gi_orphan).await.unwrap();
     assert_eq!(
-        acquire_claim_lock(&store, gi_orphan, std::time::Duration::ZERO)
+        acquire_claim_lock(&store, gi_orphan, TxHash::ZERO, std::time::Duration::ZERO)
             .await
             .unwrap(),
-        ClaimLockOutcome::Acquired
+        ClaimLockOutcome::Acquired { fence: 1 }
     );
 }
 
@@ -1841,6 +1847,10 @@ async fn test_pgstore_reverted_receipt_conditional() {
         .await
         .unwrap();
     store
+        .record_tx_note_link(&format!("{tx_pending:#x}"), "real-note")
+        .await
+        .unwrap();
+    store
         .commit_reverted_receipt_and_advance_nonce(
             tx_pending,
             dummy_txn_entry_for(signer),
@@ -1878,11 +1888,53 @@ async fn test_pgstore_reverted_receipt_conditional() {
     );
 }
 
-/// BLOCKER A — state-FIRST takeover on PgStore: a DIFFERENT tx takes over a
-/// released_failure or EXPIRED slot (nonce not consumed), but is hard-rejected while
-/// the holder is executing under a valid lease or released_success.
+/// PostgreSQL claim reclaim is fenced through the atomic submitted-state + note-link seal.
 #[tokio::test]
-async fn test_pgstore_different_tx_takeover() {
+async fn test_pgstore_claim_reclaim_fences_stale_owner() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    let base = rand_u64();
+    let gi = U256::from(base);
+    let tx_a = TxHash::from([(base % 211) as u8 + 12; 32]);
+    let tx_b = TxHash::from([(base % 199) as u8 + 13; 32]);
+    let a = store
+        .try_claim_fenced(gi, tx_a, std::time::Duration::ZERO)
+        .await
+        .unwrap()
+        .unwrap();
+    let b = store
+        .try_reclaim_claim_fenced(gi, tx_b, std::time::Duration::from_secs(90))
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(b.fence > a.fence);
+    assert!(
+        !store
+            .mark_claim_submitted_fenced(gi, tx_a, a.fence, tx_a, "stale")
+            .await
+            .unwrap()
+    );
+    assert!(!store.unclaim_fenced(&gi, tx_a, a.fence).await.unwrap());
+    assert!(
+        store
+            .mark_claim_submitted_fenced(gi, tx_b, b.fence, tx_b, "winner")
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        store
+            .get_note_link_for_tx(&format!("{tx_b:#x}"))
+            .await
+            .unwrap()
+            .as_deref(),
+        Some("winner")
+    );
+}
+
+/// PostgreSQL must permanently bind an ambiguous nonce slot to the first hash.
+#[tokio::test]
+async fn test_pgstore_different_tx_cannot_take_over() {
     let Some(store) = pg_store().await else {
         return;
     };
@@ -1893,45 +1945,20 @@ async fn test_pgstore_different_tx_takeover() {
     let ha = TxHash::from([(base % 251) as u8 + 10; 32]);
     let hb = TxHash::from([(base % 241) as u8 + 11; 32]);
 
-    // released_FAILURE → a DIFFERENT tx takes over.
     let NonceReservation::Won { fence } = store.reserve_nonce(&addr, 1, ha, lease).await.unwrap()
     else {
-        panic!("fresh must Win");
+        panic!("fresh must win");
     };
     store
         .release_reservation(&addr, 1, ha, fence, false)
         .await
         .unwrap();
-    assert!(
-        matches!(
-            store.reserve_nonce(&addr, 1, hb, lease).await.unwrap(),
-            NonceReservation::Won { .. }
-        ),
-        "a DIFFERENT tx must take over a released_failure slot"
+    assert_eq!(
+        store.reserve_nonce(&addr, 1, hb, lease).await.unwrap(),
+        NonceReservation::HeldByOther(ha)
     );
-
-    // executing + VALID lease → a DIFFERENT tx is HARD-REJECTED.
     assert!(matches!(
-        store.reserve_nonce(&addr, 2, ha, lease).await.unwrap(),
+        store.reserve_nonce(&addr, 1, ha, lease).await.unwrap(),
         NonceReservation::Won { .. }
     ));
-    assert_eq!(
-        store.reserve_nonce(&addr, 2, hb, lease).await.unwrap(),
-        NonceReservation::HeldByOther(ha)
-    );
-
-    // released_SUCCESS → a DIFFERENT tx is HARD-REJECTED (nonce consumed).
-    let NonceReservation::Won { fence: f3 } =
-        store.reserve_nonce(&addr, 3, ha, lease).await.unwrap()
-    else {
-        panic!("fresh must Win");
-    };
-    store
-        .release_reservation(&addr, 3, ha, f3, true)
-        .await
-        .unwrap();
-    assert_eq!(
-        store.reserve_nonce(&addr, 3, hb, lease).await.unwrap(),
-        NonceReservation::HeldByOther(ha)
-    );
 }

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -1877,3 +1877,61 @@ async fn test_pgstore_reverted_receipt_conditional() {
         "an absent hash gets the reverted (status 0x0) receipt"
     );
 }
+
+/// BLOCKER A — state-FIRST takeover on PgStore: a DIFFERENT tx takes over a
+/// released_failure or EXPIRED slot (nonce not consumed), but is hard-rejected while
+/// the holder is executing under a valid lease or released_success.
+#[tokio::test]
+async fn test_pgstore_different_tx_takeover() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    use crate::store::NonceReservation;
+    let lease = std::time::Duration::from_secs(90);
+    let base = rand_u64();
+    let addr = format!("0x{:040x}", base as u128);
+    let ha = TxHash::from([(base % 251) as u8 + 10; 32]);
+    let hb = TxHash::from([(base % 241) as u8 + 11; 32]);
+
+    // released_FAILURE → a DIFFERENT tx takes over.
+    let NonceReservation::Won { fence } = store.reserve_nonce(&addr, 1, ha, lease).await.unwrap()
+    else {
+        panic!("fresh must Win");
+    };
+    store
+        .release_reservation(&addr, 1, ha, fence, false)
+        .await
+        .unwrap();
+    assert!(
+        matches!(
+            store.reserve_nonce(&addr, 1, hb, lease).await.unwrap(),
+            NonceReservation::Won { .. }
+        ),
+        "a DIFFERENT tx must take over a released_failure slot"
+    );
+
+    // executing + VALID lease → a DIFFERENT tx is HARD-REJECTED.
+    assert!(matches!(
+        store.reserve_nonce(&addr, 2, ha, lease).await.unwrap(),
+        NonceReservation::Won { .. }
+    ));
+    assert_eq!(
+        store.reserve_nonce(&addr, 2, hb, lease).await.unwrap(),
+        NonceReservation::HeldByOther(ha)
+    );
+
+    // released_SUCCESS → a DIFFERENT tx is HARD-REJECTED (nonce consumed).
+    let NonceReservation::Won { fence: f3 } =
+        store.reserve_nonce(&addr, 3, ha, lease).await.unwrap()
+    else {
+        panic!("fresh must Win");
+    };
+    store
+        .release_reservation(&addr, 3, ha, f3, true)
+        .await
+        .unwrap();
+    assert_eq!(
+        store.reserve_nonce(&addr, 3, hb, lease).await.unwrap(),
+        NonceReservation::HeldByOther(ha)
+    );
+}

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -1690,3 +1690,118 @@ async fn test_pgstore_commit_reverted_receipt_and_advance_nonce() {
     assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 1);
     assert!(store.txn_receipt(tx_hash).await.unwrap().is_some());
 }
+
+/// BLOCKER 1 — `reserve_nonce` on PgStore: the first tx to reserve a (signer, nonce)
+/// wins; a different tx at the same slot loses (HeldBy the winner); the same tx is
+/// idempotent (HeldBy itself); a different nonce is free.
+#[tokio::test]
+async fn test_pgstore_reserve_nonce() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    use crate::store::NonceReservation;
+    let base = rand_u64();
+    let addr = format!("0x{:040x}", base as u128);
+    let h1 = TxHash::from([(base % 251) as u8 + 1; 32]);
+    let h2 = TxHash::from([(base % 241) as u8 + 2; 32]);
+
+    assert_eq!(
+        store.reserve_nonce(&addr, 5, h1).await.unwrap(),
+        NonceReservation::Won
+    );
+    // Same tx re-reserving → HeldBy(itself).
+    assert_eq!(
+        store.reserve_nonce(&addr, 5, h1).await.unwrap(),
+        NonceReservation::HeldBy(h1)
+    );
+    // Different tx, same slot → HeldBy(winner h1).
+    assert_eq!(
+        store.reserve_nonce(&addr, 5, h2).await.unwrap(),
+        NonceReservation::HeldBy(h1)
+    );
+    // Different nonce → free.
+    assert_eq!(
+        store.reserve_nonce(&addr, 6, h2).await.unwrap(),
+        NonceReservation::Won
+    );
+}
+
+/// BLOCKER 4 — `commit_reverted_receipt_and_advance_nonce` on PgStore is CONDITIONAL:
+/// it never overwrites a REAL receipt (pending or successful) with status 0.
+#[tokio::test]
+async fn test_pgstore_reverted_receipt_conditional() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    let base = rand_u64();
+    let signer = Address::from([(base % 251) as u8 + 3; 20]);
+    let signer_str = format!("{signer:#x}");
+
+    // (a) SUCCESS receipt must survive.
+    let tx_ok = TxHash::from([(base % 239) as u8 + 4; 32]);
+    store
+        .txn_begin(tx_ok, dummy_txn_entry_for(signer))
+        .await
+        .unwrap();
+    store.txn_commit(tx_ok, Ok(()), 5, [0u8; 32]).await.unwrap();
+    store
+        .commit_reverted_receipt_and_advance_nonce(
+            tx_ok,
+            dummy_txn_entry_for(signer),
+            "revert".into(),
+            9,
+            [0u8; 32],
+            &signer_str,
+            0,
+        )
+        .await
+        .unwrap();
+    let (r_ok, _) = store.txn_receipt(tx_ok).await.unwrap().expect("receipt");
+    assert!(
+        r_ok.is_ok(),
+        "a REAL success receipt must NOT be overwritten to failed"
+    );
+
+    // (b) PENDING receipt must stay pending.
+    let tx_pending = TxHash::from([(base % 233) as u8 + 5; 32]);
+    store
+        .txn_begin(tx_pending, dummy_txn_entry_for(signer))
+        .await
+        .unwrap();
+    store
+        .commit_reverted_receipt_and_advance_nonce(
+            tx_pending,
+            dummy_txn_entry_for(signer),
+            "revert".into(),
+            9,
+            [0u8; 32],
+            &signer_str,
+            1,
+        )
+        .await
+        .unwrap();
+    assert!(
+        store.txn_receipt(tx_pending).await.unwrap().is_none(),
+        "a REAL pending receipt must stay pending, not be finalised to failed"
+    );
+
+    // (c) ABSENT hash → reverted receipt IS written.
+    let tx_new = TxHash::from([(base % 229) as u8 + 6; 32]);
+    store
+        .commit_reverted_receipt_and_advance_nonce(
+            tx_new,
+            dummy_txn_entry_for(signer),
+            "revert".into(),
+            9,
+            [0u8; 32],
+            &signer_str,
+            2,
+        )
+        .await
+        .unwrap();
+    let (r_new, _) = store.txn_receipt(tx_new).await.unwrap().expect("receipt");
+    assert!(
+        r_new.is_err(),
+        "an absent hash gets the reverted (status 0x0) receipt"
+    );
+}

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -1704,25 +1704,97 @@ async fn test_pgstore_reserve_nonce() {
     let addr = format!("0x{:040x}", base as u128);
     let h1 = TxHash::from([(base % 251) as u8 + 1; 32]);
     let h2 = TxHash::from([(base % 241) as u8 + 2; 32]);
+    let lease = std::time::Duration::from_secs(90);
 
+    // Fresh → Won(fence).
+    let NonceReservation::Won { fence } = store.reserve_nonce(&addr, 5, h1, lease).await.unwrap()
+    else {
+        panic!("fresh slot must be Won");
+    };
+    // Same tx, valid lease → OwnedBySame.
     assert_eq!(
-        store.reserve_nonce(&addr, 5, h1).await.unwrap(),
-        NonceReservation::Won
+        store.reserve_nonce(&addr, 5, h1, lease).await.unwrap(),
+        NonceReservation::OwnedBySame
     );
-    // Same tx re-reserving → HeldBy(itself).
+    // Different tx, same slot → HeldByOther(winner h1).
     assert_eq!(
-        store.reserve_nonce(&addr, 5, h1).await.unwrap(),
-        NonceReservation::HeldBy(h1)
+        store.reserve_nonce(&addr, 5, h2, lease).await.unwrap(),
+        NonceReservation::HeldByOther(h1)
     );
-    // Different tx, same slot → HeldBy(winner h1).
+    // release-FAILURE → same tx takes over (fence bumps).
+    store
+        .release_reservation(&addr, 5, h1, fence, false)
+        .await
+        .unwrap();
+    let NonceReservation::Won { fence: fence2 } =
+        store.reserve_nonce(&addr, 5, h1, lease).await.unwrap()
+    else {
+        panic!("after release-failure the same tx must retake ownership");
+    };
+    assert!(fence2 > fence, "takeover bumps the fence");
+    // release-SUCCESS → same tx dedups.
+    store
+        .release_reservation(&addr, 5, h1, fence2, true)
+        .await
+        .unwrap();
     assert_eq!(
-        store.reserve_nonce(&addr, 5, h2).await.unwrap(),
-        NonceReservation::HeldBy(h1)
+        store.reserve_nonce(&addr, 5, h1, lease).await.unwrap(),
+        NonceReservation::OwnedBySame
     );
     // Different nonce → free.
+    assert!(matches!(
+        store.reserve_nonce(&addr, 6, h2, lease).await.unwrap(),
+        NonceReservation::Won { .. }
+    ));
+}
+
+/// BLOCKER 1 — FULL two-replica shared-PostgreSQL races. Two PgStore handles over
+/// the SAME database (two "replicas") reserve the SAME (signer, nonce) slot.
+#[tokio::test]
+async fn test_pgstore_two_replica_reservation_races() {
+    let Some(replica_a) = pg_store().await else {
+        return;
+    };
+    let Some(replica_b) = pg_store().await else {
+        return;
+    };
+    use crate::store::NonceReservation;
+    let lease = std::time::Duration::from_secs(90);
+    let base = rand_u64();
+
+    // (1) DIFFERENT-hash race at the same slot: exactly one wins, the other is
+    //     HeldByOther and must NOT execute.
+    let addr = format!("0x{:040x}", base as u128);
+    let ha = TxHash::from([(base % 251) as u8 + 7; 32]);
+    let hb = TxHash::from([(base % 241) as u8 + 8; 32]);
+    let ra = replica_a.reserve_nonce(&addr, 3, ha, lease).await.unwrap();
+    let rb = replica_b.reserve_nonce(&addr, 3, hb, lease).await.unwrap();
+    let a_won = matches!(ra, NonceReservation::Won { .. });
+    let b_won = matches!(rb, NonceReservation::Won { .. });
+    // Replica A reserved first (sequential here), so A wins and B is HeldByOther.
+    assert!(a_won, "the first replica to reserve wins: {ra:?}");
+    assert!(
+        !b_won,
+        "the second replica with a DIFFERENT hash must not win: {rb:?}"
+    );
+    assert_eq!(rb, NonceReservation::HeldByOther(ha));
+
+    // (2) SAME-hash race at another slot: replica A wins ownership; replica B
+    //     submitting the IDENTICAL tx while A's lease is valid gets OwnedBySame and
+    //     must DEDUP (not execute) — no double Miden work.
+    let addr2 = format!("0x{:040x}", base.wrapping_add(1) as u128);
+    let h = TxHash::from([(base % 233) as u8 + 9; 32]);
+    let ra2 = replica_a.reserve_nonce(&addr2, 4, h, lease).await.unwrap();
+    assert!(
+        matches!(ra2, NonceReservation::Won { .. }),
+        "A wins: {ra2:?}"
+    );
+    let rb2 = replica_b.reserve_nonce(&addr2, 4, h, lease).await.unwrap();
     assert_eq!(
-        store.reserve_nonce(&addr, 6, h2).await.unwrap(),
-        NonceReservation::Won
+        rb2,
+        NonceReservation::OwnedBySame,
+        "the same tx on another replica while the owner's lease is valid must dedup, \
+         not double-execute"
     );
 }
 

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -635,9 +635,9 @@ async fn test_pgstore_has_claim_event_for_global_index_finds_both_sources() {
     assert!(store.has_claim_event_for_global_index(&gi_b).await.unwrap());
 }
 
-/// `commit_manual_claim_event_atomic`: a single PG txn folds mark +
-/// log insert + cursor advance. Verify cursor lands at the expected
-/// block and a fresh ClaimEvent log appears.
+/// `commit_manual_claim_event_atomic`: a single PG txn folds the processed
+/// marker, log insert, and linked receipt completion. Block-tip advancement is
+/// intentionally left to the projector after the full block.
 #[tokio::test]
 async fn test_pgstore_commit_manual_claim_event_atomic() {
     let Some(store) = pg_store().await else {
@@ -674,8 +674,6 @@ async fn test_pgstore_commit_manual_claim_event_atomic() {
         .await
         .unwrap();
 
-    // Cursor advanced.
-    assert!(store.get_latest_block_number().await.unwrap() >= block);
     // Note processed.
     assert!(store.is_claim_note_processed(&note_id).await.unwrap());
     // ClaimEvent dedup query finds the row.
@@ -1738,15 +1736,15 @@ async fn test_pgstore_reserve_nonce() {
         panic!("after release-failure the same tx must retake ownership");
     };
     assert!(fence2 > fence, "takeover bumps the fence");
-    // release-SUCCESS → same tx dedups.
+    // release-SUCCESS → the exact durable tx can resume after restart.
     store
         .release_reservation(&addr, 5, h1, fence2, true)
         .await
         .unwrap();
-    assert_eq!(
+    assert!(matches!(
         store.reserve_nonce(&addr, 5, h1, lease).await.unwrap(),
-        NonceReservation::OwnedBySame
-    );
+        NonceReservation::Won { fence } if fence > fence2
+    ));
     // Different nonce → free.
     assert!(matches!(
         store.reserve_nonce(&addr, 6, h2, lease).await.unwrap(),
@@ -1911,14 +1909,14 @@ async fn test_pgstore_claim_reclaim_fences_stale_owner() {
     assert!(b.fence > a.fence);
     assert!(
         !store
-            .mark_claim_submitted_fenced(gi, tx_a, a.fence, tx_a, "stale")
+            .prepare_claim_submission_fenced(gi, tx_a, a.fence, tx_a, "stale", "stale-id", 100,)
             .await
             .unwrap()
     );
     assert!(!store.unclaim_fenced(&gi, tx_a, a.fence).await.unwrap());
     assert!(
         store
-            .mark_claim_submitted_fenced(gi, tx_b, b.fence, tx_b, "winner")
+            .prepare_claim_submission_fenced(gi, tx_b, b.fence, tx_b, "winner", "winner-id", 100,)
             .await
             .unwrap()
     );

--- a/src/synthetic_projector.rs
+++ b/src/synthetic_projector.rs
@@ -62,6 +62,8 @@ use crate::restore::{
     project_claim_note, project_ger_note,
 };
 use crate::store::Store;
+use crate::writer_worker::DecodedWriteCall;
+use alloy::primitives::TxHash;
 use miden_client::rpc::NodeRpcClient;
 use miden_client::rpc::domain::note::FetchedNote;
 use miden_client::rpc::domain::transaction::TransactionRecord;
@@ -94,6 +96,11 @@ const RECONCILE_CHUNK: u64 = 1_000;
 /// [`RECONCILE_CONCURRENCY_MAX`] to stay a polite RPC citizen.
 const RECONCILE_CONCURRENCY_DEFAULT: usize = 8;
 const RECONCILE_CONCURRENCY_MAX: usize = 16;
+
+/// Maximum exact-note duplicate checks per projector tick. The projector tick
+/// is single-flight; this bound prevents a damaged backlog from starving normal
+/// projection while guaranteeing steady progress.
+const PENDING_DUPLICATE_RECONCILE_LIMIT: usize = 16;
 
 /// Per-tick time budget for the reconciler's catch-up loop, in milliseconds.
 /// Env-tunable via `RECONCILE_TICK_BUDGET_MS`. Projection runs AFTER the
@@ -181,6 +188,12 @@ fn is_private_note_import_error<E: std::fmt::Display + ?Sized>(e: &E) -> bool {
 /// and, when registered as the live [`SyncListener`], is the **sole** assigner
 /// of the synthetic tip (`Store::latest_block_number`) — so there is no
 /// reservation race (Finding #5 eliminated by construction).
+struct PendingDuplicate {
+    tx_hash: TxHash,
+    call: DecodedWriteCall,
+    note_id: String,
+}
+
 pub struct SyntheticProjector {
     store: Arc<dyn Store>,
     block_state: Arc<BlockState>,
@@ -245,6 +258,9 @@ pub struct SyntheticProjector {
     /// Per-tick catch-up time budget (`RECONCILE_TICK_BUDGET_MS` env override,
     /// default [`RECONCILE_TICK_BUDGET_MS_DEFAULT`]).
     reconcile_budget: Duration,
+    // Last transaction hash considered by the bounded duplicate sweep. This
+    // process-local cursor is sufficient because one projector owns reconciliation.
+    pending_duplicate_cursor: std::sync::Mutex<Option<TxHash>>,
     /// In-flight B2AGG note BODIES keyed by nullifier — the projector's authoritative
     /// body-resolution source, bounded to imported-but-not-yet-projected notes.
     ///
@@ -369,12 +385,139 @@ impl SyntheticProjector {
             reconcile_chunk,
             reconcile_concurrency,
             reconcile_budget,
+            pending_duplicate_cursor: std::sync::Mutex::new(None),
             recovered_bodies: std::sync::Mutex::new(HashMap::new()),
             fetch_miss_attempts: std::sync::Mutex::new(HashMap::new()),
             last_source_window_to: AtomicU64::new(0),
             audit_resolved: std::sync::Mutex::new(HashSet::new()),
             audit_tick_counter: AtomicU64::new(0),
         })
+    }
+
+    async fn load_pending_duplicate(
+        &self,
+        tx_hash: TxHash,
+    ) -> anyhow::Result<Option<PendingDuplicate>> {
+        let Some(transaction) = self.store.txn_get(tx_hash).await? else {
+            return Ok(None);
+        };
+        if transaction.result.is_some() {
+            return Ok(None);
+        }
+        let Some(handoff) = self
+            .store
+            .get_note_handoff_for_tx(&format!("{tx_hash:#x}"))
+            .await?
+        else {
+            return Ok(None);
+        };
+        let Some(note_id) = handoff.note_id else {
+            return Ok(None);
+        };
+        let call = crate::service_send_raw_txn::decode_envelope_write_call(&transaction.envelope)?;
+        Ok(Some(PendingDuplicate {
+            tx_hash,
+            call,
+            note_id,
+        }))
+    }
+
+    async fn resolve_pending_duplicate(
+        &self,
+        client: &mut MidenClientLib,
+        pending: &PendingDuplicate,
+    ) -> anyhow::Result<crate::applied_state::ExactNoteOutcome> {
+        match &pending.call {
+            DecodedWriteCall::Ger { ger_bytes } => {
+                crate::applied_state::reconcile_ger_handoff_with_client(
+                    self.store.as_ref(),
+                    client,
+                    self.bridge_id,
+                    *ger_bytes,
+                    pending.note_id.clone(),
+                )
+                .await
+            }
+            DecodedWriteCall::Claim { params } => {
+                crate::applied_state::reconcile_claim_handoff_with_client(
+                    self.store.as_ref(),
+                    client,
+                    self.bridge_id,
+                    params.globalIndex,
+                    pending.note_id.clone(),
+                )
+                .await
+            }
+        }
+    }
+
+    async fn finalize_pending_duplicate(
+        &self,
+        pending: PendingDuplicate,
+        outcome: crate::applied_state::ExactNoteOutcome,
+    ) -> anyhow::Result<()> {
+        if outcome != crate::applied_state::ExactNoteOutcome::AppliedElsewhere {
+            // The exact note was consumed, or the evidence is absent/uncertain.
+            // Normal projection owns exact-note finalization; otherwise stay pending.
+            return Ok(());
+        }
+        let result = match pending.call {
+            DecodedWriteCall::Ger { .. } => Ok(()),
+            DecodedWriteCall::Claim { .. } => {
+                Err("execution reverted: AlreadyClaimed()".to_string())
+            }
+        };
+        let block_num = self.store.get_latest_block_number().await?;
+        self.store
+            .txn_commit_confirmed_duplicate(pending.tx_hash, result, block_num)
+            .await
+    }
+
+    async fn reconcile_pending_duplicate(
+        &self,
+        client: &mut MidenClientLib,
+        tx_hash: TxHash,
+    ) -> anyhow::Result<()> {
+        let Some(pending) = self.load_pending_duplicate(tx_hash).await? else {
+            return Ok(());
+        };
+        let outcome = self.resolve_pending_duplicate(client, &pending).await?;
+        self.finalize_pending_duplicate(pending, outcome).await
+    }
+
+    async fn reconcile_pending_duplicates(
+        &self,
+        client: &mut MidenClientLib,
+    ) -> anyhow::Result<()> {
+        let after = *self
+            .pending_duplicate_cursor
+            .lock()
+            .expect("pending duplicate cursor mutex poisoned");
+        let mut pending = self
+            .store
+            .pending_note_handoff_txs(after, PENDING_DUPLICATE_RECONCILE_LIMIT)
+            .await?;
+        if pending.is_empty() && after.is_some() {
+            pending = self
+                .store
+                .pending_note_handoff_txs(None, PENDING_DUPLICATE_RECONCILE_LIMIT)
+                .await?;
+        }
+        *self
+            .pending_duplicate_cursor
+            .lock()
+            .expect("pending duplicate cursor mutex poisoned") = pending.last().copied();
+
+        for tx_hash in pending {
+            if let Err(error) = self.reconcile_pending_duplicate(client, tx_hash).await {
+                tracing::warn!(
+                    %tx_hash,
+                    error = %format!("{error:#}"),
+                    "authoritative duplicate reconciliation is uncertain; keeping receipt null"
+                );
+            }
+        }
+        Ok(())
     }
 
     /// The next sweep window `[from, to]` the note-visibility reconciler will
@@ -1403,6 +1546,14 @@ impl SyntheticProjector {
             tracing::warn!(
                 error = %format!("{e:#}"),
                 "note reconciler failed (transient — will retry next tick)"
+            );
+        }
+        // Receipt polling is store-only. Resolve confirmed duplicates here, on
+        // the existing single-flight projector task, with a bounded batch.
+        if let Err(error) = self.reconcile_pending_duplicates(client).await {
+            tracing::warn!(
+                error = %format!("{error:#}"),
+                "pending duplicate reconciliation failed (transient — will retry next tick)"
             );
         }
         // #30 VISIBILITY BARRIER: never seal a synthetic block the reconciler
@@ -3350,5 +3501,245 @@ mod tests {
             outcome.audited, 0,
             "gated notes are excluded before the log check"
         );
+    }
+
+    fn duplicate_test_call(global_index: alloy::primitives::U256) -> DecodedWriteCall {
+        use alloy::primitives::{Address, FixedBytes};
+        DecodedWriteCall::Claim {
+            params: Box::new(crate::claim::claimAssetCall {
+                smtProofLocalExitRoot: [FixedBytes::ZERO; 32],
+                smtProofRollupExitRoot: [FixedBytes::ZERO; 32],
+                globalIndex: global_index,
+                mainnetExitRoot: FixedBytes::ZERO,
+                rollupExitRoot: FixedBytes::ZERO,
+                originNetwork: 0,
+                originTokenAddress: Address::ZERO,
+                destinationNetwork: 1,
+                destinationAddress: Address::ZERO,
+                amount: alloy::primitives::U256::from(1u8),
+                metadata: Default::default(),
+            }),
+        }
+    }
+
+    fn duplicate_test_envelope(
+        call: &DecodedWriteCall,
+        tx_hash: TxHash,
+    ) -> alloy::consensus::TxEnvelope {
+        use alloy::consensus::{Signed, TxEnvelope, TxLegacy};
+        use alloy::primitives::{FixedBytes, Signature};
+        use alloy_core::sol_types::SolCall;
+
+        let input = match call {
+            DecodedWriteCall::Claim { params } => params.abi_encode(),
+            DecodedWriteCall::Ger { ger_bytes } => crate::ger::insertGlobalExitRootCall {
+                root: FixedBytes::from(*ger_bytes),
+            }
+            .abi_encode(),
+        };
+        TxEnvelope::Legacy(Signed::new_unchecked(
+            TxLegacy {
+                input: input.into(),
+                ..Default::default()
+            },
+            Signature::test_signature(),
+            tx_hash,
+        ))
+    }
+
+    async fn begin_duplicate_test_tx(
+        store: &StdArc<dyn Store>,
+        tx_hash: TxHash,
+        call: &DecodedWriteCall,
+    ) {
+        store
+            .txn_begin(
+                tx_hash,
+                crate::store::TxnEntry {
+                    id: None,
+                    envelope: duplicate_test_envelope(call, tx_hash),
+                    signer: alloy::primitives::Address::from([0x77u8; 20]),
+                    expires_at: Some(100),
+                    logs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn background_reconciliation_finalizes_duplicate_claim_and_ger() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        store.set_latest_block_number(42).await.unwrap();
+        let projector = test_projector(&store, &StdArc::new(BlockState::new())).await;
+
+        let claim_hash = TxHash::from([0x91u8; 32]);
+        let claim = duplicate_test_call(alloy::primitives::U256::from(9u8));
+        begin_duplicate_test_tx(&store, claim_hash, &claim).await;
+        projector
+            .finalize_pending_duplicate(
+                PendingDuplicate {
+                    tx_hash: claim_hash,
+                    call: claim,
+                    note_id: "claim-note".into(),
+                },
+                crate::applied_state::ExactNoteOutcome::AppliedElsewhere,
+            )
+            .await
+            .unwrap();
+        let (claim_result, claim_block) = store
+            .txn_receipt(claim_hash)
+            .await
+            .unwrap()
+            .expect("duplicate claim receipt");
+        assert!(claim_result.is_err());
+        assert_eq!(claim_block, 42);
+
+        let ger_hash = TxHash::from([0x92u8; 32]);
+        let ger = DecodedWriteCall::Ger {
+            ger_bytes: [0x92u8; 32],
+        };
+        begin_duplicate_test_tx(&store, ger_hash, &ger).await;
+        projector
+            .finalize_pending_duplicate(
+                PendingDuplicate {
+                    tx_hash: ger_hash,
+                    call: ger,
+                    note_id: "ger-note".into(),
+                },
+                crate::applied_state::ExactNoteOutcome::AppliedElsewhere,
+            )
+            .await
+            .unwrap();
+        let (ger_result, ger_block) = store
+            .txn_receipt(ger_hash)
+            .await
+            .unwrap()
+            .expect("duplicate GER receipt");
+        assert!(ger_result.is_ok());
+        assert_eq!(ger_block, 42);
+    }
+
+    #[tokio::test]
+    async fn exact_or_uncertain_note_remains_pending_for_normal_projection() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let projector = test_projector(&store, &StdArc::new(BlockState::new())).await;
+        let tx_hash = TxHash::from([0x93u8; 32]);
+        let call = DecodedWriteCall::Ger {
+            ger_bytes: [0x93u8; 32],
+        };
+        begin_duplicate_test_tx(&store, tx_hash, &call).await;
+
+        for outcome in [
+            crate::applied_state::ExactNoteOutcome::AppliedByExactNote,
+            crate::applied_state::ExactNoteOutcome::NotApplied,
+            crate::applied_state::ExactNoteOutcome::Uncertain,
+        ] {
+            projector
+                .finalize_pending_duplicate(
+                    PendingDuplicate {
+                        tx_hash,
+                        call: call.clone(),
+                        note_id: "exact-or-unknown".into(),
+                    },
+                    outcome,
+                )
+                .await
+                .unwrap();
+            assert!(store.txn_receipt(tx_hash).await.unwrap().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn durable_claim_event_short_circuits_miden_and_missing_ger() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        store.set_latest_block_number(55).await.unwrap();
+        let projector = test_projector(&store, &StdArc::new(BlockState::new())).await;
+        let global_index = alloy::primitives::U256::from(0x5514u64);
+        let tx_hash = TxHash::from([0x94u8; 32]);
+        let call = duplicate_test_call(global_index);
+        begin_duplicate_test_tx(&store, tx_hash, &call).await;
+        store
+            .prepare_note_handoff(
+                &format!("{tx_hash:#x}"),
+                "pending-claim-commitment",
+                "not-present-in-offline-miden",
+                100,
+            )
+            .await
+            .unwrap();
+        store.try_claim(global_index).await.unwrap();
+        store
+            .commit_manual_claim_event_atomic(
+                "other-claim-note".into(),
+                "0x00000000000000000000000000000000000000aa",
+                54,
+                [0u8; 32],
+                "0x1111111111111111111111111111111111111111111111111111111111111111",
+                global_index.to_be_bytes::<32>(),
+                0,
+                &[0u8; 20],
+                &[0u8; 20],
+                1,
+            )
+            .await
+            .unwrap();
+
+        let combined_zero_ger = crate::ger::combined_ger(&[0u8; 32], &[0u8; 32]);
+        assert!(!store.is_ger_injected(&combined_zero_ger).await.unwrap());
+        let mut unavailable_miden = crate::test_helpers::offline_miden_client_lib().await;
+        projector
+            .reconcile_pending_duplicate(&mut unavailable_miden, tx_hash)
+            .await
+            .expect("durable ClaimEvent must avoid unavailable Miden state");
+
+        let (result, block) = store
+            .txn_receipt(tx_hash)
+            .await
+            .unwrap()
+            .expect("known duplicate claim is terminal");
+        assert!(result.is_err());
+        assert_eq!(block, 55);
+        assert!(
+            store
+                .pending_note_handoff_txs(None, PENDING_DUPLICATE_RECONCILE_LIMIT)
+                .await
+                .unwrap()
+                .is_empty(),
+            "terminal receipts must not be reconciled again"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_duplicate_query_is_bounded_and_cursor_ordered() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let call = DecodedWriteCall::Ger {
+            ger_bytes: [0xa5u8; 32],
+        };
+        let hashes = [
+            TxHash::from([1u8; 32]),
+            TxHash::from([2u8; 32]),
+            TxHash::from([3u8; 32]),
+        ];
+        for (index, tx_hash) in hashes.into_iter().enumerate() {
+            begin_duplicate_test_tx(&store, tx_hash, &call).await;
+            store
+                .prepare_note_handoff(
+                    &format!("{tx_hash:#x}"),
+                    &format!("commitment-{index}"),
+                    &format!("note-{index}"),
+                    100,
+                )
+                .await
+                .unwrap();
+        }
+
+        let first = store.pending_note_handoff_txs(None, 2).await.unwrap();
+        assert_eq!(first, hashes[..2]);
+        let second = store
+            .pending_note_handoff_txs(first.last().copied(), 2)
+            .await
+            .unwrap();
+        assert_eq!(second, hashes[2..]);
     }
 }

--- a/src/synthetic_projector.rs
+++ b/src/synthetic_projector.rs
@@ -491,6 +491,17 @@ impl SyntheticProjector {
                         self.reconcile_cursor.load(Ordering::Acquire)
                     )
                 })?;
+                // PREPARED handoffs persist the exact Miden NoteId before the
+                // external submit. `sync_notes` is the authoritative,
+                // inclusive creation feed, so seeing that id confirms the
+                // handoff even when a crash happened before the local client
+                // applied the accepted transaction. Do this on the raw ids,
+                // before body import/fetch (which may lag) and before the
+                // durable cursor advances past the transaction's expiry.
+                if !candidates.is_empty() {
+                    let note_ids: Vec<String> = candidates.iter().map(NoteId::to_hex).collect();
+                    self.store.confirm_prepared_note_handoffs(&note_ids).await?;
+                }
                 if !candidates.is_empty() {
                     let client = client.as_deref_mut().ok_or_else(|| {
                         anyhow::anyhow!(
@@ -2112,13 +2123,19 @@ mod tests {
     struct FakeFetcher {
         calls: std::sync::Mutex<Vec<(u64, u64)>>,
         fail_from: Option<u64>,
+        note_ids: Vec<NoteId>,
     }
 
     impl FakeFetcher {
         fn new(fail_from: Option<u64>) -> StdArc<Self> {
+            Self::with_note_ids(fail_from, Vec::new())
+        }
+
+        fn with_note_ids(fail_from: Option<u64>, note_ids: Vec<NoteId>) -> StdArc<Self> {
             StdArc::new(Self {
                 calls: std::sync::Mutex::new(Vec::new()),
                 fail_from,
+                note_ids,
             })
         }
 
@@ -2134,8 +2151,80 @@ mod tests {
             if self.fail_from == Some(from) {
                 anyhow::bail!("injected window-fetch failure ({from}..{to})");
             }
-            Ok(Vec::new())
+            Ok(self.note_ids.clone())
         }
+    }
+
+    /// A raw `sync_notes` NoteId is enough to close a PREPARED handoff even
+    /// when the subsequent body import cannot run. Conversely, a failed fetch
+    /// must neither confirm the handoff nor move the durable low-water mark.
+    #[tokio::test]
+    async fn reconcile_raw_note_id_confirmation_is_ordered_before_cursor_advance() {
+        let note_id = NoteId::from_raw(Word::new([Felt::new(0x42).unwrap(); 4]));
+        let tx_hash = "0xprepared-note";
+
+        // Successful raw-id observation: confirmation happens first. Supplying
+        // no client deliberately fails the later body-import step, proving the
+        // cursor is still held while the exact handoff is already confirmed.
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        store
+            .prepare_note_handoff(tx_hash, "details-commitment", &note_id.to_hex(), 100)
+            .await
+            .unwrap();
+        let block_state = StdArc::new(BlockState::new());
+        let projector = test_projector(&store, &block_state)
+            .await
+            .with_reconcile_tuning(200, 1, Duration::ZERO);
+        let fetcher = FakeFetcher::with_note_ids(None, vec![note_id]);
+        let f: StdArc<dyn ReconcileFetcher> = fetcher;
+        let err = projector
+            .reconcile_notes_with(None, None, &f, 200)
+            .await
+            .expect_err("candidate import without a client must fail");
+        assert!(format!("{err:#}").contains("no client handle"));
+        assert_eq!(
+            store
+                .get_note_handoff_for_tx(tx_hash)
+                .await
+                .unwrap()
+                .unwrap()
+                .state,
+            crate::store::NoteHandoffState::Submitted,
+            "raw NoteId observation must confirm before body import"
+        );
+        assert_eq!(
+            store.get_reconcile_cursor().await.unwrap(),
+            0,
+            "cursor must not advance when later window work fails"
+        );
+
+        // Failed window fetch: no raw ids were authoritatively observed, so
+        // neither confirmation nor cursor advancement is allowed.
+        let failed_store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        failed_store
+            .prepare_note_handoff(tx_hash, "details-commitment", &note_id.to_hex(), 100)
+            .await
+            .unwrap();
+        let failed_projector = test_projector(&failed_store, &block_state)
+            .await
+            .with_reconcile_tuning(200, 1, Duration::ZERO);
+        let failed_fetcher = FakeFetcher::with_note_ids(Some(1), vec![note_id]);
+        let failed: StdArc<dyn ReconcileFetcher> = failed_fetcher;
+        failed_projector
+            .reconcile_notes_with(None, None, &failed, 200)
+            .await
+            .expect_err("injected fetch failure must fail the window");
+        assert_eq!(
+            failed_store
+                .get_note_handoff_for_tx(tx_hash)
+                .await
+                .unwrap()
+                .unwrap()
+                .state,
+            crate::store::NoteHandoffState::Prepared,
+            "a failed fetch must not confirm an unobserved NoteId"
+        );
+        assert_eq!(failed_store.get_reconcile_cursor().await.unwrap(), 0);
     }
 
     /// Catch-up throughput contract: when the sweep is behind the tip, ONE

--- a/src/writer_worker.rs
+++ b/src/writer_worker.rs
@@ -52,6 +52,7 @@ use dashmap::DashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
+use tracing::Instrument;
 use ulid::Ulid;
 
 /// Default writer-worker mpsc capacity. Spec §6 decision #5: at queue cap 64
@@ -246,9 +247,8 @@ pub enum JobState {
     /// Worker successfully committed the receipt and emitted the synthetic
     /// log. `block_number` is the synthetic block the success was recorded at.
     Committed { block_number: u64 },
-    /// Worker exhausted its inline retries (or caught a panic via
-    /// `AssertUnwindSafe`). A failure receipt was best-effort written; the
-    /// caller's `eth_getTransactionReceipt` returns `status:0x0`.
+    /// Worker returned an error or its supervised dispatch task panicked. A failure
+    /// receipt was best-effort written; the caller's `eth_getTransactionReceipt` returns `status:0x0`.
     Failed,
 }
 
@@ -330,6 +330,27 @@ pub enum TryEnqueueError {
 #[derive(Debug, thiserror::Error)]
 #[error("writer queue saturated; retry")]
 pub struct WriterQueueSaturatedError;
+
+#[derive(Debug, thiserror::Error)]
+#[error("writer dispatch task panicked: {0}")]
+struct WriterDispatchPanic(String);
+
+/// Run one dispatch behind a Tokio task boundary so a panic becomes a normal
+/// job failure and cannot terminate the sole writer loop.
+async fn supervise_dispatch<F>(future: F) -> anyhow::Result<()>
+where
+    F: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    match tokio::spawn(future.in_current_span()).await {
+        Ok(result) => result,
+        Err(join_err) if join_err.is_panic() => {
+            Err(WriterDispatchPanic(join_err.to_string()).into())
+        }
+        Err(join_err) => Err(anyhow::anyhow!(
+            "writer dispatch task was cancelled: {join_err}"
+        )),
+    }
+}
 
 // ─── Public handle ───────────────────────────────────────────────────────────
 
@@ -764,14 +785,9 @@ impl WriterWorker {
         }
 
         let outcome_label;
-        let dispatch_result = std::panic::AssertUnwindSafe(dispatch_job(&self.service, job));
-        // FutureExt::catch_unwind would be cleaner but pulls in
-        // `futures-util`; we don't ship it as a dep. The bare AssertUnwindSafe
-        // here is enough because dispatch_job is itself an `async fn` — if it
-        // panics, the panic propagates through the .await and is caught by
-        // tokio::spawn's panic boundary. We log it via the worker
-        // supervision below.
-        let result: anyhow::Result<()> = dispatch_result.0.await;
+        let dispatch_service = self.service.clone();
+        let result =
+            supervise_dispatch(async move { dispatch_job(&dispatch_service, job).await }).await;
         match result {
             Ok(()) => {
                 // Best-effort: read the freshly-bumped tip to attribute the
@@ -842,10 +858,15 @@ impl WriterWorker {
                              eth_getTransactionReceipt will return null"
                         );
                     }
+                    let reason = if err.downcast_ref::<WriterDispatchPanic>().is_some() {
+                        "panic"
+                    } else {
+                        "miden"
+                    };
                     ::metrics::counter!(
                         "agglayer_writer_job_failures_total",
                         "kind" => kind.as_str(),
-                        "reason" => "miden",
+                        "reason" => reason,
                     )
                     .increment(1);
                 }
@@ -1008,6 +1029,22 @@ mod tests {
             eth_tx_hash: hash,
             job_id: Ulid::new(),
         }
+    }
+
+    #[tokio::test]
+    async fn dispatch_panic_is_contained_and_next_task_still_runs() {
+        let err = supervise_dispatch(async {
+            panic!("injected writer dispatch panic");
+            #[allow(unreachable_code)]
+            Ok(())
+        })
+        .await
+        .expect_err("the panic must be converted into a job error");
+        assert!(err.downcast_ref::<WriterDispatchPanic>().is_some());
+
+        supervise_dispatch(async { Ok(()) })
+            .await
+            .expect("the supervisor must remain usable after a panic");
     }
 
     #[tokio::test]

--- a/src/writer_worker.rs
+++ b/src/writer_worker.rs
@@ -369,6 +369,17 @@ impl WriterWorkerHandle {
         self.inflight.contains_key(hash)
     }
 
+    /// Whether this process still has executable work for `(signer, nonce)`.
+    /// A durable unlinked row without this live counterpart is a restart orphan
+    /// and must block admission of later nonces until its exact hash resumes.
+    pub fn has_non_terminal_nonce(&self, signer: &Address, nonce: u64) -> bool {
+        self.inflight.iter().any(|entry| {
+            entry.signer == *signer
+                && !entry.state.is_terminal()
+                && crate::store::envelope_nonce(&entry.envelope) == nonce
+        })
+    }
+
     /// Number of slots currently available in the mpsc channel
     /// (`Sender::capacity()`). Re-published as the
     /// `agglayer_writer_queue_depth` gauge on each enqueue attempt.
@@ -386,14 +397,9 @@ impl WriterWorkerHandle {
             .count()
     }
 
-    /// RD-940 Decision 4 — count non-terminal in-flight jobs for `signer`.
-    ///
-    /// `eth_getTransactionCount(addr, "latest")` calls this to compute the
-    /// next-committed nonce as `next-accepted - non_terminal_count`. Without
-    /// the subtraction the RPC would leak queued/submitting txs into the
-    /// `latest` view, breaking claim-sponsor's `nonce_cache.go:35` LRU.
-    /// `pending` (geth default) keeps using `nonce_get` directly — that's
-    /// what the request thread bumped on accept.
+    /// Count process-local non-terminal jobs for diagnostics and drain tests.
+    /// Transaction-count RPCs use the store's durable pending frontier, which
+    /// also covers sync mode and survives process restart.
     pub fn count_non_terminal_for_signer(&self, signer: &Address) -> usize {
         self.inflight
             .iter()
@@ -518,7 +524,7 @@ impl WriterWorker {
         }
     }
 
-    /// Spawn the writer worker and TTL sweeper. Returns a producer handle
+    /// Spawn the writer worker and maintenance sweeper. Returns a producer handle
     /// (cloneable via Arc) and a oneshot shutdown channel — send `()` (or
     /// drop the sender) to request a graceful stop. The worker drains its
     /// `recv` loop and exits; the sweeper exits when the inflight map's
@@ -543,21 +549,17 @@ impl WriterWorker {
             worker.run(&mut shutdown_rx).await;
         });
 
-        // TTL sweeper — runs independently so a stuck inflight entry can be
-        // garbage-collected even if the main worker is busy. Mirrors the
-        // pattern in `L1InfoTreeIndexer::spawn` (a separate ticker loop on
-        // the same Arc handle).
+        // Maintenance sweeper. It deliberately NEVER terminal-fails queued or
+        // submitting work: the mpsc item / MidenClient closure is owned by a
+        // different task and can still execute after a concurrent map update.
+        // Publishing status:0x0 from here would therefore race a real Miden
+        // side effect. Only the consuming worker may fail a job, after it has
+        // either completed dispatch or determined (before dispatch) that the
+        // job spent its whole TTL in the queue.
         //
-        // RD-940 Decision 5: every accepted hash MUST reach a terminal
-        // state. Two responsibilities:
-        //   1. Non-terminal entries (Queued / Submitting) older than tx_ttl
-        //      since `created_at` are forcibly transitioned to `Failed` and
-        //      a failure receipt is written so `eth_getTransactionReceipt`
-        //      transitions `null → status:0x0`. Bounds the contract — no
-        //      more forever-pending traps like the IAIC postmortem
-        //      (`docs/POSTMORTEM_2026-05-11_IAIC_TO_ADNF.md`).
-        //   2. Terminal entries older than tx_ttl since `terminal_at` are
-        //      evicted from the DashMap so it doesn't grow unbounded.
+        // This task has only two safe responsibilities:
+        //   1. renew nonce reservations while process-local work is live;
+        //   2. evict terminal entries older than tx_ttl since `terminal_at`.
         //
         // Iteration pattern: collect the hash+entry snapshots into a Vec
         // first (no `.await` while holding DashMap iter guards), then
@@ -578,8 +580,6 @@ impl WriterWorker {
                 ticker.tick().await;
                 let now = Instant::now();
 
-                // Snapshot two cohorts in a single pass.
-                let mut to_expire: Vec<(TxHash, Address)> = Vec::new();
                 let mut to_renew: Vec<(TxHash, Address, u64)> = Vec::new();
                 let mut to_evict: Vec<TxHash> = Vec::new();
                 for entry in sweeper_inflight.iter() {
@@ -590,9 +590,6 @@ impl WriterWorker {
                                 entry.signer,
                                 crate::service_send_raw_txn::envelope_nonce(&entry.envelope),
                             ));
-                            if now.duration_since(entry.created_at) > sweeper_ttl {
-                                to_expire.push((*entry.key(), entry.signer));
-                            }
                         }
                         JobState::Committed { .. } | JobState::Failed => {
                             if let Some(t) = entry.terminal_at
@@ -615,52 +612,6 @@ impl WriterWorker {
                             target: "writer_worker::lease", %hash, error = %err,
                             "failed to renew durable writer reservation"
                         );
-                    }
-                }
-
-                for (hash, _signer) in &to_expire {
-                    // Mark Failed + record terminal_at. Errors are logged
-                    // but don't block — the next sweeper tick re-tries.
-                    if let Some(mut entry) = sweeper_inflight.get_mut(hash) {
-                        entry.state = JobState::Failed;
-                        entry.terminal_at = Some(now);
-                    }
-                    let block_num = sweeper_service
-                        .store
-                        .get_latest_block_number()
-                        .await
-                        .unwrap_or(0);
-                    let block_hash = sweeper_service.block_state.get_block_hash(block_num);
-                    let reason = format!(
-                        "writer_worker: TTL expired (>{}s in non-terminal state)",
-                        sweeper_ttl.as_secs()
-                    );
-                    if let Err(e) = sweeper_service
-                        .store
-                        .txn_commit(*hash, Err(reason), block_num, block_hash)
-                        .await
-                    {
-                        tracing::warn!(
-                            target: "writer_worker::ttl",
-                            %hash,
-                            err = format!("{e:#}"),
-                            "TTL expiry: store.txn_commit(Err) failed; \
-                             eth_getTransactionReceipt may still return null. \
-                             Next sweeper tick will retry."
-                        );
-                    } else {
-                        tracing::warn!(
-                            target: "writer_worker::ttl",
-                            %hash,
-                            "TTL expiry: wrote failure receipt (status:0x0). \
-                             Caller must re-submit with a fresh nonce."
-                        );
-                        ::metrics::counter!(
-                            "agglayer_writer_job_failures_total",
-                            "kind" => "unknown",
-                            "reason" => "ttl",
-                        )
-                        .increment(1);
                     }
                 }
 
@@ -728,11 +679,12 @@ impl WriterWorker {
         // commit_ms. `queue_wait_ms` is measured from the inflight entry's
         // `created_at` (set in `try_enqueue`); the remaining elapsed
         // measurements are recorded inline below.
-        let queue_wait_ms = self
+        let queue_wait = self
             .inflight
             .get(&hash)
-            .map(|e| e.created_at.elapsed().as_millis() as u64)
-            .unwrap_or(0);
+            .map(|e| e.created_at.elapsed())
+            .unwrap_or_default();
+        let queue_wait_ms = queue_wait.as_millis() as u64;
         let span = tracing::info_span!(
             target: "writer_worker::job",
             "writer_job",
@@ -743,6 +695,68 @@ impl WriterWorker {
             queue_wait_ms,
         );
         let _entered = span.enter();
+
+        // The consuming worker is the only task allowed to expire queued
+        // work. At this point the item has been removed from mpsc and no
+        // dispatch future has been created, so a terminal failure cannot race
+        // a later Miden side effect from the same job.
+        if queue_wait >= self.tx_ttl {
+            let err = anyhow::anyhow!(
+                "writer_worker: TTL expired in queue before dispatch (>{}s)",
+                self.tx_ttl.as_secs()
+            );
+            if preserve_pending_after_handoff(&self.service.store, hash).await {
+                self.inflight.remove(&hash);
+                tracing::warn!(
+                    target: "writer_worker",
+                    %hash, kind = kind.as_str(), %job_id, signer = %signer,
+                    queue_wait_ms,
+                    "queued retry expired after an existing durable note handoff; \
+                     leaving receipt pending"
+                );
+                ::metrics::histogram!(
+                    "agglayer_writer_job_duration_seconds",
+                    "kind" => kind.as_str(),
+                    "outcome" => "pending",
+                )
+                .record(started.elapsed().as_secs_f64());
+                ::metrics::gauge!("agglayer_writer_inflight_jobs").set(self.inflight.len() as f64);
+                return;
+            }
+            if let Some(mut entry) = self.inflight.get_mut(&hash) {
+                entry.state = JobState::Failed;
+                entry.terminal_at = Some(Instant::now());
+            }
+            tracing::warn!(
+                target: "writer_worker",
+                %hash, kind = kind.as_str(), %job_id, signer = %signer,
+                queue_wait_ms,
+                "writer job expired in queue before dispatch; writing failure receipt"
+            );
+            if let Err(store_err) = write_failure_receipt(&self.service, hash, &err).await {
+                tracing::error!(
+                    target: "writer_worker",
+                    %hash,
+                    error = format!("{store_err:#}"),
+                    "writer_worker: failed to write queue-expiry receipt; \
+                     eth_getTransactionReceipt will return null"
+                );
+            }
+            ::metrics::counter!(
+                "agglayer_writer_job_failures_total",
+                "kind" => kind.as_str(),
+                "reason" => "ttl",
+            )
+            .increment(1);
+            ::metrics::histogram!(
+                "agglayer_writer_job_duration_seconds",
+                "kind" => kind.as_str(),
+                "outcome" => "failed",
+            )
+            .record(started.elapsed().as_secs_f64());
+            ::metrics::gauge!("agglayer_writer_inflight_jobs").set(self.inflight.len() as f64);
+            return;
+        }
 
         // Transition Queued → Submitting.
         if let Some(mut entry) = self.inflight.get_mut(&hash) {
@@ -792,45 +806,49 @@ impl WriterWorker {
                 );
             }
             Err(err) => {
-                if let Some(mut entry) = self.inflight.get_mut(&hash) {
-                    entry.state = JobState::Failed;
-                    entry.terminal_at = Some(Instant::now());
-                }
-                outcome_label = "failed";
-                tracing::error!(
-                    target: "writer_worker",
-                    %hash, kind = kind.as_str(), %job_id, signer = %signer,
-                    elapsed_secs = started.elapsed().as_secs_f64(),
-                    error = format!("{err:#}"),
-                    "writer_worker: job failed; writing failure receipt"
-                );
-                // Best-effort: write the failure receipt so
-                // `eth_getTransactionReceipt` transitions
-                // `null → status:0x0` and aggkit's ethtxmanager moves the
-                // tx to Failed instead of polling forever. Errors here are
-                // logged but cannot themselves fail the worker — if the
-                // store is sick the next sync will retry.
-                if let Err(store_err) = write_failure_receipt(&self.service, hash, &err).await {
+                if preserve_pending_after_handoff(&self.service.store, hash).await {
+                    self.inflight.remove(&hash);
+                    outcome_label = "pending";
+                    tracing::warn!(
+                        target: "writer_worker",
+                        %hash, kind = kind.as_str(), %job_id, signer = %signer,
+                        elapsed_secs = started.elapsed().as_secs_f64(),
+                        error = format!("{err:#}"),
+                        "writer job errored after durable note handoff; leaving receipt pending"
+                    );
+                } else {
+                    if let Some(mut entry) = self.inflight.get_mut(&hash) {
+                        entry.state = JobState::Failed;
+                        entry.terminal_at = Some(Instant::now());
+                    }
+                    outcome_label = "failed";
                     tracing::error!(
                         target: "writer_worker",
-                        %hash,
-                        error = format!("{store_err:#}"),
-                        "writer_worker: failed to write failure receipt; \
-                         eth_getTransactionReceipt will return null"
+                        %hash, kind = kind.as_str(), %job_id, signer = %signer,
+                        elapsed_secs = started.elapsed().as_secs_f64(),
+                        error = format!("{err:#}"),
+                        "writer_worker: job failed; writing failure receipt"
                     );
+                    // Best-effort: write the failure receipt so
+                    // `eth_getTransactionReceipt` transitions
+                    // `null → status:0x0` and aggkit's ethtxmanager moves the
+                    // tx to Failed instead of polling forever.
+                    if let Err(store_err) = write_failure_receipt(&self.service, hash, &err).await {
+                        tracing::error!(
+                            target: "writer_worker",
+                            %hash,
+                            error = format!("{store_err:#}"),
+                            "writer_worker: failed to write failure receipt; \
+                             eth_getTransactionReceipt will return null"
+                        );
+                    }
+                    ::metrics::counter!(
+                        "agglayer_writer_job_failures_total",
+                        "kind" => kind.as_str(),
+                        "reason" => "miden",
+                    )
+                    .increment(1);
                 }
-                // Spec F: bucket failure reasons for the job_failures_total
-                // counter. Phase 1 doesn't distinguish miden errors from
-                // store errors at this layer — reason="miden" is the
-                // catch-all for now; the TTL sweeper increments
-                // reason="ttl" directly. Refine when miden_client emits
-                // typed errors.
-                ::metrics::counter!(
-                    "agglayer_writer_job_failures_total",
-                    "kind" => kind.as_str(),
-                    "reason" => "miden",
-                )
-                .increment(1);
             }
         }
 
@@ -897,6 +915,9 @@ async fn write_failure_receipt(
     hash: TxHash,
     err: &anyhow::Error,
 ) -> anyhow::Result<()> {
+    if preserve_pending_after_handoff(&service.store, hash).await {
+        return Ok(());
+    }
     let reason = format!("writer_worker: {err:#}");
 
     // Snapshot the current tip so the receipt is attributable to a block
@@ -911,11 +932,34 @@ async fn write_failure_receipt(
     // here (it's been moved into the dispatch), but the inflight cache does;
     // for Phase 1 we accept that "no prior begin" is best-effort recoverable
     // by the future txn_commit_pending sweep at sync time. Phase 4 lands the
-    // proper TTL→status:0x0 path that always writes both rows.
+    // queue-age expiry and completed dispatch failures use this same path.
     service
         .store
         .txn_commit(hash, Err(reason), block_num, block_hash)
         .await
+}
+
+/// Fail closed when the store cannot disprove an exact note handoff. Once a
+/// handoff exists, only commit/observation or expiration reconciliation may
+/// transition the receipt; worker errors must never publish status 0.
+async fn preserve_pending_after_handoff(
+    store: &std::sync::Arc<dyn crate::store::Store>,
+    hash: TxHash,
+) -> bool {
+    let tx_key = format!("{hash:#x}");
+    match store.get_note_handoff_for_tx(&tx_key).await {
+        Ok(Some(_)) => true,
+        Ok(None) => false,
+        Err(err) => {
+            tracing::warn!(
+                target: "writer_worker",
+                %hash,
+                error = %err,
+                "could not classify note handoff; conservatively keeping receipt pending"
+            );
+            true
+        }
+    }
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -964,6 +1008,77 @@ mod tests {
             eth_tx_hash: hash,
             job_id: Ulid::new(),
         }
+    }
+
+    #[tokio::test]
+    async fn durable_note_handoff_preserves_pending_worker_outcome() {
+        let store: std::sync::Arc<dyn crate::store::Store> =
+            std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let hash = TxHash::from([0xabu8; 32]);
+        assert!(!preserve_pending_after_handoff(&store, hash).await);
+        store
+            .prepare_note_handoff(&format!("{hash:#x}"), "commitment", "note-id", 10)
+            .await
+            .unwrap();
+        assert!(preserve_pending_after_handoff(&store, hash).await);
+    }
+
+    /// Regression: expiry authority belongs to the worker that dequeued the
+    /// item. An over-age queued job is failed before `dispatch_job` is ever
+    /// constructed, so no Miden request can execute after status:0x0.
+    #[tokio::test]
+    async fn over_age_queued_job_expires_before_miden_dispatch() {
+        let service = crate::test_helpers::create_test_service();
+        let miden_client = service.miden_client.clone();
+        let mut job = fake_ger_job(29);
+        if let WriteJob::Ger { ger_bytes, .. } = &mut job {
+            *ger_bytes = [0x42; 32];
+        }
+        let hash = job.eth_tx_hash();
+
+        service
+            .store
+            .txn_begin(
+                hash,
+                crate::store::TxnEntry {
+                    id: None,
+                    envelope: job.envelope().clone(),
+                    signer: job.signer(),
+                    expires_at: None,
+                    logs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+
+        let (_sender, receiver) = mpsc::channel(1);
+        let inflight = Arc::new(DashMap::new());
+        let mut entry = InFlightEntry::from_job(&job);
+        entry.created_at = Instant::now() - Duration::from_secs(2);
+        inflight.insert(hash, entry);
+        let worker = WriterWorker {
+            receiver,
+            inflight: inflight.clone(),
+            service,
+            tx_ttl: Duration::from_secs(1),
+        };
+
+        worker.process(job).await;
+
+        assert_eq!(
+            miden_client.test_call_count(),
+            0,
+            "queue-age expiry must happen before dispatch reaches MidenClient::with"
+        );
+        assert_eq!(inflight.get(&hash).unwrap().state, JobState::Failed);
+        let receipt = worker
+            .service
+            .store
+            .txn_receipt(hash)
+            .await
+            .unwrap()
+            .expect("queue expiry writes a terminal receipt");
+        assert!(receipt.0.is_err());
     }
 
     /// Smoke test: parse_*_env returns defaults when env unset.

--- a/src/writer_worker.rs
+++ b/src/writer_worker.rs
@@ -1030,7 +1030,8 @@ mod tests {
     async fn over_age_queued_job_expires_before_miden_dispatch() {
         let service = crate::test_helpers::create_test_service();
         let miden_client = service.miden_client.clone();
-        let mut job = fake_ger_job(29);
+        let nonce = service.store.nonce_get("queue-expiry-test").await.unwrap();
+        let mut job = fake_ger_job(nonce);
         if let WriteJob::Ger { ger_bytes, .. } = &mut job {
             *ger_bytes = [0x42; 32];
         }

--- a/src/writer_worker.rs
+++ b/src/writer_worker.rs
@@ -82,8 +82,8 @@ const SWEEPER_INTERVAL: Duration = Duration::from_secs(30);
 /// next process boot to feed the `agglayer_writer_dropped_on_restart_total`
 /// counter. `/tmp` is appropriate for a k8s `emptyDir` (default behaviour on
 /// bali) — survives across container restarts within the same Pod, lost
-/// across Pod evictions, which matches the lossy semantics of the v1
-/// in-memory queue. SIGKILL leaves the tmpfile absent; combined with
+/// across Pod evictions, which remains useful as an observability signal even though the signed
+/// envelope is durably recoverable from the transaction store. SIGKILL leaves the tmpfile absent; combined with
 /// pre-kill `agglayer_writer_queue_depth` history this still pinpoints the
 /// loss window.
 pub const DROP_SNAPSHOT_PATH: &str = "/tmp/agglayer-writer-queue-snapshot";
@@ -568,7 +568,9 @@ impl WriterWorker {
         let sweeper_ttl = tx_ttl;
         let sweeper_service = service.clone();
         tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(SWEEPER_INTERVAL);
+            let reservation_lease = crate::service_send_raw_txn::reservation_lease();
+            let renewal_period = std::cmp::max(Duration::from_secs(1), reservation_lease / 3);
+            let mut ticker = tokio::time::interval(std::cmp::min(SWEEPER_INTERVAL, renewal_period));
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             // Skip the immediate first tick.
             ticker.tick().await;
@@ -578,10 +580,16 @@ impl WriterWorker {
 
                 // Snapshot two cohorts in a single pass.
                 let mut to_expire: Vec<(TxHash, Address)> = Vec::new();
+                let mut to_renew: Vec<(TxHash, Address, u64)> = Vec::new();
                 let mut to_evict: Vec<TxHash> = Vec::new();
                 for entry in sweeper_inflight.iter() {
                     match entry.state {
                         JobState::Queued | JobState::Submitting => {
+                            to_renew.push((
+                                *entry.key(),
+                                entry.signer,
+                                crate::service_send_raw_txn::envelope_nonce(&entry.envelope),
+                            ));
                             if now.duration_since(entry.created_at) > sweeper_ttl {
                                 to_expire.push((*entry.key(), entry.signer));
                             }
@@ -593,6 +601,20 @@ impl WriterWorker {
                                 to_evict.push(*entry.key());
                             }
                         }
+                    }
+                }
+
+                for (hash, signer, nonce) in &to_renew {
+                    let signer = format!("{signer:#x}");
+                    if let Err(err) = sweeper_service
+                        .store
+                        .renew_reservation(&signer, *nonce, *hash, reservation_lease)
+                        .await
+                    {
+                        tracing::warn!(
+                            target: "writer_worker::lease", %hash, error = %err,
+                            "failed to renew durable writer reservation"
+                        );
                     }
                 }
 
@@ -826,7 +848,7 @@ impl WriterWorker {
 /// Dispatch a `WriteJob` to the matching Phase-1 translator in
 /// `service_send_raw_txn`. Each variant calls the same publish/insert path the
 /// legacy sync handler does, minus the per-signer `nonce_increment` (the
-/// request thread already advanced the nonce at enqueue time — Spec §1 flow).
+/// request thread durably admitted the envelope and advanced the nonce before enqueue.
 async fn dispatch_job(service: &ServiceState, job: WriteJob) -> anyhow::Result<()> {
     match job {
         WriteJob::Claim {


### PR DESCRIPTION
## Summary

Hardens `claimAsset` and GER raw-transaction handling for the supported **one-active-proxy** deployment. It prevents AggKit nonce wedges across already-applied races, process restarts, and outcome-ambiguous Miden publication while preserving EVM-compatible receipts and bridge state reads.

This now covers both durable submission ownership and translation of already-applied Miden state:

| Situation | EVM-facing result | Logs | Miden publication |
|---|---|---:|---|
| Fresh claim or GER | Pending, then terminal success after projection | Normal synthetic event | Once |
| Claim already applied | Accepted hash; nonce consumed; `status: 0x0`; `isClaimed == true` | None | Suppressed |
| GER already applied | Accepted hash; nonce consumed; `status: 0x1`; `globalExitRootMap != 0` | None | Suppressed |
| Post-submit outcome is ambiguous | Same hash remains pending until exact-note evidence is conclusive | None while pending | Never guessed/rebuilt |
| Claim GER is not yet applied | `GlobalExitRootInvalid()` compatibility error before admission | None | Suppressed until retry |

`eth_estimateGas` remains an EVM compatibility shim only—Miden has no gas-estimation analogue and no proving or execution is performed there.

## What changes

- reads applied GER/claim state from the durable projection first and the synchronized Miden bridge maps when needed; in-flight submission locks are never treated as landed state;
- implements `globalExitRootMap(bytes32)` and `isClaimed(uint32,uint32)` compatibility reads against that authoritative state;
- translates already-applied claim and GER outcomes into the receipt/error shapes expected by the deployed AggKit/ClaimTxManager;
- accepts an already-landed claim, consumes the sponsor nonce atomically, and returns a terminal failed receipt without republishing or emitting a second `ClaimEvent`;
- accepts an already-applied GER as a successful EVM no-op without producing a second Miden note;
- persists the signed Ethereum envelope before nonce advancement, so restart recovery resumes only the exact hash;
- performs deterministic validation and queue-capacity rejection before binding the nonce reservation;
- uses the durable pending-nonce frontier for committed nonce reads, preventing later nonces from skipping a restart orphan;
- fences claim ownership through `executing -> prepared -> submitted -> landed`;
- records exact note details commitment, `NoteId`, and transaction expiration before the first external submit;
- marks a handoff submitted only after transaction commit or exact-note observation;
- keeps ambiguous post-submit outcomes pending rather than falsely failing them;
- reconciles raw tag-0 notes by exact `NoteId` before importing bodies or advancing the durable cursor;
- clears an unobserved prepared handoff only once the authoritative cursor is strictly past transaction expiration;
- commits event projection, claim fencing, handoff confirmation, linked receipt finalization, and nonce effects atomically at the store boundary;
- discards writer-local state once the durable handoff is authoritative.

```mermaid
sequenceDiagram
    participant A as AggKit / caller
    participant P as miden-agglayer RPC
    participant D as Durable store
    participant M as Miden

    A->>P: eth_sendRawTransaction(signed tx N)
    P->>D: Validate, persist envelope, reserve N
    P-->>A: Ethereum tx hash
    P->>M: Build, execute, and prove
    P->>D: PREPARED(commitment, NoteId, expiration)
    P->>M: Submit proven transaction

    alt commit or exact note observed
        P->>D: SUBMITTED
        M-->>P: note consumed / bridge state applied
        P->>D: Atomic projection + receipt + ownership update
        D-->>A: terminal receipt
    else operation already applied elsewhere
        M-->>P: bridge map applied; exact note remains unconsumed
        P->>D: Claim status 0 or GER status 1, with no logs
    else outcome remains ambiguous
        P-->>A: receipt remains null
        P->>M: Reconcile the exact NoteId
        alt exact NoteId observed
            P->>D: SUBMITTED
        else authoritative cursor > expiration
            P->>D: Clear PREPARED handoff
            A->>P: Re-submit the exact signed transaction
        end
    end
```

## Database upgrade

- Restores `011_nonce_reservations.sql` to its already-published contents.
- Adds new state only through additive migration `012_submission_handoffs.sql`.
- Existing claim/link rows upgrade fail-closed as submitted because they may already represent external side effects.

## Deployment scope

This PR supports one active proxy instance. Active-active proxies sharing PostgreSQL remain out of scope and are tracked in #142.

## Manual race coverage

`scripts/e2e-manual-user-claim.sh` captures the exact sponsor transaction at race start, decodes its `claimAsset.globalIndex`, and verifies that the losing sponsor transaction has the expected signer, reaches `status: 0x0`, and emits no logs.

## Validation

- CI check passed: formatting, release-profile Clippy, PostgreSQL-feature build, and shell checks;
- release-profile unit suite: **406 passed, 1 ignored, 0 failed**;
- CodeQL and Aikido passed;
- E2E was intentionally not run for this patch and remains delegated to the follow-up execution agent.
