### PR TITLE
fix(release): harden recovery, projection, and chaos follow-ups

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -290,6 +290,12 @@ services:
       - "--miden-node=http://miden-node:57291"
       - "--miden-store-dir=/var/lib/miden-agglayer-service"
       - "--l1-rpc-url=http://anvil:8545"
+      # finding #62 — per-origin-network RPC for Cantina #13 metadata recovery. An
+      # L2B-origin (origin_network=2) token's ABI-metadata preimage must be fetched from
+      # the L2B chain, not L1, or restore leaves its metadata Unrecoverable. Harmless on
+      # the base stack (anvil-l2b absent → the entry is never looked up; recovery connects
+      # lazily only when a network-2 faucet is actually rebuilt). Live on the l2l2 overlay.
+      - "--network-rpc-url=2=http://anvil-l2b:8545"
       - "--ger-l1-address=0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674"
       # Index L1 from genesis (block 1), not from L1 head. The kurtosis L1
       # snapshot already has the bridge deployed and its initial

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -210,3 +210,68 @@ re-upgrade against cloned state. `scripts/e2e-upgrade-test.sh` is a development
 fixture for the versions pinned inside that script; it is not a standing claim
 that arbitrary release pairs are rollback-compatible. Update its pinned image,
 override, endpoints, and assertions before using it as release evidence.
+
+
+## Release-specific notes: v0.15.8 → this release
+
+Validated by an in-place upgrade test on 2026-07-19 (fresh v0.15.8 stack →
+traffic → force-recreate onto this image → traffic; event history preserved,
+tip continuous, certification-grade chaos verdict on the upgraded stack).
+
+### Store migrations (auto-applied on startup)
+
+Eight new migrations land on first boot of the new image
+(`011_nonce_reservations` … `018_claim_mint_expected`): fenced nonce
+reservations, durable submission handoffs, L1 finality/evidence policy state,
+per-exit deposit reservations, B2AGG identity backfill, and expected-mint
+tracking. They are additive and idempotent; no manual DDL. First startup after
+the upgrade may take marginally longer while they apply — wait for `/health`
+before restoring write traffic, per the standard procedure above.
+
+### New flags (both additive; absent flags preserve old behavior)
+
+- `--network-rpc-url ID=URL` (repeatable; env `NETWORK_RPC_URLS`) — per-origin-
+  network RPC for ERC-20 metadata recovery. REQUIRED for deployments bridging
+  tokens whose origin is a second rollup (e.g. `2=http://<l2b-rpc>`): without
+  it, `--restore` and the live recovery path cannot validate an L2B-origin
+  token's metadata preimage and will defer those bridge-outs fail-closed.
+  Network 0 continues to come from `--l1-rpc-url`.
+- `--reject-unverified-ger-injection` — audit-H6 hardening; see the flag's
+  help text. Recommended in production together with a `safe`/`finalized`
+  `--l1-evidence-tag`.
+
+### Behavior changes to know about
+
+- **`--restore` now rebuilds historical claims** (Phase 2.6, node scan): after
+  a full store recovery, aggkit's aggsender can resolve pre-recovery bridge
+  exits and certificate settlement resumes. GER/hash-chain history still
+  restarts by design (the chain rebuilds through live operation).
+- **Duplicate landed claims are accepted-and-reverted** (geth-faithful,
+  status-0x0, no ClaimEvent) instead of rejected at admission, so an external
+  claim sponsor's transaction manager can never wedge on a user front-run.
+- **Abandoned nonce slots self-heal**: a reservation whose transaction
+  provably never reached durable admission (crashed mid-flight or released as
+  failure) is reclaimable by a fresh transaction at the same nonce. Metric:
+  `nonce_reservation_abandoned_reclaimed_total{cause}`.
+
+### Upgrade-procedure hazard validated by this test: run from the SAME deployment directory
+
+The e2e/compose deployment binds the Miden client store as a RELATIVE path
+(`./.miden-agglayer-data`). Recreating the service from a different checkout
+directory silently attaches a DIFFERENT store; if that store belongs to another
+chain, the client's sync is rejected by the node (`accept header validation
+failed`, genesis-commitment mismatch) and the synthetic tip freezes while the
+node keeps mining. This exact failure was reproduced during the v0.15.8→this
+release upgrade rehearsal. Rule: perform the image swap from the SAME compose
+working directory (or an absolute, unchanged store path) so every mount
+resolves identically — then verify sync (zero accept-header errors) and tip
+advancement before restoring traffic. The upgraded proxy resyncs cleanly
+through blocks mined during the swap window.
+
+### Operational follow-ups shipped with this release
+
+The operations runbook gained incident procedures for the two known
+silent-freeze modes — "Stuck GER injection (interrupted `ger_insert`)" and
+"ntx-builder silent death" (`docs/operations/runbook.md` §4) — including their
+monitoring signals and watchdog allowances. Review alerting against those
+sections when rolling this release out.

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -268,6 +268,13 @@ resolves identically — then verify sync (zero accept-header errors) and tip
 advancement before restoring traffic. The upgraded proxy resyncs cleanly
 through blocks mined during the swap window.
 
+> **Validated (2026-07-19, clean-rebuild rehearsal):** fresh v0.15.8 stack →
+> in-place upgrade to this release in the same deployment dir → **event history
+> preserved (no loss), tip continuous, post-upgrade L1↔Miden + L2↔L2 (all four
+> directions + same-address clash) GREEN, and the chaos completeness verifier
+> PASSED exact-block (ALLOW_LATE=0) with foreign/private garbo contained
+> (zero leaks).**
+
 ### Operational follow-ups shipped with this release
 
 The operations runbook gained incident procedures for the two known

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -318,6 +318,126 @@ Recovery:
    nonce to "unstick" it.
 5. Never delete admission/handoff rows manually.
 
+### Stuck GER injection (interrupted `ger_insert`) — aggoracle deadlock
+
+Known failure mode (tracked as finding #70; recurred repeatedly under fault
+testing). If the proxy is restarted/paused while a `ger_insert` writer job is
+in flight, the aggoracle's `insertGlobalExitRoot` transaction can be left
+`status='pending', block_number=0` permanently: nothing resumes the job after
+restart. Two deadlocks then stack:
+
+- the aggoracle's ethtxmanager polls that hash forever ("waiting signedTx to
+  be mined"); and
+- its monitored-transaction ID is deterministic (hash of from/to/calldata, no
+  nonce), so even a recreated aggkit re-derives the same ID, logs
+  `inject GER transaction already exists in monitoring DB`, and never sends a
+  new injection.
+
+Blast radius: GER injection stops → deposits never turn `ready_for_claim`,
+L2↔L2 settlement stalls, and the store's UpdateHashChain/ClaimEvent counts
+freeze while the chain keeps advancing. There is no error anywhere — only
+silence.
+
+**Diagnosis (in order):**
+
+1. Rule out the ntx-builder first (see the next procedure): if it is silent,
+   restart it and re-check before touching anything else — an unconsumed
+   UpdateGerNote resolves itself once consumption resumes.
+2. Stuck pending injection:
+
+   ```sql
+   SELECT tx_hash, status, block_number, created_at
+   FROM transactions
+   WHERE lower(signer) = '<aggoracle sender, lowercase>'
+     AND status = 'pending'
+     AND created_at < now() - interval '3 minutes';
+   ```
+
+   The aggoracle sender address is logged at aggkit startup
+   (`AggOracle sender address: 0x…`).
+3. Aggoracle deadlock confirmation: aggkit logs repeat
+   `inject GER transaction already exists in monitoring DB with ID 0x…` with
+   no interleaved `submitted`, and the proxy receives no
+   `eth_sendRawTransaction` from that sender.
+4. Corroborate the freeze: `ger_entries.is_injected` stops advancing;
+   `synthetic_logs` UpdateHashChain count is static while the Miden tip moves.
+
+**Recovery.** This is the one documented exception to "never delete
+admission rows / never replace a pending transaction". It is safe if and only
+if ALL of the following hold — verify each before proceeding:
+
+- the pending rows belong to the aggoracle sender only;
+- their GERs show `is_injected = false` in `ger_entries` (the injection never
+  landed — nothing external ever observed a receipt);
+- the only consumer of those hashes is the aggoracle itself, and it is reset
+  in the same procedure (fresh ethtxmanager state);
+- GER injection is content-idempotent: the same root is safely re-injected
+  under a new transaction.
+
+Procedure (order matters — client side must come back AFTER the proxy):
+
+```bash
+# 1. stop the aggoracle so it cannot re-send mid-surgery
+docker stop <aggkit-container>
+
+# 2. proxy store: remove the dead pending injection(s) + realign the nonce
+#    (psql into the proxy's PostgreSQL, agglayer_store)
+DELETE FROM tx_note_links WHERE tx_hash IN
+  (SELECT tx_hash FROM transactions
+   WHERE lower(signer)='<aggoracle>' AND status='pending');
+DELETE FROM transactions
+  WHERE lower(signer)='<aggoracle>' AND status='pending';
+-- MINED := count of that signer's success/reverted rows
+DELETE FROM nonce_reservations
+  WHERE lower(signer)='<aggoracle>' AND nonce >= MINED;
+UPDATE nonces SET nonce = MINED WHERE lower(address)='<aggoracle>';
+
+# 3. restart the proxy; wait for healthy
+docker restart <proxy-container>
+
+# 4. recreate aggkit WITH A FRESH CONTAINER (its ethtxmanager sqlite lives in
+#    the container /tmp — a plain restart resumes the deadlocked state)
+docker rm -f <aggkit-container>
+docker compose up -d --no-deps aggkit
+```
+
+**Verify:** within ~1 minute the aggoracle logs `inject GER transaction
+submitted`, the proxy mines it (`transactions.status='success'`,
+`ger_entries.is_injected` flips true, UpdateHashChain count increments), and
+new deposits turn `ready_for_claim`.
+
+**Prevention / monitoring:** alert when
+`count(pending aggoracle txs older than 3 min) > 0` or when
+`ger_entries.is_injected` is static for >5 min while the Miden tip advances.
+A supervised auto-heal implementing exactly the procedure above is acceptable.
+The product fix — resuming interrupted `ger_insert` jobs on startup via the
+durable note handoff — is tracked as finding #70; until it ships, treat this
+procedure as the standing remediation.
+
+### ntx-builder silent death (network-note consumption halts)
+
+Upstream Miden issue (finding #68). After all account actors log
+`Account actor deactivated due to idle timeout`, the ntx-builder can stop
+following the chain entirely — no further `apply_committed_block` lines, no
+error, process alive — while the tip advances. Because the bridge is a network
+account, ALL bridge note consumption (CLAIM, UpdateGerNote) halts with it:
+claims stop landing, GER injections stall (see the previous procedure — check
+this FIRST), and store event counts freeze silently.
+
+**Diagnosis:** compare the ntx-builder's last log timestamp against the Miden
+tip. Healthy operation logs `apply_committed_block` every few seconds; more
+than ~4 minutes of silence while the tip moves means it is dead. Recurrence is
+more likely when note traffic is bursty/sparse (every actor idles out) and
+intensifies under infrastructure faults.
+
+**Recovery:** `docker restart <ntx-builder-container>`. It re-applies from the
+committed tip and consumes the backlog within seconds; no state cleanup is
+needed anywhere else.
+
+**Prevention / monitoring:** alert on last-log age > 4 min while the tip
+advances; an unsupervised watchdog restart on that condition is safe and
+recommended until the upstream fix lands.
+
 ### Writer saturation
 
 Quiesce or rate-limit producers, confirm the remote prover/Miden node is not the

--- a/scripts/chaos-garbo.sh
+++ b/scripts/chaos-garbo.sh
@@ -67,6 +67,7 @@ FOREIGN_FIRED=0
 FOREIGN_GIS=""
 PRIVATE_ATTEMPTS=0
 FOREIGN_ATTEMPTS=0
+PRIVATE_NOTE_IDS=""   # PR#145: exported so the soak can assert direct ID absence
 START=0   # set before the fire window opens; used by the retry helpers
 
 # ── #41: the injectors must actually FIRE under faults ───────────────────────
@@ -148,6 +149,9 @@ garbo_private_note() {
         glog "GARBO private-note: send FAILED (transient?) — $(echo "$out" | tail -1)"; return 1; }
     note_id=$(echo "$out" | grep '\[private-note\] note-id:' | awk '{print $NF}')
     PRIVATE_FIRED=$((PRIVATE_FIRED + 1))
+    # PR#145: record the id so the soak can assert its ABSENCE from the proxy
+    # store directly (a leak persists rows before it is ever served).
+    [[ -n "$note_id" ]] && PRIVATE_NOTE_IDS="$PRIVATE_NOTE_IDS ${note_id#0x}"
     glog "GARBO private-note #$PRIVATE_FIRED id=${note_id:-?} — EXPECT: reconciler skips (synthetic_reconciler_private_skipped_total++), NEVER projected as a BridgeEvent/ClaimEvent"
 }
 
@@ -208,6 +212,7 @@ write_summary() {
         echo "GARBO_FOREIGN_GIS=\"$(echo $FOREIGN_GIS | xargs)\""
         echo "GARBO_PRIVATE_ATTEMPTS=$PRIVATE_ATTEMPTS"
         echo "GARBO_FOREIGN_ATTEMPTS=$FOREIGN_ATTEMPTS"
+        echo "GARBO_PRIVATE_NOTE_IDS=\"$(echo $PRIVATE_NOTE_IDS | xargs)\""
     } > "$GARBO_SUMMARY"
     glog "summary -> $GARBO_SUMMARY (private=$PRIVATE_FIRED foreign=$FOREIGN_FIRED)"
 }

--- a/scripts/chaos-garbo.sh
+++ b/scripts/chaos-garbo.sh
@@ -65,6 +65,46 @@ counter() {
 PRIVATE_FIRED=0
 FOREIGN_FIRED=0
 FOREIGN_GIS=""
+PRIVATE_ATTEMPTS=0
+FOREIGN_ATTEMPTS=0
+START=0   # set before the fire window opens; used by the retry helpers
+
+# ── #41: the injectors must actually FIRE under faults ───────────────────────
+# Under chaos (proxy restarts, pg pauses) a one-shot injection attempt fails and
+# a whole run used to end with private=0 foreign=0, so the soak's containment
+# check (c) could never assert. Every injection now (a) waits for the proxy to
+# be reachable, (b) retries the SAME op every ~10s until it lands or the
+# GARBO_DURATION window runs out. Attempts vs fired are both reported.
+window_remaining() {
+    local now; now=$(date +%s)
+    echo $(( GARBO_DURATION - (now - START) ))
+}
+
+proxy_ready() {
+    curl -sf -m 3 "${L2_RPC}/metrics" >/dev/null 2>&1
+}
+
+wait_proxy_ready() {
+    while [ "$(window_remaining)" -gt 0 ]; do
+        proxy_ready && return 0
+        sleep 5
+    done
+    return 1
+}
+
+# retry_until_landed <fn> — re-run <fn> (a garbo class that returns 0 iff the
+# injection landed) every ~10s, gated on proxy reachability, until it lands or
+# the window closes.
+retry_until_landed() {
+    local fn="$1"
+    while [ "$(window_remaining)" -gt 0 ]; do
+        wait_proxy_ready || return 1
+        if "$fn"; then return 0; fi
+        glog "GARBO retry: $fn did not land — retrying in 10s ($(window_remaining)s left)"
+        sleep 10
+    done
+    return 1
+}
 
 # ── setup: provision + fund a garbo wallet (for private-note sends) ──────────
 setup_garbo() {
@@ -103,8 +143,9 @@ setup_garbo() {
 garbo_private_note() {
     B2AGG_STORE_DIR="$GARBO_WALLET_STORE"
     local out note_id
+    PRIVATE_ATTEMPTS=$((PRIVATE_ATTEMPTS + 1))
     out=$(iso_tool --send-private-note --wallet-id "$WALLET_ID" 2>&1) || {
-        glog "GARBO private-note: send FAILED (transient?) — $(echo "$out" | tail -1)"; return; }
+        glog "GARBO private-note: send FAILED (transient?) — $(echo "$out" | tail -1)"; return 1; }
     note_id=$(echo "$out" | grep '\[private-note\] note-id:' | awk '{print $NF}')
     PRIVATE_FIRED=$((PRIVATE_FIRED + 1))
     glog "GARBO private-note #$PRIVATE_FIRED id=${note_id:-?} — EXPECT: reconciler skips (synthetic_reconciler_private_skipped_total++), NEVER projected as a BridgeEvent/ClaimEvent"
@@ -113,14 +154,15 @@ garbo_private_note() {
 # ── class: foreign-deployment claim (provenance gate) ────────────────────────
 garbo_foreign_claim() {
     B2AGG_STORE_DIR="$FOREIGN_STORE"
+    FOREIGN_ATTEMPTS=$((FOREIGN_ATTEMPTS + 1))
     _iso_wipe_store; mkdir -p "$B2AGG_STORE_DIR/tmp"
     local fb_out fs fg fbid ffaucet
     fb_out=$(iso_tool --create-foreign-bridge --foreign-network-id "$FOREIGN_NETWORK_ID" 2>&1) || {
-        glog "GARBO foreign-claim: --create-foreign-bridge FAILED — $(echo "$fb_out" | tail -2)"; return; }
+        glog "GARBO foreign-claim: --create-foreign-bridge FAILED — $(echo "$fb_out" | tail -2)"; return 1; }
     fs=$(echo "$fb_out" | grep "service-id:" | awk '{print $NF}')
     fg=$(echo "$fb_out" | grep "ger-manager-id:" | awk '{print $NF}')
     fbid=$(echo "$fb_out" | grep -w "bridge-id:" | awk '{print $NF}')
-    [[ -n "$fs" && -n "$fg" && -n "$fbid" ]] || { glog "GARBO foreign-claim: could not parse foreign ids"; return; }
+    [[ -n "$fs" && -n "$fg" && -n "$fbid" ]] || { glog "GARBO foreign-claim: could not parse foreign ids"; return 1; }
     local fs_inner="${fs#0x}"
     local fdest="0x00000000${fs_inner:0:16}${fs_inner:16:14}00"
 
@@ -131,7 +173,7 @@ garbo_foreign_claim() {
     empty_meta=$(cast keccak 0x)
     amt_hex=$(printf '%064x' "$DEPOSIT_AMOUNT")
     leaf_packed="0x00$(printf '%08x' 0)$(printf '0%.0s' {1..40})$(printf '%08x' "$FOREIGN_NETWORK_ID")${fdest#0x}${amt_hex}${empty_meta#0x}"
-    [[ ${#leaf_packed} -eq 228 ]] || { glog "GARBO foreign-claim: bad packed leaf len"; return; }
+    [[ ${#leaf_packed} -eq 228 ]] || { glog "GARBO foreign-claim: bad packed leaf len"; return 1; }
     leaf=$(cast keccak "$leaf_packed")
     node="${leaf#0x}"; idx="$dcnt"
     for _ in $(seq 1 32); do
@@ -149,9 +191,9 @@ garbo_foreign_claim() {
     fc_out=$(iso_tool --submit-foreign-claim \
         --claim-calldata-file /store/foreign-claim-calldata.hex \
         --foreign-bridge-id "$fbid" --foreign-service-id "$fs" --foreign-ger-manager-id "$fg" \
-        --scale-exp 10 2>&1) || { glog "GARBO foreign-claim: --submit-foreign-claim FAILED — $(echo "$fc_out" | tail -3)"; return; }
+        --scale-exp 10 2>&1) || { glog "GARBO foreign-claim: --submit-foreign-claim FAILED — $(echo "$fc_out" | tail -3)"; return 1; }
     fgi=$(echo "$fc_out" | grep "global-index:" | awk '{print $NF}')
-    [[ -n "$fgi" ]] || { glog "GARBO foreign-claim: could not parse foreign global index"; return; }
+    [[ -n "$fgi" ]] || { glog "GARBO foreign-claim: could not parse foreign global index"; return 1; }
     FOREIGN_FIRED=$((FOREIGN_FIRED + 1))
     FOREIGN_GIS="$FOREIGN_GIS ${fgi#0x}"
     glog "GARBO foreign-claim #$FOREIGN_FIRED bridge=$fbid net=$FOREIGN_NETWORK_ID gi=$fgi — EXPECT: our proxy skips it (claim_event_foreign_skipped_total++), ZERO synthetic_logs ClaimEvent rows for gi ${fgi#0x}"
@@ -164,6 +206,8 @@ write_summary() {
         echo "GARBO_PRIVATE_FIRED=$PRIVATE_FIRED"
         echo "GARBO_FOREIGN_FIRED=$FOREIGN_FIRED"
         echo "GARBO_FOREIGN_GIS=\"$(echo $FOREIGN_GIS | xargs)\""
+        echo "GARBO_PRIVATE_ATTEMPTS=$PRIVATE_ATTEMPTS"
+        echo "GARBO_FOREIGN_ATTEMPTS=$FOREIGN_ATTEMPTS"
     } > "$GARBO_SUMMARY"
     glog "summary -> $GARBO_SUMMARY (private=$PRIVATE_FIRED foreign=$FOREIGN_FIRED)"
 }
@@ -172,18 +216,30 @@ trap write_summary EXIT
 : > "$GARBO_LOG"
 glog "=== chaos-garbo start (dur=${GARBO_DURATION}s seed=$SEED foreign=$GARBO_FOREIGN net=$FOREIGN_NETWORK_ID) ==="
 if ! setup_garbo; then
-    glog "setup incomplete — running with whatever classes are available"
+    glog "setup incomplete — will retry setup inside the fire window (#41)"
 fi
 
 START=$(date +%s)
 # Fire the heavy foreign-claim class ONCE early (it needs several minutes).
-if [[ "$GARBO_FOREIGN" == "1" ]]; then garbo_foreign_claim; fi
+# #41: retried until it actually lands (or the window closes) — a one-shot
+# attempt during a proxy restart used to end the run with foreign=0.
+if [[ "$GARBO_FOREIGN" == "1" ]]; then
+    retry_until_landed garbo_foreign_claim \
+        || glog "GARBO foreign-claim: window closed before it landed (attempts=$FOREIGN_ATTEMPTS)"
+fi
 # Then spam private / tag-0 notes at random intervals for the rest of the window.
+# #41: each slot retries the SAME note until it lands; a run that got wallet
+# setup interrupted retries setup here instead of firing nothing forever.
 while [ $(( $(date +%s) - START )) -lt "$GARBO_DURATION" ]; do
     gap=$(( GARBO_MIN_GAP + RANDOM % (GARBO_MAX_GAP - GARBO_MIN_GAP + 1) ))
     sleep "$gap"
     [ $(( $(date +%s) - START )) -ge "$GARBO_DURATION" ] && break
-    [[ -n "${WALLET_ID:-}" ]] && garbo_private_note
+    if [[ -z "${WALLET_ID:-}" ]]; then
+        wait_proxy_ready && setup_garbo || glog "GARBO setup retry failed — will retry next slot"
+        continue
+    fi
+    retry_until_landed garbo_private_note || break
 done
 glog "=== chaos-garbo done: private=$PRIVATE_FIRED foreign=$FOREIGN_FIRED ==="
+glog "garbo attempts vs fired: private=$PRIVATE_ATTEMPTS/$PRIVATE_FIRED foreign=$FOREIGN_ATTEMPTS/$FOREIGN_FIRED"
 # EXIT trap writes the summary.

--- a/scripts/e2e-bridge-loadtest-isolated.sh
+++ b/scripts/e2e-bridge-loadtest-isolated.sh
@@ -677,7 +677,25 @@ if [[ "${VERIFY:-1}" == "1" ]]; then
     VERIFY_RC=${PIPESTATUS[0]}
     r "verification exit: $VERIFY_RC"
 fi
-exit $(( LOCK_COUNT > 0 ? 1 : VERIFY_RC ))
+# PR#145: STRICT_OPS=1 (set by the mixed runner, which runs with VERIFY=0)
+# makes the OPERATIONAL result part of the exit — previously VERIFY=0 exited 0
+# even when submissions failed or submitted ops were never claimed, so the
+# parent's LT_RC could be a false green with missing L1 workload. The predicate
+# lives in lib-chaos-verdict.sh so the same rule is unit-tested and the parent
+# consumes a real exit code instead of parsing human-readable logs.
+OPS_RC=0
+if [[ "${STRICT_OPS:-0}" == "1" ]]; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/lib-chaos-verdict.sh"
+    if l1_ops_ok "$TOT_SUB_L1" "$PLAN_L1" "$TOT_SUB_L2" "$PLAN_L2" \
+                 "$TOT_FAIL_L1" "$TOT_FAIL_L2" "$G_CLM" "$G_SUB"; then
+        r "strict-ops verdict: OK (sub $TOT_SUB_L1/$PLAN_L1 + $TOT_SUB_L2/$PLAN_L2, fail 0, claimed $G_CLM/$G_SUB)"
+    else
+        OPS_RC=1
+        r "strict-ops verdict: FAIL — sub L1=$TOT_SUB_L1/$PLAN_L1 L2=$TOT_SUB_L2/$PLAN_L2 fail=$TOT_FAIL_L1/$TOT_FAIL_L2 claimed=$G_CLM/$G_SUB (incomplete L1 workload)"
+    fi
+fi
+exit $(( LOCK_COUNT > 0 ? 1 : (VERIFY_RC != 0 ? VERIFY_RC : OPS_RC) ))
 # Forensics: archive proxy logs (reconciler warnings, import errors, sweep
 # lines) so rung teardown can't destroy the evidence for a failed run.
 docker logs "$AGGLAYER_CONTAINER" > "$OUT_DIR/proxy-$STAMP.log" 2>&1 || true

--- a/scripts/e2e-cantina13-metadata-recovery.sh
+++ b/scripts/e2e-cantina13-metadata-recovery.sh
@@ -430,18 +430,15 @@ docker exec "$PG_CONTAINER" pg_dump -U agglayer agglayer_store > "$BACKUP" 2>/de
 [[ -s "$BACKUP" ]] || fail "DB backup failed (empty dump) — refusing to drop without a backup"
 pass "DB backed up ($(wc -c < "$BACKUP") bytes → $BACKUP)"
 
-# Preserve the proxy's per-signer account-nonce state across the rebuild. DROP SCHEMA
-# wipes the `nonces` / `nonce_reservations` tables, but those hold LEGITIMATE EVM
-# account nonces for external claim submitters (aggkit claimsponsor / bridge-autoclaim).
-# They are proxy-internal (L2 claim txns are NOT on-chain, so `--restore` cannot rebuild
-# them) and are NOT corrupted. Without this, a submitter whose nonce advanced pre-drop
-# (e.g. the sponsor at nonce N) sends its next claim at nonce N to a reset proxy that now
-# expects 0 → future-nonce wedge → post-recovery deposit-claims stall forever (finding #65).
-NONCE_DUMP="/tmp/agglayer_nonces.cantina13.$$.sql"
-docker exec "$PG_CONTAINER" pg_dump -U agglayer -d agglayer_store --data-only \
-    -t public.nonces -t public.nonce_reservations > "$NONCE_DUMP" 2>/dev/null
-[[ -s "$NONCE_DUMP" ]] && pass "Preserved account-nonce state ($(wc -l < "$NONCE_DUMP") lines) for post-recovery submitter continuity" \
-    || warn "no account-nonce state to preserve (empty) — continuing"
+# finding #65 — we deliberately do NOT preserve the proxy's per-signer nonce tables.
+# The proxy IS the synthetic L2, so DROP SCHEMA legitimately resets its `nonces` /
+# `nonce_reservations` to 0 on the from-scratch rebuild — that is correct, not a bug to
+# paper over. The external claim submitter (zkevm-bridge-service claimsponsor) caches its
+# nonce in ITS OWN store (bridge_db `sync.monitored_txs`); a proxy-only recovery would
+# leave that cache at a stale nonce N against a reset-to-0 proxy → future-nonce wedge.
+# The REALISTIC operational recovery resyncs the bridge-service alongside the proxy (see
+# the resync block after the proxy comes back healthy below): both return to nonce 0 and
+# re-driven claims dedup by global_index (finding #55).
 
 MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-x}" MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-x}" "${E2E_COMPOSE[@]}" stop miden-agglayer >/dev/null 2>&1
 pg "DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO agglayer;" >/dev/null
@@ -457,20 +454,32 @@ set -e
 grep -q 'RESTORE: complete' "$RESTORE_LOG" || fail "restore-from-scratch did not complete"
 pass "Store rebuilt from on-chain (faucet identity + metadata re-recovered)"
 
-# Restore the preserved account-nonce state into the freshly-migrated (empty) tables
-# BEFORE starting the live proxy, so external claim submitters resume at their real
-# nonce instead of wedging on a future-nonce against a reset-to-0 proxy (finding #65).
-if [[ -s "$NONCE_DUMP" ]]; then
-    docker exec -i "$PG_CONTAINER" psql -U agglayer -d agglayer_store < "$NONCE_DUMP" >/dev/null 2>&1 \
-        && pass "Account-nonce state restored — post-recovery deposit-claims will not wedge" \
-        || warn "account-nonce restore hit an error — continuing (verify Phase C liveness below)"
-fi
-
 MARK_B=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-x}" MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-x}" "${E2E_COMPOSE[@]}" start miden-agglayer >/dev/null 2>&1
 wait_for "proxy healthy after rebuild" \
     "[[ \$(docker inspect -f '{{.State.Health.Status}}' $AGGLAYER_CONTAINER 2>/dev/null) == healthy ]]" \
     180 3
+
+# ── REALISTIC RECOVERY: resync the bridge-service (finding #65) ───────────────────────
+# The proxy's per-signer nonces reset to 0 on the from-scratch rebuild. The external
+# claim submitter (zkevm-bridge-service claimsponsor) persists its cached nonce in
+# bridge_db (`sync.monitored_txs`) and would otherwise keep submitting at its stale
+# nonce → future-nonce wedge against the reset-to-0 proxy. A realistic operational
+# recovery resyncs it alongside the proxy: drop its storage and restart so it
+# re-migrates, re-syncs deposits from the recovered proxy, and re-fetches
+# eth_getTransactionCount (=0). Re-driven claims are idempotent (landed claims dedup by
+# global_index — finding #55). The bridge-service auto-migrates its schema on startup.
+BRIDGE_PG_CONTAINER="${BRIDGE_PG_CONTAINER:-${COMPOSE_PROJECT_NAME}-postgres-1}"
+"${E2E_COMPOSE[@]}" stop bridge-service bridge-autoclaim >/dev/null 2>&1
+docker exec "$BRIDGE_PG_CONTAINER" psql -U bridge_user -d bridge_db \
+    -c "DROP SCHEMA IF EXISTS sync CASCADE; DROP SCHEMA IF EXISTS mt CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO bridge_user;" >/dev/null 2>&1 \
+    && pass "bridge-service storage dropped — cached sponsor nonce invalidated (realistic resync)" \
+    || fail "finding #65: failed to drop bridge_db for bridge-service resync"
+"${E2E_COMPOSE[@]}" up -d --no-deps bridge-service bridge-autoclaim >/dev/null 2>&1
+wait_for "bridge-service resynced + reachable after recovery" \
+    "[[ \$(curl -s -m3 -o /dev/null -w '%{http_code}' $BRIDGE_SERVICE_URL/ 2>/dev/null) =~ ^(200|404)$ ]]" \
+    180 5
+pass "bridge-service resynced — re-migrated, re-fetches sponsor nonce 0 from the recovered proxy"
 
 # After the rebuild the leaf's REAL metadata recovers (correct origin from on-chain →
 # L1 name()/symbol()/decimals()) → the REAL BridgeEvent emits at its reserved index →

--- a/scripts/e2e-chaos-soak.sh
+++ b/scripts/e2e-chaos-soak.sh
@@ -39,6 +39,10 @@ POST_CHAOS_SETTLE="${POST_CHAOS_SETTLE:-150}"
 L2L2_FWD="${L2L2_FWD:-2}"
 L2L2_BACK="${L2L2_BACK:-2}"
 FRESH="${FRESH:-0}"
+# PR#145: PASS certifies EXACT-BLOCK fidelity by default — late events fail.
+# A consciously-degraded run (e.g. a grown/recovered stack) may set ALLOW_LATE=1;
+# the verdict line prints the mode either way.
+ALLOW_LATE="${ALLOW_LATE:-0}"
 TOOL_BIN="${TOOL_BIN:-$PROJECT_DIR/target/debug/bridge-out-tool}"   # repo-local default; override with $TOOL_BIN
 # #41: fail FAST if the debug tool is missing — a late WARN used to let the whole
 # storm run and then skip the completeness verdict entirely.
@@ -95,7 +99,7 @@ GARBO_PID=$!
 # split the soak's N evenly across L1->Miden / Miden->L1.
 say "=== mixed loadtest under storm (L1 ${N} split $((N / 2))/$((N - N / 2)), L2<->L2 $L2L2_FWD/$L2L2_BACK) ==="
 N_L1_FWD=$((N / 2)) N_L1_BACK=$((N - N / 2)) L2L2_FWD="$L2L2_FWD" L2L2_BACK="$L2L2_BACK" \
-    MIX_VERIFY=0 ALLOW_LATE=1 COMPOSE_PROJECT_NAME="$PROJECT" \
+    MIX_VERIFY=0 ALLOW_LATE="$ALLOW_LATE" COMPOSE_PROJECT_NAME="$PROJECT" \
     timeout 3600 "$SCRIPT_DIR/e2e-loadtest-mixed.sh" >/tmp/chaos-lt.out 2>&1
 LT_RC=$?
 say "mixed loadtest exited rc=$LT_RC"
@@ -133,7 +137,7 @@ sleep "$POST_CHAOS_SETTLE"
 say "=== (a) verify-event-completeness (legit traffic) ==="
 VC_RC=2
 if [[ -x "$TOOL_BIN" ]]; then
-    ALLOW_LATE="${ALLOW_LATE:-1}" TOOL_BIN="$TOOL_BIN" \
+    ALLOW_LATE="$ALLOW_LATE" TOOL_BIN="$TOOL_BIN" \
         NODE_CONTAINER="${PROJECT}-miden-node-1" AGGLAYER_CONTAINER="$AGGLAYER_CONTAINER" \
         "$SCRIPT_DIR/verify-event-completeness.sh" > /tmp/chaos-verify.out 2>&1
     VC_RC=$?
@@ -143,16 +147,16 @@ else
 fi
 LOCKS=$(docker logs "$AGGLAYER_CONTAINER" 2>&1 | grep -c "database is locked" || true)
 
-# ── 5a'. STORE CORROBORATION (#41) — the authoritative completeness verdict ──
-# The verifier's node-DB denominator legitimately over-counts: observed (non-
-# injected) GERs emit no UpdateHashChain, L2<->L2/reclaim claims aren't proxy-
-# sponsored, and on a RECOVERED stack the whole-history GER denominator is
-# permanently ahead of the by-design-reset log view. The proxy STORE reconciling
-# against its own authoritative sources is the real integrity signal:
-#   UHC logs == injected GERs, CLAIM logs >= landed, BRIDGE logs == emitted,
-#   and no unemitted / unbridgeable / alerted-mint rows (unclaimable is reported
-#   but non-fatal — a user-front-run leaves a benign row).
-say "=== (a') store corroboration (authoritative) ==="
+# ── 5a'. STORE CORROBORATION (#41) — ADDITIONAL failure signal, never a PASS ─
+# PR#145 review: both sides of this comparison are proxy-owned PostgreSQL
+# (synthetic_logs vs ger_entries / claim_watcher_processed /
+# bridge_out_processed) compared as aggregate counts — it cannot prove events
+# the proxy never observed, nor identity / exact-block fidelity. The
+# INDEPENDENT verifier above is the completeness authority; this section can
+# only VETO a verifier-pass (a store DROP always fails) and serves as a
+# diagnostic when the verifier's node denominator over-counts (observed GERs
+# emit no UpdateHashChain; non-sponsored claims; recovered-stack history).
+say "=== (a') store corroboration (additional failure signal) ==="
 SC_UHC=$(pgq "SELECT COUNT(*) FROM synthetic_logs WHERE topics[1] LIKE '0x65d3bf36%';")
 SC_CLAIM=$(pgq "SELECT COUNT(*) FROM synthetic_logs WHERE topics[1] LIKE '0x1df3f2a9%';")
 SC_BRIDGE=$(pgq "SELECT COUNT(*) FROM synthetic_logs WHERE topics[1] LIKE '0x50178120%';")
@@ -173,7 +177,8 @@ STORE_DROP=""
 [[ -n "${SC_BRIDGE:-}" && -n "${SC_EMIT:-}" && "${SC_BRIDGE}" -lt "${SC_EMIT}" ]] 2>/dev/null && STORE_DROP="$STORE_DROP BRIDGE<emit(${SC_BRIDGE}<${SC_EMIT})"
 if [[ -z "$STORE_DROP" ]]; then
     STORE_OK=1; say "  store corroboration: CLEAN"
-    [[ "$VC_RC" != "0" ]] && say "  (verifier mismatch with a CLEAN store = denominator artifact, not a drop)"
+    # Diagnostic label ONLY — a verifier fail still fails the verdict (PR#145).
+    [[ "$VC_RC" != "0" ]] && say "  (diagnostic: verifier mismatch with a CLEAN store is usually a denominator artifact — but the independent verifier remains authoritative)"
 else
     STORE_OK=0; say "  store corroboration: DROP —$STORE_DROP"
 fi
@@ -207,40 +212,69 @@ for gi_hex in ${GARBO_FOREIGN_GIS:-}; do
     fi
 done
 [[ "${GARBO_FOREIGN_FIRED:-0}" -gt 0 && -z "${GARBO_FOREIGN_GIS:-}" ]] && { say "  WARN: foreign fired but no gi recorded"; }
+# PR#145: DIRECT private/tag-0 containment — each fired private note's id must
+# be ABSENT from every proxy table a projected note would persist into
+# (bridge_out_processed, tx_note_links, unbridgeable_bridge_outs). A leak by
+# definition persists rows in the proxy's own store before getLogs can serve
+# it, so ID absence here is a positive containment proof independent of the
+# in-memory skip counters (which reset on a chaos proxy restart).
+PRIVATE_LEAK=0
+PRIV_IDS_CHECKED=0
+for pid_hex in ${GARBO_PRIVATE_NOTE_IDS:-}; do
+    pid_lc=$(echo "$pid_hex" | tr 'A-F' 'a-f'); pid_lc="${pid_lc#0x}"
+    [[ -z "$pid_lc" ]] && continue
+    PRIV_IDS_CHECKED=$((PRIV_IDS_CHECKED + 1))
+    rows=$(pgq "SELECT (SELECT COUNT(*) FROM bridge_out_processed WHERE lower(note_id) LIKE '%${pid_lc}%')
+              + (SELECT COUNT(*) FROM tx_note_links WHERE lower(coalesce(note_id,'')) LIKE '%${pid_lc}%' OR lower(coalesce(note_commitment,'')) LIKE '%${pid_lc}%')
+              + (SELECT COUNT(*) FROM unbridgeable_bridge_outs WHERE lower(note_id) LIKE '%${pid_lc}%');")
+    if [[ "${rows:-0}" != "0" ]]; then
+        say "  GARBO LEAK: private note 0x$pid_lc persisted $rows proxy row(s) — CONTAINMENT BREACH"
+        PRIVATE_LEAK=$((PRIVATE_LEAK + rows)); GARBO_OK=0
+    fi
+done
+if [[ "$PRIV_IDS_CHECKED" -gt 0 && "$PRIVATE_LEAK" == "0" ]]; then
+    say "  private notes: $PRIV_IDS_CHECKED id(s) checked, 0 persisted proxy rows (contained)"
+elif [[ "${GARBO_PRIVATE_FIRED:-0}" -gt 0 && "$PRIV_IDS_CHECKED" == "0" ]]; then
+    # Fired but ids not recorded (old summary / parse miss): fall back to the
+    # independent verifier (its extra==0), which the overall verdict already
+    # requires via VC_RC==0.
+    say "  WARN: private fired but no note ids recorded — relying on the independent verifier's extra==0"
+fi
 # Skip counters (best-effort — in-memory, may have reset on a chaos proxy restart).
 NOW_PRIV_SKIP=$(counter synthetic_reconciler_private_skipped_total)
 NOW_FOREIGN_SKIP=$(counter claim_event_foreign_skipped_total)
 say "  private_skipped_total: $BASE_PRIV_SKIP -> $NOW_PRIV_SKIP (garbo private fired=${GARBO_PRIVATE_FIRED:-0})"
 say "  foreign_skipped_total: $BASE_FOREIGN_SKIP -> $NOW_FOREIGN_SKIP (garbo foreign fired=${GARBO_FOREIGN_FIRED:-0})"
-# The verify's extra==0 (checked below via VC_RC) is the restart-robust proof
-# that NO private/tag-0/garbo note leaked as a real BridgeEvent/ClaimEvent.
+# The verify's extra==0 (required below via VC_RC==0) is the restart-robust
+# proof that NO private/tag-0/garbo note leaked as a real BridgeEvent/ClaimEvent.
 
 # ── 6. two-sided verdict ─────────────────────────────────────────────────────
+# PR#145: predicates live in lib-chaos-verdict.sh (unit-tested by
+# scripts/test-chaos-verdict.sh). The INDEPENDENT verifier is required
+# (VC_RC==0); store corroboration is an additional veto, never an override.
+# shellcheck source=lib-chaos-verdict.sh
+source "$SCRIPT_DIR/lib-chaos-verdict.sh"
 say "======================================================================"
 say "  UNIFIED CHAOS SOAK RESULT"
-say "    N=$N  faults=$FAULTS_DONE  garbo(private=${GARBO_PRIVATE_FIRED:-0} foreign=${GARBO_FOREIGN_FIRED:-0})"
-say "    loadtest_rc=$LT_RC  verify_rc=$VC_RC  store_locks=$LOCKS  foreign_leak=$FOREIGN_LEAK"
-# The mixed loadtest (MIX_VERIFY=0) exits 0 on a clean completion and non-zero
-# ONLY if its driver ABORTED (a fail() — e.g. a wedge or a harness bug). A
-# crashed driver means the full mixed load never ran, so it must NOT green even
-# if the (reduced) traffic verifies — else a dead driver false-passes.
-# #41: completeness = verifier PASS *or* store-corroboration CLEAN (the verifier
-# denominator over-counts by design in several benign cases); a store DROP always
-# fails regardless of the verifier.
+say "    N=$N  faults=$FAULTS_DONE  garbo(private=${GARBO_PRIVATE_FIRED:-0} foreign=${GARBO_FOREIGN_FIRED:-0})  allow_late=$ALLOW_LATE"
+say "    loadtest_rc=$LT_RC  verify_rc=$VC_RC  store_locks=$LOCKS  foreign_leak=$FOREIGN_LEAK  private_leak=$PRIVATE_LEAK"
+# The mixed loadtest (MIX_VERIFY=0) now enforces its FULL operational verdict
+# (all fwd/back landed, clash distinct, L1 rc) and skips only the duplicate
+# verifier run — a nonzero LT_RC means an operation never landed OR the driver
+# aborted; either must fail here.
 LEGIT_OK=0
-if [[ ( "$VC_RC" == "0" || "${STORE_OK:-0}" == "1" ) && "${LOCKS:-1}" == "0" && "$LT_RC" == "0" ]]; then LEGIT_OK=1; fi
-[[ "${STORE_OK:-0}" == "0" ]] && LEGIT_OK=0
+chaos_legit_ok "$VC_RC" "${STORE_OK:-0}" "${LOCKS:-1}" "$LT_RC" && LEGIT_OK=1
+GARBO_VERDICT_OK=0
+[[ "$GARBO_OK" == "1" ]] && chaos_garbo_ok "$FOREIGN_LEAK" "$PRIVATE_LEAK" && GARBO_VERDICT_OK=1
 # (c) chaos ACTUALLY happened — a soak that injected no infra faults or fired no garbo
 # class would otherwise false-pass on an empty run. Require >=1 injected fault AND each
 # enabled garbo class fired (private always; foreign only when GARBO_FOREIGN=1).
-CHAOS_OK=1
-[[ "${FAULTS_DONE:-0}" -ge 1 ]]              || CHAOS_OK=0
-[[ "${GARBO_PRIVATE_FIRED:-0}" -ge 1 ]]      || CHAOS_OK=0
-[[ "${GARBO_FOREIGN:-1}" != "1" || "${GARBO_FOREIGN_FIRED:-0}" -ge 1 ]] || CHAOS_OK=0
-say "    (a) LEGIT completeness: $([[ $LEGIT_OK == 1 ]] && echo PASS || echo FAIL)  (verify_rc=$VC_RC store=$([[ ${STORE_OK:-0} == 1 ]] && echo CLEAN || echo DROP) locks=$LOCKS loadtest_rc=$LT_RC)"
-say "    (b) GARBO containment:  $([[ $GARBO_OK == 1 ]] && echo PASS || echo FAIL)  (foreign_leak=$FOREIGN_LEAK)"
+CHAOS_OK=0
+chaos_fired_ok "${FAULTS_DONE:-0}" "${GARBO_PRIVATE_FIRED:-0}" "${GARBO_FOREIGN:-1}" "${GARBO_FOREIGN_FIRED:-0}" && CHAOS_OK=1
+say "    (a) LEGIT completeness: $([[ $LEGIT_OK == 1 ]] && echo PASS || echo FAIL)  (verify_rc=$VC_RC store=$([[ ${STORE_OK:-0} == 1 ]] && echo CLEAN || echo DROP) locks=$LOCKS loadtest_rc=$LT_RC allow_late=$ALLOW_LATE)"
+say "    (b) GARBO containment:  $([[ $GARBO_VERDICT_OK == 1 ]] && echo PASS || echo FAIL)  (foreign_leak=$FOREIGN_LEAK private_leak=$PRIVATE_LEAK)"
 say "    (c) CHAOS actually fired: $([[ $CHAOS_OK == 1 ]] && echo PASS || echo FAIL)  (faults=${FAULTS_DONE:-0} private=${GARBO_PRIVATE_FIRED:-0} foreign=${GARBO_FOREIGN_FIRED:-0})"
-if [[ "$LEGIT_OK" == "1" && "$GARBO_OK" == "1" && "$CHAOS_OK" == "1" ]]; then
+if [[ "$LEGIT_OK" == "1" && "$GARBO_VERDICT_OK" == "1" && "$CHAOS_OK" == "1" ]]; then
     say "  >>> CHAOS SOAK PASS — every legit event survived exact-block; every garbo input contained <<<"
     say "======================================================================"
     exit 0

--- a/scripts/e2e-chaos-soak.sh
+++ b/scripts/e2e-chaos-soak.sh
@@ -40,6 +40,13 @@ L2L2_FWD="${L2L2_FWD:-2}"
 L2L2_BACK="${L2L2_BACK:-2}"
 FRESH="${FRESH:-0}"
 TOOL_BIN="${TOOL_BIN:-$PROJECT_DIR/target/debug/bridge-out-tool}"   # repo-local default; override with $TOOL_BIN
+# #41: fail FAST if the debug tool is missing — a late WARN used to let the whole
+# storm run and then skip the completeness verdict entirely.
+if [[ ! -x "$TOOL_BIN" ]]; then
+    echo "FATAL: $TOOL_BIN not found/executable — the completeness verdict cannot run." >&2
+    echo "       Build it first:  cargo build --bin bridge-out-tool   (then re-run, or pass TOOL_BIN=...)" >&2
+    exit 4
+fi
 
 CHAOS_LOG="${CHAOS_LOG:-/tmp/chaos-events.log}"
 GARBO_LOG="${GARBO_LOG:-/tmp/chaos-garbo.log}"
@@ -112,6 +119,7 @@ say "chaos stopped: $FAULTS_DONE faults injected (log: $CHAOS_LOG)"
 # shellcheck disable=SC1090
 [[ -f "$GARBO_SUMMARY" ]] && source "$GARBO_SUMMARY" || true
 say "garbo fired: private=${GARBO_PRIVATE_FIRED:-0} foreign=${GARBO_FOREIGN_FIRED:-0} gis='${GARBO_FOREIGN_GIS:-}'"
+say "garbo attempts vs fired: private=${GARBO_PRIVATE_ATTEMPTS:-?}/${GARBO_PRIVATE_FIRED:-0} foreign=${GARBO_FOREIGN_ATTEMPTS:-?}/${GARBO_FOREIGN_FIRED:-0} (#41: injections retry until landed)"
 
 # ── 4. post-chaos heal ───────────────────────────────────────────────────────
 say "=== post-chaos settle (${POST_CHAOS_SETTLE}s heal window) ==="
@@ -134,6 +142,41 @@ else
     say "WARN: $TOOL_BIN not found — completeness cannot run"
 fi
 LOCKS=$(docker logs "$AGGLAYER_CONTAINER" 2>&1 | grep -c "database is locked" || true)
+
+# ── 5a'. STORE CORROBORATION (#41) — the authoritative completeness verdict ──
+# The verifier's node-DB denominator legitimately over-counts: observed (non-
+# injected) GERs emit no UpdateHashChain, L2<->L2/reclaim claims aren't proxy-
+# sponsored, and on a RECOVERED stack the whole-history GER denominator is
+# permanently ahead of the by-design-reset log view. The proxy STORE reconciling
+# against its own authoritative sources is the real integrity signal:
+#   UHC logs == injected GERs, CLAIM logs >= landed, BRIDGE logs == emitted,
+#   and no unemitted / unbridgeable / alerted-mint rows (unclaimable is reported
+#   but non-fatal — a user-front-run leaves a benign row).
+say "=== (a') store corroboration (authoritative) ==="
+SC_UHC=$(pgq "SELECT COUNT(*) FROM synthetic_logs WHERE topics[1] LIKE '0x65d3bf36%';")
+SC_CLAIM=$(pgq "SELECT COUNT(*) FROM synthetic_logs WHERE topics[1] LIKE '0x1df3f2a9%';")
+SC_BRIDGE=$(pgq "SELECT COUNT(*) FROM synthetic_logs WHERE topics[1] LIKE '0x50178120%';")
+SC_INJ=$(pgq "SELECT COUNT(*) FROM ger_entries WHERE is_injected;")
+SC_LANDED=$(pgq "SELECT COUNT(*) FROM claim_watcher_processed;")
+SC_EMIT=$(pgq "SELECT COUNT(*) FROM bridge_out_processed WHERE emitted;")
+SC_UNEMIT=$(pgq "SELECT COUNT(*) FROM bridge_out_processed WHERE emitted = false;")
+SC_UNBRIDGE=$(pgq "SELECT COUNT(*) FROM unbridgeable_bridge_outs;")
+SC_UNCLAIM=$(pgq "SELECT COUNT(*) FROM unclaimable_claims;")
+SC_ALERTED=$(pgq "SELECT COUNT(*) FILTER (WHERE alerted) FROM monitor_expected_mints;")
+say "  store: UHC=${SC_UHC:-?}/inj=${SC_INJ:-?} CLAIM=${SC_CLAIM:-?}/landed=${SC_LANDED:-?} BRIDGE=${SC_BRIDGE:-?}/emit=${SC_EMIT:-?} unemit=${SC_UNEMIT:-?} unbridge=${SC_UNBRIDGE:-?} unclaim=${SC_UNCLAIM:-?}(non-fatal) alerted=${SC_ALERTED:-?}"
+STORE_DROP=""
+[[ "${SC_UNEMIT:-1}" != "0" ]]   && STORE_DROP="$STORE_DROP unemitted=${SC_UNEMIT:-?}"
+[[ "${SC_UNBRIDGE:-1}" != "0" ]] && STORE_DROP="$STORE_DROP unbridgeable=${SC_UNBRIDGE:-?}"
+[[ "${SC_ALERTED:-1}" != "0" ]]  && STORE_DROP="$STORE_DROP alerted-mint=${SC_ALERTED:-?}"
+[[ -n "${SC_UHC:-}" && -n "${SC_INJ:-}" && "${SC_UHC}" -lt "${SC_INJ}" ]] 2>/dev/null && STORE_DROP="$STORE_DROP UHC<inj(${SC_UHC}<${SC_INJ})"
+[[ -n "${SC_CLAIM:-}" && -n "${SC_LANDED:-}" && "${SC_CLAIM}" -lt "${SC_LANDED}" ]] 2>/dev/null && STORE_DROP="$STORE_DROP CLAIM<landed(${SC_CLAIM}<${SC_LANDED})"
+[[ -n "${SC_BRIDGE:-}" && -n "${SC_EMIT:-}" && "${SC_BRIDGE}" -lt "${SC_EMIT}" ]] 2>/dev/null && STORE_DROP="$STORE_DROP BRIDGE<emit(${SC_BRIDGE}<${SC_EMIT})"
+if [[ -z "$STORE_DROP" ]]; then
+    STORE_OK=1; say "  store corroboration: CLEAN"
+    [[ "$VC_RC" != "0" ]] && say "  (verifier mismatch with a CLEAN store = denominator artifact, not a drop)"
+else
+    STORE_OK=0; say "  store corroboration: DROP —$STORE_DROP"
+fi
 
 # ── 5b. GARBO containment (the second verdict) ───────────────────────────────
 say "=== (b) garbo containment ==="
@@ -169,7 +212,12 @@ say "    loadtest_rc=$LT_RC  verify_rc=$VC_RC  store_locks=$LOCKS  foreign_leak=
 # ONLY if its driver ABORTED (a fail() — e.g. a wedge or a harness bug). A
 # crashed driver means the full mixed load never ran, so it must NOT green even
 # if the (reduced) traffic verifies — else a dead driver false-passes.
-LEGIT_OK=0; [[ "$VC_RC" == "0" && "${LOCKS:-1}" == "0" && "$LT_RC" == "0" ]] && LEGIT_OK=1
+# #41: completeness = verifier PASS *or* store-corroboration CLEAN (the verifier
+# denominator over-counts by design in several benign cases); a store DROP always
+# fails regardless of the verifier.
+LEGIT_OK=0
+if [[ ( "$VC_RC" == "0" || "${STORE_OK:-0}" == "1" ) && "${LOCKS:-1}" == "0" && "$LT_RC" == "0" ]]; then LEGIT_OK=1; fi
+[[ "${STORE_OK:-0}" == "0" ]] && LEGIT_OK=0
 # (c) chaos ACTUALLY happened — a soak that injected no infra faults or fired no garbo
 # class would otherwise false-pass on an empty run. Require >=1 injected fault AND each
 # enabled garbo class fired (private always; foreign only when GARBO_FOREIGN=1).
@@ -177,7 +225,7 @@ CHAOS_OK=1
 [[ "${FAULTS_DONE:-0}" -ge 1 ]]              || CHAOS_OK=0
 [[ "${GARBO_PRIVATE_FIRED:-0}" -ge 1 ]]      || CHAOS_OK=0
 [[ "${GARBO_FOREIGN:-1}" != "1" || "${GARBO_FOREIGN_FIRED:-0}" -ge 1 ]] || CHAOS_OK=0
-say "    (a) LEGIT completeness: $([[ $LEGIT_OK == 1 ]] && echo PASS || echo FAIL)  (verify_rc=$VC_RC locks=$LOCKS loadtest_rc=$LT_RC)"
+say "    (a) LEGIT completeness: $([[ $LEGIT_OK == 1 ]] && echo PASS || echo FAIL)  (verify_rc=$VC_RC store=$([[ ${STORE_OK:-0} == 1 ]] && echo CLEAN || echo DROP) locks=$LOCKS loadtest_rc=$LT_RC)"
 say "    (b) GARBO containment:  $([[ $GARBO_OK == 1 ]] && echo PASS || echo FAIL)  (foreign_leak=$FOREIGN_LEAK)"
 say "    (c) CHAOS actually fired: $([[ $CHAOS_OK == 1 ]] && echo PASS || echo FAIL)  (faults=${FAULTS_DONE:-0} private=${GARBO_PRIVATE_FIRED:-0} foreign=${GARBO_FOREIGN_FIRED:-0})"
 if [[ "$LEGIT_OK" == "1" && "$GARBO_OK" == "1" && "$CHAOS_OK" == "1" ]]; then

--- a/scripts/e2e-chaos-soak.sh
+++ b/scripts/e2e-chaos-soak.sh
@@ -178,6 +178,18 @@ else
     STORE_OK=0; say "  store corroboration: DROP —$STORE_DROP"
 fi
 
+# ntx-builder liveness (task #68: it dies SILENTLY after idle-timeout actor
+# deactivation while the chain keeps moving — bridge note consumption halts with
+# it). WARN, not fail: an ops watchdog (docker restart) heals it, but a chaos run
+# where it died explains any missing CLAIM/GER growth.
+NTX_LAST=$(docker logs --timestamps --tail 1 "${PROJECT}-ntx-builder-1" 2>/dev/null | cut -c1-19)
+NTX_AGE=$(( $(date -u +%s) - $(date -u -d "${NTX_LAST:-1970-01-01T00:00:00}" +%s 2>/dev/null || echo 0) ))
+if [[ "${NTX_AGE:-0}" -gt 300 ]]; then
+    say "  ⚠ ntx-builder silent for ${NTX_AGE}s (task #68 silent-death) — restart it: docker restart ${PROJECT}-ntx-builder-1"
+else
+    say "  ntx-builder alive (last log ${NTX_AGE}s ago)"
+fi
+
 # ── 5b. GARBO containment (the second verdict) ───────────────────────────────
 say "=== (b) garbo containment ==="
 GARBO_OK=1

--- a/scripts/e2e-chaos-soak.sh
+++ b/scripts/e2e-chaos-soak.sh
@@ -275,7 +275,11 @@ say "    (a) LEGIT completeness: $([[ $LEGIT_OK == 1 ]] && echo PASS || echo FAI
 say "    (b) GARBO containment:  $([[ $GARBO_VERDICT_OK == 1 ]] && echo PASS || echo FAIL)  (foreign_leak=$FOREIGN_LEAK private_leak=$PRIVATE_LEAK)"
 say "    (c) CHAOS actually fired: $([[ $CHAOS_OK == 1 ]] && echo PASS || echo FAIL)  (faults=${FAULTS_DONE:-0} private=${GARBO_PRIVATE_FIRED:-0} foreign=${GARBO_FOREIGN_FIRED:-0})"
 if [[ "$LEGIT_OK" == "1" && "$GARBO_VERDICT_OK" == "1" && "$CHAOS_OK" == "1" ]]; then
-    say "  >>> CHAOS SOAK PASS — every legit event survived exact-block; every garbo input contained <<<"
+    if [[ "$ALLOW_LATE" == "0" ]]; then
+        say "  >>> CHAOS SOAK PASS — every legit event survived exact-block; every garbo input contained <<<"
+    else
+        say "  >>> CHAOS SOAK PASS — every legit event survived (ALLOW_LATE=1: late events permitted, NOT exact-block certified); every garbo input contained <<<"
+    fi
     say "======================================================================"
     exit 0
 else

--- a/scripts/e2e-loadtest-mixed.sh
+++ b/scripts/e2e-loadtest-mixed.sh
@@ -256,8 +256,11 @@ COL_HEX=""; COL=""; BACK_DEST=""
 LT_OUT=/tmp/mixed-l1-loadtest.out; LT_PID=""
 if [[ "$SKIP_L1_LOAD" != "1" ]]; then
     step "Launching L1<->Miden bulk load ($N_L1_FWD L1->Miden + $N_L1_BACK Miden->L1) in background"
+    # PR#145: STRICT_OPS=1 — with VERIFY=0 the child's exit must still reflect
+    # its OPERATIONAL result (all planned ops submitted, zero failures, all
+    # submitted ops claimed), or LT_RC=0 is a false green with missing L1 work.
     COMPOSE_PROJECT_NAME="$COMPOSE_PROJECT_NAME" AGGLAYER_CONTAINER="$AGGLAYER_CONTAINER" \
-        PLAN_L1_TARGET="$N_L1_FWD" PLAN_L2_TARGET="$N_L1_BACK" VERIFY=0 ALLOW_LATE=1 \
+        PLAN_L1_TARGET="$N_L1_FWD" PLAN_L2_TARGET="$N_L1_BACK" VERIFY=0 STRICT_OPS=1 ALLOW_LATE=1 \
         "$SCRIPT_DIR/e2e-bridge-loadtest-isolated.sh" > "$LT_OUT" 2>&1 &
     LT_PID=$!
     log "  L1<->Miden loadtest PID $LT_PID (log: $LT_OUT)"

--- a/scripts/e2e-loadtest-mixed.sh
+++ b/scripts/e2e-loadtest-mixed.sh
@@ -65,6 +65,71 @@ for c in cast forge psql curl python3 docker; do command -v "$c" >/dev/null || f
 MIX_LOG="${MIX_LOG:-/tmp/mixed-l2l2.log}"; : > "$MIX_LOG"
 mix() { echo -e "${CYAN:-}[$(date +%H:%M:%S)] MIX:${NC:-} $*" | tee -a "$MIX_LOG"; }
 
+# ── #41: settle-aware nudge (chaos-tolerant) ─────────────────────────────────
+# nudge_until's hard NUDGE_TRIES cap false-fails whole phases under chaos: the
+# claim is often ACCEPTED on Miden (its ClaimEvent lands) while the cross-chain
+# settlement merely needs a few more cert cycles than the cap allows.
+# nudge_until_settled keeps the exact nudge cadence (nudge_cert + 75s poll per
+# round) and the tight NUDGE_TRIES fast path, but past the cap it extends up to
+# a DEADLINE (L2L2_SETTLE_TIMEOUT, default 900s) — and only while there is
+# OBSERVABLE PROGRESS (agglayer cert height advancing in aggkit logs, or new
+# ClaimEvents landing in synthetic_logs). Healthy stacks still resolve in the
+# first rounds, so the non-chaos suite is not slowed. The failure message
+# distinguishes "accepted but not settled" from "never accepted".
+L2L2_SETTLE_TIMEOUT="${L2L2_SETTLE_TIMEOUT:-900}"
+_settle_cert_height() {
+    ( set +o pipefail; docker logs --tail 400 "${COMPOSE_PROJECT_NAME}-aggkit-1" 2>&1 \
+        | grep -aoE 'Height: [0-9]+' | tail -1 | awk '{print $2}' ) 2>/dev/null
+}
+_settle_claim_count() {
+    pgq "SELECT COUNT(*) FROM synthetic_logs WHERE topics[1] LIKE '0x1df3f2a9%';" 2>/dev/null
+}
+nudge_until_settled() {
+    local desc="$1"; shift
+    local base_tries="${NUDGE_TRIES:-6}" t=0 waited start now elapsed
+    local h_prev c_prev c_init h_now c_now stall=0
+    start=$(date +%s)
+    h_prev=$(_settle_cert_height); h_prev="${h_prev:-0}"
+    c_init=$(_settle_claim_count); c_init="${c_init:-0}"; c_prev="$c_init"
+    while :; do
+        t=$((t + 1))
+        nudge_cert
+        waited=0
+        while [[ $waited -lt 75 ]]; do
+            if ( set +o pipefail; "$@" ) 2>/dev/null; then
+                log "  nudge round $t unblocked: $desc"; return 0
+            fi
+            sleep 5; waited=$((waited + 5)); echo -n "."
+        done
+        echo ""
+        now=$(date +%s); elapsed=$((now - start))
+        if [[ $t -lt $base_tries ]]; then
+            warn "nudge round $t/$base_tries did not unblock: $desc — re-nudging"
+            continue
+        fi
+        [[ $elapsed -ge $L2L2_SETTLE_TIMEOUT ]] && break
+        h_now=$(_settle_cert_height); h_now="${h_now:-0}"
+        c_now=$(_settle_claim_count); c_now="${c_now:-0}"
+        if [[ "$h_now" -gt "$h_prev" || "$c_now" -gt "$c_prev" ]] 2>/dev/null; then
+            stall=0
+            warn "nudge round $t: not settled but PROGRESS observed (cert height ${h_prev}→${h_now}, claims ${c_prev}→${c_now}) — extending (${elapsed}s/${L2L2_SETTLE_TIMEOUT}s): $desc"
+        else
+            stall=$((stall + 1))
+            warn "nudge round $t: no observable progress (cert height ${h_now}, claims ${c_now}; stall ${stall}/2) — $desc"
+            [[ $stall -ge 2 ]] && break
+        fi
+        h_prev="$h_now"; c_prev="$c_now"
+    done
+    now=$(date +%s); elapsed=$((now - start))
+    c_now=$(_settle_claim_count); c_now="${c_now:-0}"
+    if [[ "$c_now" -gt "$c_init" ]] 2>/dev/null; then
+        warn "SETTLE-TIMEOUT: accepted on Miden (ClaimEvents ${c_init}→${c_now}) but NOT settled within ${elapsed}s (L2L2_SETTLE_TIMEOUT=${L2L2_SETTLE_TIMEOUT}, rounds=$t): $desc"
+    else
+        warn "SETTLE-TIMEOUT: never accepted (no ClaimEvent landed in ${elapsed}s, rounds=$t): $desc"
+    fi
+    return 1
+}
+
 # ── mixed-specific predicate helpers (named callbacks for wait_for/nudge_until) ─
 _mixed_wallet_ge() { [[ "$(iso_wallet_balance "$1" "$2")" -ge "$3" ]]; }                 # <bridge_id> <faucet_id> <min_units>
 _mixed_l2b_balance_eq() {                                                                # <token> <holder> <want_wei>
@@ -163,7 +228,7 @@ SEED_DEP=$(find_deposit "$DEST_ADDR" "$L2B_NETWORK_ID" "$MOP_LOWER" "$L2B_BRIDGE
 [[ -n "$SEED_DEP" ]] || fail "seed deposit not indexed on the L2B service"
 SEED_CNT=$(dep_field "$SEED_DEP" deposit_cnt); SEED_GI=$(dep_field "$SEED_DEP" global_index)
 SEED_META=$(echo "$SEED_DEP" | python3 -c "import json,sys; m=json.load(sys.stdin).get('metadata','0x'); print(m if m and m != '0x' else '0x')")
-nudge_until "seed (MOP,net2) claim accepted on Miden (ClaimEvent gi $SEED_GI)" \
+nudge_until_settled "seed (MOP,net2) claim accepted on Miden (ClaimEvent gi $SEED_GI)" \
     _pred_submit_forward_claim "$SEED_CNT" "$SEED_GI" 2 "$MOP" "$MIDEN_NETWORK_ID" "$DEST_ADDR" "$FWD_SEED_WEI" "$SEED_META" \
     || fail "seed (MOP,net2) claim never landed on Miden"
 
@@ -281,7 +346,7 @@ for dep in sorted(d.get('deposits',[]), key=lambda x:x.get('deposit_cnt',0)):
         print('%s|%s|%s' % (dep['deposit_cnt'], dep['global_index'], dep.get('metadata','0x') or '0x'))" 2>/dev/null)
     for entry in ${FWD_ROWS[@]+"${FWD_ROWS[@]}"}; do
         IFS='|' read -r cnt gi meta <<<"$entry"
-        if nudge_until "fwd ClaimEvent (gi $gi)" \
+        if nudge_until_settled "fwd ClaimEvent (gi $gi)" \
             _pred_submit_forward_claim "$cnt" "$gi" 2 "$MOP" "$MIDEN_NETWORK_ID" "$DEST_ADDR" "$FWD_OP_WEI" "$meta"; then
             bump fwd_ok; mix "fwd CLAIMED (gi $gi)"
         else mix "fwd claim did NOT land (gi $gi)"; fi
@@ -295,11 +360,11 @@ if [[ "$(cat "$CNT_DIR/clash")" == "submitted" ]]; then
     if [[ -n "$cdep" ]]; then
         ccnt=$(dep_field "$cdep" deposit_cnt); cgi=$(dep_field "$cdep" global_index)
         cmeta=$(echo "$cdep" | python3 -c "import json,sys; m=json.load(sys.stdin).get('metadata','0x'); print(m if m and m != '0x' else '0x')")
-        nudge_until "clash net-2 (COL) claim accepted on Miden (gi $cgi)" \
+        nudge_until_settled "clash net-2 (COL) claim accepted on Miden (gi $cgi)" \
             _pred_submit_forward_claim "$ccnt" "$cgi" 2 "$COL" "$MIDEN_NETWORK_ID" "$DEST_ADDR" "$COL_L2B_WEI" "$cmeta" \
             || mix "clash net-2 claim did NOT land (gi $cgi)"
     else mix "clash net-2 COL deposit not indexed on the L2B service"; fi
-    if nudge_until "clash: TWO COL faucet rows" \
+    if nudge_until_settled "clash: TWO COL faucet rows" \
         _pred_pg_eq "SELECT COUNT(*) FROM faucet_registry WHERE encode(origin_address,'hex')='${COL_HEX}';" "2"; then
         f0=$(pgq "SELECT lower(faucet_id) FROM faucet_registry WHERE encode(origin_address,'hex')='${COL_HEX}' AND origin_network=0;")
         f2=$(pgq "SELECT lower(faucet_id) FROM faucet_registry WHERE encode(origin_address,'hex')='${COL_HEX}' AND origin_network=${L2B_NETWORK_ID};")

--- a/scripts/e2e-loadtest-mixed.sh
+++ b/scripts/e2e-loadtest-mixed.sh
@@ -412,13 +412,18 @@ CLASH=$(cat "$CNT_DIR/clash")
 
 step "Verdict: settle margin, then event-completeness across net-0/1/2"
 sleep "${MIX_SETTLE:-60}"
+# PR#145: MIX_VERIFY=0 skips ONLY the duplicate completeness-verifier invocation
+# (the caller runs the ONE authoritative verify post-heal). It must NOT skip the
+# operational verdict below — previously an early `exit 0` here meant LT_RC=0
+# certified only that the driver reached this line, and an operation that was
+# never submitted/consumed is also absent from the caller's later node
+# denominator, so the miss could never be reconstructed.
 VC_RC=2
 if [[ "${MIX_VERIFY:-1}" != "1" ]]; then
     log "MIX_VERIFY=0 — skipping internal completeness (caller verifies post-heal)"
     log "  L1<->Miden rc=$LT_RC  fwd=$FWD_OK/$FWD_SUB  back=$BACK_OK/$BACK_SUB  clash=$CLASH"
-    exit 0
-fi
-if [[ -x "$TOOL_BIN" ]]; then
+    VC_RC="skip"
+elif [[ -x "$TOOL_BIN" ]]; then
     ALLOW_LATE="${ALLOW_LATE:-1}" TOOL_BIN="$TOOL_BIN" \
         NODE_CONTAINER="$NODE_CONTAINER" AGGLAYER_CONTAINER="$AGGLAYER_CONTAINER" \
         "$SCRIPT_DIR/verify-event-completeness.sh" > /tmp/mixed-verify.out 2>&1
@@ -431,22 +436,18 @@ fi
 # emitting a second "0" (an `|| echo 0` here would make LOCKS="0\n0" and fail the check).
 LOCKS=$(docker logs "$AGGLAYER_CONTAINER" 2>&1 | grep -c "database is locked" || true)
 
+# shellcheck source=lib-chaos-verdict.sh
+source "$SCRIPT_DIR/lib-chaos-verdict.sh"
 log "======================================================================"
 log "  MIXED LOADTEST RESULT"
 log "    L1<->Miden loadtest rc      = $LT_RC ($N_L1_FWD L1->Miden + $N_L1_BACK Miden->L1)"
 log "    L2B->Miden forward ops      = $FWD_OK/$FWD_SUB claimed"
 log "    Miden->L2B back ops         = $BACK_OK/$BACK_SUB released"
 log "    address clash               = $CLASH (want: distinct)"
-log "    event-completeness rc       = $VC_RC (0 = PASS)"
+log "    event-completeness rc       = $VC_RC (0 = PASS; 'skip' = caller verifies)"
 log "    proxy store-locks           = $LOCKS"
-OK=1
-[[ "$FWD_OK" == "$FWD_SUB" && "$FWD_SUB" -gt 0 ]] || OK=0
-[[ "$BACK_OK" == "$BACK_SUB" && "$BACK_SUB" -gt 0 ]] || OK=0
-[[ "$CLASH" == "distinct" ]] || OK=0
-[[ "$VC_RC" == "0" ]] || OK=0
-[[ "${LOCKS:-1}" == "0" ]] || OK=0
-[[ "$LT_RC" == "0" || "$SKIP_L1_LOAD" == "1" ]] || OK=0
-if [[ "$OK" == "1" ]]; then
+if mixed_ops_ok "$FWD_OK" "$FWD_SUB" "$BACK_OK" "$BACK_SUB" "$CLASH" \
+        "$LT_RC" "${SKIP_L1_LOAD:-0}" "$VC_RC" "${LOCKS:-1}"; then
     log "  >>> MIXED LOADTEST PASS — all 4 directions landed + clash distinct <<<"
     log "======================================================================"
     exit 0

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -71,18 +71,15 @@ case "$test_filter" in
         echo ""
         "$SCRIPT_DIR/e2e-reconciler-private-note.sh"
         echo ""
-        # ABSOLUTELY LAST on purpose: its final phase leaves a self-targeted
-        # poison leaf in the LET (by design of the Cantina #13 circuit-break
-        # repro), which wedges any certificate settlement that would happen
-        # after it — so no settlement-dependent test may follow.
-        "$SCRIPT_DIR/e2e-cantina13-metadata-recovery.sh"
-        echo ""
-        # L2<->L2 + native Miden-originated tiers — canonical part of the full suite on
-        # this branch. They need the docker-compose.l2l2.yml overlay (postgres-l2b /
+        # ── L2<->L2 + native Miden-originated tiers — run BEFORE cantina13 so the
+        # recovery below is exercised against real multi-network state (finding #62: an
+        # L2B-origin (net 2) token's metadata must restore via its OWN chain's RPC, not
+        # L1). They need the docker-compose.l2l2.yml overlay (postgres-l2b /
         # bridge-service-l2b), so GUARD on the overlay being up: on the base stack they're
         # skipped with a warning; on the l2l2 stack they run. `e2e-test.sh l2l2` runs the
         # L2<->L2 group (forward/clash/back); the native round-trips exercise a
-        # Miden-originated token to BOTH destinations (->L2B and ->L1).
+        # Miden-originated token to BOTH destinations (->L2B and ->L1). Running them before
+        # cantina13's poison leaf also lets their certificate settlement complete un-wedged.
         if docker ps --format '{{.Names}}' 2>/dev/null | grep -q 'postgres-l2b'; then
             echo "== L2<->L2 group (L2B overlay present) =="
             "$SCRIPT_DIR/e2e-test.sh" l2l2
@@ -94,6 +91,14 @@ case "$test_filter" in
         else
             echo "SKIP L2<->L2 + native tiers — L2B overlay not up (base stack). Run 'make e2e-l2l2-up' to include them."
         fi
+        echo ""
+        # cantina13 recovery — runs AFTER the L2<->L2 + native tiers so its from-scratch
+        # DROP + --restore rebuilds the whole multi-network faucet set (L1 net0, L2B net2,
+        # native net1) from on-chain — the finding #62 proof inside the full suite. Its
+        # final phase leaves a self-targeted poison leaf in the LET (Cantina #13
+        # circuit-break repro) that wedges any certificate settlement after it, so only the
+        # L1->L2-only manual-user-claim may follow.
+        "$SCRIPT_DIR/e2e-cantina13-metadata-recovery.sh"
         echo ""
         # VERY LAST in the suite — defense in depth: the manual-user-claim
         # script deliberately front-runs the sponsor's autoclaimer, which

--- a/scripts/lib-chaos-verdict.sh
+++ b/scripts/lib-chaos-verdict.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# lib-chaos-verdict.sh — PURE verdict predicates for the chaos soak + mixed
+# loadtest. No side effects, no docker/pg access: every input is a plain
+# argument so the verdicts are unit-testable (scripts/test-chaos-verdict.sh).
+#
+# PR #145 review (release-certification blocker): the independent
+# verify-event-completeness verifier is THE completeness authority. Proxy-owned
+# store corroboration is an ADDITIONAL failure signal (it can veto a
+# verifier-pass on a store drop) and NEVER overrides a verifier fail — both
+# sides of the store comparison live in proxy-owned PostgreSQL, so agreeing
+# aggregates cannot prove events the proxy never observed, nor catch identity /
+# exact-block mismatches the verifier checks.
+
+# chaos_legit_ok VC_RC STORE_OK LOCKS LT_RC
+#   Completeness verdict: verifier MUST pass (VC_RC==0), store corroboration
+#   MUST be clean (STORE_OK==1 — additional veto, not an alternative), zero
+#   proxy store-lock errors, and the mixed-loadtest driver completed (LT_RC==0
+#   — with the ops verdict enforced even under MIX_VERIFY=0, a nonzero LT_RC
+#   now also means "an operation never landed", not just "driver aborted").
+chaos_legit_ok() {
+    local vc_rc="$1" store_ok="$2" locks="$3" lt_rc="$4"
+    [[ "$vc_rc" == "0" && "$store_ok" == "1" && "$locks" == "0" && "$lt_rc" == "0" ]]
+}
+
+# chaos_garbo_ok FOREIGN_LEAK PRIVATE_LEAK
+#   Containment verdict: zero foreign-claim ClaimEvent rows for the fabricated
+#   global indexes AND zero persisted traces of the garbo private/tag-0 note
+#   ids in the proxy store (the direct absence assertion; a leak by definition
+#   persists rows in the proxy's own tables before it is served). The
+#   independent verifier's extra==0 additionally backs this via
+#   chaos_legit_ok's VC_RC requirement in the overall verdict.
+chaos_garbo_ok() {
+    local foreign_leak="$1" private_leak="$2"
+    [[ "$foreign_leak" == "0" && "$private_leak" == "0" ]]
+}
+
+# chaos_fired_ok FAULTS PRIVATE_FIRED FOREIGN_ENABLED FOREIGN_FIRED
+#   The storm actually happened: >=1 infra fault, the private class fired, and
+#   the foreign class fired whenever it was enabled.
+chaos_fired_ok() {
+    local faults="$1" private_fired="$2" foreign_enabled="$3" foreign_fired="$4"
+    [[ "${faults:-0}" -ge 1 ]] || return 1
+    [[ "${private_fired:-0}" -ge 1 ]] || return 1
+    [[ "$foreign_enabled" != "1" || "${foreign_fired:-0}" -ge 1 ]] || return 1
+    return 0
+}
+
+# chaos_verdict VC_RC STORE_OK LOCKS LT_RC FOREIGN_LEAK PRIVATE_LEAK \
+#               FAULTS PRIVATE_FIRED FOREIGN_ENABLED FOREIGN_FIRED
+#   The overall two-sided (+liveness) soak verdict. 0 = PASS.
+chaos_verdict() {
+    chaos_legit_ok "$1" "$2" "$3" "$4" || return 1
+    chaos_garbo_ok "$5" "$6" || return 1
+    chaos_fired_ok "$7" "$8" "$9" "${10}" || return 1
+    return 0
+}
+
+# mixed_ops_ok FWD_OK FWD_SUB BACK_OK BACK_SUB CLASH LT_RC SKIP_L1 VC_RC LOCKS
+#   The mixed loadtest's operational verdict. VC_RC may be the literal string
+#   "skip" (MIX_VERIFY=0: the caller runs the ONE authoritative verifier
+#   post-heal) — that skips ONLY the verifier requirement; every operational
+#   requirement (all forwards claimed, all backs released, clash distinct, L1
+#   loadtest green unless explicitly skipped, zero store locks) still gates.
+mixed_ops_ok() {
+    local fwd_ok="$1" fwd_sub="$2" back_ok="$3" back_sub="$4" clash="$5" \
+          lt_rc="$6" skip_l1="$7" vc_rc="$8" locks="$9"
+    [[ "$fwd_ok" == "$fwd_sub" && "${fwd_sub:-0}" -gt 0 ]] || return 1
+    [[ "$back_ok" == "$back_sub" && "${back_sub:-0}" -gt 0 ]] || return 1
+    [[ "$clash" == "distinct" ]] || return 1
+    [[ "$lt_rc" == "0" || "$skip_l1" == "1" ]] || return 1
+    [[ "$vc_rc" == "skip" || "$vc_rc" == "0" ]] || return 1
+    [[ "${locks:-1}" == "0" ]] || return 1
+    return 0
+}

--- a/scripts/lib-chaos-verdict.sh
+++ b/scripts/lib-chaos-verdict.sh
@@ -55,6 +55,24 @@ chaos_verdict() {
     return 0
 }
 
+# l1_ops_ok SUB_L1 PLAN_L1 SUB_L2 PLAN_L2 FAIL_L1 FAIL_L2 G_CLM G_SUB
+#   The nested L1<->Miden bulk load's operational verdict (PR#145 follow-up:
+#   with VERIFY=0 the child's exit was `LOCK_COUNT>0 ? 1 : 0`, so failed or
+#   never-claimed L1 work exited 0 and the four-direction soak could PASS with
+#   missing L1 workload). 0 = OK iff every planned op was submitted
+#   (SUB==PLAN, both directions), zero submission failures, and every
+#   submitted op was claimed (G_CLM==G_SUB). Lives in the CHILD (STRICT_OPS=1)
+#   so the parent consumes a real exit code instead of parsing human logs.
+l1_ops_ok() {
+    local sub_l1="$1" plan_l1="$2" sub_l2="$3" plan_l2="$4" \
+          fail_l1="$5" fail_l2="$6" g_clm="$7" g_sub="$8"
+    [[ "${sub_l1:-0}" == "${plan_l1:--1}" ]] || return 1
+    [[ "${sub_l2:-0}" == "${plan_l2:--1}" ]] || return 1
+    [[ "${fail_l1:-1}" == "0" && "${fail_l2:-1}" == "0" ]] || return 1
+    [[ "${g_clm:-0}" == "${g_sub:--1}" ]] || return 1
+    return 0
+}
+
 # mixed_ops_ok FWD_OK FWD_SUB BACK_OK BACK_SUB CLASH LT_RC SKIP_L1 VC_RC LOCKS
 #   The mixed loadtest's operational verdict. VC_RC may be the literal string
 #   "skip" (MIX_VERIFY=0: the caller runs the ONE authoritative verifier

--- a/scripts/test-chaos-verdict.sh
+++ b/scripts/test-chaos-verdict.sh
@@ -57,6 +57,17 @@ nok "verifier fail (MIX_VERIFY=1) fails"            mixed_ops_ok  2  2  2  2  di
 ok  "all ops complete + vc=skip passes"             mixed_ops_ok  2  2  2  2  distinct 0  0  skip 0
 ok  "all ops complete + vc=0 passes"                mixed_ops_ok  2  2  2  2  distinct 0  0  0    0
 
+
+# ── l1_ops_ok (PR#145 follow-up: the nested L1<->Miden child's STRICT_OPS
+#    verdict — the real operational failure the parent consumes as LT_RC) ─────
+#                                                            SUB1 PLN1 SUB2 PLN2 F1 F2 CLM SUB
+ok  "l1: all planned submitted, none failed, all claimed"  l1_ops_ok 15 15 15 15 0 0 30 30
+nok "l1: target shortfall L1->L2 (sub < plan) fails"       l1_ops_ok 14 15 15 15 0 0 29 29
+nok "l1: target shortfall L2->L1 (sub < plan) fails"       l1_ops_ok 15 15 12 15 0 0 27 27
+nok "l1: explicit submission failure fails"                l1_ops_ok 15 15 15 15 1 0 30 30
+nok "l1: submitted-but-unclaimed work fails"               l1_ops_ok 15 15 15 15 0 0 28 30
+nok "l1: empty/unset counters fail closed"                 l1_ops_ok "" "" "" "" "" "" "" ""
+
 echo "──────────────────────────────────────────────"
 if [[ "$FAILS" == "0" ]]; then
     echo "CHAOS-VERDICT TESTS: ALL PASS"

--- a/scripts/test-chaos-verdict.sh
+++ b/scripts/test-chaos-verdict.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# test-chaos-verdict.sh — unit tests for the PURE verdict predicates in
+# lib-chaos-verdict.sh (PR#145 review regression coverage). Touches NO stack:
+# every predicate input is a plain argument.
+#
+#   ./scripts/test-chaos-verdict.sh   # exits 0 iff every assertion holds
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-chaos-verdict.sh
+source "$SCRIPT_DIR/lib-chaos-verdict.sh"
+
+FAILS=0
+ok()   { local d="$1"; shift; if "$@"; then echo "PASS  $d"; else echo "FAIL  $d (expected pass)"; FAILS=$((FAILS+1)); fi; }
+nok()  { local d="$1"; shift; if "$@"; then echo "FAIL  $d (expected fail)"; FAILS=$((FAILS+1)); else echo "PASS  $d"; fi; }
+
+echo "── chaos_legit_ok: the independent verifier is REQUIRED ──"
+#           desc                                                fn             VC STORE LOCKS LT
+nok "verifier FAIL + store CLEAN must FAIL (no override)"  chaos_legit_ok  1  1  0  0
+nok "verifier FAIL + store DROP must FAIL"                 chaos_legit_ok  1  0  0  0
+nok "verifier PASS + store DROP must FAIL (veto)"          chaos_legit_ok  0  0  0  0
+nok "verifier PASS + store CLEAN + locks must FAIL"        chaos_legit_ok  0  1  3  0
+nok "verifier PASS + store CLEAN + loadtest fail must FAIL" chaos_legit_ok 0  1  0  1
+ok  "verifier PASS + store CLEAN + no locks + lt ok PASSES" chaos_legit_ok 0  1  0  0
+
+echo "── chaos_garbo_ok: containment needs zero leaks of BOTH classes ──"
+#           desc                                       fn            FOREIGN PRIVATE
+nok "foreign leak must FAIL"                     chaos_garbo_ok  2  0
+nok "private-derived persisted event must FAIL"  chaos_garbo_ok  0  1
+nok "both leaks must FAIL"                       chaos_garbo_ok  3  1
+ok  "zero leaks PASSES"                          chaos_garbo_ok  0  0
+
+echo "── chaos_fired_ok: an empty storm must not certify ──"
+#           desc                                fn             FAULTS PRIV F_EN F_FIRED
+nok "no faults must FAIL"                 chaos_fired_ok  0  2  1  1
+nok "private never fired must FAIL"       chaos_fired_ok  3  0  1  1
+nok "foreign enabled but 0 fired FAILS"   chaos_fired_ok  3  2  1  0
+ok  "foreign disabled + 0 fired PASSES"   chaos_fired_ok  3  2  0  0
+ok  "all classes fired PASSES"            chaos_fired_ok  3  2  1  1
+
+echo "── chaos_verdict: end-to-end combinations ──"
+#           desc                              fn            VC ST LK LT FL PL FA PF FE FF
+nok "VC_RC=1 STORE_OK=1 fails overall"  chaos_verdict  1  1  0  0  0  0  3  2  1  1
+nok "private leak fails overall"        chaos_verdict  0  1  0  0  0  1  3  2  1  1
+nok "incomplete loadtest fails overall" chaos_verdict  0  1  0  1  0  0  3  2  1  1
+ok  "complete ops + VC_RC=0 passes"     chaos_verdict  0  1  0  0  0  0  3  2  1  1
+
+echo "── mixed_ops_ok: MIX_VERIFY=0 must still enforce every operation ──"
+#           desc                                          fn           F_OK F_SUB B_OK B_SUB CLASH    LT SKIP VC   LOCKS
+nok "incomplete forwards fail even with vc=skip"    mixed_ops_ok  1  2  2  2  distinct 0  0  skip 0
+nok "incomplete backs fail even with vc=skip"       mixed_ops_ok  2  2  1  2  distinct 0  0  skip 0
+nok "zero submitted forwards fail (empty run)"      mixed_ops_ok  0  0  2  2  distinct 0  0  skip 0
+nok "non-distinct clash fails even with vc=skip"    mixed_ops_ok  2  2  2  2  same     0  0  skip 0
+nok "L1 loadtest fail (not skipped) fails"          mixed_ops_ok  2  2  2  2  distinct 1  0  skip 0
+ok  "L1 loadtest fail but SKIP_L1=1 passes"         mixed_ops_ok  2  2  2  2  distinct 1  1  skip 0
+nok "store locks fail even with vc=skip"            mixed_ops_ok  2  2  2  2  distinct 0  0  skip 2
+nok "verifier fail (MIX_VERIFY=1) fails"            mixed_ops_ok  2  2  2  2  distinct 0  0  1    0
+ok  "all ops complete + vc=skip passes"             mixed_ops_ok  2  2  2  2  distinct 0  0  skip 0
+ok  "all ops complete + vc=0 passes"                mixed_ops_ok  2  2  2  2  distinct 0  0  0    0
+
+echo "──────────────────────────────────────────────"
+if [[ "$FAILS" == "0" ]]; then
+    echo "CHAOS-VERDICT TESTS: ALL PASS"
+    exit 0
+else
+    echo "CHAOS-VERDICT TESTS: $FAILS FAILURE(S)"
+    exit 1
+fi

--- a/src/bridge_out.rs
+++ b/src/bridge_out.rs
@@ -3571,7 +3571,7 @@ mod tests {
             block_state.get_block_hash(block),
             crate::bridge_address::get_bridge_address(),
             None,
-            None,
+            &crate::metadata_recovery::NetworkRpcMap::new(),
         )
         .await
         .unwrap()
@@ -3626,7 +3626,7 @@ mod tests {
             block_state.get_block_hash(100),
             crate::bridge_address::get_bridge_address(),
             None,
-            None,
+            &crate::metadata_recovery::NetworkRpcMap::new(),
         )
         .await;
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,19 @@ struct Command {
     #[arg(long, env = "L1_RPC_URL")]
     l1_rpc_url: Option<String>,
 
+    /// Additional per-origin-network RPC endpoints for Cantina #13 metadata
+    /// recovery, as `ID=URL` (e.g. `--network-rpc-url 2=http://anvil-l2b:8545`).
+    /// Network 0 is taken from `--l1-rpc-url`. Repeatable — one per network whose
+    /// tokens (L2B, …) may need ERC-20 metadata recovered from their own chain
+    /// during restore (finding #62). Without it, only network-0 (L1) tokens
+    /// recover — the pre-#62 behavior.
+    #[arg(
+        long = "network-rpc-url",
+        value_name = "ID=URL",
+        env = "NETWORK_RPC_URLS"
+    )]
+    network_rpc_urls: Vec<String>,
+
     /// L1 GER contract address for exit root resolution
     #[arg(long, env = "GER_L1_ADDRESS")]
     ger_l1_address: Option<String>,
@@ -856,6 +869,27 @@ async fn main() -> anyhow::Result<()> {
 
     let sync_listener = Arc::new(StoreSyncListener::new(store.clone(), block_state.clone()));
 
+    // Finding #62: per-origin-network RPC map for Cantina #13 metadata recovery.
+    // Network 0 = L1 (from --l1-rpc-url); extra networks (L2B=2, …) from
+    // --network-rpc-url ID=URL. Consumed by both the live projector and --restore
+    // so an L2B-origin ERC-20 recovers its metadata from its OWN chain.
+    let network_rpcs = {
+        let mut m = miden_agglayer_service::metadata_recovery::NetworkRpcMap::new();
+        if let Some(l1) = command.l1_rpc_url.clone() {
+            m.insert(0, l1);
+        }
+        for spec in &command.network_rpc_urls {
+            let (id, url) = spec
+                .split_once('=')
+                .ok_or_else(|| anyhow::anyhow!("--network-rpc-url must be ID=URL, got: {spec}"))?;
+            let id: u32 = id.parse().map_err(|e| {
+                anyhow::anyhow!("--network-rpc-url network id must be a u32, got '{id}': {e}")
+            })?;
+            m.insert(id, url.to_string());
+        }
+        m
+    };
+
     // Register the projector LAST so it observes the same consumed-note feed the
     // monitors saw this tick, then advances the synthetic tip itself (no race —
     // it is the only writer of `latest_block_number`, Finding #5).
@@ -865,7 +899,7 @@ async fn main() -> anyhow::Result<()> {
             block_state.clone(),
             &accounts.0,
             local_network_id_u32,
-            command.l1_rpc_url.clone(),
+            network_rpcs.clone(),
             // Use the same resolved node URL as MidenClient, including its localhost default.
             miden_agglayer_service::miden_client::effective_node_url(command.miden_node.clone()),
             command.miden_api_key.clone(),
@@ -916,7 +950,7 @@ async fn main() -> anyhow::Result<()> {
             &accounts.0,
             local_network_id_u32,
             &block_state,
-            command.l1_rpc_url.clone(),
+            network_rpcs.clone(),
             restore_node_url.as_str(),
             command.miden_api_key.as_deref(),
         )
@@ -1319,6 +1353,7 @@ mod hardening_tests {
             bridge_address: miden_agglayer_service::bridge_address::DEFAULT_BRIDGE_ADDRESS
                 .to_string(),
             l1_rpc_url: None,
+            network_rpc_urls: vec![],
             ger_l1_address: None,
             l1_indexer_from_block: None,
             l1_evidence_tag: "latest".to_string(),

--- a/src/metadata_recovery.rs
+++ b/src/metadata_recovery.rs
@@ -21,7 +21,7 @@
 //! [`FaucetEntry`]: crate::store::FaucetEntry
 //! [`AggLayerBridge::faucet_metadata_map_slot_name`]: miden_base_agglayer::AggLayerBridge
 
-use miden_base_agglayer::{AggLayerBridge, AggLayerFaucet, MetadataHash};
+use miden_base_agglayer::{AggLayerBridge, MetadataHash};
 use miden_protocol::account::{Account, AccountId, AccountStorage, StorageSlotContent};
 use miden_protocol::{Felt, Word};
 
@@ -350,15 +350,24 @@ pub fn find_registered_faucet_for_origin(
 
 /// Build the all-Miden recovery candidate from the faucet account.
 ///
-/// NOTE: the AggLayer faucet sets its token name == symbol and stores a
-/// *sanitised* symbol, so this candidate only validates for tokens whose origin
-/// `name == symbol` and whose symbol survived sanitisation unchanged. It is tried
-/// first because it needs no RPC; the keccak gate makes trying it safe.
+/// Accepts BOTH supported faucet kinds via [`crate::faucet_ops::classify_faucet_account`]:
+/// an AggLayer-owned wrapped faucet (foreign-origin tokens) AND a native operator
+/// `FungibleFaucet` (Miden-originated tokens). This matters for a NATIVE token whose
+/// `origin_network` is this Miden deployment: there is no external chain to query for its
+/// ERC-20 metadata, so the Miden faucet is the ONLY authoritative source — and its
+/// registered preimage is `abi.encode(name, symbol, decimals)` with `name == symbol` (the
+/// admin register-native path defaults `name` to `symbol`). Previously this tried only
+/// `AggLayerFaucet::try_faucet_from_account`, so an externally-deployed native operator
+/// faucet yielded NO candidate and its metadata was unrecoverable on restore — a poison
+/// leaf that halts the entire restore. Behavior for AggLayer faucets is unchanged (classify
+/// tries that type first). Both kinds expose the same `token_name()`/`symbol()`. The token
+/// name still must equal the symbol for the candidate to validate; the keccak gate makes
+/// trying it safe.
 fn miden_faucet_candidate(
     faucet_account: &Account,
     origin_decimals: u8,
 ) -> Option<MetadataCandidate> {
-    let faucet = AggLayerFaucet::try_faucet_from_account(faucet_account).ok()?;
+    let (_kind, faucet) = crate::faucet_ops::classify_faucet_account(faucet_account).ok()?;
     Some(MetadataCandidate {
         name: faucet.token_name().as_str().to_string(),
         symbol: faucet.symbol().to_string(),

--- a/src/metadata_recovery.rs
+++ b/src/metadata_recovery.rs
@@ -32,6 +32,16 @@ use miden_protocol::{Felt, Word};
 /// a reachable L1 RPC for the token's origin network.
 pub const METADATA_UNRECOVERABLE_METRIC: &str = "bridge_out_metadata_unrecoverable_total";
 
+/// Maps an `origin_network` id → the RPC URL that serves that network's token
+/// contracts (network 0 = L1, network 2 = a second rollup / L2B, …). Cantina #13
+/// metadata recovery uses it to fetch ERC-20 `name()`/`symbol()`/`decimals()`
+/// from the token's ACTUAL origin chain instead of always dialing L1 — a token
+/// whose origin is L2B (origin_network=2) would otherwise be validated against
+/// the wrong chain and fail the keccak gate (finding #62). An empty map means "no
+/// RPC for any network" (recovery falls back to the all-Miden candidate only),
+/// which is exactly the pre-#62 behavior when no `l1_rpc_url` was configured.
+pub type NetworkRpcMap = std::collections::HashMap<u32, String>;
+
 /// Native-ETH sentinel: an all-zero origin token address. Native ETH legitimately
 /// carries empty metadata and must never be touched by recovery.
 const NATIVE_TOKEN_ADDRESS: [u8; 20] = [0u8; 20];
@@ -641,6 +651,73 @@ mod tests {
             assert_eq!(origin.origin_address, USDC);
             assert_eq!(origin.origin_network, 6);
             assert_eq!(origin.scale, 10);
+        }
+
+        // ── Finding #62 — multi-network restore-metadata ─────────────────────
+
+        /// The per-network RPC selection (the exact `network_rpcs.get(&n)` used at
+        /// the two restore recovery sites) routes an L2B-origin (network 2) token
+        /// to the L2B RPC and an L1 (network 0) token to the L1 RPC — and yields
+        /// None for an unmapped network (recovery then relies on the all-Miden
+        /// candidate only, the pre-#62 behavior). This is what stops an L2B token
+        /// being validated against the wrong (L1) chain and failing the keccak gate.
+        #[test]
+        fn finding_62_network_rpc_map_selects_rpc_by_origin_network() {
+            let mut rpcs = NetworkRpcMap::new();
+            rpcs.insert(0, "http://l1:8545".to_string());
+            rpcs.insert(2, "http://anvil-l2b:8545".to_string());
+
+            assert_eq!(rpcs.get(&0).map(String::as_str), Some("http://l1:8545"));
+            assert_eq!(
+                rpcs.get(&2).map(String::as_str),
+                Some("http://anvil-l2b:8545")
+            );
+            // An unmapped network (e.g. a third rollup we weren't configured for)
+            // selects no RPC — recovery falls back to the all-Miden candidate.
+            assert_eq!(rpcs.get(&3).map(String::as_str), None);
+            // Empty map == pre-#62 "no L1 RPC configured": every lookup is None.
+            assert_eq!(NetworkRpcMap::new().get(&0).map(String::as_str), None);
+        }
+
+        /// A restore rebuild for an L2B-origin faucet (origin_network=2) must carry
+        /// the correct `symbol` and `origin_network` into the rebuilt row. The
+        /// symbol comes from the Miden faucet account (network-independent), so it
+        /// survives restore regardless of which chain the metadata PREIMAGE is
+        /// recovered from — proving the registry row itself is network-agnostic
+        /// and only the metadata-preimage RPC (tested above) was single-network.
+        #[tokio::test]
+        async fn finding_62_restore_rebuilds_l2b_origin_row_with_symbol() {
+            let faucet = faucet_id();
+            // origin_network = 2 (L2B), a token that would previously be validated
+            // against L1 and lose its metadata.
+            let bridge_storage = fabricate_bridge_storage(faucet, USDC, 2, 4);
+            let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+
+            let conv = read_faucet_conversion_metadata(&bridge_storage, faucet).unwrap();
+            assert_eq!(conv.origin_network, 2, "L2B network must decode faithfully");
+            let miden_decimals = 6u8;
+            store
+                .register_faucet(FaucetEntry {
+                    faucet_id: faucet,
+                    origin_address: conv.origin_address,
+                    origin_network: conv.origin_network,
+                    symbol: "MOP".into(),
+                    origin_decimals: miden_decimals + conv.scale,
+                    miden_decimals,
+                    scale: conv.scale,
+                    metadata: vec![],
+                })
+                .await
+                .unwrap();
+
+            let origin = resolve_faucet_origin(faucet, &*store)
+                .await
+                .expect("rebuilt L2B row must resolve");
+            assert_eq!(origin.origin_network, 2);
+            assert_eq!(origin.origin_address, USDC);
+            let row = store.get_faucet_by_id(faucet).await.unwrap().unwrap();
+            assert_eq!(row.symbol, "MOP", "L2B token symbol must survive restore");
+            assert_eq!(row.origin_network, 2);
         }
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -96,6 +96,14 @@ pub fn init_metrics() {
          slot (across replicas or a stale replacement) and the reservation kept exactly one; the \
          winner advances the nonce and the loser is dropped, mirroring geth."
     );
+    describe_counter!(
+        "nonce_reservation_expired_reclaimed_total",
+        "Wedge #5 abandoned-slot reclamation: a (signer, nonce) reservation left 'executing' \
+         with an EXPIRED lease by an admission that crashed before durable admission (no \
+         transactions row = provably no external submit) was taken over by a DIFFERENT tx. \
+         Without this, an external submitter that signs a fresh tx per retry (the \
+         zkevm-bridge-service claimtxman) is rejected at that nonce forever."
+    );
     describe_counter!("ger_injections_total", "Total GER injections");
     describe_gauge!(
         "projector_visibility_barrier_held_blocks",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -97,11 +97,13 @@ pub fn init_metrics() {
          winner advances the nonce and the loser is dropped, mirroring geth."
     );
     describe_counter!(
-        "nonce_reservation_expired_reclaimed_total",
-        "Wedge #5 abandoned-slot reclamation: a (signer, nonce) reservation left 'executing' \
-         with an EXPIRED lease by an admission that crashed before durable admission (no \
-         transactions row = provably no external submit) was taken over by a DIFFERENT tx. \
-         Without this, an external submitter that signs a fresh tx per retry (the \
+        "nonce_reservation_abandoned_reclaimed_total",
+        "Wedge #5 abandoned-slot reclamation: a (signer, nonce) reservation whose admission \
+         provably never reached durable admission (no transactions row = no external submit) \
+         was taken over by a DIFFERENT tx. Labeled by cause: 'expired_executing' (the \
+         admission crashed, leaving 'executing' past its lease) or 'released_failure' (a \
+         normal pre-admission error, e.g. writer-queue saturation, released the slot as \
+         failure). Without this, an external submitter that signs a fresh tx per retry (the \
          zkevm-bridge-service claimtxman) is rejected at that nonce forever."
     );
     describe_counter!("ger_injections_total", "Total GER injections");

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -1683,20 +1683,44 @@ pub(crate) async fn project_claim_note(
     // envelope), a reconstruct when it is ABSENT — either derived-hash synthesis (no real
     // eth-tx), OR the crash window where the note→hash link survived but the envelope did
     // NOT (which the derived-hash-only backfill would never repair, so the ClaimEvent would
-    // otherwise ride a hash with empty calldata forever). Best-effort: unrecoverable faucet
-    // metadata leaves the envelope absent (empty calldata; operator registers the faucet,
-    // backfill heals) — non-fatal, the ClaimEvent still commits below.
-    if let Err(e) =
-        insert_pending_claim_calldata(store, details.storage(), &note_id_str, &tx_hash).await
-    {
-        tracing::warn!(
-            target: "restore::claims",
-            note_id = %note_id_str,
-            tx_hash = %tx_hash,
-            error = %format!("{e:#}"),
-            "synthesised claim: calldata pre-insert failed (transient — the projector \
-             backfill retries next tick)"
-        );
+    // otherwise ride a hash with empty calldata forever).
+    //
+    // FAIL-CLOSED (MA#27 review follow-up): if the calldata cannot be ensured — either a
+    // transient error, or `Ok(false)` because the faucet metadata preimage is unrecoverable
+    // — DO NOT publish the ClaimEvent and DO NOT mark the note processed. Return an error so
+    // block projection RETRIES on a later tick (once the faucet is registered the
+    // reconstruction succeeds and the event emits with valid calldata). Publishing here
+    // would seal an IMMUTABLE ClaimEvent riding a hash with empty calldata: aggkit's
+    // full-claim parser wedges ("input too short: 0 bytes"), and because the note is marked
+    // processed nothing ever retries. A projector halt (surfaced via the metric + log below)
+    // is the correct fail-closed posture — the claim is already provably ours (the
+    // provenance gate ran above), so unrecoverable calldata is a real operator-actionable
+    // registry gap, not a note to skip.
+    match insert_pending_claim_calldata(store, details.storage(), &note_id_str, &tx_hash).await {
+        Ok(true) => {}
+        Ok(false) => {
+            ::metrics::counter!("synthetic_claim_calldata_fail_closed_total").increment(1);
+            tracing::error!(
+                target: "restore::claims",
+                note_id = %note_id_str,
+                tx_hash = %tx_hash,
+                global_index = %hex::encode(decoded.global_index),
+                "synthesised claim: full claimAsset calldata UNRECOVERABLE (faucet metadata \
+                 not in registry) — refusing to publish a ClaimEvent with empty calldata; \
+                 projection HALTS and retries (operator: register/repair the faucet)"
+            );
+            anyhow::bail!(
+                "claim {note_id_str}: full claimAsset calldata unrecoverable — fail-closed, \
+                 projection will retry (register/repair faucet metadata to unblock)"
+            );
+        }
+        Err(e) => {
+            ::metrics::counter!("synthetic_claim_calldata_fail_closed_total").increment(1);
+            return Err(e.context(format!(
+                "claim {note_id_str}: failed to ensure claimAsset calldata before publishing \
+                 ClaimEvent — fail-closed, projection will retry"
+            )));
+        }
     }
 
     store
@@ -3292,6 +3316,18 @@ mod tests {
     /// `consumer`, with a per-test `gi_byte` to keep global indexes distinct
     /// across tests (Dedup 2 keys on global_index).
     fn claim_input_note(consumer: Option<AccountId>, gi_byte: u8) -> InputNoteRecord {
+        // Default: empty metadata → truthful by hash → reconstructable with no registry entry.
+        claim_input_note_meta(consumer, gi_byte, &[])
+    }
+
+    /// Like [`claim_input_note`] but with a caller-chosen metadata preimage, so a test can
+    /// force a claim whose full calldata is UNRECOVERABLE (a non-empty metadata hash with no
+    /// registry preimage that hashes to it) — the fail-closed path.
+    fn claim_input_note_meta(
+        consumer: Option<AccountId>,
+        gi_byte: u8,
+        metadata: &[u8],
+    ) -> InputNoteRecord {
         use miden_base_agglayer::{
             ClaimNote, ClaimNoteStorage, EthAddress, EthAmount, ExitRoot, GlobalIndex, LeafData,
             MetadataHash, ProofData, SmtNode,
@@ -3321,7 +3357,7 @@ mod tests {
                 destination_network: 1,
                 destination_address: EthAddress::new([0xCD; 20]),
                 amount: EthAmount::new(amount_bytes),
-                metadata_hash: MetadataHash::from_abi_encoded(&[]),
+                metadata_hash: MetadataHash::from_abi_encoded(metadata),
             },
             miden_claim_amount: Felt::ZERO,
         };
@@ -3928,6 +3964,55 @@ mod tests {
         assert!(
             data.envelope.input().len() > 4 + 64 * 32,
             "full calldata (proofs included), not a stub"
+        );
+    }
+
+    /// #67 gap 1 — FAIL-CLOSED reconstruction. A claim that is provably OURS (consumed by our
+    /// bridge) but whose full claimAsset calldata is UNRECOVERABLE (a non-empty metadata hash
+    /// with no registry preimage) must NOT publish a ClaimEvent and must NOT mark the note
+    /// processed: `project_claim_note` returns `Err` so block projection retries (once the
+    /// faucet is registered the reconstruction succeeds). PRE-#67 this fell through and sealed
+    /// an IMMUTABLE ClaimEvent riding a hash with empty calldata — aggkit's full-claim parser
+    /// wedges forever and, because the note was marked processed, nothing ever retries.
+    #[tokio::test]
+    async fn project_claim_note_fail_closed_when_calldata_unrecoverable() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        // Non-empty metadata hash with NO registry preimage → unrecoverable calldata. Consumed
+        // by OUR bridge so it passes the provenance gate and reaches the reconstruction step.
+        let note = claim_input_note_meta(
+            Some(id(TEST_TARGET_BRIDGE)),
+            0x93,
+            b"preimage the registry never saw",
+        );
+        let note_id = hex::encode(note.details_commitment().as_bytes());
+
+        let outcome = project_claim_note(
+            &store,
+            &note,
+            &std::collections::HashMap::new(),
+            id(TEST_SENDER_MANAGER),
+            id(TEST_TARGET_BRIDGE),
+            8831,
+            [0xAA; 32],
+            get_bridge_address(),
+        )
+        .await;
+        assert!(
+            outcome.is_err(),
+            "unrecoverable calldata must FAIL CLOSED (Err → projection retries), not emit"
+        );
+        // No ClaimEvent was sealed …
+        let mut gi = [0u8; 32];
+        gi[31] = 0x93;
+        assert!(
+            !store.has_claim_event_for_global_index(&gi).await.unwrap(),
+            "no ClaimEvent may exist for a claim whose calldata is unrecoverable"
+        );
+        // … and the note is NOT marked processed, so a later tick (post faucet-registration)
+        // re-runs the projection instead of a permanent fast-skip.
+        assert!(
+            !store.is_claim_note_processed(&note_id).await.unwrap(),
+            "the note must NOT be marked processed — projection must be able to retry"
         );
     }
 

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -242,14 +242,42 @@ struct RecoveredBridgeBody {
     attachments: NoteAttachments,
 }
 
+/// Finding #69 — a public CLAIM body recovered straight from the node scan.
+/// Unlike the client-store path, the node's public note record retains the
+/// full `NoteMetadata` (sender), which is the provenance the mint-proof half of
+/// [`classify_claim_note`] needs after `--reset-miden-store` wiped the local
+/// output-note records.
+struct RecoveredClaimBody {
+    details: NoteDetails,
+    metadata: NoteMetadata,
+    attachments: NoteAttachments,
+}
+
+#[derive(Default)]
 struct RecoveredBridgeOuts {
     id_by_nullifier: std::collections::HashMap<Nullifier, NoteId>,
     by_id: std::collections::HashMap<NoteId, RecoveredBridgeBody>,
+    /// Finding #69 — CLAIM bodies collected by the same block walk.
+    claim_id_by_nullifier: std::collections::HashMap<Nullifier, NoteId>,
+    claims_by_id: std::collections::HashMap<NoteId, RecoveredClaimBody>,
 }
 
 struct ReplayBridgeOut {
     id: NoteId,
     body: RecoveredBridgeBody,
+    block: u64,
+    tx_order: u32,
+}
+
+/// Finding #69 — a bridge-consumed CLAIM joined to its consuming bridge
+/// transaction: the node-scan analogue of the client-store records Phase 2.5
+/// replays. `block`/`tx_order` come from the bridge's authoritative
+/// `sync_transactions` execution order, so the synthetic ClaimEvent lands at
+/// the claim's ORIGINAL consumption block (Miden-1:1), which is exactly what
+/// aggkit's aggsender needs to resolve a pre-recovery bridge exit to a block.
+struct ReplayClaim {
+    id: NoteId,
+    body: RecoveredClaimBody,
     block: u64,
     tx_order: u32,
 }
@@ -329,9 +357,10 @@ pub async fn restore(
         "Phase 1.5 complete: found {} B2AGG note(s)",
         recovered.by_id.len()
     );
-    let bridge_replay = restore_bridge_replay(&*rpc, accounts.bridge.0, recovered, scan_tip)
-        .await
-        .map_err(|e| anyhow::anyhow!("restore bridge-out ordering scan failed: {e:#}"))?;
+    let (bridge_replay, claim_replay) =
+        restore_bridge_replay(&*rpc, accounts.bridge.0, recovered, scan_tip)
+            .await
+            .map_err(|e| anyhow::anyhow!("restore bridge-out ordering scan failed: {e:#}"))?;
     if bridge_replay.len() as u64 != let_leaves {
         anyhow::bail!(
             "restore bridge-out cardinality mismatch at Miden block {miden_tip}: \
@@ -440,6 +469,31 @@ pub async fn restore(
     total_logs += claim_logs;
     tracing::info!("Phase 2.5 complete: {claims} claims, {claim_logs} logs");
 
+    // Phase 2.6: Replay node-scanned bridge-consumed CLAIM notes — finding #69
+    //
+    // Phase 2.5's source is the local miden-client store, which
+    // `--reset-miden-store` wipes — so a from-scratch recovery restored ZERO
+    // historical claims, and aggkit's aggsender could never resolve its last
+    // settled certificate's "last imported bridge exit" to a block ("no claim
+    // found for bridge exit hash …") → Miden-side certificate settlement dead
+    // after a full recovery. This phase replays the SAME claims from the node
+    // scan (Phase 1.5) joined to the bridge's consuming transactions, at their
+    // original consumption blocks. The shared `project_claim_parts` dedups make
+    // 2.5 + 2.6 idempotent in either order. Deliberately CLAIMS ONLY — the
+    // historical GER/UpdateHashChain view still resets by design.
+    tracing::info!("Phase 2.6: replaying node-scanned CLAIM notes (finding #69)...");
+    let node_claims = restore_claims_from_node(
+        store,
+        block_state,
+        claim_replay,
+        accounts.service.0,
+        accounts.bridge.0,
+    )
+    .await?;
+    total_logs += node_claims;
+    tracing::info!("Phase 2.6 complete: {node_claims} claims from node scan");
+    let claims = claims + node_claims;
+
     // Phase 3: Scan consumed UpdateGerNote notes on Miden
     tracing::info!("Phase 3: scanning consumed UpdateGerNote notes on Miden...");
     let (gers, ger_logs) =
@@ -545,8 +599,12 @@ async fn scan_bridge_out_bodies(
 ) -> anyhow::Result<RecoveredBridgeOuts> {
     use miden_client::rpc::domain::note::FetchedNote;
     use miden_protocol::block::BlockNumber;
+    let claim_root = miden_base_agglayer::ClaimNote::script().root();
     let mut by_id = std::collections::HashMap::new();
     let mut id_by_nullifier = std::collections::HashMap::new();
+    let mut claims_by_id: std::collections::HashMap<NoteId, RecoveredClaimBody> =
+        std::collections::HashMap::new();
+    let mut claim_id_by_nullifier = std::collections::HashMap::new();
     let mut scanned = 0usize;
     for b in 0..=to_block {
         let block = rpc
@@ -567,6 +625,10 @@ async fn scan_bridge_out_bodies(
                     let id = note.id();
                     let nullifier = note.nullifier();
                     let attachments = note.attachments().clone();
+                    // Finding #69: capture the public note's metadata BEFORE the
+                    // details conversion drops it — it carries the sender the
+                    // mint-proof provenance path needs post `--reset-miden-store`.
+                    let metadata = *note.metadata();
                     let details: NoteDetails = note.into();
                     if is_b2agg_note(&details) {
                         if by_id
@@ -584,6 +646,26 @@ async fn scan_bridge_out_bodies(
                         if id_by_nullifier.insert(nullifier, id).is_some() {
                             anyhow::bail!("recovery: duplicate B2AGG nullifier {nullifier}");
                         }
+                    } else if details.script().root() == claim_root {
+                        // Finding #69: retain public CLAIM bodies so restore can
+                        // replay historical ClaimEvents even when the client
+                        // store (Phase 2.5's source) was reset.
+                        if claims_by_id
+                            .insert(
+                                id,
+                                RecoveredClaimBody {
+                                    details,
+                                    metadata,
+                                    attachments,
+                                },
+                            )
+                            .is_some()
+                        {
+                            anyhow::bail!("recovery: duplicate CLAIM NoteId {id}");
+                        }
+                        if claim_id_by_nullifier.insert(nullifier, id).is_some() {
+                            anyhow::bail!("recovery: duplicate CLAIM nullifier {nullifier}");
+                        }
                     }
                 }
             }
@@ -596,6 +678,7 @@ async fn scan_bridge_out_bodies(
                 to_block,
                 scanned,
                 b2agg = by_id.len(),
+                claims = claims_by_id.len(),
                 "recovery scan: progress"
             );
         }
@@ -607,24 +690,28 @@ async fn scan_bridge_out_bodies(
         to_block,
         blocks_scanned = scanned,
         b2agg = by_id.len(),
-        "recovery scan complete: B2AGG bridge-out notes found on the node"
+        claims = claims_by_id.len(),
+        "recovery scan complete: B2AGG bridge-out + CLAIM notes found on the node"
     );
 
     Ok(RecoveredBridgeOuts {
         id_by_nullifier,
         by_id,
+        claim_id_by_nullifier,
+        claims_by_id,
     })
 }
 
 /// Joins the recovered bodies to bridge-consumed inputs. The execution-chain helper and
 /// input iteration already produce exact `(block, tx, input)` order, so no second sort or
-/// commitment-based identity recovery is needed.
+/// commitment-based identity recovery is needed. One `sync_transactions` fetch feeds both
+/// the B2AGG replay and (finding #69) the CLAIM replay.
 async fn restore_bridge_replay(
     rpc: &dyn miden_client::rpc::NodeRpcClient,
     bridge_id: AccountId,
-    recovered: RecoveredBridgeOuts,
+    mut recovered: RecoveredBridgeOuts,
     to_block: u32,
-) -> anyhow::Result<Vec<ReplayBridgeOut>> {
+) -> anyhow::Result<(Vec<ReplayBridgeOut>, Vec<ReplayClaim>)> {
     use miden_protocol::block::BlockNumber;
 
     let txs = rpc
@@ -636,7 +723,11 @@ async fn restore_bridge_replay(
         .await
         .map_err(|e| anyhow::anyhow!("restore: sync bridge transactions 0..{to_block}: {e}"))?;
 
-    build_bridge_replay(&txs, bridge_id, recovered)
+    let claims_by_id = std::mem::take(&mut recovered.claims_by_id);
+    let claim_id_by_nullifier = std::mem::take(&mut recovered.claim_id_by_nullifier);
+    let bridge_replay = build_bridge_replay(&txs, bridge_id, recovered)?;
+    let claim_replay = build_claim_replay(&txs, bridge_id, claims_by_id, claim_id_by_nullifier)?;
+    Ok((bridge_replay, claim_replay))
 }
 
 fn build_bridge_replay(
@@ -647,6 +738,7 @@ fn build_bridge_replay(
     let RecoveredBridgeOuts {
         id_by_nullifier,
         mut by_id,
+        ..
     } = recovered;
     let mut replay = Vec::new();
     for (block, order, tx) in ordered_account_transactions(txs, bridge_id)? {
@@ -676,6 +768,49 @@ fn build_bridge_replay(
         bridge = %bridge_id,
         bridge_outs = replay.len(),
         "restore: authoritative bridge-out replay built from transaction execution order"
+    );
+    Ok(replay)
+}
+
+/// Finding #69 — join node-scanned CLAIM bodies to the bridge's consuming
+/// transactions, exactly like [`build_bridge_replay`] does for B2AGG (input
+/// note header id, or nullifier fallback). A CLAIM that joins here was
+/// provably consumed by OUR bridge — the MA#3 consumer trust root — which is
+/// the provenance [`classify_claim_note`] accepts regardless of minter.
+fn build_claim_replay(
+    txs: &[miden_client::rpc::domain::transaction::TransactionRecord],
+    bridge_id: AccountId,
+    mut claims_by_id: std::collections::HashMap<NoteId, RecoveredClaimBody>,
+    claim_id_by_nullifier: std::collections::HashMap<Nullifier, NoteId>,
+) -> anyhow::Result<Vec<ReplayClaim>> {
+    let mut replay = Vec::new();
+    for (block, order, tx) in ordered_account_transactions(txs, bridge_id)? {
+        for input in tx.transaction_header.input_notes().iter() {
+            let id = input
+                .header()
+                .map(|header| header.id())
+                .or_else(|| claim_id_by_nullifier.get(&input.nullifier()).copied());
+            let Some(id) = id else { continue };
+            let Some(body) = claims_by_id.remove(&id) else {
+                continue;
+            };
+            if let Some(header) = input.header()
+                && header.details_commitment() != body.details.commitment()
+            {
+                anyhow::bail!("restore: CLAIM NoteId {id} body/transaction commitment mismatch");
+            }
+            replay.push(ReplayClaim {
+                id,
+                body,
+                block,
+                tx_order: order,
+            });
+        }
+    }
+    tracing::info!(
+        bridge = %bridge_id,
+        claims = replay.len(),
+        "restore: bridge-consumed CLAIM replay built from transaction execution order (finding #69)"
     );
     Ok(replay)
 }
@@ -1574,25 +1709,61 @@ pub(crate) async fn project_claim_note(
     block_hash: [u8; 32],
     bridge_address: &str,
 ) -> anyhow::Result<ClaimProjectOutcome> {
+    let note_id_str = hex::encode(note.details_commitment().as_bytes());
+    let effective_metadata = note
+        .metadata()
+        .or_else(|| output_metadata.get(&note.details_commitment().as_bytes()));
+    project_claim_parts(
+        store,
+        note_id_str,
+        note.details(),
+        effective_metadata,
+        note.consumer_account(),
+        note.attachments(),
+        expected_sender,
+        bridge_id,
+        block_number,
+        block_hash,
+        bridge_address,
+    )
+    .await
+}
+
+/// Core of the CLAIM derivation over PLAIN note parts, so it serves both note
+/// sources: client-store [`InputNoteRecord`]s (the live projector + Phase 2.5,
+/// via the [`project_claim_note`] adapter) and node-scanned public bodies
+/// (Phase 2.6, finding #69 — where the client store was reset and the metadata
+/// comes from the node's public record, with consumer attribution proven by
+/// the bridge's `sync_transactions` join). Behavior is byte-identical to the
+/// pre-refactor `project_claim_note`: same gates, same dedups, same atomic
+/// commit.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn project_claim_parts(
+    store: &Arc<dyn Store>,
+    note_id_str: String,
+    details: &NoteDetails,
+    effective_metadata: Option<&NoteMetadata>,
+    consumer_account: Option<AccountId>,
+    attachments: &NoteAttachments,
+    expected_sender: AccountId,
+    bridge_id: AccountId,
+    block_number: u64,
+    block_hash: [u8; 32],
+    bridge_address: &str,
+) -> anyhow::Result<ClaimProjectOutcome> {
     let claim_root = miden_base_agglayer::ClaimNote::script().root();
-    let details = note.details();
     if details.script().root() != claim_root {
         return Ok(ClaimProjectOutcome::Skipped);
     }
-
-    let note_id_str = hex::encode(note.details_commitment().as_bytes());
 
     // Provenance gate — BEFORE any storage read, dedup mark, or emission
     // (the MA#28 posture). On a chain shared with a foreign miden-agglayer
     // deployment, foreign claims share our ClaimNote script root; projecting
     // them poisons synthetic_logs with ClaimEvents our L1 never saw.
-    let effective_metadata = note
-        .metadata()
-        .or_else(|| output_metadata.get(&note.details_commitment().as_bytes()));
     if classify_claim_note(
-        note.consumer_account(),
+        consumer_account,
         effective_metadata,
-        note.attachments(),
+        attachments,
         expected_sender,
         bridge_id,
     ) == ClaimNoteVerdict::Foreign
@@ -1601,7 +1772,7 @@ pub(crate) async fn project_claim_note(
         tracing::warn!(
             target: "restore::claims",
             note_id = %note_id_str,
-            consumer = ?note.consumer_account(),
+            consumer = ?consumer_account,
             sender = ?effective_metadata.map(|m| m.sender()),
             expected_sender = %expected_sender,
             bridge = %bridge_id,
@@ -1870,6 +2041,57 @@ async fn restore_claims(
 
     let (count, logs) = *result.lock().unwrap();
     Ok((count, logs))
+}
+
+/// Phase 2.6 (finding #69): replay bridge-consumed CLAIM notes recovered by the
+/// NODE scan — the source that survives `--reset-miden-store`, unlike Phase
+/// 2.5's client-store records. Each claim is projected at its original
+/// consumption block via [`project_claim_parts`]; `consumer_account` is our
+/// bridge by construction (the `sync_transactions` join proved the bridge
+/// consumed it — the MA#3 trust root), and the node's public metadata provides
+/// the MA#28 mint-proof fallback. Returns the number of ClaimEvents emitted
+/// (each is also one synthetic log).
+async fn restore_claims_from_node(
+    store: &Arc<dyn Store>,
+    block_state: &Arc<BlockState>,
+    mut claim_replay: Vec<ReplayClaim>,
+    expected_sender: AccountId,
+    bridge_id: AccountId,
+) -> anyhow::Result<usize> {
+    // The join already yields execution order; keep it deterministic even if a
+    // future refactor changes the producer.
+    claim_replay.sort_by_key(|item| (item.block, item.tx_order));
+    let bridge_address = get_bridge_address();
+    let mut emitted = 0usize;
+    for replay in claim_replay {
+        let note_id_str = hex::encode(replay.body.details.commitment().as_bytes());
+        let block_hash = block_state.get_block_hash(replay.block);
+        tracing::debug!(
+            target: "restore::claims",
+            note = %replay.id,
+            block = replay.block,
+            "restore: replaying node-scanned CLAIM (finding #69)"
+        );
+        if project_claim_parts(
+            store,
+            note_id_str,
+            &replay.body.details,
+            Some(&replay.body.metadata),
+            Some(bridge_id),
+            &replay.body.attachments,
+            expected_sender,
+            bridge_id,
+            replay.block,
+            block_hash,
+            bridge_address,
+        )
+        .await?
+            == ClaimProjectOutcome::Emitted
+        {
+            emitted += 1;
+        }
+    }
+    Ok(emitted)
 }
 
 /// Outcome of projecting one consumed note through the GER derivation.
@@ -2625,6 +2847,7 @@ mod tests {
                     )
                 })
                 .collect(),
+            ..Default::default()
         };
         let replay = build_bridge_replay(&[tx], bridge_id, recovered).unwrap();
         assert_eq!(replay.iter().map(|item| item.id).collect::<Vec<_>>(), ids);
@@ -3380,6 +3603,174 @@ mod tests {
             consumed_tx_order: None,
         });
         InputNoteRecord::new(details, NoteAttachments::default(), None, state)
+    }
+
+    // ── Finding #69 — node-scan CLAIM replay (Phase 2.6) ─────────────────────
+
+    /// Finding #69 (a): `build_claim_replay` joins a node-scanned CLAIM body to
+    /// the bridge transaction that consumed it via the NULLIFIER fallback (the
+    /// input-note commitment carries no header), yielding the claim at the
+    /// bridge tx's authoritative `(block, tx_order)`.
+    #[test]
+    fn finding69_build_claim_replay_joins_by_nullifier_fallback() {
+        use miden_client::rpc::domain::transaction::TransactionRecord;
+        use miden_protocol::asset::FungibleAsset;
+        use miden_protocol::block::BlockNumber;
+        use miden_protocol::note::Nullifier;
+        use miden_protocol::transaction::{InputNoteCommitment, InputNotes, TransactionHeader};
+
+        let (faucet_id, bridge_id, _sender_id) = ma3_accounts();
+        let details = claim_input_note(Some(bridge_id), 0x69).details().clone();
+        let (metadata, attachments) = make_metadata(id(TEST_SENDER_MANAGER), Some(bridge_id));
+        let note_id = miden_protocol::note::NoteId::new(details.commitment(), &metadata);
+
+        let nullifier = Nullifier::from_raw(Word::new([Felt::new(9).unwrap(); 4]));
+        // No header on the input commitment → the join MUST fall back to the
+        // nullifier map (the shape `ConsumedExternal` history produces).
+        let inputs = InputNotes::new(vec![InputNoteCommitment::from_parts_unchecked(
+            nullifier, None,
+        )])
+        .unwrap();
+        let tx = TransactionRecord {
+            block_num: BlockNumber::from(11u32),
+            transaction_header: TransactionHeader::new(
+                bridge_id,
+                Word::default(),
+                Word::new([Felt::new(1).unwrap(); 4]),
+                inputs,
+                vec![],
+                FungibleAsset::new(faucet_id, 0).unwrap(),
+            ),
+            output_notes: vec![],
+            erased_output_notes: vec![],
+        };
+
+        let claims_by_id = std::collections::HashMap::from([(
+            note_id,
+            RecoveredClaimBody {
+                details,
+                metadata,
+                attachments,
+            },
+        )]);
+        let claim_id_by_nullifier = std::collections::HashMap::from([(nullifier, note_id)]);
+
+        let replay =
+            build_claim_replay(&[tx], bridge_id, claims_by_id, claim_id_by_nullifier).unwrap();
+        assert_eq!(replay.len(), 1, "the consumed claim must join exactly once");
+        assert_eq!(replay[0].id, note_id);
+        assert_eq!(
+            (replay[0].block, replay[0].tx_order),
+            (11, 0),
+            "claim must carry the consuming bridge tx's (block, tx_order)"
+        );
+    }
+
+    /// Finding #69 (b): `project_claim_parts` over node-scanned parts
+    /// (consumer = our bridge, metadata sender = our service) emits a
+    /// ClaimEvent, marks the note processed, does NOT seal the block, and is
+    /// idempotent — the second call short-circuits on Dedup 1.
+    #[tokio::test]
+    async fn finding69_project_claim_parts_emits_and_dedups() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let bridge_id = id(TEST_TARGET_BRIDGE);
+        let service = id(TEST_SENDER_MANAGER);
+        let details = claim_input_note(Some(bridge_id), 0x77).details().clone();
+        let (metadata, attachments) = make_metadata(service, Some(bridge_id));
+        let note_id_str = hex::encode(details.commitment().as_bytes());
+
+        let outcome = project_claim_parts(
+            &store,
+            note_id_str.clone(),
+            &details,
+            Some(&metadata),
+            Some(bridge_id),
+            &attachments,
+            service,
+            bridge_id,
+            9,
+            [9u8; 32],
+            get_bridge_address(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outcome, ClaimProjectOutcome::Emitted);
+        assert!(store.is_claim_note_processed(&note_id_str).await.unwrap());
+        let mut gi = [0u8; 32];
+        gi[31] = 0x77;
+        assert!(store.has_claim_event_for_global_index(&gi).await.unwrap());
+        assert_eq!(
+            store.get_latest_block_number().await.unwrap(),
+            0,
+            "a node-scan claim replay must not seal its block"
+        );
+
+        let again = project_claim_parts(
+            &store,
+            note_id_str.clone(),
+            &details,
+            Some(&metadata),
+            Some(bridge_id),
+            &attachments,
+            service,
+            bridge_id,
+            9,
+            [9u8; 32],
+            get_bridge_address(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            again,
+            ClaimProjectOutcome::Skipped,
+            "second replay of the same claim must dedup"
+        );
+    }
+
+    /// Finding #69 (c): a FOREIGN claim (consumed by a foreign bridge, minted
+    /// by a foreign sender) fed through `project_claim_parts` is a fail-closed
+    /// skip — no ClaimEvent, no processed mark.
+    #[tokio::test]
+    async fn finding69_project_claim_parts_foreign_is_fail_closed_skip() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let bridge_id = id(TEST_TARGET_BRIDGE);
+        let service = id(TEST_SENDER_MANAGER);
+        let foreign_sender = id(TEST_SENDER_ATTACKER);
+        let foreign_bridge = id(TEST_TARGET_OTHER);
+        let details = claim_input_note(Some(foreign_bridge), 0x78)
+            .details()
+            .clone();
+        // Foreign deployment: minted by the foreign service, targeting the
+        // foreign bridge — neither our consumer proof nor our mint proof holds.
+        let (metadata, attachments) = make_metadata(foreign_sender, Some(foreign_bridge));
+        let note_id_str = hex::encode(details.commitment().as_bytes());
+
+        let outcome = project_claim_parts(
+            &store,
+            note_id_str.clone(),
+            &details,
+            Some(&metadata),
+            Some(foreign_bridge),
+            &attachments,
+            service,
+            bridge_id,
+            9,
+            [9u8; 32],
+            get_bridge_address(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outcome, ClaimProjectOutcome::Skipped);
+        assert!(
+            !store.is_claim_note_processed(&note_id_str).await.unwrap(),
+            "foreign claim must not be marked processed"
+        );
+        let mut gi = [0u8; 32];
+        gi[31] = 0x78;
+        assert!(
+            !store.has_claim_event_for_global_index(&gi).await.unwrap(),
+            "foreign claim must not emit a ClaimEvent"
+        );
     }
 
     /// RED→GREEN PoC for the live finding: a consumed claim-shaped note whose

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -266,7 +266,7 @@ pub async fn restore(
     accounts: &AccountsConfig,
     local_network_id: u32,
     block_state: &Arc<BlockState>,
-    l1_rpc_url: Option<String>,
+    network_rpcs: crate::metadata_recovery::NetworkRpcMap,
     node_url: &str,
     api_key: Option<&str>,
 ) -> anyhow::Result<RestoreResult> {
@@ -401,7 +401,7 @@ pub async fn restore(
     // aborts restore.
     tracing::info!("Phase 1.7: rebuilding faucet identities from bridge state (Cantina #6)...");
     let faucet_identities_rebuilt =
-        restore_faucet_identities(store, miden_client, accounts, l1_rpc_url.clone()).await?;
+        restore_faucet_identities(store, miden_client, accounts, &network_rpcs).await?;
     tracing::info!(
         "Phase 1.7 complete: {faucet_identities_rebuilt} faucet identity row(s) rebuilt"
     );
@@ -414,7 +414,7 @@ pub async fn restore(
         accounts.bridge.0,
         local_network_id,
         block_state,
-        l1_rpc_url.clone(),
+        &network_rpcs,
         bridge_replay,
     )
     .await?;
@@ -697,11 +697,13 @@ async fn restore_faucet_identities(
     store: &Arc<dyn Store>,
     miden_client: &MidenClient,
     accounts: &AccountsConfig,
-    l1_rpc_url: Option<String>,
+    network_rpcs: &crate::metadata_recovery::NetworkRpcMap,
 ) -> anyhow::Result<usize> {
     let store_clone = store.clone();
     let bridge_id = accounts.bridge.0;
-    let l1_url = l1_rpc_url;
+    // Owned clone moved into the `with(...)` closure; per-faucet RPC selection is
+    // keyed on the faucet's origin_network (finding #62 multi-network recovery).
+    let network_rpcs = network_rpcs.clone();
 
     let count = Arc::new(std::sync::Mutex::new(0usize));
     let count_inner = count.clone();
@@ -754,7 +756,9 @@ async fn restore_faucet_identities(
                         &bridge_account,
                         faucet_id,
                         &conversion,
-                        l1_url.as_deref(),
+                        network_rpcs
+                            .get(&conversion.origin_network)
+                            .map(String::as_str),
                     )
                     .await
                     {
@@ -824,11 +828,14 @@ async fn restore_bridge_outs(
     bridge_id: AccountId,
     local_network_id: u32,
     block_state: &Arc<BlockState>,
-    l1_rpc_url: Option<String>,
+    network_rpcs: &crate::metadata_recovery::NetworkRpcMap,
     bridge_replay: Vec<ReplayBridgeOut>,
 ) -> anyhow::Result<(usize, usize)> {
     let store_clone = store.clone();
     let block_state_clone = block_state.clone();
+    // Owned clone moved into the `with(...)` closure; per-bridge-out RPC selection
+    // is keyed on the resolved faucet origin_network (finding #62).
+    let network_rpcs = network_rpcs.clone();
     let result = Arc::new(std::sync::Mutex::new((0usize, 0usize)));
     let result_inner = result.clone();
 
@@ -864,7 +871,7 @@ async fn restore_bridge_outs(
                         block_hash,
                         bridge_address,
                         Some(&mut *client),
-                        l1_rpc_url.as_deref(),
+                        &network_rpcs,
                     )
                     .await?;
                     if outcome == B2AggRestoreOutcome::Emitted {
@@ -918,7 +925,7 @@ pub(crate) async fn project_b2agg_note(
     block_hash: [u8; 32],
     bridge_address: &str,
     client: Option<&mut MidenClientLib>,
-    l1_rpc_url: Option<&str>,
+    network_rpcs: &crate::metadata_recovery::NetworkRpcMap,
 ) -> anyhow::Result<B2AggRestoreOutcome> {
     let details = note.details();
     if !is_b2agg_note(details) {
@@ -1124,7 +1131,9 @@ pub(crate) async fn project_b2agg_note(
             faucet_id,
             bridge_account.as_ref(),
             faucet_account.as_ref(),
-            l1_rpc_url,
+            // Finding #62: dial the token's ACTUAL origin-network RPC (L1 for
+            // network 0, L2B for network 2, …) so the keccak gate validates.
+            network_rpcs.get(&origin.origin_network).map(String::as_str),
         )
         .await
     };
@@ -2667,7 +2676,7 @@ mod tests {
             [7u8; 32],
             get_bridge_address(),
             None,
-            None,
+            &crate::metadata_recovery::NetworkRpcMap::new(),
         )
         .await
         .unwrap();
@@ -2706,7 +2715,7 @@ mod tests {
             [7u8; 32],
             get_bridge_address(),
             None,
-            None,
+            &crate::metadata_recovery::NetworkRpcMap::new(),
         )
         .await
         .unwrap();
@@ -2751,7 +2760,7 @@ mod tests {
             [7u8; 32],
             get_bridge_address(),
             None,
-            None,
+            &crate::metadata_recovery::NetworkRpcMap::new(),
         )
         .await
         .unwrap();
@@ -2789,7 +2798,7 @@ mod tests {
             [7u8; 32],
             get_bridge_address(),
             None,
-            None,
+            &crate::metadata_recovery::NetworkRpcMap::new(),
         )
         .await
         .unwrap();
@@ -2830,7 +2839,7 @@ mod tests {
             [7u8; 32],
             get_bridge_address(),
             None,
-            None,
+            &crate::metadata_recovery::NetworkRpcMap::new(),
         )
         .await
         .unwrap();
@@ -2889,7 +2898,7 @@ mod tests {
             [7u8; 32],
             get_bridge_address(),
             None,
-            None,
+            &crate::metadata_recovery::NetworkRpcMap::new(),
         )
         .await
         .unwrap();
@@ -2941,7 +2950,7 @@ mod tests {
             [7u8; 32],
             get_bridge_address(),
             None,
-            None,
+            &crate::metadata_recovery::NetworkRpcMap::new(),
         )
         .await
         .unwrap();
@@ -2987,7 +2996,7 @@ mod tests {
             [7u8; 32],
             get_bridge_address(),
             None,
-            None,
+            &crate::metadata_recovery::NetworkRpcMap::new(),
         )
         .await
         .unwrap();
@@ -3072,7 +3081,7 @@ mod tests {
             [7u8; 32],
             get_bridge_address(),
             None,
-            None,
+            &crate::metadata_recovery::NetworkRpcMap::new(),
         )
         .await
         .unwrap();

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -4422,14 +4422,14 @@ mod tests {
         assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 0);
     }
 
-    /// Crash outcomes on an AMBIGUOUS slot: once an attempt released (it may
-    /// have crossed an external side-effect boundary) or was durably admitted
-    /// (a `transactions` row exists), the slot stays bound to the first signed
-    /// transaction — even after lease expiry. Only that exact hash may recover
-    /// the durable intent. (The one exception — an expired `executing` slot
-    /// that was NEVER durably admitted, i.e. provably nothing external
-    /// happened — is the wedge-#5 reclamation, covered by
-    /// `wedge5_abandoned_expired_slot_reclaimable_by_different_tx`.)
+    /// Crash outcomes on an AMBIGUOUS slot: once an attempt was durably
+    /// admitted (a `transactions` row exists — it may have crossed an external
+    /// side-effect boundary), the slot stays bound to the first signed
+    /// transaction — whether it later released failure or its lease expired.
+    /// Only that exact hash may recover the durable intent. (The exceptions —
+    /// an expired `executing` slot or a `released_failure` slot that was NEVER
+    /// durably admitted, i.e. provably nothing external happened — are the
+    /// wedge-#5 reclamations, covered by the `wedge5_*` tests.)
     #[tokio::test]
     async fn blocker_a_different_tx_never_takes_over_ambiguous_slot() {
         use crate::store::NonceReservation;
@@ -4445,31 +4445,15 @@ mod tests {
         else {
             panic!("fresh must win");
         };
-        store
-            .release_reservation(addr, 1, ha, fence, false)
-            .await
-            .unwrap();
-        assert_eq!(
-            store.reserve_nonce(addr, 1, hb, lease).await.unwrap(),
-            NonceReservation::HeldByOther(ha),
-            "failure cannot authorize a replacement after an ambiguous external outcome"
-        );
-        assert!(matches!(
-            store.reserve_nonce(addr, 1, ha, lease).await.unwrap(),
-            NonceReservation::Won { .. }
-        ));
-
-        assert!(matches!(
-            store.reserve_nonce(addr, 2, ha, lease).await.unwrap(),
-            NonceReservation::Won { .. }
-        ));
-        // Durably admit `ha` — the slot's outcome is now genuinely ambiguous
-        // after a crash (the pending-tx machinery tracks it), so expiry must
-        // NOT grant a different tx the slot.
+        // Durably admit `ha` BEFORE it releases failure — the outcome is now
+        // genuinely ambiguous (the pending-tx machinery tracks it), so neither
+        // a released failure nor lease expiry may grant a different tx the
+        // slot. (A released failure WITHOUT durable admission is NOT ambiguous
+        // — that is the wedge-#5 reclamation, tested separately.)
         let txn = TxLegacy {
             input: vec![].into(),
             chain_id: Some(1),
-            nonce: 2,
+            nonce: 1,
             ..Default::default()
         };
         let signed = Signed::new_unchecked(txn, Signature::test_signature(), TxHash::default());
@@ -4488,6 +4472,26 @@ mod tests {
             )
             .await
             .unwrap();
+        store
+            .release_reservation(addr, 1, ha, fence, false)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.reserve_nonce(addr, 1, hb, lease).await.unwrap(),
+            NonceReservation::HeldByOther(ha),
+            "failure cannot authorize a replacement after an ambiguous external outcome"
+        );
+        assert!(matches!(
+            store.reserve_nonce(addr, 1, ha, lease).await.unwrap(),
+            NonceReservation::Won { .. }
+        ));
+
+        // Same tx (already durably admitted above) reserved at another nonce:
+        // lease expiry must not grant a different tx the slot either.
+        assert!(matches!(
+            store.reserve_nonce(addr, 2, ha, lease).await.unwrap(),
+            NonceReservation::Won { .. }
+        ));
         concrete.test_expire_reservation_lease(addr, 2);
         assert_eq!(
             store.reserve_nonce(addr, 2, hb, lease).await.unwrap(),
@@ -4499,6 +4503,142 @@ mod tests {
             store.reserve_nonce(addr, 2, ha, lease).await.unwrap(),
             NonceReservation::Won { .. }
         ));
+    }
+
+    /// Wedge #5 (PR#145 blocker 1) — a slot released as FAILURE whose hash was
+    /// never durably admitted (the normal pre-admission error path: e.g. the
+    /// second writer-queue capacity check in `dispatch_after_reservation` fails
+    /// AFTER the reservation, and the outer path releases `success=false`
+    /// before any `txn_begin*`) is ABANDONED: a different tx reclaims it
+    /// immediately — no lease expiry required — with a bumped fence.
+    #[tokio::test]
+    async fn wedge5_released_failure_unadmitted_slot_reclaimable_by_different_tx() {
+        use crate::store::NonceReservation;
+        let store: std::sync::Arc<dyn crate::store::Store> =
+            std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let addr = "0x00000000000000000000000000000000000000a7";
+        let h1 = TxHash::from([0x71u8; 32]);
+        let h2 = TxHash::from([0x72u8; 32]);
+        let lease = std::time::Duration::from_secs(90);
+
+        let NonceReservation::Won { fence } =
+            store.reserve_nonce(addr, 4, h1, lease).await.unwrap()
+        else {
+            panic!("fresh slot must be Won");
+        };
+        // Pre-admission failure: released as failure, NO transactions row.
+        store
+            .release_reservation(addr, 4, h1, fence, false)
+            .await
+            .unwrap();
+        // A DIFFERENT tx reclaims immediately (no expiry) with a bumped fence.
+        let NonceReservation::Won { fence: fence2 } =
+            store.reserve_nonce(addr, 4, h2, lease).await.unwrap()
+        else {
+            panic!("released_failure without durable admission must be reclaimable");
+        };
+        assert!(fence2 > fence, "reclamation must bump the fence");
+    }
+
+    /// Wedge #5 guard — a `released_failure` slot whose tx WAS durably admitted
+    /// (a `transactions` row exists) stays hash-bound: the failure may have
+    /// crossed an external side-effect boundary, so a different tx must NOT
+    /// take it over.
+    #[tokio::test]
+    async fn wedge5_released_failure_admitted_slot_stays_held() {
+        use crate::store::NonceReservation;
+        let store: std::sync::Arc<dyn crate::store::Store> =
+            std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let addr = "0x00000000000000000000000000000000000000a8";
+        let h1 = TxHash::from([0x81u8; 32]);
+        let h2 = TxHash::from([0x82u8; 32]);
+        let lease = std::time::Duration::from_secs(90);
+
+        let NonceReservation::Won { fence } =
+            store.reserve_nonce(addr, 5, h1, lease).await.unwrap()
+        else {
+            panic!("fresh slot must be Won");
+        };
+        let txn = TxLegacy {
+            input: vec![].into(),
+            chain_id: Some(1),
+            nonce: 5,
+            ..Default::default()
+        };
+        let signed = Signed::new_unchecked(txn, Signature::test_signature(), TxHash::default());
+        let envelope = TxEnvelope::Legacy(signed);
+        let signer = envelope.recover_signer().expect("recover signer");
+        store
+            .txn_begin(
+                h1,
+                crate::store::TxnEntry {
+                    id: None,
+                    envelope,
+                    signer,
+                    expires_at: None,
+                    logs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .release_reservation(addr, 5, h1, fence, false)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.reserve_nonce(addr, 5, h2, lease).await.unwrap(),
+            NonceReservation::HeldByOther(h1),
+            "a released_failure slot with a durable transactions row must stay hash-bound"
+        );
+    }
+
+    /// Wedge #5 end-to-end (PR#145 blocker 1): after another attempt won the
+    /// `(signer, nonce)` slot and failed PRE-admission (the interleaving:
+    /// second writer-queue capacity check errors in
+    /// `dispatch_after_reservation` AFTER the reservation, outer path releases
+    /// `success=false`, no `transactions` row), an external submitter's
+    /// freshly-signed DIFFERENT tx at the SAME nonce must be ACCEPTED by the
+    /// service. (Deterministically forcing the second capacity check itself
+    /// would need a concurrent slot-consumer between the two checks — the
+    /// pre-reservation check at the top of `service_send_raw_txn` passes only
+    /// while capacity remains — so this test stages exactly the store
+    /// transition that path produces and proves the service-level outcome.)
+    #[tokio::test]
+    async fn wedge5_released_failure_unadmitted_allows_fresh_hash_service_retry() {
+        let service = create_test_service();
+        let store = service.store.clone();
+        let calldata = insertGlobalExitRootCall {
+            root: FixedBytes::from([0xE7u8; 32]),
+        }
+        .abi_encode();
+        let (input_hex, signer) = encode_legacy_tx(calldata); // nonce 0
+        let signer_str = format!("{signer:#x}");
+
+        // Another attempt (different hash) won the slot, then failed
+        // pre-admission and released failure — no transactions row.
+        let other = TxHash::from([0xE8u8; 32]);
+        let crate::store::NonceReservation::Won { fence } = store
+            .reserve_nonce(&signer_str, 0, other, reservation_lease())
+            .await
+            .unwrap()
+        else {
+            panic!("fresh slot must be Won");
+        };
+        store
+            .release_reservation(&signer_str, 0, other, fence, false)
+            .await
+            .unwrap();
+
+        // The fresh-hash retry at the same nonce is ACCEPTED (pre-fix: rejected
+        // "reserved by a different tx" forever) and executes.
+        service_send_raw_txn(service, input_hex)
+            .await
+            .expect("a fresh-hash retry must reclaim the released_failure unadmitted slot");
+        assert_eq!(
+            store.nonce_get(&signer_str).await.unwrap(),
+            1,
+            "the reclaimed retry must execute and advance the nonce"
+        );
     }
 
     /// Writer admission persists the recoverable envelope before nonce CAS and enqueue.

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -4286,6 +4286,108 @@ mod tests {
         );
     }
 
+    /// Wedge #5 — ABANDONED-slot reclamation. An admission that crashes AFTER
+    /// `reserve_nonce` but BEFORE durable admission leaves the slot `executing`
+    /// with an expiring lease and NO `transactions` row. External submitters
+    /// (the zkevm-bridge-service claimtxman) sign a FRESH tx per retry — never
+    /// the bound hash — so without reclamation that nonce rejects every retry
+    /// forever (observed live: the sponsor wedged at nonce 78 until operator
+    /// surgery). Once the lease expires and the bound hash was never durably
+    /// admitted, a DIFFERENT tx must take the slot over with a bumped fence,
+    /// and the zombie owner must be fenced out.
+    #[tokio::test]
+    async fn wedge5_abandoned_expired_slot_reclaimable_by_different_tx() {
+        use crate::store::NonceReservation;
+        let concrete = std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let store: std::sync::Arc<dyn crate::store::Store> = concrete.clone();
+        let addr = "0x00000000000000000000000000000000000000a5";
+        let h1 = TxHash::from([0x51u8; 32]);
+        let h2 = TxHash::from([0x52u8; 32]);
+        let lease = std::time::Duration::from_secs(90);
+
+        // h1 wins the slot, then the admission "crashes" pre-durable-admission.
+        let NonceReservation::Won { fence } =
+            store.reserve_nonce(addr, 7, h1, lease).await.unwrap()
+        else {
+            panic!("fresh slot must be Won");
+        };
+        // While the lease is VALID, a different tx is still hard-rejected.
+        assert_eq!(
+            store.reserve_nonce(addr, 7, h2, lease).await.unwrap(),
+            NonceReservation::HeldByOther(h1),
+            "a valid executing lease must keep rejecting a different tx"
+        );
+        concrete.test_expire_reservation_lease(addr, 7);
+        // Expired + never durably admitted → the DIFFERENT tx reclaims the slot.
+        let NonceReservation::Won { fence: fence2 } =
+            store.reserve_nonce(addr, 7, h2, lease).await.unwrap()
+        else {
+            panic!("an abandoned (expired, unadmitted) slot must be reclaimable by a different tx");
+        };
+        assert!(fence2 > fence, "reclamation must bump the fence");
+        // The zombie owner is FENCED OUT: its stale release is ignored and the
+        // new owner still holds the slot.
+        store
+            .release_reservation(addr, 7, h1, fence, false)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.reserve_nonce(addr, 7, h2, lease).await.unwrap(),
+            NonceReservation::OwnedBySame,
+            "the zombie's fenced-out release must not evict the reclaiming owner"
+        );
+    }
+
+    /// Wedge #5 guard — an expired `executing` slot whose tx WAS durably
+    /// admitted (a `transactions` row exists) stays hash-bound: its external
+    /// outcome is tracked by the pending-tx machinery (crash-gap repair /
+    /// projector attribution), so a different tx must NOT take it over.
+    #[tokio::test]
+    async fn wedge5_expired_but_admitted_slot_stays_held() {
+        use crate::store::NonceReservation;
+        let concrete = std::sync::Arc::new(crate::store::memory::InMemoryStore::new());
+        let store: std::sync::Arc<dyn crate::store::Store> = concrete.clone();
+        let addr = "0x00000000000000000000000000000000000000a6";
+        let h1 = TxHash::from([0x61u8; 32]);
+        let h2 = TxHash::from([0x62u8; 32]);
+        let lease = std::time::Duration::from_secs(90);
+
+        assert!(matches!(
+            store.reserve_nonce(addr, 3, h1, lease).await.unwrap(),
+            NonceReservation::Won { .. }
+        ));
+        // h1 IS durably admitted before the crash window closes.
+        let txn = TxLegacy {
+            input: vec![].into(),
+            chain_id: Some(1),
+            nonce: 3,
+            ..Default::default()
+        };
+        let signed = Signed::new_unchecked(txn, Signature::test_signature(), TxHash::default());
+        let envelope = TxEnvelope::Legacy(signed);
+        let signer = envelope.recover_signer().expect("recover signer");
+        store
+            .txn_begin(
+                h1,
+                crate::store::TxnEntry {
+                    id: None,
+                    envelope,
+                    signer,
+                    expires_at: None,
+                    logs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        concrete.test_expire_reservation_lease(addr, 3);
+        // Expired but ADMITTED → still held; a replacement would be ambiguous.
+        assert_eq!(
+            store.reserve_nonce(addr, 3, h2, lease).await.unwrap(),
+            NonceReservation::HeldByOther(h1),
+            "an expired slot with a durable transactions row must stay hash-bound"
+        );
+    }
+
     /// BLOCKER 1 — end-to-end: a submission whose (signer, nonce) slot was already
     /// reserved by a DIFFERENT tx (another replica won) is REJECTED and does NOT
     /// execute — no nonce advance, no receipt.
@@ -4320,9 +4422,14 @@ mod tests {
         assert_eq!(store.nonce_get(&signer_str).await.unwrap(), 0);
     }
 
-    /// Crash outcomes are ambiguous: a nonce slot is permanently bound to the
-    /// first signed transaction, even after failure or lease expiry. Only that
-    /// exact hash may recover the durable intent.
+    /// Crash outcomes on an AMBIGUOUS slot: once an attempt released (it may
+    /// have crossed an external side-effect boundary) or was durably admitted
+    /// (a `transactions` row exists), the slot stays bound to the first signed
+    /// transaction — even after lease expiry. Only that exact hash may recover
+    /// the durable intent. (The one exception — an expired `executing` slot
+    /// that was NEVER durably admitted, i.e. provably nothing external
+    /// happened — is the wedge-#5 reclamation, covered by
+    /// `wedge5_abandoned_expired_slot_reclaimable_by_different_tx`.)
     #[tokio::test]
     async fn blocker_a_different_tx_never_takes_over_ambiguous_slot() {
         use crate::store::NonceReservation;
@@ -4356,11 +4463,37 @@ mod tests {
             store.reserve_nonce(addr, 2, ha, lease).await.unwrap(),
             NonceReservation::Won { .. }
         ));
+        // Durably admit `ha` — the slot's outcome is now genuinely ambiguous
+        // after a crash (the pending-tx machinery tracks it), so expiry must
+        // NOT grant a different tx the slot.
+        let txn = TxLegacy {
+            input: vec![].into(),
+            chain_id: Some(1),
+            nonce: 2,
+            ..Default::default()
+        };
+        let signed = Signed::new_unchecked(txn, Signature::test_signature(), TxHash::default());
+        let envelope = TxEnvelope::Legacy(signed);
+        let signer = envelope.recover_signer().expect("recover signer");
+        store
+            .txn_begin(
+                ha,
+                crate::store::TxnEntry {
+                    id: None,
+                    envelope,
+                    signer,
+                    expires_at: None,
+                    logs: vec![],
+                },
+            )
+            .await
+            .unwrap();
         concrete.test_expire_reservation_lease(addr, 2);
         assert_eq!(
             store.reserve_nonce(addr, 2, hb, lease).await.unwrap(),
             NonceReservation::HeldByOther(ha),
-            "expiry is crash recovery for the same hash, never replacement permission"
+            "expiry is crash recovery for the same hash, never replacement permission \
+             once the tx was durably admitted"
         );
         assert!(matches!(
             store.reserve_nonce(addr, 2, ha, lease).await.unwrap(),

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1294,16 +1294,34 @@ impl Store for InMemoryStore {
                 Ok(NonceReservation::Won { fence: 1 })
             }
             Some(r) => {
-                // A nonce slot is permanently bound to its first tx hash. Even a
-                // failed or expired attempt may have crossed an external side-effect
-                // boundary, so a different replacement can never take it over.
+                // A nonce slot is bound to its first tx hash: a failed or expired
+                // attempt may have crossed an external side-effect boundary, so a
+                // different replacement may only take over an ABANDONED slot (see
+                // the wedge-#5 rule below), never a released or admitted one.
                 let takeover = r.tx_hash == tx_hash
                     && (matches!(
                         r.state,
                         ReservationState::ReleasedFailure | ReservationState::ReleasedSuccess
                     ) || r.lease_expires_at <= now);
-                if takeover {
+                // Wedge #5 — ABANDONED-slot reclamation for a DIFFERENT tx: the
+                // reservation precedes durable admission, so a crash in that
+                // window leaves `executing` + expired lease + no durable
+                // `transactions` row (provably nothing was submitted externally).
+                // External submitters sign a fresh tx per retry, so without this
+                // the crashed slot rejects every retry at its nonce forever.
+                // Mirrors the PgStore rule; LRU eviction could theoretically make
+                // an admitted hash look absent here, but this in-memory store is
+                // test/dev-only — PostgreSQL is authoritative in deployments.
+                let abandoned = r.tx_hash != tx_hash
+                    && r.state == ReservationState::Executing
+                    && r.lease_expires_at <= now
+                    && !self.transactions.lock().contains(&r.tx_hash);
+                if takeover || abandoned {
                     let fence = r.fence + 1;
+                    if abandoned {
+                        ::metrics::counter!("nonce_reservation_expired_reclaimed_total")
+                            .increment(1);
+                    }
                     reservations.insert(
                         key,
                         Reservation {

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1305,22 +1305,34 @@ impl Store for InMemoryStore {
                     ) || r.lease_expires_at <= now);
                 // Wedge #5 — ABANDONED-slot reclamation for a DIFFERENT tx: the
                 // reservation precedes durable admission, so a crash in that
-                // window leaves `executing` + expired lease + no durable
+                // window leaves `executing` + expired lease, and a NORMAL
+                // pre-admission error (e.g. writer-queue saturation) releases
+                // `released_failure` — in both cases with no durable
                 // `transactions` row (provably nothing was submitted externally).
                 // External submitters sign a fresh tx per retry, so without this
-                // the crashed slot rejects every retry at its nonce forever.
+                // such a slot rejects every retry at its nonce forever.
                 // Mirrors the PgStore rule; LRU eviction could theoretically make
                 // an admitted hash look absent here, but this in-memory store is
                 // test/dev-only — PostgreSQL is authoritative in deployments.
+                let abandoned_state = (r.state == ReservationState::Executing
+                    && r.lease_expires_at <= now)
+                    || r.state == ReservationState::ReleasedFailure;
                 let abandoned = r.tx_hash != tx_hash
-                    && r.state == ReservationState::Executing
-                    && r.lease_expires_at <= now
+                    && abandoned_state
                     && !self.transactions.lock().contains(&r.tx_hash);
                 if takeover || abandoned {
                     let fence = r.fence + 1;
                     if abandoned {
-                        ::metrics::counter!("nonce_reservation_expired_reclaimed_total")
-                            .increment(1);
+                        let cause = if r.state == ReservationState::ReleasedFailure {
+                            "released_failure"
+                        } else {
+                            "expired_executing"
+                        };
+                        ::metrics::counter!(
+                            "nonce_reservation_abandoned_reclaimed_total",
+                            "cause" => cause
+                        )
+                        .increment(1);
                     }
                     reservations.insert(
                         key,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -659,16 +659,17 @@ pub trait Store: Send + Sync + 'static {
     ///   * the SAME tx after lease expiry, `released_failure`, or
     ///     `released_success` → takeover:
     ///     [`NonceReservation::Won`] with a bumped fence (retry admission);
-    ///   * a DIFFERENT tx on an ABANDONED slot — `executing`, lease EXPIRED,
-    ///     and the bound hash never durably admitted (no `transactions` row ⇒
-    ///     the admission crashed before any external side effect) → takeover:
-    ///     [`NonceReservation::Won`] with a bumped fence (wedge #5: external
-    ///     submitters sign a fresh tx per retry, so a crashed slot must not
-    ///     poison its nonce forever).
+    ///   * a DIFFERENT tx on an ABANDONED slot — (`executing` with an EXPIRED
+    ///     lease) OR `released_failure`, and the bound hash never durably
+    ///     admitted (no `transactions` row ⇒ the admission crashed, or failed a
+    ///     normal pre-admission check like writer-queue saturation, before any
+    ///     external side effect) → takeover: [`NonceReservation::Won`] with a
+    ///     bumped fence (wedge #5: external submitters sign a fresh tx per
+    ///     retry, so such a slot must not poison its nonce forever).
     /// `lease` is how long the winner owns admission before another replica
     /// presenting the SAME hash may take over on expiry (crash recovery). A
-    /// released or durably-admitted slot remains permanently bound to its
-    /// first hash.
+    /// `released_success` or durably-admitted slot remains permanently bound
+    /// to its first hash.
     async fn reserve_nonce(
         &self,
         addr: &str,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -658,10 +658,17 @@ pub trait Store: Send + Sync + 'static {
     ///     [`NonceReservation::OwnedBySame`] (dedup, do NOT execute);
     ///   * the SAME tx after lease expiry, `released_failure`, or
     ///     `released_success` → takeover:
-    ///     [`NonceReservation::Won`] with a bumped fence (retry admission).
+    ///     [`NonceReservation::Won`] with a bumped fence (retry admission);
+    ///   * a DIFFERENT tx on an ABANDONED slot — `executing`, lease EXPIRED,
+    ///     and the bound hash never durably admitted (no `transactions` row ⇒
+    ///     the admission crashed before any external side effect) → takeover:
+    ///     [`NonceReservation::Won`] with a bumped fence (wedge #5: external
+    ///     submitters sign a fresh tx per retry, so a crashed slot must not
+    ///     poison its nonce forever).
     /// `lease` is how long the winner owns admission before another replica
-    /// presenting the SAME hash may take over on expiry (crash recovery). The
-    /// slot remains permanently bound to its first hash.
+    /// presenting the SAME hash may take over on expiry (crash recovery). A
+    /// released or durably-admitted slot remains permanently bound to its
+    /// first hash.
     async fn reserve_nonce(
         &self,
         addr: &str,

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1681,9 +1681,11 @@ impl Store for PgStore {
                 let state: String = row.get(1);
                 let expired: bool = row.get(2);
                 let fence: i64 = row.get(3);
-                // A nonce slot is permanently bound to its first transaction hash.
-                // Expiry only permits recovery by that exact signed transaction; a
-                // replacement is unsafe because the prior external outcome may be ambiguous.
+                // A nonce slot is bound to its first transaction hash. Expiry
+                // permits recovery by that exact signed transaction; a DIFFERENT
+                // replacement is unsafe while the prior external outcome may be
+                // ambiguous — it may only take over an ABANDONED slot (executing,
+                // lease expired, never durably admitted; wedge-#5 rule below).
                 let same_tx = row_hash.eq_ignore_ascii_case(&hash_str);
                 let takeover = same_tx
                     && (state == "released_failure" || state == "released_success" || expired);
@@ -1709,16 +1711,78 @@ impl Store for PgStore {
                 } else if row_hash.eq_ignore_ascii_case(&hash_str) {
                     NonceReservation::OwnedBySame
                 } else {
-                    // NIT — propagate a parse error WITH context instead of
-                    // substituting the zero hash.
-                    let other =
-                        <TxHash as std::str::FromStr>::from_str(&row_hash).map_err(|e| {
-                            anyhow::anyhow!(
-                                "nonce_reservations row for signer {key} nonce {nonce} has an \
-                             unparsable tx_hash {row_hash:?}: {e}"
+                    // Wedge #5 — ABANDONED-slot reclamation for a DIFFERENT tx.
+                    // The reservation is taken BEFORE durable admission
+                    // (`txn_begin*`), which itself precedes any external submit.
+                    // A crash in that window leaves the slot `executing` with an
+                    // expiring lease, its bound hash absent from `transactions`,
+                    // and the nonce unadvanced. External submitters (the
+                    // zkevm-bridge-service claimtxman) sign a FRESH tx per retry
+                    // — never the bound hash — so without this rule the crashed
+                    // slot rejects every retry at its nonce forever (observed
+                    // live: sponsor wedged at nonce 78 until operator surgery).
+                    // Reclaim iff: `executing` AND lease expired (the owner is
+                    // contractually dead — a live admission renews its lease)
+                    // AND the bound hash was never durably admitted (no
+                    // `transactions` row ⇒ provably nothing was submitted
+                    // externally ⇒ a replacement is unambiguous). Released slots
+                    // stay permanently hash-bound (receipt identity), and an
+                    // expired `executing` slot WITH a durable row stays held —
+                    // its outcome is tracked by the pending-tx machinery.
+                    let abandoned = if state == "executing" && expired {
+                        let admitted: bool = tx
+                            .query_one(
+                                "SELECT EXISTS(SELECT 1 FROM transactions WHERE tx_hash = $1)",
+                                &[&row_hash],
                             )
-                        })?;
-                    NonceReservation::HeldByOther(other)
+                            .await?
+                            .get(0);
+                        !admitted
+                    } else {
+                        false
+                    };
+                    if abandoned {
+                        let new_fence = fence + 1;
+                        tx.execute(
+                            "UPDATE nonce_reservations SET tx_hash = $5, state = 'executing',
+                             lease_expires_at = now() + ($3 || ' seconds')::interval,
+                             fence_token = $4
+                             WHERE signer = $1 AND nonce = $2",
+                            &[
+                                &key,
+                                &(nonce as i64),
+                                &lease_secs.to_string(),
+                                &new_fence,
+                                &hash_str,
+                            ],
+                        )
+                        .await?;
+                        ::metrics::counter!("nonce_reservation_expired_reclaimed_total")
+                            .increment(1);
+                        tracing::warn!(
+                            signer = %key,
+                            nonce,
+                            abandoned_tx = %row_hash,
+                            new_tx = %hash_str,
+                            "reserve_nonce: reclaimed an abandoned admission slot \
+                             (executing, lease expired, never durably admitted) for a \
+                             different tx (wedge #5)"
+                        );
+                        NonceReservation::Won {
+                            fence: new_fence as u64,
+                        }
+                    } else {
+                        // NIT — propagate a parse error WITH context instead of
+                        // substituting the zero hash.
+                        let other =
+                            <TxHash as std::str::FromStr>::from_str(&row_hash).map_err(|e| {
+                                anyhow::anyhow!(
+                                    "nonce_reservations row for signer {key} nonce {nonce} has an \
+                             unparsable tx_hash {row_hash:?}: {e}"
+                                )
+                            })?;
+                        NonceReservation::HeldByOther(other)
+                    }
                 }
             }
         };

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1714,34 +1714,49 @@ impl Store for PgStore {
                     // Wedge #5 — ABANDONED-slot reclamation for a DIFFERENT tx.
                     // The reservation is taken BEFORE durable admission
                     // (`txn_begin*`), which itself precedes any external submit.
-                    // A crash in that window leaves the slot `executing` with an
-                    // expiring lease, its bound hash absent from `transactions`,
-                    // and the nonce unadvanced. External submitters (the
+                    // Two paths leave a provably-unadmitted slot behind:
+                    //   * a CRASH in that window → `executing` with an expiring
+                    //     lease (the owner is contractually dead — a live
+                    //     admission renews its lease);
+                    //   * a NORMAL pre-admission error (e.g.
+                    //     `WriterQueueSaturatedError` in
+                    //     `dispatch_after_reservation`, which fails after the
+                    //     reservation but before `txn_begin_if_absent`) → the
+                    //     outer path releases `released_failure`.
+                    // In both, the bound hash is absent from `transactions` and
+                    // the nonce is unadvanced. External submitters (the
                     // zkevm-bridge-service claimtxman) sign a FRESH tx per retry
-                    // — never the bound hash — so without this rule the crashed
-                    // slot rejects every retry at its nonce forever (observed
-                    // live: sponsor wedged at nonce 78 until operator surgery).
-                    // Reclaim iff: `executing` AND lease expired (the owner is
-                    // contractually dead — a live admission renews its lease)
-                    // AND the bound hash was never durably admitted (no
-                    // `transactions` row ⇒ provably nothing was submitted
-                    // externally ⇒ a replacement is unambiguous). Released slots
-                    // stay permanently hash-bound (receipt identity), and an
-                    // expired `executing` slot WITH a durable row stays held —
-                    // its outcome is tracked by the pending-tx machinery.
-                    let abandoned = if state == "executing" && expired {
-                        let admitted: bool = tx
-                            .query_one(
-                                "SELECT EXISTS(SELECT 1 FROM transactions WHERE tx_hash = $1)",
-                                &[&row_hash],
-                            )
-                            .await?
-                            .get(0);
-                        !admitted
+                    // — never the bound hash — so without this rule such a slot
+                    // rejects every retry at its nonce forever (observed live:
+                    // sponsor wedged at nonce 78 until operator surgery).
+                    // Reclaim iff: (`executing` AND lease expired) OR
+                    // `released_failure`, AND the bound hash was never durably
+                    // admitted (no `transactions` row ⇒ provably nothing was
+                    // submitted externally ⇒ a replacement is unambiguous).
+                    // `released_success` slots and any slot WITH a durable row
+                    // stay permanently hash-bound (receipt identity / pending-tx
+                    // machinery).
+                    let reclaim_cause = if state == "released_failure" {
+                        Some("released_failure")
+                    } else if state == "executing" && expired {
+                        Some("expired_executing")
                     } else {
-                        false
+                        None
                     };
-                    if abandoned {
+                    let abandoned_cause = match reclaim_cause {
+                        Some(cause) => {
+                            let admitted: bool = tx
+                                .query_one(
+                                    "SELECT EXISTS(SELECT 1 FROM transactions WHERE tx_hash = $1)",
+                                    &[&row_hash],
+                                )
+                                .await?
+                                .get(0);
+                            if admitted { None } else { Some(cause) }
+                        }
+                        None => None,
+                    };
+                    if let Some(cause) = abandoned_cause {
                         let new_fence = fence + 1;
                         tx.execute(
                             "UPDATE nonce_reservations SET tx_hash = $5, state = 'executing',
@@ -1757,16 +1772,19 @@ impl Store for PgStore {
                             ],
                         )
                         .await?;
-                        ::metrics::counter!("nonce_reservation_expired_reclaimed_total")
-                            .increment(1);
+                        ::metrics::counter!(
+                            "nonce_reservation_abandoned_reclaimed_total",
+                            "cause" => cause
+                        )
+                        .increment(1);
                         tracing::warn!(
                             signer = %key,
                             nonce,
+                            cause,
                             abandoned_tx = %row_hash,
                             new_tx = %hash_str,
                             "reserve_nonce: reclaimed an abandoned admission slot \
-                             (executing, lease expired, never durably admitted) for a \
-                             different tx (wedge #5)"
+                             (never durably admitted) for a different tx (wedge #5)"
                         );
                         NonceReservation::Won {
                             fence: new_fence as u64,

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -2087,6 +2087,92 @@ async fn test_pgstore_reserve_nonce() {
     ));
 }
 
+/// Wedge #5 — abandoned-slot reclamation. An admission that crashes AFTER
+/// `reserve_nonce` but BEFORE durable admission leaves the slot `executing`
+/// with an expired lease and NO `transactions` row; a DIFFERENT tx must then
+/// take it over (fence bumps, zombie fenced out). Guard: the same expired slot
+/// WITH a durable `transactions` row stays hash-bound (HeldByOther).
+#[tokio::test]
+async fn test_pgstore_wedge5_abandoned_slot_reclamation() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    use crate::store::NonceReservation;
+    let base = rand_u64();
+    let addr = format!("0x{:040x}", (base ^ 0x5ED5) as u128);
+    let h1 = TxHash::from([(base % 199) as u8 + 3; 32]);
+    let h2 = TxHash::from([(base % 193) as u8 + 4; 32]);
+    let lease = std::time::Duration::from_secs(90);
+
+    let NonceReservation::Won { fence } = store.reserve_nonce(&addr, 9, h1, lease).await.unwrap()
+    else {
+        panic!("fresh slot must be Won");
+    };
+    // A VALID executing lease still hard-rejects a different tx.
+    assert_eq!(
+        store.reserve_nonce(&addr, 9, h2, lease).await.unwrap(),
+        NonceReservation::HeldByOther(h1)
+    );
+
+    // Backdate the lease via raw SQL — the crashed-admission signature
+    // (executing, expired, never durably admitted).
+    let db_url = std::env::var("DATABASE_URL").expect("DATABASE_URL");
+    let (client, conn) = tokio_postgres::connect(&db_url, tokio_postgres::NoTls)
+        .await
+        .expect("raw connection");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    client
+        .execute(
+            "UPDATE nonce_reservations SET lease_expires_at = now() - interval '1 second'
+             WHERE signer = $1 AND nonce = 9",
+            &[&addr.to_lowercase()],
+        )
+        .await
+        .expect("backdate lease");
+
+    // Expired + unadmitted → the DIFFERENT tx reclaims with a bumped fence.
+    let NonceReservation::Won { fence: fence2 } =
+        store.reserve_nonce(&addr, 9, h2, lease).await.unwrap()
+    else {
+        panic!("an abandoned (expired, unadmitted) slot must be reclaimable by a different tx");
+    };
+    assert!(fence2 > fence, "reclamation must bump the fence");
+    // The zombie owner is fenced out; the reclaiming owner keeps the slot.
+    store
+        .release_reservation(&addr, 9, h1, fence, false)
+        .await
+        .unwrap();
+    assert_eq!(
+        store.reserve_nonce(&addr, 9, h2, lease).await.unwrap(),
+        NonceReservation::OwnedBySame,
+        "the zombie's fenced-out release must not evict the reclaiming owner"
+    );
+
+    // Guard: expired but durably ADMITTED (transactions row exists) stays held.
+    let h3 = TxHash::from([(base % 191) as u8 + 5; 32]);
+    let h4 = TxHash::from([(base % 181) as u8 + 6; 32]);
+    assert!(matches!(
+        store.reserve_nonce(&addr, 10, h3, lease).await.unwrap(),
+        NonceReservation::Won { .. }
+    ));
+    store.txn_begin(h3, dummy_txn_entry()).await.unwrap();
+    client
+        .execute(
+            "UPDATE nonce_reservations SET lease_expires_at = now() - interval '1 second'
+             WHERE signer = $1 AND nonce = 10",
+            &[&addr.to_lowercase()],
+        )
+        .await
+        .expect("backdate lease");
+    assert_eq!(
+        store.reserve_nonce(&addr, 10, h4, lease).await.unwrap(),
+        NonceReservation::HeldByOther(h3),
+        "an expired slot with a durable transactions row must stay hash-bound"
+    );
+}
+
 /// BLOCKER 1 — FULL two-replica shared-PostgreSQL races. Two PgStore handles over
 /// the SAME database (two "replicas") reserve the SAME (signer, nonce) slot.
 #[tokio::test]

--- a/src/store/postgres_tests.rs
+++ b/src/store/postgres_tests.rs
@@ -2173,6 +2173,59 @@ async fn test_pgstore_wedge5_abandoned_slot_reclamation() {
     );
 }
 
+/// Wedge #5 (PR#145 blocker 1) — the identical production transition on
+/// PostgreSQL: a slot released as FAILURE whose hash was never durably admitted
+/// (pre-admission error path, e.g. writer-queue saturation after the
+/// reservation) is reclaimable by a DIFFERENT tx immediately, fence bumped; a
+/// `released_failure` slot WITH a durable `transactions` row stays hash-bound.
+#[tokio::test]
+async fn test_pgstore_wedge5_released_failure_reclamation() {
+    let Some(store) = pg_store().await else {
+        return;
+    };
+    use crate::store::NonceReservation;
+    let base = rand_u64();
+    let addr = format!("0x{:040x}", (base ^ 0x5EDF) as u128);
+    let h1 = TxHash::from([(base % 197) as u8 + 7; 32]);
+    let h2 = TxHash::from([(base % 179) as u8 + 8; 32]);
+    let lease = std::time::Duration::from_secs(90);
+
+    // Released failure, NEVER durably admitted → reclaimable immediately.
+    let NonceReservation::Won { fence } = store.reserve_nonce(&addr, 11, h1, lease).await.unwrap()
+    else {
+        panic!("fresh slot must be Won");
+    };
+    store
+        .release_reservation(&addr, 11, h1, fence, false)
+        .await
+        .unwrap();
+    let NonceReservation::Won { fence: fence2 } =
+        store.reserve_nonce(&addr, 11, h2, lease).await.unwrap()
+    else {
+        panic!("released_failure without durable admission must be reclaimable");
+    };
+    assert!(fence2 > fence, "reclamation must bump the fence");
+
+    // Released failure WITH a durable transactions row → stays hash-bound.
+    let h3 = TxHash::from([(base % 173) as u8 + 9; 32]);
+    let h4 = TxHash::from([(base % 167) as u8 + 10; 32]);
+    let NonceReservation::Won { fence: fence3 } =
+        store.reserve_nonce(&addr, 12, h3, lease).await.unwrap()
+    else {
+        panic!("fresh slot must be Won");
+    };
+    store.txn_begin(h3, dummy_txn_entry()).await.unwrap();
+    store
+        .release_reservation(&addr, 12, h3, fence3, false)
+        .await
+        .unwrap();
+    assert_eq!(
+        store.reserve_nonce(&addr, 12, h4, lease).await.unwrap(),
+        NonceReservation::HeldByOther(h3),
+        "a released_failure slot with a durable transactions row must stay hash-bound"
+    );
+}
+
 /// BLOCKER 1 — FULL two-replica shared-PostgreSQL races. Two PgStore handles over
 /// the SAME database (two "replicas") reserve the SAME (signer, nonce) slot.
 #[tokio::test]

--- a/src/synthetic_projector.rs
+++ b/src/synthetic_projector.rs
@@ -1320,6 +1320,33 @@ impl SyntheticProjector {
             }
         }
 
+        // #66 — emitted-frontier gate, enforced AT EMIT TIME (after this block's notes are
+        // projected, BEFORE the block seals) rather than only at tick-start. A reserved-but-
+        // unemitted LET leaf here is a getLogs `depositCount` gap; aggkit's L2 bridgesync
+        // requires contiguous deposit indices and HALTS ("state is inconsistent") on a gap,
+        // wedging every later Miden certificate. Fail-closed: refuse to seal past it so aggkit
+        // sees a contiguous prefix and WAITS. This placement fixes two modes of the old
+        // tick-start-only gate:
+        //   * WITHIN-TICK gap (part 2): the block used to seal WITH the gap exposed, and only
+        //     the NEXT tick's gate caught it — a window where aggkit could scan the gap. The
+        //     check now runs before THIS seal, so a poison leaf never seals.
+        //   * CRASH-after-reserve (part 1): a leaf reserved-but-unemitted by a crash between
+        //     reserve and emit was re-projected by the note loop ABOVE (reserve is idempotent;
+        //     the emit now completes), so it is already emitted here and the gate passes — an
+        //     automatic self-heal instead of the old permanent halt (which fired at tick-start
+        //     BEFORE the re-projection that would have healed it).
+        // A genuinely unrecoverable leaf (unrecoverable metadata / quarantined / self-target)
+        // is still unemitted here and HALTS fail-closed.
+        if let Some((idx, note)) = self.store.first_unemitted_reservation().await? {
+            ::metrics::counter!("bridge_unemitted_reservation_halt_total").increment(1);
+            anyhow::bail!(
+                "projector halted (fail-closed): note {note} (LET index {idx}) is reserved \
+                 but its BridgeEvent was never emitted (unrecoverable metadata / quarantined \
+                 leaf). Sealing past it would leave a getLogs gap that halts aggkit bridgesync. \
+                 Fix the leaf's metadata (registry backfill, or back up + drop the DB and \
+                 re-run `--restore` to rebuild from on-chain), then restart."
+            );
+        }
         // Write-before-advance: every synthetic log for `miden_block` is now in the
         // DB, so it is safe to advance the synthetic tip to == the Miden block.
         // Runs for EMPTY Miden blocks too (advance the tip even with 0 logs), so the
@@ -1559,16 +1586,11 @@ impl SyntheticProjector {
         // for the withheld leaf. Recovery is operator-driven: fix the leaf's metadata
         // (registry backfill / a full DB drop + `--restore` rebuild from on-chain) so the
         // leaf emits its real event.
-        if let Some((idx, note)) = self.store.first_unemitted_reservation().await? {
-            ::metrics::counter!("bridge_unemitted_reservation_halt_total").increment(1);
-            anyhow::bail!(
-                "projector halted (fail-closed): note {note} (LET index {idx}) is reserved \
-                 but its BridgeEvent was never emitted (unrecoverable metadata / quarantined \
-                 leaf). Sealing past it would leave a getLogs gap that halts aggkit bridgesync. \
-                 Fix the leaf's metadata (registry backfill, or back up + drop the DB and \
-                 re-run `--restore` to rebuild from on-chain), then restart."
-            );
-        }
+        // #66 — the emitted-frontier gate moved INTO `project_block_notes` (enforced per-block
+        // before each seal), so a poison leaf halts before its own block seals (no within-tick
+        // gap) and a crash-reserved leaf is re-emitted by re-projection before the check (no
+        // permanent halt). The old tick-start check here fired BEFORE that re-projection could
+        // heal a crash, and only AFTER a block had already sealed with the gap exposed.
         let no_notes: Vec<(Option<NoteId>, &InputNoteRecord)> = Vec::new();
         while cursor < tip {
             let next = cursor + 1;
@@ -3797,21 +3819,27 @@ mod tests {
         );
     }
 
-    /// A skipped LET leaf still consumes its index; the following valid event must encode 1.
+    /// #66 — a reserved-but-unemitted leaf HALTS the block AT EMIT TIME (before the seal), and
+    /// is RECOVERABLE. Leaf 0 is an unregistered faucet → it reserves LET index 0 (Cantina #7:
+    /// the on-chain leaf takes its slot) but cannot emit (UnknownFaucet). Sealing the block
+    /// would expose a getLogs `depositCount` gap at index 0 (leaf 1 at index 1 would be visible
+    /// past it) and wedge aggkit. The per-block emitted-frontier gate refuses to seal: the tick
+    /// HALTS fail-closed, the tip does NOT advance, and the cursor stays behind block 5 — so
+    /// once the faucet is registered, re-projecting block 5 emits leaf 0 and the gate passes.
+    /// (Pre-#66 the gate ran only at tick-start, so block 5 SEALED with the gap exposed and the
+    /// cursor advanced past leaf 0 — a PERMANENT wedge that registration could no longer heal.)
     #[tokio::test]
-    async fn skipped_let_leaf_reserves_its_deposit_index() {
+    async fn poison_leaf_halts_before_sealing_and_is_recoverable() {
         let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
         let block_state = StdArc::new(BlockState::new());
         let projector = test_projector(&store, &block_state).await;
 
-        // Leaf 0: a DISTINCT, unregistered faucet → quarantines as UnknownFaucet
-        // (reserves index 0, emits nothing). Leaf 1: the registered FAUCET → emits.
         let unregistered_faucet = aid("0xaa0000000000bc110000bc000000de");
         let quarantined = b2agg_note_faucet(5, Some(0), unregistered_faucet, 71);
-        register_faucet(&store).await;
+        register_faucet(&store).await; // registers the DEFAULT faucet (leaf 1's), not leaf 0's
         let valid = b2agg_note_with_amount(5, Some(1), 72);
 
-        let written = projector
+        let err = projector
             .project_notes(
                 &[quarantined.clone(), valid.clone()],
                 &HashMap::new(),
@@ -3820,36 +3848,74 @@ mod tests {
                 &HashMap::new(),
             )
             .await
-            .unwrap();
-        assert_eq!(written, 1, "only the valid leaf emits");
+            .expect_err("a reserved-but-unemitted poison leaf must HALT before the block seals");
+        assert!(
+            format!("{err:#}").contains("reserved") && format!("{err:#}").contains("never emitted"),
+            "halt must name the unemitted reservation: {err:#}"
+        );
+        // Cantina #7 — the poison leaf STILL reserved its index (held the LET slot) before halt.
         assert_eq!(
             store.get_deposit_count().await.unwrap(),
             2,
-            "both leaves indexed"
+            "both leaves reserved their LET indices"
+        );
+        // Fail-closed: the block did NOT seal — aggkit sees a contiguous prefix, nothing past
+        // the gap. THIS is the within-tick fix: the tip never advances over the poison leaf.
+        assert_eq!(
+            store.get_latest_block_number().await.unwrap(),
+            0,
+            "the tip must not advance past the reserved-but-unemitted leaf"
+        );
+    }
+
+    /// #66 part 1 — a leaf whose index was RESERVED before a crash (reserve committed, the
+    /// BridgeEvent not yet emitted) must be RE-EMITTED on re-projection, NOT halt forever.
+    /// Pre-#66 the gate ran at tick-start and halted BEFORE the re-projection that heals it — a
+    /// permanent halt for a recoverable leaf. Now the gate runs after the block's notes project,
+    /// so the re-emit completes first and the gate passes.
+    #[tokio::test]
+    async fn crash_reserved_leaf_re_emits_on_reprojection() {
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        let block_state = StdArc::new(BlockState::new());
+        register_faucet(&store).await;
+        let note = b2agg_note_with_amount(5, Some(0), 72);
+        // The dedup key is the note's NoteId (project_notes gives a headerless B2AGG fixture the
+        // same deterministic identity project_b2agg_note keys on:
+        // NoteId::new(details_commitment, metadata{bridge_id, Public})).
+        let metadata = miden_protocol::note::NoteMetadata::new(
+            miden_protocol::note::PartialNoteMetadata::new(
+                aid(BRIDGE),
+                miden_protocol::note::NoteType::Public,
+            ),
+            &miden_protocol::note::NoteAttachments::default(),
+        );
+        let key = miden_protocol::note::NoteId::new(note.details_commitment(), &metadata).to_hex();
+        // Simulate the crash: the LET index was reserved but the BridgeEvent was never emitted.
+        store.reserve_deposit_index(&key).await.unwrap();
+        assert!(
+            store.first_unemitted_reservation().await.unwrap().is_some(),
+            "precondition: a reserved-but-unemitted leaf exists (the crash window)"
         );
 
-        let logs = logs_in_range(&store, 0, 5).await;
-        assert_eq!(logs.len(), 1);
-        assert_eq!(bridge_deposit_count(&logs[0]), 1);
-
-        // Retry/restart: a fresh projector over the SAME store re-projects idempotently —
-        // indices are stable, nothing double-allocates, no second event.
-        let projector2 = test_projector(&store, &block_state).await;
-        let rewritten = projector2
-            .project_notes(
-                &[quarantined.clone(), valid.clone()],
-                &HashMap::new(),
-                5,
-                None,
-                &HashMap::new(),
-            )
+        // Re-project (restart): project_b2agg_note re-reserves idempotently + EMITS → the gate
+        // passes → the block seals. Recoverable, not a permanent halt.
+        let projector = test_projector(&store, &block_state).await;
+        let written = projector
+            .project_notes(&[note], &HashMap::new(), 5, None, &HashMap::new())
             .await
-            .unwrap();
-        assert_eq!(rewritten, 0, "replay emits nothing new");
+            .expect("a recoverable reserved-but-unemitted leaf must re-emit, not halt");
         assert_eq!(
-            store.get_deposit_count().await.unwrap(),
-            2,
-            "no re-allocation"
+            written, 1,
+            "the crash-reserved leaf re-emits its BridgeEvent"
+        );
+        assert!(
+            store.first_unemitted_reservation().await.unwrap().is_none(),
+            "the reservation is now emitted — no poison leaf remains"
+        );
+        assert_eq!(
+            store.get_latest_block_number().await.unwrap(),
+            5,
+            "the block seals once the crash-reserved leaf re-emits"
         );
     }
 

--- a/src/synthetic_projector.rs
+++ b/src/synthetic_projector.rs
@@ -938,9 +938,19 @@ impl SyntheticProjector {
             } // lock dropped before the awaits below
             let note_id_str = hex::encode(key);
             let derived = crate::claim_watcher::derive_manual_claim_tx_hash(&note_id_str);
-            let logs = self.store.get_logs_for_tx(&derived).await?;
-            let resolved = if let Some(log) = logs.first() {
-                // A derived-hash ClaimEvent exists → the full calldata must be servable.
+            // The ClaimEvent may ride the DERIVED hash (derived-hash synthesis, no real
+            // eth-tx) OR the REAL linked eth-tx hash (`publish_claim`'s recorded link — the
+            // normal case). Repair under WHICHEVER hash actually carries the event. The old
+            // derived-only check silently marked a real-hash event "resolved forever" without
+            // verifying its envelope existed, so it never healed the {processed note +
+            // real-hash ClaimEvent + missing transaction envelope} crash window — a state
+            // that also survives an upgrade (the note is already processed, so the projection
+            // path never re-runs). `persist_synthetic_claim_tx` is idempotent: a no-op when
+            // the envelope is already present + committed, a reconstruct when it is absent,
+            // and returns `false` (stay unresolved, retry next tick) when the faucet metadata
+            // is still unrecoverable.
+            let derived_logs = self.store.get_logs_for_tx(&derived).await?;
+            let resolved = if let Some(log) = derived_logs.first() {
                 crate::restore::persist_synthetic_claim_tx(
                     &self.store,
                     note.details().storage(),
@@ -950,11 +960,29 @@ impl SyntheticProjector {
                     log.block_hash,
                 )
                 .await?
+            } else if let Some(real) = self.store.get_tx_for_note(&note_id_str).await? {
+                // A real link exists. If a ClaimEvent rides it, ensure its full calldata is
+                // servable under that hash (the crash-window heal). Only resolve once valid
+                // calldata is stored; if no event rides it yet the note is not projected —
+                // re-check next tick, do NOT resolve.
+                match self.store.get_logs_for_tx(&real).await?.first() {
+                    Some(log) => {
+                        crate::restore::persist_synthetic_claim_tx(
+                            &self.store,
+                            note.details().storage(),
+                            &note_id_str,
+                            &real,
+                            log.block_number,
+                            log.block_hash,
+                        )
+                        .await?
+                    }
+                    None => false,
+                }
             } else {
-                // No derived-hash event. Once the note's consumption block is projected,
-                // its ClaimEvent (if any) rides a real eth-tx hash — nothing to backfill,
-                // resolved forever. Before that, re-check next tick (the synthesis path
-                // usually persists it first; this is only the crash backstop).
+                // No derived-hash event AND no recorded real link. Once the consumption block
+                // is projected and no event exists anywhere, there is nothing to backfill (a
+                // skipped/foreign claim) — resolved forever. Before that, re-check next tick.
                 note.state()
                     .consumed_block_height()
                     .map(|h| h.as_u64())
@@ -1349,6 +1377,25 @@ impl SyntheticProjector {
                 "reconcile cursor is ahead of the Miden tip"
             );
         }
+        // Claim-calldata REPAIR runs EVERY tick — including at the tip — so a historical
+        // broken ClaimEvent (full calldata never stored: an older-build synthesis, or a crash
+        // between recording the note→hash link and persisting the envelope) heals on the very
+        // next tick, NOT only when new traffic advances the cursor past the tip. It therefore
+        // runs BEFORE the at-tip early return. The consumed feed it needs is also used by
+        // block projection and the completeness auditor below, so fetch it once here.
+        let consumed = client
+            .get_input_notes(NoteFilter::Consumed)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to get consumed input notes: {e}"))?;
+        if let Err(e) = self
+            .backfill_synthetic_claim_calldata(&consumed, cursor)
+            .await
+        {
+            tracing::warn!(
+                error = %format!("{e:#}"),
+                "synthesized-claim calldata backfill failed (non-fatal — retried next tick)"
+            );
+        }
         if cursor >= tip {
             return Ok(cursor);
         }
@@ -1374,10 +1421,8 @@ impl SyntheticProjector {
         // every bridge consumption through the B2AGG body path) is what keeps a GER/CLAIM
         // consumption — whose body the authoritative feed reports before the store's B2AGG
         // import frontier would have it — from wedging the tip.
-        let consumed = client
-            .get_input_notes(NoteFilter::Consumed)
-            .await
-            .map_err(|e| anyhow::anyhow!("failed to get consumed input notes: {e}"))?;
+        // `consumed` was fetched above (before the at-tip early return, for the calldata
+        // backfill) and is reused here for block projection.
         // CLAIM / GER from the store's consumed feed, at their finalized consumption block.
         // B2AGG is skipped here — sourced authoritatively below (keeping the two sources
         // disjoint keeps the reasoning clean; `is_note_processed` would dedup either way).
@@ -1538,19 +1583,7 @@ impl SyntheticProjector {
             self.cursor.store(next, Ordering::Release);
             cursor = next;
         }
-        // Synthesized-claim calldata backfill (every tick, O(new CLAIM notes) via the
-        // resolved-set): heals derived-hash ClaimEvents whose full claimAsset calldata is
-        // not yet persisted — older-build synthesis, or a crash between the event commit
-        // and the calldata persist. Non-fatal: a failure warns and retries next tick.
-        if let Err(e) = self
-            .backfill_synthetic_claim_calldata(&consumed, cursor)
-            .await
-        {
-            tracing::warn!(
-                error = %format!("{e:#}"),
-                "synthesized-claim calldata backfill failed (non-fatal — retried next tick)"
-            );
-        }
+        // (Claim-calldata backfill already ran once this tick, before the at-tip early return.)
         // COMPLETENESS AUDITOR (detection only, every AUDIT_EVERY_N_TICKS ticks): diff the
         // store's consumed-B2AGG view against the synthetic log store for comfortably-sealed
         // blocks. Reuses this tick's already-fetched `consumed` feed — zero extra queries.
@@ -2609,6 +2642,92 @@ mod tests {
             logs[0].transaction_hash,
             derive_manual_claim_tx_hash(&note_commitment),
             "must NOT fall back to the derived hash when a link exists"
+        );
+    }
+
+    /// #67 gaps 2+3 — HEAL a historical real-hash failure. A note that is already
+    /// {processed + ClaimEvent under the REAL linked hash + MISSING transaction envelope} —
+    /// the pre-upgrade crash window (crash between recording the link and persisting the
+    /// envelope) — is UNREPAIRABLE by pre-#67 code: the projection path never re-runs (Dedup-1
+    /// skips the processed note) and the backfill only checked the DERIVED hash, marking the
+    /// note "resolved forever" while its real-hash ClaimEvent kept serving empty calldata.
+    /// POST-#67 the backfill checks the real linked hash and reconstructs the envelope under
+    /// it, so `eth_getTransactionByHash(real)` serves the full claimAsset calldata again.
+    #[tokio::test]
+    async fn backfill_heals_historical_real_hash_event_with_missing_envelope() {
+        use alloy::consensus::Transaction;
+        use alloy_core::sol_types::SolCall;
+        let store: StdArc<dyn Store> = StdArc::new(InMemoryStore::new());
+        register_faucet(&store).await;
+
+        let n_claim = claim_note(5, Some(0));
+        let note_commitment = hex::encode(n_claim.details_commitment().as_bytes());
+        let real_tx = "0x2222222222222222222222222222222222222222222222222222222222222222";
+        // The surviving link — recorded by `publish_claim` before the crash.
+        store
+            .record_tx_note_link(real_tx, &note_commitment)
+            .await
+            .unwrap();
+        // The crash-window state: a ClaimEvent rides `real_tx`, the note is already processed,
+        // but the transaction envelope was never persisted (empty calldata).
+        let mut gi = [0u8; 32];
+        gi[31] = 0x5C;
+        store
+            .add_claim_event(
+                "0x00000000000000000000000000000000000000aa",
+                5,
+                [0u8; 32],
+                real_tx,
+                &gi,
+                0,
+                &[0xAB; 20],
+                &[0xCD; 20],
+                1_000,
+            )
+            .await
+            .unwrap();
+        store
+            .mark_claim_note_processed(note_commitment.clone(), gi, 5)
+            .await
+            .unwrap();
+        let real_hash: alloy::primitives::TxHash = real_tx.parse().unwrap();
+        assert!(
+            store.txn_get(real_hash).await.unwrap().is_none(),
+            "precondition: the envelope is MISSING (crash before persisting it)"
+        );
+        assert!(
+            !store.get_logs_for_tx(real_tx).await.unwrap().is_empty(),
+            "precondition: the ClaimEvent rides the real linked hash"
+        );
+        assert!(
+            store
+                .get_logs_for_tx(&derive_manual_claim_tx_hash(&note_commitment))
+                .await
+                .unwrap()
+                .is_empty(),
+            "precondition: NOTHING under the derived hash (the derived-only backfill was blind)"
+        );
+
+        let block_state = StdArc::new(BlockState::new());
+        let projector = test_projector(&store, &block_state).await;
+        // cursor >= 5 (block projected) → pre-#67 the backfill marked this resolved-forever
+        // with empty calldata. POST-#67 it reconstructs under the real hash.
+        projector
+            .backfill_synthetic_claim_calldata(&[n_claim], 5)
+            .await
+            .unwrap();
+
+        let data =
+            store.txn_get(real_hash).await.unwrap().expect(
+                "backfill must reconstruct the missing envelope under the REAL linked hash",
+            );
+        assert!(
+            crate::claim::claimAssetCall::abi_decode(data.envelope.input()).is_ok(),
+            "the served input is the full claimAsset calldata, not the empty-calldata wedge"
+        );
+        assert!(
+            data.envelope.input().len() > 4 + 64 * 32,
+            "full calldata (both SMT proofs included), not a stub"
         );
     }
 

--- a/src/synthetic_projector.rs
+++ b/src/synthetic_projector.rs
@@ -202,12 +202,14 @@ pub struct SyntheticProjector {
     /// deployment, foreign claims share our ClaimNote script root and must
     /// not be projected (see `restore::classify_claim_note`).
     expected_claim_sender: AccountId,
-    /// L1 JSON-RPC endpoint for the Cantina #13 Layer-2 ERC-20 metadata
-    /// recovery path (mirrors `BridgeOutScanner::l1_rpc_url`). Threaded into
-    /// `project_b2agg_note` so legacy/DB-loss faucet rows with empty ERC-20
-    /// metadata recover + validate instead of being skipped. `None` disables
-    /// the L1 fallback (recovery then relies solely on the all-Miden candidate).
-    l1_rpc_url: Option<String>,
+    /// Per-origin-network JSON-RPC endpoints for the Cantina #13 Layer-2 ERC-20
+    /// metadata recovery path. Threaded into `project_b2agg_note`, which selects
+    /// the RPC for each bridge-out's `origin_network` (L1 for network 0, L2B for
+    /// network 2, …) so a legacy/DB-loss faucet row with empty ERC-20 metadata
+    /// recovers + validates against the token's ACTUAL origin chain instead of
+    /// being skipped (finding #62). An empty map relies solely on the all-Miden
+    /// candidate — the pre-#62 behavior when no L1 RPC was configured.
+    network_rpcs: crate::metadata_recovery::NetworkRpcMap,
     /// Last projected Miden block height — an in-memory cache of the persisted
     /// `Store::get_projector_cursor`. The projector is the single owner of this
     /// cursor (SINGLE-PROCESS ONLY) and persists every advance in `tick`.
@@ -278,7 +280,7 @@ impl SyntheticProjector {
         block_state: Arc<BlockState>,
         accounts: &AccountsConfig,
         local_network_id: u32,
-        l1_rpc_url: Option<String>,
+        network_rpcs: crate::metadata_recovery::NetworkRpcMap,
         node_url: String,
         node_api_key: Option<String>,
     ) -> anyhow::Result<Self> {
@@ -329,7 +331,7 @@ impl SyntheticProjector {
             local_network_id,
             expected_ger_sender,
             expected_claim_sender: accounts.service.0,
-            l1_rpc_url,
+            network_rpcs,
             cursor: AtomicU64::new(start_cursor),
             node_rpc,
             reconcile_cursor: AtomicU64::new(start_reconcile),
@@ -1273,9 +1275,10 @@ impl SyntheticProjector {
                     block_hash,
                     bridge_address,
                     // Cantina #13 recovery context: the live client + the projector's
-                    // L1 RPC, so legacy/empty-metadata ERC-20 bridge-outs recover.
+                    // per-network RPC map, so legacy/empty-metadata ERC-20 bridge-outs
+                    // recover against their actual origin chain (finding #62).
                     client.as_deref_mut(),
-                    self.l1_rpc_url.as_deref(),
+                    &self.network_rpcs,
                 )
                 .await?
                     == B2AggRestoreOutcome::Emitted
@@ -2007,7 +2010,7 @@ mod tests {
             block_state.clone(),
             &test_accounts(),
             7,
-            None,
+            crate::metadata_recovery::NetworkRpcMap::new(),
             crate::miden_client::effective_node_url(None),
             None,
         )


### PR DESCRIPTION
## Context

Post-`v0.15.8` hardening from failures observed on the real long-running multi-chain stack and during chaos/recovery testing. This is not speculative cleanup: it closes concrete recovery wedges, projection gaps, stale-nonce behavior, and false confidence in the soak harness.

## Runtime fixes

| Finding | Change | Operational effect |
|---|---|---|
| #67 | Fail-close CLAIM projection until full `claimAsset` calldata is recoverable; repair historical real-hash envelopes even at the projector tip | Prevents immutable ClaimEvents with unusable calldata from wedging AggKit recovery |
| #66 | Check the reserved-but-unemitted LET frontier immediately before each synthetic block seals | Prevents within-tick `depositCount` gaps and lets crash-reserved leaves heal by re-projection |
| #62 | Select metadata-recovery RPC by token `origin_network` | Restores L2B-origin ERC-20 metadata from L2B instead of incorrectly querying L1 |
| native recovery | Accept both AggLayer wrapped faucets and native Miden `FungibleFaucet`s as hash-gated metadata sources | Allows native Miden-originated assets to survive full restore |
| #69 | Recover historical bridge-consumed CLAIMs from the node scan and replay them in original Miden execution order | Rebuilds ClaimEvents after `--reset-miden-store`, allowing aggsender certificate recovery to resume |
| #55 | Reclaim an expired nonce reservation only when its original hash has no durable transaction row | Repairs the observed crashed-before-admission external-submitter wedge |

## Recovery and chaos validation

- replaces preservation of proxy nonce tables with a realistic bridge-service database resync after full proxy recovery;
- runs L2↔L2 and native-token tiers before the from-scratch recovery so the rebuild covers L1-, L2B-, and Miden-originated assets;
- retries garbo injections through proxy/PostgreSQL faults and requires enabled injection classes to actually fire;
- extends L2↔L2 settlement waits only while certificate/ClaimEvent progress remains observable;
- corroborates the external completeness verifier with proxy-store state and surfaces a silent `ntx-builder` as an explicit warning;
- fails the chaos run early when its completeness tool is unavailable.

```mermaid
flowchart LR
    Node[Miden node history] --> Restore[Full restore]
    L1[L1 token RPC] --> Metadata[Origin-aware metadata recovery]
    L2B[L2B token RPC] --> Metadata
    Metadata --> Restore
    Restore --> Claims[Historical ClaimEvents + calldata]
    Restore --> Exits[BridgeEvents]

    Consumed[Consumed Miden block] --> Projector[Synthetic projector]
    Projector --> Gate{All reserved LET leaves emitted?}
    Gate -->|yes| Seal[Seal synthetic block]
    Gate -->|no| Halt[Fail closed and retry]
    Seal --> AggKit[AggKit / aggsender]

    Chaos[Fault + garbo traffic] --> Verdict[Verifier + store + liveness verdict]
```

## Evidence captured by the branch

- full recovery on the grown ~25.7k-block stack restored 326 historical claims and allowed aggsender initial-state recovery to complete;
- L2B-origin and native Miden-originated token metadata were recovered byte-for-byte after a full database/store reset;
- post-recovery bridge traffic resumed in both directions;
- focused recovery, projector, nonce-reservation, metadata, PostgreSQL-gated, and shell-harness regressions are included.

This PR is initially a draft while the combined release-follow-up diff and CI are reviewed.
