### PR TITLE
fix(admin): validate native-faucet metadata against deployed account

### DIFF
--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -319,17 +319,17 @@ leaf). To detect it:
    faucet's on-chain `MetadataHash`. A row whose stored preimage keccak differs
    from the deployed faucet's hash is mismatched.
 
-2. Remediate. Re-registration does **not** repair a mismatched row:
-   `admin_registerNativeFaucet` is register-if-absent (idempotent) — for an
-   origin that already has a route it returns the existing row unchanged and
-   never rewrites its metadata. A kept stack with a mismatched legacy row must
-   therefore be remediated by removing that row (operator-authorized DB action)
-   and re-registering the faucet against its deployed account — the fresh
-   registration then validates + persists authoritative metadata (supplying the
-   faucet's actual name, or omitting `name` to adopt it; a custom `name != symbol`
-   is preserved, never normalized). Recovery must not reconstruct history by
-   guessing; the only safe source is the deployed faucet account. On the
-   supported clean-slate rollout this situation does not arise.
+2. Do not attempt an in-place repair. `admin_registerNativeFaucet` is
+   register-if-absent (idempotent) — it never rewrites an existing row — so
+   re-registration cannot fix a mismatched row. Surgical row deletion +
+   re-registration is also **not** a repair: it discards the only locally
+   retained legacy preimage and overwrites the bridge's current metadata hash,
+   yet it cannot repair historical B2AGG leaves/events already committed with
+   the old hash. The supported rollout is clean-slate, so legacy state is not
+   migrated and this situation does not arise on it. If a mismatched row is
+   ever observed on a stack that must be kept: preserve and back up the current
+   state, quarantine the affected faucet, and escalate — or rebuild from a
+   clean deployment. Do not perform surgical row edits.
 
 ## 4. Incident procedures
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -291,10 +291,16 @@ preimage is reconstructable from authoritative chain state during `--restore`
 mismatched symbol, decimals, or name is rejected up-front with a specific error
 and leaves no registry row.
 
+**Legacy state is not migrated.** The supported rollout is clean-slate: the new
+deployment starts fresh with this validation active, so no legacy mismatched row
+carries into it, and no in-place repair path is provided. The detection below is
+for diagnosing an unexpected mismatched row on a stack that must be kept — not a
+supported migration.
+
 A row registered by an **older build** may still carry a preimage that does not
 match its deployed faucet account. Recovery does **not** silently guess a
 preimage — an unrecoverable native row halts `--restore` fail-closed (its poison
-leaf). To detect and remediate before that happens:
+leaf). To detect it:
 
 1. Detect. For each native row (`origin_network` == the proxy's configured
    `network_id`), compare the stored preimage against the deployed faucet
@@ -313,12 +319,17 @@ leaf). To detect and remediate before that happens:
    faucet's on-chain `MetadataHash`. A row whose stored preimage keccak differs
    from the deployed faucet's hash is mismatched.
 
-2. Remediate. Re-register the faucet against its deployed account so the row and
-   the emitted bridge metadata are rewritten from authoritative state. Because a
-   custom `name != symbol` is valid, supply the faucet's actual name (or omit
-   `name` to adopt it) — never normalize it to the symbol. Recovery must not
-   reconstruct history by guessing; the only safe source is the deployed faucet
-   account.
+2. Remediate. Re-registration does **not** repair a mismatched row:
+   `admin_registerNativeFaucet` is register-if-absent (idempotent) — for an
+   origin that already has a route it returns the existing row unchanged and
+   never rewrites its metadata. A kept stack with a mismatched legacy row must
+   therefore be remediated by removing that row (operator-authorized DB action)
+   and re-registering the faucet against its deployed account — the fresh
+   registration then validates + persists authoritative metadata (supplying the
+   faucet's actual name, or omitting `name` to adopt it; a custom `name != symbol`
+   is preserved, never normalized). Recovery must not reconstruct history by
+   guessing; the only safe source is the deployed faucet account. On the
+   supported clean-slate rollout this situation does not arise.
 
 ## 4. Incident procedures
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -280,6 +280,46 @@ sweep.
 Never substitute `--init` for recovery: it creates new account identities and
 can strand control/balances associated with the old ones.
 
+### Detecting + remediating a mismatched native-faucet registry row
+
+`admin_registerNativeFaucet` now validates caller-supplied metadata against the
+deployed Miden faucet account before writing anything (issue #149): the persisted
++ emitted metadata-hash preimage `abi.encode(name, symbol, decimals)` is taken
+from the faucet account, never from caller-supplied params. This guarantees the
+preimage is reconstructable from authoritative chain state during `--restore`
+(recovery derives its only native-token candidate from the faucet account). A
+mismatched symbol, decimals, or name is rejected up-front with a specific error
+and leaves no registry row.
+
+A row registered by an **older build** may still carry a preimage that does not
+match its deployed faucet account. Recovery does **not** silently guess a
+preimage — an unrecoverable native row halts `--restore` fail-closed (its poison
+leaf). To detect and remediate before that happens:
+
+1. Detect. For each native row (`origin_network` == the proxy's configured
+   `network_id`), compare the stored preimage against the deployed faucet
+   account's authoritative `token_name` / `symbol` / `decimals`:
+
+   ```sql
+   -- stored preimage (hex) per native faucet
+   SELECT faucet_id, symbol, origin_decimals, encode(metadata,'hex')
+   FROM faucet_registry
+   WHERE origin_network = <configured network_id>;
+   ```
+
+   Read the faucet account's authoritative metadata from Miden (the same
+   `token_name()` / `symbol()` / `decimals()` the proxy reads at registration),
+   ABI-encode `(name, symbol, decimals)`, and confirm its `keccak256` equals the
+   faucet's on-chain `MetadataHash`. A row whose stored preimage keccak differs
+   from the deployed faucet's hash is mismatched.
+
+2. Remediate. Re-register the faucet against its deployed account so the row and
+   the emitted bridge metadata are rewritten from authoritative state. Because a
+   custom `name != symbol` is valid, supply the faucet's actual name (or omit
+   `name` to adopt it) — never normalize it to the symbol. Recovery must not
+   reconstruct history by guessing; the only safe source is the deployed faucet
+   account.
+
 ## 4. Incident procedures
 
 ### Node outage or `/health` 503

--- a/scripts/e2e-cantina13-metadata-recovery.sh
+++ b/scripts/e2e-cantina13-metadata-recovery.sh
@@ -439,16 +439,26 @@ pass "DB backed up ($(wc -c < "$BACKUP") bytes → $BACKUP)"
 # reuses rows that already exist in the full suite — no extra registration, no separate
 # proxy-only reset (PR #150 re-review). If either row is absent (cantina13 run outside
 # the full suite), SKIP — the assertion is only meaningful with the prior tiers present.
-_s149_row() { pg "SELECT faucet_id||'|'||origin_network||'|'||encode(origin_address,'hex')||'|'||symbol||'|'||origin_decimals||'|'||encode(metadata,'hex') FROM faucet_registry WHERE $1 ORDER BY faucet_id LIMIT 1"; }
-S149_NATIVE_ROW=$(_s149_row "symbol='WMDN'")
+# FULL identity: faucet_id | origin_network | origin_address | symbol |
+# origin_decimals | miden_decimals | scale | metadata-preimage — miden_decimals
+# and scale included so a restore with wrong CONVERSION params can't pass (PR #150).
+_s149_row() { pg "SELECT faucet_id||'|'||origin_network||'|'||encode(origin_address,'hex')||'|'||symbol||'|'||origin_decimals||'|'||miden_decimals||'|'||scale||'|'||encode(metadata,'hex') FROM faucet_registry WHERE $1 ORDER BY faucet_id LIMIT 1"; }
+# Constrain the native custom-name capture to the NATIVE route (origin_network ==
+# the proxy's own net id): symbol='WMDN' alone could select a foreign-origin WMDN
+# row on a warm/shared stack and prove survival of the WRONG route (PR #150).
+S149_NATIVE_ROW=$(_s149_row "symbol='WMDN' AND origin_network=${LOCAL_NETWORK_ID}")
 S149_NET2_ROW=$(_s149_row "origin_network=2")
 if [[ -n "$S149_NATIVE_ROW" && -n "$S149_NET2_ROW" ]]; then
     S149_CHECK=1
     S149_NATIVE_FID="${S149_NATIVE_ROW%%|*}"; S149_NET2_FID="${S149_NET2_ROW%%|*}"
     pass "#149 restore-survival PRE: captured native custom-name row (WMDN $S149_NATIVE_FID) + net-2 row ($S149_NET2_FID)"
+elif [[ "${REQUIRE_S149_RESTORE:-0}" == "1" ]]; then
+    # In the full overlay suite the prior L2L2/native phases MUST have created both
+    # rows; a regression there must FAIL the release gate, not silently skip (PR #150).
+    fail "#149 restore-survival: REQUIRE_S149_RESTORE=1 but a prerequisite row is absent (native WMDN net=$LOCAL_NETWORK_ID: ${S149_NATIVE_ROW:-<none>} | net-2: ${S149_NET2_ROW:-<none>}) — a prior phase regressed"
 else
     S149_CHECK=0
-    log "#149 restore-survival: SKIP — no WMDN native and/or net-2 row present (cantina13 run outside the full suite)"
+    log "#149 restore-survival: SKIP — no WMDN native and/or net-2 row present (standalone cantina13, REQUIRE_S149_RESTORE unset)"
 fi
 
 # finding #65 — we deliberately do NOT preserve the proxy's per-signer nonce tables.

--- a/scripts/e2e-cantina13-metadata-recovery.sh
+++ b/scripts/e2e-cantina13-metadata-recovery.sh
@@ -446,8 +446,14 @@ _s149_row() { pg "SELECT faucet_id||'|'||origin_network||'|'||encode(origin_addr
 # Constrain the native custom-name capture to the NATIVE route (origin_network ==
 # the proxy's own net id): symbol='WMDN' alone could select a foreign-origin WMDN
 # row on a warm/shared stack and prove survival of the WRONG route (PR #150).
-S149_NATIVE_ROW=$(_s149_row "symbol='WMDN' AND origin_network=${LOCAL_NETWORK_ID}")
-S149_NET2_ROW=$(_s149_row "origin_network=2")
+# REQUIRE non-empty metadata (octet_length > 0): a row whose preimage is empty
+# would still yield a non-empty _s149_row tuple, and the POST equality would accept
+# empty->empty — a false-green that never exercises recovery of the preimage (for
+# net-2, recovery from its OWN network RPC, finding #62). An empty-metadata row is
+# treated as ABSENT here, so the absent-row policy below (fail if REQUIRE, else skip)
+# applies (PR #150 re-review).
+S149_NATIVE_ROW=$(_s149_row "symbol='WMDN' AND origin_network=${LOCAL_NETWORK_ID} AND octet_length(metadata) > 0")
+S149_NET2_ROW=$(_s149_row "origin_network=2 AND octet_length(metadata) > 0")
 if [[ -n "$S149_NATIVE_ROW" && -n "$S149_NET2_ROW" ]]; then
     S149_CHECK=1
     S149_NATIVE_FID="${S149_NATIVE_ROW%%|*}"; S149_NET2_FID="${S149_NET2_ROW%%|*}"
@@ -455,7 +461,7 @@ if [[ -n "$S149_NATIVE_ROW" && -n "$S149_NET2_ROW" ]]; then
 elif [[ "${REQUIRE_S149_RESTORE:-0}" == "1" ]]; then
     # In the full overlay suite the prior L2L2/native phases MUST have created both
     # rows; a regression there must FAIL the release gate, not silently skip (PR #150).
-    fail "#149 restore-survival: REQUIRE_S149_RESTORE=1 but a prerequisite row is absent (native WMDN net=$LOCAL_NETWORK_ID: ${S149_NATIVE_ROW:-<none>} | net-2: ${S149_NET2_ROW:-<none>}) — a prior phase regressed"
+    fail "#149 restore-survival: REQUIRE_S149_RESTORE=1 but a prerequisite row is absent or has empty metadata (native WMDN net=$LOCAL_NETWORK_ID: ${S149_NATIVE_ROW:-<none>} | net-2: ${S149_NET2_ROW:-<none>}) — a prior phase regressed"
 else
     S149_CHECK=0
     log "#149 restore-survival: SKIP — no WMDN native and/or net-2 row present (standalone cantina13, REQUIRE_S149_RESTORE unset)"

--- a/scripts/e2e-cantina13-metadata-recovery.sh
+++ b/scripts/e2e-cantina13-metadata-recovery.sh
@@ -430,6 +430,27 @@ docker exec "$PG_CONTAINER" pg_dump -U agglayer agglayer_store > "$BACKUP" 2>/de
 [[ -s "$BACKUP" ]] || fail "DB backup failed (empty dump) — refusing to drop without a backup"
 pass "DB backed up ($(wc -c < "$BACKUP") bytes → $BACKUP)"
 
+# ── #149 restore-survival PRE-capture (reuses existing full-suite rows) ────────────────
+# Before the from-scratch DROP + --restore, snapshot a native CUSTOM-NAME row and a
+# network-2 row so we can prove they SURVIVE recovery with FULL identity
+# (faucet_id | origin_network | origin_address | symbol | origin_decimals | preimage).
+# The native custom-name (WMDN, name != symbol) row comes from e2e-miden-origin.sh's
+# custom-name faucet (step 1d); a net-2 (L2B-origin) row comes from the l2l2 tier. This
+# reuses rows that already exist in the full suite — no extra registration, no separate
+# proxy-only reset (PR #150 re-review). If either row is absent (cantina13 run outside
+# the full suite), SKIP — the assertion is only meaningful with the prior tiers present.
+_s149_row() { pg "SELECT faucet_id||'|'||origin_network||'|'||encode(origin_address,'hex')||'|'||symbol||'|'||origin_decimals||'|'||encode(metadata,'hex') FROM faucet_registry WHERE $1 ORDER BY faucet_id LIMIT 1"; }
+S149_NATIVE_ROW=$(_s149_row "symbol='WMDN'")
+S149_NET2_ROW=$(_s149_row "origin_network=2")
+if [[ -n "$S149_NATIVE_ROW" && -n "$S149_NET2_ROW" ]]; then
+    S149_CHECK=1
+    S149_NATIVE_FID="${S149_NATIVE_ROW%%|*}"; S149_NET2_FID="${S149_NET2_ROW%%|*}"
+    pass "#149 restore-survival PRE: captured native custom-name row (WMDN $S149_NATIVE_FID) + net-2 row ($S149_NET2_FID)"
+else
+    S149_CHECK=0
+    log "#149 restore-survival: SKIP — no WMDN native and/or net-2 row present (cantina13 run outside the full suite)"
+fi
+
 # finding #65 — we deliberately do NOT preserve the proxy's per-signer nonce tables.
 # The proxy IS the synthetic L2, so DROP SCHEMA legitimately resets its `nonces` /
 # `nonce_reservations` to 0 on the from-scratch rebuild — that is correct, not a bug to
@@ -480,6 +501,38 @@ wait_for "bridge-service resynced + reachable after recovery" \
     "[[ \$(curl -s -m3 -o /dev/null -w '%{http_code}' $BRIDGE_SERVICE_URL/ 2>/dev/null) =~ ^(200|404)$ ]]" \
     180 5
 pass "bridge-service resynced — re-migrated, re-fetches sponsor nonce 0 from the recovered proxy"
+
+# ── #149 restore-survival POST: both rows survived recovery with full identity ────────
+# The from-scratch --restore rebuilds every faucet_registry row from authoritative
+# on-chain state. Assert the captured native custom-name row AND net-2 row survive with
+# a BYTE-IDENTICAL identity string (same faucet_id / origin_network / origin_address /
+# symbol / origin_decimals / metadata preimage) — this is the explicit native + net-2
+# registry-row acceptance criterion (PR #150 re-review, blocker 1: prove native ROUTE
+# identity, not just that some row exists). name != symbol preservation is checked too.
+if [[ "${S149_CHECK:-0}" == "1" ]]; then
+    S149_POST_NATIVE=""; S149_POST_NET2=""
+    for _i in $(seq 1 60); do
+        S149_POST_NATIVE=$(_s149_row "faucet_id='$S149_NATIVE_FID'")
+        S149_POST_NET2=$(_s149_row "faucet_id='$S149_NET2_FID'")
+        [[ -n "$S149_POST_NATIVE" && -n "$S149_POST_NET2" ]] && break
+        sleep 3
+    done
+    [[ -n "$S149_POST_NATIVE" ]] || fail "#149 restore-survival: native custom-name row ($S149_NATIVE_FID) did NOT survive --restore"
+    [[ "$S149_POST_NATIVE" == "$S149_NATIVE_ROW" ]] \
+        || fail "#149 restore-survival: native row identity/preimage CHANGED across restore — pre=[$S149_NATIVE_ROW] post=[$S149_POST_NATIVE]"
+    [[ -n "$S149_POST_NET2" ]] || fail "#149 restore-survival: network-2 row ($S149_NET2_FID) did NOT survive --restore"
+    [[ "$S149_POST_NET2" == "$S149_NET2_ROW" ]] \
+        || fail "#149 restore-survival: net-2 row identity/preimage CHANGED across restore — pre=[$S149_NET2_ROW] post=[$S149_POST_NET2]"
+    # name != symbol preserved: the WMDN preimage is abi.encode("Wrapped Midnight","WMDN",8)
+    # (e2e-miden-origin.sh CUSTOM_NAME/CUSTOM_SYMBOL); its name-hex must be present in the
+    # recovered preimage AND differ from the symbol-hex (proving it was not normalized).
+    S149_NAME_HEX=$(python3 -c "print('Wrapped Midnight'.encode().hex())")
+    S149_SYM_HEX=$(python3 -c "print('WMDN'.encode().hex())")
+    S149_POST_META="${S149_POST_NATIVE##*|}"
+    [[ "$S149_POST_META" == *"$S149_NAME_HEX"* && "$S149_NAME_HEX" != "$S149_SYM_HEX" ]] \
+        || fail "#149 restore-survival: recovered native preimage lost the custom name 'Wrapped Midnight' (name != symbol not preserved)"
+    pass "#149 restore-survival: native custom-name row (name != symbol) AND net-2 row survived --restore with identical origin_network / origin_address / symbol / decimals + byte-identical preimage"
+fi
 
 # After the rebuild the leaf's REAL metadata recovers (correct origin from on-chain →
 # L1 name()/symbol()/decimals()) → the REAL BridgeEvent emits at its reserved index →

--- a/scripts/e2e-miden-origin.sh
+++ b/scripts/e2e-miden-origin.sh
@@ -126,6 +126,84 @@ done
   || fail "native faucet origin_network='$NATIVE_NET', expected $MIDEN_NETWORK_ID (proxy must record the CONFIGURED net id)"
 pass "proxy allowlisted native faucet on the bridge (origin_network=$MIDEN_NETWORK_ID)"
 
+# ── 1c. #149 — registration validates against the deployed faucet account ─────
+# The deployed MDN faucet is authoritative (symbol=MDN, decimals=8). A registration
+# whose metadata DIFFERS from the faucet account must be REJECTED before any state
+# change, so recovery never has to reconstruct an unreconstructable preimage. Use a
+# FRESH origin address each time (idempotency keys on (origin_address, net) — a repeat
+# on the SAME origin would short-circuit and return the existing route without
+# validating). Assert: JSON-RPC error with the specific reason AND no registry row.
+step "1c. #149: mismatched native-faucet metadata is rejected before any state change"
+_reg_mismatch() { # $1=symbol $2=decimals $3=origin_addr  -> echoes the JSON response
+  curl -s "$L2_RPC" -H "Content-Type: application/json" -H "$ADMIN_BEARER" -d "{
+    \"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"admin_registerNativeFaucet\",
+    \"params\":[{\"faucet_id\":\"$NATIVE_FAUCET_ID\",\"origin_token_address\":\"$3\",
+      \"symbol\":\"$1\",\"decimals\":$2}]}" 2>/dev/null
+}
+BAD_SYM_ORIGIN="0x0bad51$(python3 -c "import secrets;print(secrets.token_hex(17))")"
+BAD_DEC_ORIGIN="0x0badde$(python3 -c "import secrets;print(secrets.token_hex(17))")"
+BAD_NAME_ORIGIN="0x0bad1a$(python3 -c "import secrets;print(secrets.token_hex(17))")"
+# wrong symbol
+RESP=$(_reg_mismatch "WRONG" 8 "$BAD_SYM_ORIGIN")
+echo "$RESP" | grep -qi 'symbol mismatch' \
+  || fail "#149: wrong-symbol registration should error 'symbol mismatch', got: $RESP"
+[[ -z "$(pgq "SELECT 1 FROM faucet_registry WHERE lower(origin_address)=lower('${BAD_SYM_ORIGIN#0x}') OR lower(origin_address)=lower('$BAD_SYM_ORIGIN');")" ]] \
+  || fail "#149: wrong-symbol registration must leave NO registry row"
+# wrong decimals
+RESP=$(_reg_mismatch "MDN" 6 "$BAD_DEC_ORIGIN")
+echo "$RESP" | grep -qi 'decimals mismatch' \
+  || fail "#149: wrong-decimals registration should error 'decimals mismatch', got: $RESP"
+# wrong (non-matching) explicit name
+RESP=$(curl -s "$L2_RPC" -H "Content-Type: application/json" -H "$ADMIN_BEARER" -d "{
+  \"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"admin_registerNativeFaucet\",
+  \"params\":[{\"faucet_id\":\"$NATIVE_FAUCET_ID\",\"origin_token_address\":\"$BAD_NAME_ORIGIN\",
+    \"symbol\":\"MDN\",\"decimals\":8,\"name\":\"Not The Real Name\"}]}" 2>/dev/null)
+echo "$RESP" | grep -qi 'name mismatch' \
+  || fail "#149: wrong-name registration should error 'name mismatch', got: $RESP"
+pass "#149: mismatched symbol/decimals/name each rejected before any state change (no registry rows)"
+
+# ── 1d. #149 — a custom-name (name != symbol) faucet is preserved exactly ──────
+# Deploy a SECOND native faucet whose on-chain token NAME differs from its symbol
+# (--native-name), register it with `name` OMITTED so the proxy ADOPTS the authoritative
+# on-chain name, and assert the persisted metadata preimage carries the custom name
+# (never normalized to the symbol) — so its keccak hash is reconstructable on restore.
+step "1d. #149: custom-name (name != symbol) native faucet — name adopted + preserved"
+CUSTOM_NAME="Wrapped Midnight"
+CUSTOM_SYMBOL="WMDN"
+_cn_log="$(mktemp)"
+iso_tool --create-native-faucet --native-name "$CUSTOM_NAME" --native-symbol "$CUSTOM_SYMBOL" \
+    --native-decimals 8 --mint-units 0 --wallet-id "$WALLET_ID" > "$_cn_log" 2>&1 || true
+CUSTOM_FAUCET_ID=$(awk '/faucet-id:/{print $NF}' "$_cn_log")
+[[ -n "$CUSTOM_FAUCET_ID" ]] || { cat "$_cn_log"; rm -f "$_cn_log"; fail "#149: custom-name faucet deploy failed"; }
+rm -f "$_cn_log"
+CUSTOM_ORIGIN="0x0c0574$(python3 -c "import secrets;print(secrets.token_hex(17))")"
+# Register with name OMITTED — the proxy must adopt the on-chain name "Wrapped Midnight".
+RESP=$(curl -sf "$L2_RPC" -H "Content-Type: application/json" -H "$ADMIN_BEARER" -d "{
+  \"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"admin_registerNativeFaucet\",
+  \"params\":[{\"faucet_id\":\"$CUSTOM_FAUCET_ID\",\"origin_token_address\":\"$CUSTOM_ORIGIN\",
+    \"symbol\":\"$CUSTOM_SYMBOL\",\"decimals\":8}]}" 2>/dev/null) \
+  || fail "#149: custom-name registration (name omitted) should SUCCEED, got: $RESP"
+echo "$RESP" | python3 -c "import json,sys; sys.exit(0 if 'result' in json.load(sys.stdin) else 1)" \
+  || fail "#149: custom-name registration returned no result: $RESP"
+# Poll for the persisted metadata preimage, then assert it carries the custom NAME
+# (never collapsed to the symbol). The preimage is abi.encode(name, symbol, decimals),
+# so the UTF-8 bytes of both strings appear in it; name_hex must be present AND differ
+# from symbol_hex (proving name != symbol was preserved, not normalized).
+NAME_HEX=$(python3 -c "print('$CUSTOM_NAME'.encode().hex())")
+SYMBOL_HEX=$(python3 -c "print('$CUSTOM_SYMBOL'.encode().hex())")
+META_HEX=""
+for _i in $(seq 1 40); do
+    META_HEX=$(pgq "SELECT encode(metadata,'hex') FROM faucet_registry WHERE lower(faucet_id)=lower('$CUSTOM_FAUCET_ID');")
+    [[ -n "$META_HEX" && "$META_HEX" == *"$NAME_HEX"* ]] && break
+    sleep 3
+done
+[[ -n "$META_HEX" ]] || fail "#149: custom-name faucet_registry.metadata never persisted"
+[[ "$META_HEX" == *"$NAME_HEX"* ]] \
+  || fail "#149: persisted preimage must contain the custom name '$CUSTOM_NAME' (name_hex=$NAME_HEX); got metadata=$META_HEX"
+[[ "$NAME_HEX" != "$SYMBOL_HEX" ]] \
+  || fail "#149: test setup error — custom name must differ from symbol"
+pass "#149: custom name '$CUSTOM_NAME' (!= symbol '$CUSTOM_SYMBOL') adopted + preserved in the metadata preimage"
+
 # ── 2. Bridge OUT Miden -> L2B (bridge locks the native asset) ────────────────
 step "2. Bridge out $OUT_UNITS native MDN Miden -> $DEST_LABEL (bridge LOCKS; proxy emits originNetwork=$MIDEN_NETWORK_ID)"
 # Bridge OUT to a FRESH funded account whose key we KEEP, so step 4 can approve + bridge
@@ -230,6 +308,92 @@ WRAPPED_SUPPLY=$(cast call "$WRAPPED_L2B" "totalSupply()(uint256)" --rpc-url "$D
 [[ "${WRAPPED_SUPPLY:-0}" -eq 0 ]] \
     || fail "wrapped native-Miden supply on L2B = $WRAPPED_SUPPLY, expected 0 (not fully burned)"
 pass "NET-ZERO: native holder = $NATIVE_BAL units; wrapped $DEST_LABEL supply = 0"
+
+# ── 1e. #149 — --restore preserves the native custom-name row AND a network-2 row ─
+# The restore side of #149: a custom-name (name != symbol) native faucet's metadata
+# preimage must be reconstructable from authoritative chain state after DB loss (it is,
+# because #149 persists the authoritative name), and multi-network recovery must rebuild
+# a network-2 (L2B-origin) row too. Register a net-2 token, drop + rebuild the proxy
+# store from on-chain (same runbook as e2e-cantina13-metadata-recovery.sh), and assert
+# BOTH rows survive with byte-identical metadata preimages. l2b-only (net-2 needs L2B).
+if [[ "$DEST" == "l2b" && "${RUN_1E_RESTORE:-0}" == "1" ]]; then
+    # 1e does a destructive drop + --reset-miden-store --restore. That must NOT run
+    # inside a looped/regression gate (it resets the shared stack mid-suite and any
+    # test after it on the same stack starts degraded). Gated behind RUN_1E_RESTORE=1
+    # so the gate runs it EXACTLY ONCE, as the final step, on an otherwise-quiet stack.
+    # Its assertions read faucet_registry via psql, which survives regardless.
+    step "1e. #149: drop + --restore preserves the native custom-name row AND a network-2 row"
+
+    # Add a network-2 (L2B-origin) wrapped-token row so a net-2 identity exists to recover.
+    NET2_ORIGIN="0x0e2b02$(python3 -c "import secrets;print(secrets.token_hex(17))")"
+    RESP=$(curl -sf "$L2_RPC" -H "Content-Type: application/json" -H "$ADMIN_BEARER" -d "{
+      \"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"admin_registerFaucet\",
+      \"params\":[{\"symbol\":\"L2BT\",\"origin_token_address\":\"$NET2_ORIGIN\",
+        \"origin_network\":2,\"origin_decimals\":6}]}" 2>/dev/null) \
+      || fail "#149/1e: admin_registerFaucet (net-2) unreachable: $RESP"
+    NET2_FAUCET_ID=""
+    for _i in $(seq 1 40); do
+        NET2_FAUCET_ID=$(pgq "SELECT faucet_id FROM faucet_registry WHERE origin_network=2 AND (lower(origin_address)=lower('${NET2_ORIGIN#0x}') OR lower(origin_address)=lower('$NET2_ORIGIN'));")
+        [[ -n "$NET2_FAUCET_ID" ]] && break
+        sleep 3
+    done
+    [[ -n "$NET2_FAUCET_ID" ]] || fail "#149/1e: network-2 registry row never created (net-2 registration failed: $RESP)"
+    pass "1e PRE: network-2 (L2B-origin) token registered: faucet=$NET2_FAUCET_ID"
+
+    # Capture PRE metadata preimages for BOTH rows (WMDN native custom-name from 1d + net-2).
+    PRE_NATIVE_META=$(pgq "SELECT encode(metadata,'hex') FROM faucet_registry WHERE lower(faucet_id)=lower('$CUSTOM_FAUCET_ID');")
+    PRE_NET2_META=$(pgq "SELECT encode(metadata,'hex') FROM faucet_registry WHERE lower(faucet_id)=lower('$NET2_FAUCET_ID');")
+    [[ -n "$PRE_NATIVE_META" && -n "$PRE_NET2_META" ]] \
+      || fail "#149/1e: PRE metadata missing (native=$PRE_NATIVE_META net2=$PRE_NET2_META)"
+    WMDN_NAME_HEX=$(python3 -c "print('$CUSTOM_NAME'.encode().hex())")
+
+    # Drop + rebuild the proxy store from on-chain — identical runbook to cantina13.
+    E2E_COMPOSE=(docker compose -f "$PROJECT_DIR/docker-compose.e2e.yml" -f "$PROJECT_DIR/docker-compose.l2l2.yml" --env-file "$FIXTURES_DIR/.env")
+    PG_CONTAINER="${PG_CONTAINER:-${COMPOSE_PROJECT_NAME}-agglayer-postgres-1}"
+    BASE_ARGS=$(docker inspect -f '{{range .Args}}{{.}} {{end}}' "$AGGLAYER_CONTAINER")
+    echo "$BASE_ARGS" | grep -q 'network-rpc-url=2=' \
+      || fail "#149/1e: proxy BASE_ARGS missing --network-rpc-url=2 (net-2 metadata recovery needs it)"
+
+    BACKUP="/tmp/agglayer_store.miden-origin-1e.$$.sql"
+    docker exec "$PG_CONTAINER" pg_dump -U agglayer agglayer_store > "$BACKUP" 2>/dev/null
+    [[ -s "$BACKUP" ]] || fail "#149/1e: DB backup failed (empty) — refusing to drop without a backup"
+
+    MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-x}" MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-x}" "${E2E_COMPOSE[@]}" stop miden-agglayer >/dev/null 2>&1
+    pgq "DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO agglayer;" >/dev/null
+    pass "1e: proxy store DROPPED (from scratch)"
+
+    RESTORE_LOG=$(mktemp); set +e
+    MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-x}" MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-x}" "${E2E_COMPOSE[@]}" \
+        run --rm --no-deps miden-agglayer $BASE_ARGS --reset-miden-store --restore > "$RESTORE_LOG" 2>&1
+    RESTORE_RC=$?; set -e
+    [[ "$RESTORE_RC" -eq 0 ]] || { tail -30 "$RESTORE_LOG" >&2; fail "#149/1e: restore-from-scratch exited $RESTORE_RC"; }
+    grep -q 'RESTORE: complete' "$RESTORE_LOG" || { tail -30 "$RESTORE_LOG" >&2; fail "#149/1e: restore did not complete"; }
+    MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-x}" MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-x}" "${E2E_COMPOSE[@]}" start miden-agglayer >/dev/null 2>&1
+    wait_for "proxy healthy after 1e rebuild" \
+        "[[ \$(docker inspect -f '{{.State.Health.Status}}' $AGGLAYER_CONTAINER 2>/dev/null) == healthy ]]" 180 3
+    pass "1e: store rebuilt from on-chain"
+
+    # POST: BOTH rows survive with byte-identical metadata preimages (name != symbol
+    # preserved on the native row). Restore rebuilds faucet identities + metadata eagerly
+    # (rebuild_faucet_entry_from_chain), so poll for the rows then compare.
+    POST_NATIVE_META=""; POST_NET2_META=""
+    for _i in $(seq 1 60); do
+        POST_NATIVE_META=$(pgq "SELECT encode(metadata,'hex') FROM faucet_registry WHERE lower(faucet_id)=lower('$CUSTOM_FAUCET_ID');")
+        POST_NET2_META=$(pgq "SELECT encode(metadata,'hex') FROM faucet_registry WHERE lower(faucet_id)=lower('$NET2_FAUCET_ID') AND origin_network=2;")
+        [[ -n "$POST_NATIVE_META" && -n "$POST_NET2_META" ]] && break
+        sleep 3
+    done
+    [[ -n "$POST_NATIVE_META" ]] || fail "#149/1e: native custom-name row ($CUSTOM_FAUCET_ID) did NOT survive restore"
+    [[ "$POST_NATIVE_META" == "$PRE_NATIVE_META" ]] \
+      || fail "#149/1e: native custom-name preimage CHANGED across restore (pre=$PRE_NATIVE_META post=$POST_NATIVE_META)"
+    [[ "$POST_NATIVE_META" == *"$WMDN_NAME_HEX"* ]] \
+      || fail "#149/1e: recovered native preimage lost the custom name '$CUSTOM_NAME' (name_hex=$WMDN_NAME_HEX)"
+    [[ -n "$POST_NET2_META" ]] || fail "#149/1e: network-2 row ($NET2_FAUCET_ID) did NOT survive restore"
+    [[ "$POST_NET2_META" == "$PRE_NET2_META" ]] \
+      || fail "#149/1e: network-2 preimage CHANGED across restore (pre=$PRE_NET2_META post=$POST_NET2_META)"
+    rm -f "$BACKUP" "$RESTORE_LOG"
+    pass "1e: --restore preserved BOTH the native custom-name row (name != symbol) AND the network-2 row with byte-identical metadata preimages"
+fi
 
 log "======================================================================"
 log "  MIDEN-ORIGINATED ROUND-TRIP PASS — native lock/unlock, exact-block, net-zero"

--- a/scripts/e2e-miden-origin.sh
+++ b/scripts/e2e-miden-origin.sh
@@ -146,7 +146,14 @@ BAD_NAME_ORIGIN="0x0bad1a$(python3 -c "import secrets;print(secrets.token_hex(17
 # origin_address is BYTEA: `lower(origin_address)` is an invalid Postgres call that
 # pgq suppresses → empty output → a FALSE-GREEN "no row" even if one exists (PR #150
 # review). Compare `encode(origin_address,'hex')` against the hex origin instead.
-_no_registry_row() { [[ -z "$(pgq "SELECT 1 FROM faucet_registry WHERE encode(origin_address,'hex')=lower('${1#0x}');")" ]]; }
+# A rejected registration must leave EXACTLY zero rows. Use COUNT(*) and require it
+# to equal "0": a pgq/connection/query error (stderr suppressed) yields a nonzero
+# exit or empty output — both must FAIL, not silently pass a `-z` check (PR #150).
+_no_registry_row() {
+  local n
+  n=$(pgq "SELECT COUNT(*) FROM faucet_registry WHERE encode(origin_address,'hex')=lower('${1#0x}');") || return 1
+  [[ "$n" == "0" ]]
+}
 # wrong symbol → 'symbol mismatch', and NO registry row
 RESP=$(_reg_mismatch "WRONG" 8 "$BAD_SYM_ORIGIN")
 echo "$RESP" | grep -qi 'symbol mismatch' \
@@ -165,10 +172,23 @@ RESP=$(curl -s "$L2_RPC" -H "Content-Type: application/json" -H "$ADMIN_BEARER" 
 echo "$RESP" | grep -qi 'name mismatch' \
   || fail "#149: wrong-name registration should error 'name mismatch', got: $RESP"
 _no_registry_row "$BAD_NAME_ORIGIN" || fail "#149: wrong-name registration must leave NO registry row"
-# No-bridge-metadata side: register_faucet_in_bridge runs only AFTER validation passes,
-# so a rejected registration also emits NO ConfigAggBridgeNote — unit-proven by
-# native_registration_fails_closed_when_metadata_unreadable (test_call_count()==1).
-pass "#149: mismatched symbol/decimals/name each rejected before any state change — NO registry row for any (+ no bridge metadata, unit-proven)"
+# No-bridge-note EVIDENCE (PR #150 re-review): register_faucet_in_bridge (the
+# ConfigAggBridgeNote) runs only AFTER validation passes. To prove the ON-CHAIN
+# config/token map has no entry for these origins (not merely that the direct
+# store-write was skipped), wait one full faucet-reconciler cycle (default 30s
+# poll) and re-assert NO row: the reconciler reads the bridge's on-chain config
+# and materializes a store row for ANY note it finds, so a row appearing here
+# would mean a config note WAS emitted for a rejected origin.
+sleep 35
+_no_registry_row "$BAD_SYM_ORIGIN"  || fail "#149: wrong-symbol registration emitted an on-chain bridge config note (row appeared after a reconciler poll)"
+_no_registry_row "$BAD_DEC_ORIGIN"  || fail "#149: wrong-decimals registration emitted an on-chain bridge config note (row appeared after a reconciler poll)"
+_no_registry_row "$BAD_NAME_ORIGIN" || fail "#149: wrong-name registration emitted an on-chain bridge config note (row appeared after a reconciler poll)"
+# So the no-row assertions above (COUNT(*) == 0, error-safe, post-reconciler-poll)
+# evidence that no bridge configuration was emitted for these origins. The
+# per-field mismatch REJECTION is unit-tested directly (native_metadata_*_mismatch_*
+# on resolve_native_faucet_metadata, the sole validation gate the endpoint calls via
+# `?` before any bridge/store write).
+pass "#149: mismatched symbol/decimals/name each rejected before any state change — NO registry row for any (⇒ no bridge config emitted)"
 
 # ── 1d. #149 — a custom-name (name != symbol) faucet is preserved exactly ──────
 # Deploy a SECOND native faucet whose on-chain token NAME differs from its symbol
@@ -211,30 +231,10 @@ done
 [[ "$NAME_HEX" != "$SYMBOL_HEX" ]] \
   || fail "#149: test setup error — custom name must differ from symbol"
 pass "#149: custom name '$CUSTOM_NAME' (!= symbol '$CUSTOM_SYMBOL') adopted + preserved in the metadata preimage"
-
-# ── 1e-PRE: register the network-2 row EARLY (while the miden client is FRESH) ──
-# The restore-survival assertion (step 1e, gated by RUN_1E_RESTORE) needs a net-2
-# (L2B-origin) registry row to prove multi-network recovery. Register it HERE,
-# before the native round-trip — NOT mid-1e — because admin_registerFaucet(net-2)
-# after the round-trip trips a miden-client-worker death (finding #76, unrelated
-# to #149's admin_registerNativeFaucet path). On a fresh client it registers
-# cleanly (as e2e-l2l2-forward.sh does).
-if [[ "$DEST" == "l2b" && "${RUN_1E_RESTORE:-0}" == "1" ]]; then
-    NET2_ORIGIN="0x0e2b02$(python3 -c "import secrets;print(secrets.token_hex(17))")"
-    RESP=$(curl -sf "$L2_RPC" -H "Content-Type: application/json" -H "$ADMIN_BEARER" -d "{
-      \"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"admin_registerFaucet\",
-      \"params\":[{\"symbol\":\"L2BT\",\"origin_token_address\":\"$NET2_ORIGIN\",
-        \"origin_network\":2,\"origin_decimals\":6}]}" 2>/dev/null) \
-      || fail "#149/1e-PRE: admin_registerFaucet (net-2) unreachable: $RESP"
-    NET2_FAUCET_ID=""
-    for _i in $(seq 1 40); do
-        NET2_FAUCET_ID=$(pgq "SELECT faucet_id FROM faucet_registry WHERE origin_network=2 AND encode(origin_address,'hex')=lower('${NET2_ORIGIN#0x}');")
-        [[ -n "$NET2_FAUCET_ID" ]] && break
-        sleep 3
-    done
-    [[ -n "$NET2_FAUCET_ID" ]] || fail "#149/1e-PRE: network-2 registry row never created (net-2 registration failed: $RESP)"
-    pass "1e-PRE: network-2 (L2B-origin) token registered early (fresh client): faucet=$NET2_FAUCET_ID"
-fi
+# The custom-name (WMDN, name != symbol) native row created here is what the
+# restore-survival assertion in e2e-cantina13-metadata-recovery.sh reuses (its
+# coordinated proxy + bridge-service drop+restore proves the row survives). The
+# destructive in-script restore leg was removed per the PR #150 re-review.
 
 # ── 2. Bridge OUT Miden -> L2B (bridge locks the native asset) ────────────────
 step "2. Bridge out $OUT_UNITS native MDN Miden -> $DEST_LABEL (bridge LOCKS; proxy emits originNetwork=$MIDEN_NETWORK_ID)"
@@ -340,79 +340,6 @@ WRAPPED_SUPPLY=$(cast call "$WRAPPED_L2B" "totalSupply()(uint256)" --rpc-url "$D
 [[ "${WRAPPED_SUPPLY:-0}" -eq 0 ]] \
     || fail "wrapped native-Miden supply on L2B = $WRAPPED_SUPPLY, expected 0 (not fully burned)"
 pass "NET-ZERO: native holder = $NATIVE_BAL units; wrapped $DEST_LABEL supply = 0"
-
-# ── 1e. #149 — --restore preserves the native custom-name row AND a network-2 row ─
-# The restore side of #149: a custom-name (name != symbol) native faucet's metadata
-# preimage must be reconstructable from authoritative chain state after DB loss (it is,
-# because #149 persists the authoritative name), and multi-network recovery must rebuild
-# a network-2 (L2B-origin) row too. Register a net-2 token, drop + rebuild the proxy
-# store from on-chain (same runbook as e2e-cantina13-metadata-recovery.sh), and assert
-# BOTH rows survive with byte-identical metadata preimages. l2b-only (net-2 needs L2B).
-if [[ "$DEST" == "l2b" && "${RUN_1E_RESTORE:-0}" == "1" ]]; then
-    # 1e does a destructive drop + --reset-miden-store --restore. That must NOT run
-    # inside a looped/regression gate (it resets the shared stack mid-suite and any
-    # test after it on the same stack starts degraded). Gated behind RUN_1E_RESTORE=1
-    # so the gate runs it EXACTLY ONCE, as the final step, on an otherwise-quiet stack.
-    # Its assertions read faucet_registry via psql, which survives regardless.
-    step "1e. #149: drop + --restore preserves the native custom-name row AND a network-2 row"
-
-    # NET2_FAUCET_ID was registered EARLY (1e-PRE, fresh client) to avoid finding #76.
-    [[ -n "${NET2_FAUCET_ID:-}" ]] || fail "#149/1e: NET2_FAUCET_ID not set (1e-PRE early registration must have run)"
-
-    # Capture PRE metadata preimages for BOTH rows (WMDN native custom-name from 1d + net-2).
-    PRE_NATIVE_META=$(pgq "SELECT encode(metadata,'hex') FROM faucet_registry WHERE lower(faucet_id)=lower('$CUSTOM_FAUCET_ID');")
-    PRE_NET2_META=$(pgq "SELECT encode(metadata,'hex') FROM faucet_registry WHERE lower(faucet_id)=lower('$NET2_FAUCET_ID');")
-    [[ -n "$PRE_NATIVE_META" && -n "$PRE_NET2_META" ]] \
-      || fail "#149/1e: PRE metadata missing (native=$PRE_NATIVE_META net2=$PRE_NET2_META)"
-    WMDN_NAME_HEX=$(python3 -c "print('$CUSTOM_NAME'.encode().hex())")
-
-    # Drop + rebuild the proxy store from on-chain — identical runbook to cantina13.
-    E2E_COMPOSE=(docker compose -f "$PROJECT_DIR/docker-compose.e2e.yml" -f "$PROJECT_DIR/docker-compose.l2l2.yml" --env-file "$FIXTURES_DIR/.env")
-    PG_CONTAINER="${PG_CONTAINER:-${COMPOSE_PROJECT_NAME}-agglayer-postgres-1}"
-    BASE_ARGS=$(docker inspect -f '{{range .Args}}{{.}} {{end}}' "$AGGLAYER_CONTAINER")
-    echo "$BASE_ARGS" | grep -q 'network-rpc-url=2=' \
-      || fail "#149/1e: proxy BASE_ARGS missing --network-rpc-url=2 (net-2 metadata recovery needs it)"
-
-    BACKUP="/tmp/agglayer_store.miden-origin-1e.$$.sql"
-    docker exec "$PG_CONTAINER" pg_dump -U agglayer agglayer_store > "$BACKUP" 2>/dev/null
-    [[ -s "$BACKUP" ]] || fail "#149/1e: DB backup failed (empty) — refusing to drop without a backup"
-
-    MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-x}" MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-x}" "${E2E_COMPOSE[@]}" stop miden-agglayer >/dev/null 2>&1
-    pgq "DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO agglayer;" >/dev/null
-    pass "1e: proxy store DROPPED (from scratch)"
-
-    RESTORE_LOG=$(mktemp); set +e
-    MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-x}" MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-x}" "${E2E_COMPOSE[@]}" \
-        run --rm --no-deps miden-agglayer $BASE_ARGS --reset-miden-store --restore > "$RESTORE_LOG" 2>&1
-    RESTORE_RC=$?; set -e
-    [[ "$RESTORE_RC" -eq 0 ]] || { tail -30 "$RESTORE_LOG" >&2; fail "#149/1e: restore-from-scratch exited $RESTORE_RC"; }
-    grep -q 'RESTORE: complete' "$RESTORE_LOG" || { tail -30 "$RESTORE_LOG" >&2; fail "#149/1e: restore did not complete"; }
-    MIDEN_NODE_GIT_URL="${MIDEN_NODE_GIT_URL:-x}" MIDEN_NODE_GIT_REF="${MIDEN_NODE_GIT_REF:-x}" "${E2E_COMPOSE[@]}" start miden-agglayer >/dev/null 2>&1
-    wait_for "proxy healthy after 1e rebuild" \
-        "[[ \$(docker inspect -f '{{.State.Health.Status}}' $AGGLAYER_CONTAINER 2>/dev/null) == healthy ]]" 180 3
-    pass "1e: store rebuilt from on-chain"
-
-    # POST: BOTH rows survive with byte-identical metadata preimages (name != symbol
-    # preserved on the native row). Restore rebuilds faucet identities + metadata eagerly
-    # (rebuild_faucet_entry_from_chain), so poll for the rows then compare.
-    POST_NATIVE_META=""; POST_NET2_META=""
-    for _i in $(seq 1 60); do
-        POST_NATIVE_META=$(pgq "SELECT encode(metadata,'hex') FROM faucet_registry WHERE lower(faucet_id)=lower('$CUSTOM_FAUCET_ID');")
-        POST_NET2_META=$(pgq "SELECT encode(metadata,'hex') FROM faucet_registry WHERE lower(faucet_id)=lower('$NET2_FAUCET_ID') AND origin_network=2;")
-        [[ -n "$POST_NATIVE_META" && -n "$POST_NET2_META" ]] && break
-        sleep 3
-    done
-    [[ -n "$POST_NATIVE_META" ]] || fail "#149/1e: native custom-name row ($CUSTOM_FAUCET_ID) did NOT survive restore"
-    [[ "$POST_NATIVE_META" == "$PRE_NATIVE_META" ]] \
-      || fail "#149/1e: native custom-name preimage CHANGED across restore (pre=$PRE_NATIVE_META post=$POST_NATIVE_META)"
-    [[ "$POST_NATIVE_META" == *"$WMDN_NAME_HEX"* ]] \
-      || fail "#149/1e: recovered native preimage lost the custom name '$CUSTOM_NAME' (name_hex=$WMDN_NAME_HEX)"
-    [[ -n "$POST_NET2_META" ]] || fail "#149/1e: network-2 row ($NET2_FAUCET_ID) did NOT survive restore"
-    [[ "$POST_NET2_META" == "$PRE_NET2_META" ]] \
-      || fail "#149/1e: network-2 preimage CHANGED across restore (pre=$PRE_NET2_META post=$POST_NET2_META)"
-    rm -f "$BACKUP" "$RESTORE_LOG"
-    pass "1e: --restore preserved BOTH the native custom-name row (name != symbol) AND the network-2 row with byte-identical metadata preimages"
-fi
 
 log "======================================================================"
 log "  MIDEN-ORIGINATED ROUND-TRIP PASS — native lock/unlock, exact-block, net-zero"

--- a/scripts/e2e-miden-origin.sh
+++ b/scripts/e2e-miden-origin.sh
@@ -143,24 +143,32 @@ _reg_mismatch() { # $1=symbol $2=decimals $3=origin_addr  -> echoes the JSON res
 BAD_SYM_ORIGIN="0x0bad51$(python3 -c "import secrets;print(secrets.token_hex(17))")"
 BAD_DEC_ORIGIN="0x0badde$(python3 -c "import secrets;print(secrets.token_hex(17))")"
 BAD_NAME_ORIGIN="0x0bad1a$(python3 -c "import secrets;print(secrets.token_hex(17))")"
-# wrong symbol
+# origin_address is BYTEA: `lower(origin_address)` is an invalid Postgres call that
+# pgq suppresses → empty output → a FALSE-GREEN "no row" even if one exists (PR #150
+# review). Compare `encode(origin_address,'hex')` against the hex origin instead.
+_no_registry_row() { [[ -z "$(pgq "SELECT 1 FROM faucet_registry WHERE encode(origin_address,'hex')=lower('${1#0x}');")" ]]; }
+# wrong symbol → 'symbol mismatch', and NO registry row
 RESP=$(_reg_mismatch "WRONG" 8 "$BAD_SYM_ORIGIN")
 echo "$RESP" | grep -qi 'symbol mismatch' \
   || fail "#149: wrong-symbol registration should error 'symbol mismatch', got: $RESP"
-[[ -z "$(pgq "SELECT 1 FROM faucet_registry WHERE lower(origin_address)=lower('${BAD_SYM_ORIGIN#0x}') OR lower(origin_address)=lower('$BAD_SYM_ORIGIN');")" ]] \
-  || fail "#149: wrong-symbol registration must leave NO registry row"
-# wrong decimals
+_no_registry_row "$BAD_SYM_ORIGIN" || fail "#149: wrong-symbol registration must leave NO registry row"
+# wrong decimals → 'decimals mismatch', and NO registry row
 RESP=$(_reg_mismatch "MDN" 6 "$BAD_DEC_ORIGIN")
 echo "$RESP" | grep -qi 'decimals mismatch' \
   || fail "#149: wrong-decimals registration should error 'decimals mismatch', got: $RESP"
-# wrong (non-matching) explicit name
+_no_registry_row "$BAD_DEC_ORIGIN" || fail "#149: wrong-decimals registration must leave NO registry row"
+# wrong (non-matching) explicit name → 'name mismatch', and NO registry row
 RESP=$(curl -s "$L2_RPC" -H "Content-Type: application/json" -H "$ADMIN_BEARER" -d "{
   \"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"admin_registerNativeFaucet\",
   \"params\":[{\"faucet_id\":\"$NATIVE_FAUCET_ID\",\"origin_token_address\":\"$BAD_NAME_ORIGIN\",
     \"symbol\":\"MDN\",\"decimals\":8,\"name\":\"Not The Real Name\"}]}" 2>/dev/null)
 echo "$RESP" | grep -qi 'name mismatch' \
   || fail "#149: wrong-name registration should error 'name mismatch', got: $RESP"
-pass "#149: mismatched symbol/decimals/name each rejected before any state change (no registry rows)"
+_no_registry_row "$BAD_NAME_ORIGIN" || fail "#149: wrong-name registration must leave NO registry row"
+# No-bridge-metadata side: register_faucet_in_bridge runs only AFTER validation passes,
+# so a rejected registration also emits NO ConfigAggBridgeNote — unit-proven by
+# native_registration_fails_closed_when_metadata_unreadable (test_call_count()==1).
+pass "#149: mismatched symbol/decimals/name each rejected before any state change — NO registry row for any (+ no bridge metadata, unit-proven)"
 
 # ── 1d. #149 — a custom-name (name != symbol) faucet is preserved exactly ──────
 # Deploy a SECOND native faucet whose on-chain token NAME differs from its symbol
@@ -203,6 +211,30 @@ done
 [[ "$NAME_HEX" != "$SYMBOL_HEX" ]] \
   || fail "#149: test setup error — custom name must differ from symbol"
 pass "#149: custom name '$CUSTOM_NAME' (!= symbol '$CUSTOM_SYMBOL') adopted + preserved in the metadata preimage"
+
+# ── 1e-PRE: register the network-2 row EARLY (while the miden client is FRESH) ──
+# The restore-survival assertion (step 1e, gated by RUN_1E_RESTORE) needs a net-2
+# (L2B-origin) registry row to prove multi-network recovery. Register it HERE,
+# before the native round-trip — NOT mid-1e — because admin_registerFaucet(net-2)
+# after the round-trip trips a miden-client-worker death (finding #76, unrelated
+# to #149's admin_registerNativeFaucet path). On a fresh client it registers
+# cleanly (as e2e-l2l2-forward.sh does).
+if [[ "$DEST" == "l2b" && "${RUN_1E_RESTORE:-0}" == "1" ]]; then
+    NET2_ORIGIN="0x0e2b02$(python3 -c "import secrets;print(secrets.token_hex(17))")"
+    RESP=$(curl -sf "$L2_RPC" -H "Content-Type: application/json" -H "$ADMIN_BEARER" -d "{
+      \"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"admin_registerFaucet\",
+      \"params\":[{\"symbol\":\"L2BT\",\"origin_token_address\":\"$NET2_ORIGIN\",
+        \"origin_network\":2,\"origin_decimals\":6}]}" 2>/dev/null) \
+      || fail "#149/1e-PRE: admin_registerFaucet (net-2) unreachable: $RESP"
+    NET2_FAUCET_ID=""
+    for _i in $(seq 1 40); do
+        NET2_FAUCET_ID=$(pgq "SELECT faucet_id FROM faucet_registry WHERE origin_network=2 AND encode(origin_address,'hex')=lower('${NET2_ORIGIN#0x}');")
+        [[ -n "$NET2_FAUCET_ID" ]] && break
+        sleep 3
+    done
+    [[ -n "$NET2_FAUCET_ID" ]] || fail "#149/1e-PRE: network-2 registry row never created (net-2 registration failed: $RESP)"
+    pass "1e-PRE: network-2 (L2B-origin) token registered early (fresh client): faucet=$NET2_FAUCET_ID"
+fi
 
 # ── 2. Bridge OUT Miden -> L2B (bridge locks the native asset) ────────────────
 step "2. Bridge out $OUT_UNITS native MDN Miden -> $DEST_LABEL (bridge LOCKS; proxy emits originNetwork=$MIDEN_NETWORK_ID)"
@@ -324,21 +356,8 @@ if [[ "$DEST" == "l2b" && "${RUN_1E_RESTORE:-0}" == "1" ]]; then
     # Its assertions read faucet_registry via psql, which survives regardless.
     step "1e. #149: drop + --restore preserves the native custom-name row AND a network-2 row"
 
-    # Add a network-2 (L2B-origin) wrapped-token row so a net-2 identity exists to recover.
-    NET2_ORIGIN="0x0e2b02$(python3 -c "import secrets;print(secrets.token_hex(17))")"
-    RESP=$(curl -sf "$L2_RPC" -H "Content-Type: application/json" -H "$ADMIN_BEARER" -d "{
-      \"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"admin_registerFaucet\",
-      \"params\":[{\"symbol\":\"L2BT\",\"origin_token_address\":\"$NET2_ORIGIN\",
-        \"origin_network\":2,\"origin_decimals\":6}]}" 2>/dev/null) \
-      || fail "#149/1e: admin_registerFaucet (net-2) unreachable: $RESP"
-    NET2_FAUCET_ID=""
-    for _i in $(seq 1 40); do
-        NET2_FAUCET_ID=$(pgq "SELECT faucet_id FROM faucet_registry WHERE origin_network=2 AND (lower(origin_address)=lower('${NET2_ORIGIN#0x}') OR lower(origin_address)=lower('$NET2_ORIGIN'));")
-        [[ -n "$NET2_FAUCET_ID" ]] && break
-        sleep 3
-    done
-    [[ -n "$NET2_FAUCET_ID" ]] || fail "#149/1e: network-2 registry row never created (net-2 registration failed: $RESP)"
-    pass "1e PRE: network-2 (L2B-origin) token registered: faucet=$NET2_FAUCET_ID"
+    # NET2_FAUCET_ID was registered EARLY (1e-PRE, fresh client) to avoid finding #76.
+    [[ -n "${NET2_FAUCET_ID:-}" ]] || fail "#149/1e: NET2_FAUCET_ID not set (1e-PRE early registration must have run)"
 
     # Capture PRE metadata preimages for BOTH rows (WMDN native custom-name from 1d + net-2).
     PRE_NATIVE_META=$(pgq "SELECT encode(metadata,'hex') FROM faucet_registry WHERE lower(faucet_id)=lower('$CUSTOM_FAUCET_ID');")

--- a/scripts/e2e-miden-origin.sh
+++ b/scripts/e2e-miden-origin.sh
@@ -173,16 +173,17 @@ echo "$RESP" | grep -qi 'name mismatch' \
   || fail "#149: wrong-name registration should error 'name mismatch', got: $RESP"
 _no_registry_row "$BAD_NAME_ORIGIN" || fail "#149: wrong-name registration must leave NO registry row"
 # The no-row checks above are the store-side evidence. That the bridge
-# ConfigAggBridgeNote is NOT emitted on a mismatch is guaranteed STRUCTURALLY,
-# not by an on-chain probe here: admin_register_native_faucet calls the sole
-# validation gate `resolve_native_faucet_metadata(...)?` BEFORE the
-# register_faucet_in_bridge `.with()` call, so a mismatch (Err) returns before
-# any bridge note or store write. That per-field gate is unit-tested directly
-# (native_metadata_{symbol,decimals,name}_mismatch_rejected). (No reconciler
-# inference: FaucetRegistryReconciler is a tripwire keyed on faucet_id, not
-# origin, and these mismatches reuse the already-registered NATIVE_FAUCET_ID —
-# it cannot evidence a bad-origin note. PR #150 re-review.)
-pass "#149: mismatched symbol/decimals/name each rejected before any state change — NO registry row for any (bridge note skipped: validation Err precedes the register call; unit-tested gate)"
+# ConfigAggBridgeNote is NOT emitted on a mismatch is proven by an EXECUTABLE unit
+# regression: `native_registration_mismatch_skips_bridge_registration` drives a
+# SUCCESSFUL authoritative read followed by a mismatch through
+# `register_native_validated` and asserts the register_faucet_in_bridge `.with()`
+# is NEVER called (miden_client.test_call_count()==0), versus ==1 on a matching
+# control — so a mismatch provably reaches no bridge note (the register `.with()`
+# is conditional on validation passing). Per-field rejection is additionally
+# unit-tested on the pure gate (native_metadata_{symbol,decimals,name}_mismatch_
+# rejected). (No reconciler inference here: FaucetRegistryReconciler is a tripwire
+# keyed on faucet_id, and these mismatches reuse NATIVE_FAUCET_ID. PR #150.)
+pass "#149: mismatched symbol/decimals/name each rejected before any state change — NO registry row for any (bridge note skipped: proven by native_registration_mismatch_skips_bridge_registration, count==0 vs 1)"
 
 # ── 1d. #149 — a custom-name (name != symbol) faucet is preserved exactly ──────
 # Deploy a SECOND native faucet whose on-chain token NAME differs from its symbol

--- a/scripts/e2e-miden-origin.sh
+++ b/scripts/e2e-miden-origin.sh
@@ -172,23 +172,17 @@ RESP=$(curl -s "$L2_RPC" -H "Content-Type: application/json" -H "$ADMIN_BEARER" 
 echo "$RESP" | grep -qi 'name mismatch' \
   || fail "#149: wrong-name registration should error 'name mismatch', got: $RESP"
 _no_registry_row "$BAD_NAME_ORIGIN" || fail "#149: wrong-name registration must leave NO registry row"
-# No-bridge-note EVIDENCE (PR #150 re-review): register_faucet_in_bridge (the
-# ConfigAggBridgeNote) runs only AFTER validation passes. To prove the ON-CHAIN
-# config/token map has no entry for these origins (not merely that the direct
-# store-write was skipped), wait one full faucet-reconciler cycle (default 30s
-# poll) and re-assert NO row: the reconciler reads the bridge's on-chain config
-# and materializes a store row for ANY note it finds, so a row appearing here
-# would mean a config note WAS emitted for a rejected origin.
-sleep 35
-_no_registry_row "$BAD_SYM_ORIGIN"  || fail "#149: wrong-symbol registration emitted an on-chain bridge config note (row appeared after a reconciler poll)"
-_no_registry_row "$BAD_DEC_ORIGIN"  || fail "#149: wrong-decimals registration emitted an on-chain bridge config note (row appeared after a reconciler poll)"
-_no_registry_row "$BAD_NAME_ORIGIN" || fail "#149: wrong-name registration emitted an on-chain bridge config note (row appeared after a reconciler poll)"
-# So the no-row assertions above (COUNT(*) == 0, error-safe, post-reconciler-poll)
-# evidence that no bridge configuration was emitted for these origins. The
-# per-field mismatch REJECTION is unit-tested directly (native_metadata_*_mismatch_*
-# on resolve_native_faucet_metadata, the sole validation gate the endpoint calls via
-# `?` before any bridge/store write).
-pass "#149: mismatched symbol/decimals/name each rejected before any state change — NO registry row for any (⇒ no bridge config emitted)"
+# The no-row checks above are the store-side evidence. That the bridge
+# ConfigAggBridgeNote is NOT emitted on a mismatch is guaranteed STRUCTURALLY,
+# not by an on-chain probe here: admin_register_native_faucet calls the sole
+# validation gate `resolve_native_faucet_metadata(...)?` BEFORE the
+# register_faucet_in_bridge `.with()` call, so a mismatch (Err) returns before
+# any bridge note or store write. That per-field gate is unit-tested directly
+# (native_metadata_{symbol,decimals,name}_mismatch_rejected). (No reconciler
+# inference: FaucetRegistryReconciler is a tripwire keyed on faucet_id, not
+# origin, and these mismatches reuse the already-registered NATIVE_FAUCET_ID —
+# it cannot evidence a bad-origin note. PR #150 re-review.)
+pass "#149: mismatched symbol/decimals/name each rejected before any state change — NO registry row for any (bridge note skipped: validation Err precedes the register call; unit-tested gate)"
 
 # ── 1d. #149 — a custom-name (name != symbol) faucet is preserved exactly ──────
 # Deploy a SECOND native faucet whose on-chain token NAME differs from its symbol

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -88,16 +88,12 @@ case "$test_filter" in
             DEST=l2b "$SCRIPT_DIR/e2e-miden-origin.sh"
             echo ""
             DEST=l1  "$SCRIPT_DIR/e2e-miden-origin.sh"
-            echo ""
-            # #149 restore acceptance: a dedicated one-shot proving a native CUSTOM-NAME
-            # faucet (name != symbol) AND a network-2 row survive a from-scratch drop +
-            # --restore with byte-identical metadata preimages (RUN_1E_RESTORE=1). It is
-            # DESTRUCTIVE (rebuilds the store from chain) so it runs as its own phase,
-            # immediately before cantina13 (which does its own from-scratch restore next,
-            # so back-to-back restores are safe). Without this wiring the restore leg is
-            # dead code — PR #150 review.
-            echo "== #149 native-faucet metadata restore-survival (drop + --restore) =="
-            RUN_1E_RESTORE=1 DEST=l2b "$SCRIPT_DIR/e2e-miden-origin.sh"
+            # #149 restore acceptance (native custom-name row + net-2 row survive
+            # --restore with byte-identical preimages + full identity) is asserted by
+            # cantina13 below, which reuses the WMDN name!=symbol native row created by
+            # the DEST=l2b run above and a net-2 row from the l2l2 tier, and does its own
+            # COORDINATED proxy + bridge-service drop+restore (PR #150 re-review — no
+            # separate destructive proxy-only reset that would wedge cantina13).
         else
             echo "SKIP L2<->L2 + native tiers — L2B overlay not up (base stack). Run 'make e2e-l2l2-up' to include them."
         fi

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -88,6 +88,16 @@ case "$test_filter" in
             DEST=l2b "$SCRIPT_DIR/e2e-miden-origin.sh"
             echo ""
             DEST=l1  "$SCRIPT_DIR/e2e-miden-origin.sh"
+            echo ""
+            # #149 restore acceptance: a dedicated one-shot proving a native CUSTOM-NAME
+            # faucet (name != symbol) AND a network-2 row survive a from-scratch drop +
+            # --restore with byte-identical metadata preimages (RUN_1E_RESTORE=1). It is
+            # DESTRUCTIVE (rebuilds the store from chain) so it runs as its own phase,
+            # immediately before cantina13 (which does its own from-scratch restore next,
+            # so back-to-back restores are safe). Without this wiring the restore leg is
+            # dead code — PR #150 review.
+            echo "== #149 native-faucet metadata restore-survival (drop + --restore) =="
+            RUN_1E_RESTORE=1 DEST=l2b "$SCRIPT_DIR/e2e-miden-origin.sh"
         else
             echo "SKIP L2<->L2 + native tiers — L2B overlay not up (base stack). Run 'make e2e-l2l2-up' to include them."
         fi

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -104,7 +104,11 @@ case "$test_filter" in
         # final phase leaves a self-targeted poison leaf in the LET (Cantina #13
         # circuit-break repro) that wedges any certificate settlement after it, so only the
         # L1->L2-only manual-user-claim may follow.
-        "$SCRIPT_DIR/e2e-cantina13-metadata-recovery.sh"
+        # #149: when the L2B overlay is up (so the native+net-2 prerequisite rows were
+        # created by the tiers above), REQUIRE the restore-survival assertion — a missing
+        # row then FAILS the gate instead of silently skipping (PR #150 re-review).
+        REQUIRE_S149_RESTORE="$(docker ps --format '{{.Names}}' 2>/dev/null | grep -q 'postgres-l2b' && echo 1 || echo 0)" \
+            "$SCRIPT_DIR/e2e-cantina13-metadata-recovery.sh"
         echo ""
         # VERY LAST in the suite — defense in depth: the manual-user-claim
         # script deliberately front-runs the sponsor's autoclaimer, which

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -182,6 +182,13 @@ struct Args {
     #[arg(long, default_value = "MDN")]
     native_symbol: String,
 
+    /// Custom token NAME for --create-native-faucet (Miden TokenName). Defaults to the
+    /// symbol when omitted. Use a distinct value to deploy a `name != symbol` faucet —
+    /// exercises issue #149 (registration must adopt/validate the on-chain token name,
+    /// and recovery must preserve a custom name's exact metadata preimage).
+    #[arg(long)]
+    native_name: Option<String>,
+
     /// Custom decimals for --create-native-faucet.
     #[arg(long, default_value_t = 8)]
     native_decimals: u8,
@@ -556,8 +563,14 @@ async fn main() -> anyhow::Result<()> {
         // 1. Deploy the operator-owned fungible faucet (custom symbol/decimals).
         let symbol = TokenSymbol::new(&args.native_symbol)
             .map_err(|e| anyhow!("invalid TokenSymbol {:?}: {e:?}", args.native_symbol))?;
-        let name =
-            TokenName::new(&symbol.to_string()).map_err(|e| anyhow!("invalid TokenName: {e:?}"))?;
+        // #149: name defaults to the symbol, but --native-name lets an external party
+        // deploy a custom-name (name != symbol) faucet. The proxy's registration reads
+        // this on-chain token name authoritatively; recovery must preserve it exactly.
+        let name_str = args
+            .native_name
+            .clone()
+            .unwrap_or_else(|| symbol.to_string());
+        let name = TokenName::new(&name_str).map_err(|e| anyhow!("invalid TokenName: {e:?}"))?;
         let faucet_component = FungibleFaucet::builder()
             .name(name)
             .symbol(symbol)

--- a/src/service_admin.rs
+++ b/src/service_admin.rs
@@ -442,8 +442,19 @@ pub async fn admin_register_native_faucet(
                              found after import"
                         )
                     })?;
-                // Both supported kinds expose the standard FungibleFaucet metadata.
-                let (_kind, faucet) = faucet_ops::classify_faucet_account(&faucet_account)?;
+                // Both supported kinds expose the standard FungibleFaucet metadata, but
+                // admin_registerNativeFaucet is for operator-owned NATIVE faucets only.
+                // Guard against an operator accidentally reclassifying an already-deployed
+                // AggLayer-owned (bridge mint/burn) faucet as native (PR #150 review).
+                let (kind, faucet) = faucet_ops::classify_faucet_account(&faucet_account)?;
+                if kind != faucet_ops::FaucetKind::NativeFungible {
+                    anyhow::bail!(
+                        "admin_registerNativeFaucet: faucet account {faucet_id} is an \
+                         AggLayer-owned (bridge mint/burn) faucet, not an operator-owned \
+                         native FungibleFaucet — refusing to register it as native; no \
+                         registry row written"
+                    );
+                }
                 *authoritative_read.lock().unwrap() = Some(AuthoritativeFaucetMetadata {
                     name: faucet.token_name().as_str().to_string(),
                     symbol: faucet.symbol().to_string(),

--- a/src/service_admin.rs
+++ b/src/service_admin.rs
@@ -472,15 +472,46 @@ pub async fn admin_register_native_faucet(
         )
     })?;
 
-    // #149 — validate the caller-supplied values against authoritative chain state
-    // (symbol, decimals, and name each independently) and RESOLVE the metadata to
-    // persist/emit from the faucet account. Any mismatch bails here, before the
-    // bridge ConfigAggBridgeNote or the registry row — no partial state change.
+    // #149 — validate + register from AUTHORITATIVE state. Split out so the
+    // "successful read → mismatch → NO bridge ConfigAggBridgeNote" path is
+    // executable in a unit test (PR #150): the test calls `register_native_validated`
+    // with a materialized authoritative triple and asserts the bridge-register
+    // `with()` is never reached on a mismatch (test_call_count()==0 vs 1 on a match).
+    register_native_validated(
+        &state,
+        faucet_id,
+        origin_address,
+        origin_network,
+        scale,
+        &params,
+        &authoritative,
+    )
+    .await
+}
+
+/// #149 — the validate-then-register tail of `admin_register_native_faucet`, split
+/// out so it is unit-testable with a caller-supplied authoritative triple (the
+/// production caller reads that triple from the deployed faucet account first).
+///
+/// Validates the requested metadata against `authoritative` and, only if it passes,
+/// emits the bridge `ConfigAggBridgeNote` (via `register_faucet_in_bridge`) and
+/// persists the registry row — both built from the RESOLVED (authoritative) values.
+/// A mismatch returns `Err` BEFORE the `register_faucet_in_bridge` `with()` call, so
+/// no bridge note and no registry row are produced (no partial state).
+async fn register_native_validated(
+    state: &ServiceState,
+    faucet_id: AccountId,
+    origin_address: [u8; 20],
+    origin_network: u32,
+    scale: u8,
+    params: &RegisterNativeFaucetParams,
+    authoritative: &AuthoritativeFaucetMetadata,
+) -> anyhow::Result<String> {
     let resolved = resolve_native_faucet_metadata(
         params.name.as_deref(),
         &params.symbol,
         params.decimals,
-        &authoritative,
+        authoritative,
     )?;
 
     // abi.encode(name, symbol, decimals) — same preimage the bridge/L2 wrapped-token
@@ -720,6 +751,101 @@ mod tests {
             service.miden_client.test_call_count(),
             1,
             "bridge ConfigAggBridgeNote must not be emitted on a failed registration"
+        );
+    }
+
+    /// #149 (PR #150) — EXECUTABLE proof that a SUCCESSFUL authoritative read
+    /// FOLLOWED BY a metadata mismatch never reaches the bridge-register `with()`
+    /// (never emits a `ConfigAggBridgeNote`). `register_native_validated` takes a
+    /// materialized authoritative triple, so — unlike the endpoint test, whose mock
+    /// never runs the read closure — this drives the mismatch path directly.
+    /// `test_call_count() == 0` after a mismatch vs `== 1` after a match proves the
+    /// register `with()` is conditional on validation passing (not vacuously zero).
+    #[tokio::test]
+    async fn native_registration_mismatch_skips_bridge_registration() {
+        let service = create_test_service();
+        // A SUCCESSFUL authoritative read: the deployed faucet has symbol=MDN, decimals=8.
+        let auth = authoritative("MDN", "MDN", 8);
+        let faucet_id = AccountId::from_hex(&native_params(None).faucet_id).unwrap();
+        let origin = parse_eth_address(&native_params(None).origin_token_address).unwrap();
+        let net = service.network_id;
+
+        // symbol mismatch → Err, and the bridge-register with() is NEVER called.
+        let mut p = native_params(None);
+        p.symbol = "WRONG".into();
+        let err = register_native_validated(&service, faucet_id, origin, net, 0, &p, &auth)
+            .await
+            .expect_err("symbol mismatch must be rejected");
+        assert!(
+            err.to_string().contains("symbol mismatch"),
+            "unexpected: {err}"
+        );
+        assert_eq!(
+            service.miden_client.test_call_count(),
+            0,
+            "no bridge ConfigAggBridgeNote may be emitted on a symbol mismatch"
+        );
+        assert!(
+            service
+                .store
+                .get_faucet_by_origin(&origin, net)
+                .await
+                .unwrap()
+                .is_none(),
+            "a rejected registration must leave no registry row"
+        );
+
+        // decimals mismatch → Err, still no bridge call.
+        let mut pd = native_params(None);
+        pd.decimals = 6;
+        let err = register_native_validated(&service, faucet_id, origin, net, 0, &pd, &auth)
+            .await
+            .expect_err("decimals mismatch must be rejected");
+        assert!(
+            err.to_string().contains("decimals mismatch"),
+            "unexpected: {err}"
+        );
+        assert_eq!(service.miden_client.test_call_count(), 0);
+
+        // name mismatch (explicit custom name != authoritative) → Err, still no bridge call.
+        let err = register_native_validated(
+            &service,
+            faucet_id,
+            origin,
+            net,
+            0,
+            &native_params(Some("Not The Real Name")),
+            &auth,
+        )
+        .await
+        .expect_err("name mismatch must be rejected");
+        assert!(
+            err.to_string().contains("name mismatch"),
+            "unexpected: {err}"
+        );
+        assert_eq!(
+            service.miden_client.test_call_count(),
+            0,
+            "no bridge note emitted across the symbol/decimals/name mismatches"
+        );
+
+        // POSITIVE CONTROL: a MATCHING authoritative DOES reach the bridge-register
+        // with() (count 0 -> 1), proving the count==0 assertions above are meaningful.
+        register_native_validated(
+            &service,
+            faucet_id,
+            origin,
+            net,
+            0,
+            &native_params(None),
+            &auth,
+        )
+        .await
+        .expect("matching metadata registers");
+        assert_eq!(
+            service.miden_client.test_call_count(),
+            1,
+            "the register path DOES call the bridge with() when validation passes"
         );
     }
 

--- a/src/service_admin.rs
+++ b/src/service_admin.rs
@@ -280,6 +280,89 @@ pub struct RegisterNativeFaucetParams {
     pub name: Option<String>,
 }
 
+/// Authoritative token metadata read from a deployed Miden faucet account
+/// (`token_name` / `symbol` / `decimals`). This is the ONLY source from which the
+/// registered metadata-hash preimage can be reconstructed after database loss, so
+/// it — not caller-supplied params — is what `admin_registerNativeFaucet` persists.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AuthoritativeFaucetMetadata {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+}
+
+/// Resolved native-faucet metadata to persist/emit — always the deployed faucet
+/// account's authoritative values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedNativeMetadata {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+}
+
+/// Issue #149 — validate caller-supplied native-faucet metadata against the
+/// deployed Miden faucet account's authoritative values and RESOLVE the metadata
+/// to persist/emit from that authoritative state.
+///
+/// The proxy persists + emits a metadata hash whose preimage is
+/// `abi.encode(name, symbol, decimals)`; after database loss, recovery
+/// reconstructs that preimage ONLY from the deployed faucet account
+/// (`metadata_recovery::miden_faucet_candidate`). If the registered preimage came
+/// from caller-supplied params that differ from the deployed faucet, the hash's
+/// preimage is unreconstructable and its poison leaf halts restore fail-closed.
+///
+/// Rules (each mismatch rejected INDEPENDENTLY, before any state change):
+/// - `symbol` must equal the faucet's actual symbol.
+/// - `decimals` must equal the faucet's actual decimals.
+/// - `name`, if supplied, must equal the faucet's actual token name EXACTLY — a
+///   custom `name != symbol` is valid and preserved, never normalized to symbol.
+/// - `name` omitted → resolve to the faucet's actual token name (so an omitted
+///   name always succeeds with the authoritative name).
+///
+/// Pure (no I/O) so the whole decision is unit-testable; the caller supplies the
+/// authoritative triple read from the faucet account.
+pub(crate) fn resolve_native_faucet_metadata(
+    requested_name: Option<&str>,
+    requested_symbol: &str,
+    requested_decimals: u8,
+    authoritative: &AuthoritativeFaucetMetadata,
+) -> anyhow::Result<ResolvedNativeMetadata> {
+    if requested_symbol != authoritative.symbol {
+        anyhow::bail!(
+            "admin_registerNativeFaucet: symbol mismatch — requested {requested_symbol:?}, \
+             deployed faucet account has {:?}; the deployed faucet is authoritative. No \
+             registry row was written; re-register with the faucet's actual symbol.",
+            authoritative.symbol
+        );
+    }
+    if requested_decimals != authoritative.decimals {
+        anyhow::bail!(
+            "admin_registerNativeFaucet: decimals mismatch — requested {requested_decimals}, \
+             deployed faucet account has {}; the deployed faucet is authoritative. No \
+             registry row was written; re-register with the faucet's actual decimals.",
+            authoritative.decimals
+        );
+    }
+    if let Some(name) = requested_name
+        && name != authoritative.name
+    {
+        anyhow::bail!(
+            "admin_registerNativeFaucet: name mismatch — requested {name:?}, deployed faucet \
+             account has {:?}; a custom name must match the on-chain token name exactly and \
+             is never normalized. No registry row was written; re-register with the faucet's \
+             actual name or omit `name` to adopt it.",
+            authoritative.name
+        );
+    }
+    // Omitted name resolves to the authoritative name (which may legitimately differ
+    // from the symbol — a valid custom name is preserved, never collapsed to symbol).
+    Ok(ResolvedNativeMetadata {
+        name: authoritative.name.clone(),
+        symbol: authoritative.symbol.clone(),
+        decimals: authoritative.decimals,
+    })
+}
+
 /// `admin_registerNativeFaucet` — allowlist an EXTERNALLY-deployed Miden-ORIGINATED
 /// (native lock/unlock) faucet on the bridge. Faucet bridging is a PERMISSIONED
 /// ALLOWLIST: only the bridge admin can register, and the admin IS this proxy's
@@ -304,7 +387,6 @@ pub async fn admin_register_native_faucet(
     let origin_address = parse_eth_address(&params.origin_token_address)?;
     let origin_network = state.network_id;
     let scale = 0u8;
-    let miden_decimals = params.decimals;
 
     // Idempotent: an existing native route for this (origin_address, origin_network) is
     // returned as-is (register-if-absent), matching admin_registerFaucet's contract.
@@ -325,15 +407,80 @@ pub async fn admin_register_native_faucet(
         return Ok(existing.faucet_id.to_hex());
     }
 
+    // #149 — read the deployed faucet account's AUTHORITATIVE metadata BEFORE any
+    // state change. The persisted + emitted metadata-hash preimage
+    // (`abi.encode(name, symbol, decimals)`) must be reconstructable from chain
+    // state after database loss: recovery derives its only candidate from the
+    // faucet account (`metadata_recovery::miden_faucet_candidate`). So the
+    // registered preimage MUST come from the faucet account, not caller-supplied
+    // params — otherwise the hash is unrecoverable and its poison leaf halts
+    // restore. `with()` returning before this populates the slot (or erroring) is
+    // fail-closed: we bail before touching the bridge or the registry.
+    let authoritative = Arc::new(std::sync::Mutex::new(None::<AuthoritativeFaucetMetadata>));
+    let authoritative_read = authoritative.clone();
+    state
+        .miden_client
+        .with(move |client| {
+            Box::new(async move {
+                // Native faucets are externally deployed and NOT in
+                // bridge_accounts.toml, so import them on demand before reading.
+                if client.get_account(faucet_id).await.ok().flatten().is_none()
+                    && let Err(e) = client.import_account_by_id(faucet_id).await
+                {
+                    anyhow::bail!(
+                        "admin_registerNativeFaucet: cannot import faucet account \
+                         {faucet_id} from node: {e}"
+                    );
+                }
+                let faucet_account = client
+                    .get_account(faucet_id)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("get_account({faucet_id}): {e}"))?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "admin_registerNativeFaucet: faucet account {faucet_id} not \
+                             found after import"
+                        )
+                    })?;
+                // Both supported kinds expose the standard FungibleFaucet metadata.
+                let (_kind, faucet) = faucet_ops::classify_faucet_account(&faucet_account)?;
+                *authoritative_read.lock().unwrap() = Some(AuthoritativeFaucetMetadata {
+                    name: faucet.token_name().as_str().to_string(),
+                    symbol: faucet.symbol().to_string(),
+                    decimals: faucet.decimals(),
+                });
+                Ok(())
+            })
+        })
+        .await?;
+    let authoritative = authoritative.lock().unwrap().take().ok_or_else(|| {
+        anyhow::anyhow!(
+            "admin_registerNativeFaucet: could not read faucet account {faucet_id} \
+             metadata (no authoritative token name/symbol/decimals); refusing to register \
+             — no registry row written"
+        )
+    })?;
+
+    // #149 — validate the caller-supplied values against authoritative chain state
+    // (symbol, decimals, and name each independently) and RESOLVE the metadata to
+    // persist/emit from the faucet account. Any mismatch bails here, before the
+    // bridge ConfigAggBridgeNote or the registry row — no partial state change.
+    let resolved = resolve_native_faucet_metadata(
+        params.name.as_deref(),
+        &params.symbol,
+        params.decimals,
+        &authoritative,
+    )?;
+
     // abi.encode(name, symbol, decimals) — same preimage the bridge/L2 wrapped-token
     // metadata hashes to (Cantina #13); reused for the on-Miden MetadataHash + the
-    // stored FaucetEntry.metadata so a later bridge-out emits matching metadata.
+    // stored FaucetEntry.metadata so a later bridge-out emits matching metadata. Built
+    // from the AUTHORITATIVE (resolved) values so the preimage is always recoverable.
     use alloy_core::sol_types::SolValue;
-    let metadata_name = params.name.clone().unwrap_or_else(|| params.symbol.clone());
     let metadata_bytes = AdminTokenMetadata {
-        name: metadata_name,
-        symbol: params.symbol.clone(),
-        decimals: params.decimals,
+        name: resolved.name.clone(),
+        symbol: resolved.symbol.clone(),
+        decimals: resolved.decimals,
     }
     .abi_encode_params();
     let metadata_hash = MetadataHash::from_abi_encoded(&metadata_bytes);
@@ -341,7 +488,7 @@ pub async fn admin_register_native_faucet(
     let accounts = &state.accounts.0;
     let service_id = accounts.service.0;
     let bridge_id = accounts.bridge.0;
-    let symbol_clone = params.symbol.clone();
+    let symbol_clone = resolved.symbol.clone();
 
     // REQUEST: admin ConfigAggBridgeNote registering the EXISTING faucet as native
     // (is_native = true). Register only — the faucet was deployed externally.
@@ -368,16 +515,17 @@ pub async fn admin_register_native_faucet(
         .await?;
 
     // Persist the proxy-store row (origin_network == the configured net id => is_native
-    // is derivable; no separate column).
+    // is derivable; no separate column). All fields come from the authoritative
+    // (resolved) metadata, never caller-supplied.
     state
         .store
         .register_faucet(FaucetEntry {
             faucet_id,
             origin_address,
             origin_network,
-            symbol: params.symbol,
-            origin_decimals: miden_decimals, // native: no L1<->Miden scaling
-            miden_decimals,
+            symbol: resolved.symbol.clone(),
+            origin_decimals: resolved.decimals, // native: no L1<->Miden scaling
+            miden_decimals: resolved.decimals,
             scale,
             metadata: metadata_bytes,
         })
@@ -412,6 +560,157 @@ mod tests {
     use crate::store::FaucetEntry;
     use crate::test_helpers::create_test_service;
     use miden_protocol::account::AccountId;
+
+    // ── #149: pure native-faucet metadata validation/resolution ──────────────
+    // The deployed faucet account is authoritative; caller-supplied metadata is
+    // validated against it and the persisted preimage is resolved FROM it.
+
+    fn authoritative(name: &str, symbol: &str, decimals: u8) -> AuthoritativeFaucetMetadata {
+        AuthoritativeFaucetMetadata {
+            name: name.into(),
+            symbol: symbol.into(),
+            decimals,
+        }
+    }
+
+    /// Exact match (name == symbol) resolves to the authoritative triple.
+    #[test]
+    fn native_metadata_exact_match_resolves() {
+        let auth = authoritative("MDN", "MDN", 8);
+        let resolved =
+            resolve_native_faucet_metadata(Some("MDN"), "MDN", 8, &auth).expect("match succeeds");
+        assert_eq!(resolved.name, "MDN");
+        assert_eq!(resolved.symbol, "MDN");
+        assert_eq!(resolved.decimals, 8);
+    }
+
+    /// A wrong symbol is rejected independently with a specific error.
+    #[test]
+    fn native_metadata_symbol_mismatch_rejected() {
+        let auth = authoritative("MDN", "MDN", 8);
+        let err = resolve_native_faucet_metadata(Some("MDN"), "WRONG", 8, &auth).unwrap_err();
+        assert!(
+            err.to_string().contains("symbol mismatch"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Wrong decimals are rejected independently.
+    #[test]
+    fn native_metadata_decimals_mismatch_rejected() {
+        let auth = authoritative("MDN", "MDN", 8);
+        let err = resolve_native_faucet_metadata(Some("MDN"), "MDN", 6, &auth).unwrap_err();
+        assert!(
+            err.to_string().contains("decimals mismatch"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A supplied name that differs from the on-chain token name is rejected —
+    /// a custom name must match exactly, never normalized.
+    #[test]
+    fn native_metadata_name_mismatch_rejected() {
+        let auth = authoritative("Wrapped Midnight", "MDN", 8);
+        let err =
+            resolve_native_faucet_metadata(Some("Something Else"), "MDN", 8, &auth).unwrap_err();
+        assert!(
+            err.to_string().contains("name mismatch"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// An omitted name adopts the authoritative token name, and a custom
+    /// `name != symbol` is preserved exactly (never collapsed to the symbol) — so
+    /// the resolved preimage keccak-matches the deployed faucet's stored hash and
+    /// survives database-loss restore.
+    #[test]
+    fn native_metadata_omitted_name_adopts_custom_name() {
+        let auth = authoritative("Wrapped Midnight", "MDN", 8);
+        let resolved = resolve_native_faucet_metadata(None, "MDN", 8, &auth)
+            .expect("omitted name succeeds by adopting the authoritative name");
+        assert_eq!(resolved.name, "Wrapped Midnight");
+        assert_ne!(
+            resolved.name, resolved.symbol,
+            "a custom name must be preserved, not normalized to the symbol"
+        );
+        assert_eq!(resolved.symbol, "MDN");
+        // The persisted preimage is abi.encode(resolved.name, symbol, decimals);
+        // recovery's miden_faucet_candidate rebuilds the SAME triple from the
+        // faucet account's token_name(), so the keccak hash matches on restore.
+        use alloy_core::sol_types::SolValue;
+        let bytes = AdminTokenMetadata {
+            name: resolved.name.clone(),
+            symbol: resolved.symbol.clone(),
+            decimals: resolved.decimals,
+        }
+        .abi_encode_params();
+        let from_authoritative = AdminTokenMetadata {
+            name: auth.name.clone(),
+            symbol: auth.symbol.clone(),
+            decimals: auth.decimals,
+        }
+        .abi_encode_params();
+        assert_eq!(
+            bytes, from_authoritative,
+            "resolved preimage must equal the authoritative preimage"
+        );
+    }
+
+    /// A matching explicit custom name succeeds and is preserved.
+    #[test]
+    fn native_metadata_matching_custom_name_succeeds() {
+        let auth = authoritative("Wrapped Midnight", "MDN", 8);
+        let resolved = resolve_native_faucet_metadata(Some("Wrapped Midnight"), "MDN", 8, &auth)
+            .expect("matching custom name succeeds");
+        assert_eq!(resolved.name, "Wrapped Midnight");
+    }
+
+    fn native_params(name: Option<&str>) -> RegisterNativeFaucetParams {
+        RegisterNativeFaucetParams {
+            // A valid protocol-0.15 faucet account id.
+            faucet_id: "0xac0000000000dd110000ee000000fc".into(),
+            origin_token_address: "0x000000000000000000000000000000000000dEaD".into(),
+            symbol: "MDN".into(),
+            decimals: 8,
+            name: name.map(str::to_string),
+        }
+    }
+
+    /// #149 fail-closed: when the authoritative faucet metadata cannot be read
+    /// (the test client never yields an account), registration bails BEFORE the
+    /// bridge ConfigAggBridgeNote and BEFORE any registry write — no partial
+    /// state. `test_call_count() == 1` proves only the read was attempted and the
+    /// bridge-register `with()` was never reached.
+    #[tokio::test]
+    async fn native_registration_fails_closed_when_metadata_unreadable() {
+        let service = create_test_service();
+        let origin = parse_eth_address("0x000000000000000000000000000000000000dEaD").unwrap();
+
+        let err = admin_register_native_faucet(service.clone(), native_params(Some("MDN")))
+            .await
+            .expect_err("must fail closed when the faucet account metadata is unreadable");
+        assert!(
+            err.to_string().contains("could not read faucet account"),
+            "unexpected error: {err}"
+        );
+        // No registry row written.
+        assert!(
+            service
+                .store
+                .get_faucet_by_origin(&origin, service.network_id)
+                .await
+                .unwrap()
+                .is_none(),
+            "a failed registration must leave no registry row"
+        );
+        // Only the authoritative-read `with()` was attempted; the bridge-register
+        // `with()` (which would emit the ConfigAggBridgeNote) was never reached.
+        assert_eq!(
+            service.miden_client.test_call_count(),
+            1,
+            "bridge ConfigAggBridgeNote must not be emitted on a failed registration"
+        );
+    }
 
     const ORIGIN_HEX: &str = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
     // A valid protocol-0.15 account id, reused as the poisoned faucet's id.


### PR DESCRIPTION
## Summary

- read the referenced deployed Miden faucet before native-faucet registration
- validate the requested name, symbol, and decimals against the faucet's authoritative metadata
- persist the authoritative metadata preimage, including valid custom names that differ from the symbol
- add unit and Miden-origin E2E coverage for mismatch rejection, custom-name preservation, and database-loss restore
- document how operators can detect and remediate legacy mismatched registry rows

## Why

`admin_registerNativeFaucet` previously trusted caller-supplied metadata. If those values differed from the deployed faucet account, the proxy could persist a metadata-hash preimage that could not be reconstructed from chain state during database-loss recovery.

This change makes the deployed faucet authoritative and rejects mismatches before bridge configuration or registry persistence.

## Test coverage added

- unit tests for exact matches, independent field mismatches, omitted names, and custom `name != symbol`
- fail-closed registration test when authoritative faucet metadata cannot be read
- Miden-origin E2E assertions for mismatch rejection and custom-name persistence
- opt-in destructive restore regression covering both a native custom-name row and a network-2 row

Closes #149
