### PR TITLE
docs(ops): provisioning guide — key custody, remote signer, KMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ including `eth_sendRawTransaction`, transaction/receipt lookups, block lookups,
   migration container.
 - The production write path is a bounded single writer. Accepted signed
   envelopes, nonce reservations, and exact note handoffs are persisted in the
-  store. If a submission remains pending after a restart, rebroadcast the
+  store. Valid future-nonce envelopes are parked in a persisted but
+  intentionally ephemeral txpool until promotion or reconciliation; ordinary
+  rows still resident at their block TTL may be evicted, while rows stamped
+  during accepted full-loss recovery are TTL-exempt. If a submission remains
+  pending after a restart, rebroadcast the
   **same signed transaction**; do not construct a replacement with the same
   nonce.
 
@@ -73,16 +77,20 @@ settings include:
 | `--bind`, `--port` | `BIND_ADDR`, none | HTTP listen address and port; defaults are `0.0.0.0:8546` |
 | `--miden-node` | none | Miden gRPC URL, or `devnet`/`testnet`; defaults to local port `57291` |
 | `--miden-store-dir` | none | Persistent miden-client sqlite, keystore, and account config directory |
-| `--database-url` | `DATABASE_URL` | Enables the production Postgres store; omission selects the in-memory store |
+| `--database-url` | `DATABASE_URL` | Selects the durable Postgres store. A serving start without it is refused unless `ALLOW_EPHEMERAL_STORE=1` explicitly accepts dev/test data loss |
 | `--chain-id` | `CHAIN_ID` | Value returned by `eth_chainId` |
 | `--network-id` | `NETWORK_ID` | AggLayer rollup network ID stored in the bridge account |
 | `--bridge-address` | `BRIDGE_ADDRESS` | Address stamped on synthetic bridge logs |
 | `--l1-rpc-url` | `L1_RPC_URL` | L1 reads, metadata recovery, and GER decomposition |
 | `--ger-l1-address` | `GER_L1_ADDRESS` | L1 GER contract used by the InfoTree indexer |
+| `--l1-indexer-from-block` | `L1_INDEXER_FROM_BLOCK` | Required on a fresh database under strict H6; start at or before rollup deployment |
+| `--l1-evidence-tag` | `L1_EVIDENCE_TAG` | L1 evidence frontier; hardening requires `safe` or `finalized` |
 | `--miden-prover-url` | `MIDEN_PROVER_URL` | Remote Miden transaction prover |
+| `--signer-url` | `AGGLAYER_SIGNER_URL` | Web3Signer-compatible custody endpoint; hardening accepts only loopback HTTP |
+| `--signer-key` | `AGGLAYER_SIGNER_KEYS` | Required distinct `service` and `ger-manager` public-key bindings |
 | `--admin-api-key` | `ADMIN_API_KEY` | Bearer token for `admin_*`; without it all admin calls are disabled |
 | `--allowed-signers` | `ALLOWED_SIGNERS` | Comma-separated EVM submitter allow-list; without it all signed submissions are rejected |
-| `--require-hardening` | `REQUIRE_HARDENING` | Refuses startup unless admin auth, signer allow-list, non-wildcard CORS, and a reachable remote prover are configured |
+| `--require-hardening` | `REQUIRE_HARDENING` | Also requires remote-only loopback custody, admin auth, signer allow-list, non-wildcard CORS, reachable remote prover, and complete strict-H6 L1 evidence configuration |
 | `--read-only` | `AGGLAYER_READ_ONLY` | Allows reads/reindexing while refusing every Miden transaction submission |
 
 The writer queue is configured with `AGGLAYER_WRITER_QUEUE_DEPTH` (default
@@ -91,6 +99,15 @@ can fail work only before dispatch when no durable handoff exists; the same TTL
 also controls eviction of old terminal entries from the in-memory status map.
 It never expires queued/submitting work from the maintenance sweeper or turns
 an ambiguous post-handoff submission into a failure.
+
+The future-nonce parking queue is separate from the writer channel. Production
+persists it in Postgres so a process restart does not silently erase accepted
+rows, but it is intentionally an ephemeral txpool rather than a delivery
+guarantee: it is bounded at 256 entries per signer and 4096 globally, and any
+non-recovery row still resident after 3600 projected Miden blocks may be
+evicted. The persistence requirement is why the serving process refuses the
+in-memory store by default. Senders must retain and rebroadcast signed
+envelopes whose hashes stop resolving.
 
 ### Store-directory containment
 
@@ -107,17 +124,19 @@ do not pass it to an existing deployment unless creating new account identities
 is intentional.
 
 ```bash
-./target/debug/miden-agglayer-service \
+ALLOW_EPHEMERAL_STORE=1 ./target/debug/miden-agglayer-service \
   --miden-node http://127.0.0.1:57291 \
   --miden-store-dir ./.miden-dev \
+  --insecure-local-keystore \
   --bind 127.0.0.1 \
   --port 8546
 ```
 
-This is a read-capable development configuration. Because the signer allow-list
-is fail-closed, `eth_sendRawTransaction` is rejected until `--allowed-signers`
-is configured. `--insecure-allow-any-signer` exists only for a loopback/private
-development boundary and is incompatible with `--require-hardening`.
+This explicitly accepts local-key and in-memory-store data loss for development.
+Because the signer allow-list is fail-closed, `eth_sendRawTransaction` is
+rejected until `--allowed-signers` is configured.
+`--insecure-allow-any-signer` exists only for a loopback/private development
+boundary and is incompatible with `--require-hardening`.
 
 A production-shaped invocation should use Postgres, a persistent store,
 explicit signer/admin policy, L1 GER settings, and a remote prover:
@@ -127,6 +146,10 @@ DATABASE_URL="$DATABASE_URL" \
 ADMIN_API_KEY="$ADMIN_API_KEY" \
 ALLOWED_SIGNERS="$ALLOWED_SIGNERS" \
 MIDEN_PROVER_URL="$MIDEN_PROVER_URL" \
+AGGLAYER_SIGNER_URL="http://127.0.0.1:9000" \
+AGGLAYER_SIGNER_KEYS="$AGGLAYER_SIGNER_KEYS" \
+L1_EVIDENCE_TAG="finalized" \
+L1_INDEXER_FROM_BLOCK="$ROLLUP_DEPLOYMENT_BLOCK" \
 miden-agglayer-service \
   --miden-node "$MIDEN_NODE_URL" \
   --miden-store-dir /var/lib/miden-agglayer-service \
@@ -140,7 +163,16 @@ miden-agglayer-service \
 ```
 
 Supply secrets through the deployment secret mechanism, not literal shell
-history. If a reverse proxy or sidecar is the network boundary, adapt `--bind`
+history. The example is a first boot on a fresh database; an existing database
+with a non-zero, policy-matched L1 evidence cursor does not need
+`L1_INDEXER_FROM_BLOCK`. Treat it as a one-boot initial-backfill override and
+remove it after catch-up succeeds; it outranks the stored cursor and otherwise
+rewinds the scan on every restart. The signer must share the proxy's network
+namespace (or sit behind a loopback relay), bind its signing listener only to
+loopback, and not publish that listener through a host port, Service, or
+Ingress. The binary must include the `postgres` feature. See the
+[provisioning guide](docs/operations/provisioning.md) before initializing
+accounts. If a reverse proxy or sidecar is the network boundary, adapt `--bind`
 to that topology while keeping port `8546` private.
 
 ## Health and metrics

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,15 +99,22 @@ sequenceDiagram
     C->>R: eth_sendRawTransaction
     R->>R: decode, chain-id and signer checks
     R->>S: known-hash and state checks
-    R->>S: fenced signer/nonce reservation
-    R->>S: persist signed envelope
-    R->>S: compare-and-set next accepted nonce
-    R->>W: non-blocking enqueue
-    R-->>C: transaction hash
-    W->>M: serialized claim or GER dispatch
-    M->>S: persist exact note handoff
-    M->>N: submit proven Miden transaction
-    N-->>M: accepted or rejected
+    R->>S: read executable nonce and durable lower intent
+    alt valid future nonce with a gap
+        R->>S: persist envelope in bounded ephemeral queued_txns
+        R-->>C: transaction hash (accepted, still pending)
+    else executable nonce
+        R->>S: fenced signer/nonce reservation
+        R->>S: persist signed envelope
+        R->>S: compare-and-set next accepted nonce
+        R->>W: non-blocking enqueue
+        R->>S: promote contiguous parked successors
+        R-->>C: transaction hash
+        W->>M: serialized claim or GER dispatch
+        M->>S: persist exact note handoff
+        M->>N: submit proven Miden transaction
+        N-->>M: accepted or rejected
+    end
 ```
 
 Important behavior:
@@ -115,6 +122,18 @@ Important behavior:
 - The default queue capacity is 64 and is configurable through
   `AGGLAYER_WRITER_QUEUE_DEPTH`.
 - Queue saturation is returned as JSON-RPC error `-32005`.
+- A valid nonce above the executable frontier is parked in `queued_txns` and
+  returns its hash immediately. When the missing nonce is admitted, the
+  proxy attempts to promote the contiguous parked run in order and retries
+  retained failures periodically. The production pool survives a process
+  restart in Postgres but is intentionally ephemeral, not a delivery guarantee.
+  It is bounded at 256 rows per signer and 4096 globally; non-recovery rows
+  still resident at their 3600-projected-block TTL may be evicted. Rows stamped
+  during an accepted full-loss recovery window are TTL-exempt; they remain
+  until admission/reconciliation, or until an operator handles a surfaced
+  stranded row.
+- Serving without durable Postgres is refused unless
+  `ALLOW_EPHEMERAL_STORE=1` explicitly opts into development/test data loss.
 - A repeated signed transaction is deduplicated by transaction hash before the
   nonce check. A durable unlinked intent can be resumed after restart by
   submitting the same signed transaction again.

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -285,8 +285,7 @@ through blocks mined during the swap window.
 
 ### Operational follow-ups shipped with this release
 
-The operations runbook gained incident procedures for the two known
-silent-freeze modes — "Stuck GER injection (interrupted `ger_insert`)" and
-"ntx-builder silent death" (`docs/operations/runbook.md` §4) — including their
-monitoring signals and watchdog allowances. Review alerting against those
+The operations runbook documents automatic recovery and escalation signals for
+interrupted GER/claim writer jobs, plus the separate "ntx-builder silent death"
+procedure (`docs/operations/runbook.md` §4). Review alerting against those
 sections when rolling this release out.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -7,6 +7,7 @@ historical cluster value.
 
 | Document | Purpose |
 |---|---|
+| [Provisioning](provisioning.md) | Standing up a deployment: key custody, remote signer / KMS, roles, and the startup invariants |
 | [Runbook](runbook.md) | Production constraints, startup, safe shutdown, recovery choices, and incident procedures |
 | [Monitoring](monitoring.md) | Health/metrics endpoints, high-signal metrics, alerts, and dashboards |
 | [Diagnostics](diagnostics.md) | Read-only collection and symptom-to-cause investigation |

--- a/docs/operations/diagnostics.md
+++ b/docs/operations/diagnostics.md
@@ -139,6 +139,12 @@ FROM nonce_reservations
 ORDER BY created_at DESC
 LIMIT 200;
 
+-- Valid future-nonce envelopes retained while awaiting promotion.
+SELECT signer, nonce, tx_hash, expires_at, parked_during_recovery, created_at
+FROM queued_txns
+ORDER BY created_at DESC
+LIMIT 200;
+
 -- GER state and unresolved decomposition.
 SELECT encode(ger_hash, 'hex') AS ger,
        encode(mainnet_exit_root, 'hex') AS mainnet_exit_root,

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -59,6 +59,15 @@ The writer queue capacity defaults to 64 and is configured by
 and applies to time waiting in the queue before dispatch; it also controls how
 long terminal entries remain in the process-local status cache.
 
+The future-nonce parking queue is a separate, Postgres-backed but intentionally
+ephemeral txpool. Persistence prevents a process restart from silently erasing
+accepted rows; it is not a delivery guarantee. The pool is bounded at 256 rows
+per signer and 4096 globally. Any non-recovery row still resident when its
+3600-projected-block TTL is reached may be evicted and its capacity reclaimed,
+including after a failed promotion attempt. A row stamped during the accepted
+full-loss recovery window is TTL-exempt; it remains until
+admission/reconciliation, or until an operator handles a surfaced stranded row.
+
 | Metric | Labels/meaning |
 |---|---|
 | `agglayer_writer_queue_depth` | Jobs currently waiting in the bounded channel |
@@ -68,8 +77,18 @@ long terminal entries remain in the process-local status cache.
 | `agglayer_writer_job_failures_total{kind,reason}` | Terminal failures; reasons emitted by current paths include `ttl`, `miden`, and `panic` |
 | `agglayer_writer_drain_outcome_total{outcome}` | Graceful shutdowns labelled `clean` or `partial` |
 | `agglayer_writer_dropped_on_restart_total` | Residual in-memory jobs reported from the prior graceful-shutdown snapshot |
-| `rpc_future_nonce_wait_total` | Future nonces that entered the bounded ordering wait |
-| `rpc_nonce_mismatch_total` | Nonce requests rejected after the wait/check |
+| `rpc_future_nonce_parked_total` | Valid future-nonce envelopes accepted into the Postgres-backed ephemeral txpool, including idempotent same-hash rebroadcasts |
+| `rpc_future_nonce_promoted_total` | Parked envelopes durably admitted after their nonce gap filled |
+| `rpc_future_nonce_evicted_total` | Non-recovery rows evicted after their block TTL; hash visibility and capacity were removed |
+| `rpc_future_nonce_conflict_total` | Different envelopes attempted the same `(signer, nonce)`; first parked transaction remains authoritative |
+| `rpc_future_nonce_bound_exceeded_total` | Per-signer or global parking bound rejected a future-nonce envelope |
+| `rpc_future_nonce_promote_unconfirmed_total` | Promotion returned success without a durable transaction row; queue row was retained for retry |
+| `rpc_future_nonce_drain_budget_exceeded_total` | One signer's mempool sweep slice exceeded its 20-second budget and was deferred |
+| `rpc_future_nonce_stale_row_reconciled_total` | Redundant parked row below the frontier was removed after durable admission was confirmed |
+| `rpc_future_nonce_stranded_total` | Acknowledged parked transaction fell below the frontier without a durable transaction row; operator action required |
+| `rpc_nonce_ledger_bootstrapped_total` | A signer with no nonce row after full database loss adopted its lowest eligible parked nonce as the recovered baseline |
+| `rpc_nonce_recovery_mode_expired_total` | The durable full-loss first-contact window reached its configured wall-clock limit |
+| `rpc_nonce_mismatch_total` | Past or otherwise invalid nonce requests rejected by the ordering check |
 | `rpc_nonce_reservation_lost_total` | A different transaction won the durable `(signer, nonce)` slot |
 | `rpc_nonce_repaired_after_commit_gap_total` | Same-hash replay repaired a receipt-to-nonce crash gap |
 
@@ -80,6 +99,12 @@ Recommended alerts from the code's metric contract:
 - p99 writer duration above 60 seconds for 10 minutes: page;
 - queue-full rejection rate above 0.1/second for 5 minutes: page;
 - writer failure rate above 0.5/second for 5 minutes: page;
+- any increase in `rpc_future_nonce_stranded_total`: page immediately;
+- any increase in `rpc_future_nonce_promote_unconfirmed_total`: investigate;
+- sustained `rpc_future_nonce_bound_exceeded_total`: page and locate the
+  missing lower nonce before raising bounds;
+- sustained eviction or drain-budget exhaustion: warn and verify sender
+  rebroadcast plus nonce progression; and
 - any increase in `agglayer_writer_dropped_on_restart_total`: page and arrange
   rebroadcast of the original signed transactions.
 
@@ -178,16 +203,27 @@ to a plain-fungible view when the AggLayer decode fails, so trusting it would le
 a drifted bridge-owned faucet be silently reclassified as a benign native one —
 the blindness this monitor exists to prevent.
 
-## Remote signer (KMS custody)
+## Remote signer custody
 
-When `--signer-url` is set, every account signature leaves this host. The proxy
-never falls back to a local key, so losing the signer stalls claims and GER
-injection outright — and the fail-closed startup check only covers boot.
+When `--signer-url` is set, every account signing request is delegated out of
+the proxy process. The proxy never falls back to a local key, so losing the
+signer stalls claims and GER injection outright — and the fail-closed startup
+check only covers boot. Whether the private-key operation also leaves the host
+depends on the signer's backend; `file-raw`, `azure-secret`, and `hashicorp` do
+not prove off-host, non-export custody.
 
 | Metric | Meaning |
 |---|---|
+| `remote_signer_verified_accounts` | Startup-only count of persisted/imported account records whose auth keys matched their configured bindings and the signer's initial key directory; expect `2` on a new deployment, or potentially `1` for a supported legacy config without `ger_manager`. |
 | `remote_signer_signatures_total` | Signatures the signer produced. |
 | `remote_signer_signature_failures_total` | Signatures it failed to produce (unreachable, refused, or no key for the requested commitment). |
+
+A binding failure prevents the service and metrics listener from coming up; it
+does not necessarily appear as a low gauge. Alert on target/process absence and
+require `remote_signer_verified_accounts` to equal the account-role inventory
+in `bridge_accounts.toml` after every successful start (`2` for a new
+deployment; potentially `1` for a supported legacy config without
+`ger_manager`).
 
 Alert on the RATE, not the absolute value. A counter never returns to zero, so
 "sustained non-zero" would page forever after a single transient failure:
@@ -213,8 +249,12 @@ authenticates the *server* to us and encrypts the channel, but this client sends
 no certificate, token or other identity, so any caller that can reach the signing
 API still has a signing oracle — and a KMS only prevents key *extraction*, not
 key *use*. Until caller authentication is implemented, run Web3Signer (or an
-authenticated relay in front of it) on the same host/pod and point
-`--signer-url` at `127.0.0.1`.
+authenticated relay in front of it) in the proxy's same network namespace and
+point `--signer-url` at `http://127.0.0.1:<port>`. Separate containers on the
+same host normally do not share loopback. The signer or relay must itself bind
+the signing API only to loopback and must not publish it through a host port,
+Service, or Ingress; the proxy's loopback URL does not constrain the signer's
+listener.
 
 ## Bridge integrity: page on increase
 

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -1,0 +1,273 @@
+# Provisioning
+
+How to stand up a deployment of this service, with emphasis on key custody:
+where account keys live, who creates them, and the order operations must happen
+in so a broken custody setup fails at startup rather than mid-transaction.
+
+Like the rest of `docs/operations`, this document is deployment-neutral.
+Resolve `$NAMESPACE`, `$WORKLOAD`, `$SIGNER_URL`, `$DATABASE_URL` and secret
+names from the deployment you are operating.
+
+## The custody map
+
+Four distinct kinds of secret exist in a deployment. They are provisioned by
+different parties and must not be conflated:
+
+| Secret | Owner | Provisioned by | Held by the proxy? |
+|---|---|---|---|
+| Miden **account** keys (`service`, `ger-manager`) | KMS / HSM / vault | your key-management process, **before** first boot | No — never, in remote custody |
+| `--admin-api-key` | deployment secret store | deploy pipeline | Yes, in memory (compared constant-time) |
+| `--miden-api-key` | node gateway operator | node operator | Yes, in memory (redacted in logs) |
+| L1/aggkit EVM keys (aggoracle, aggsender, claimtxman) | those components' own config | the aggkit/bridge deployment | No — not this service's concern |
+
+Only the first row is what "remote signing" and "KMS" refer to. This document
+covers that row; the others are ordinary deployment secrets.
+
+## Two custody modes
+
+Custody is resolved once per process at startup and is mutually exclusive.
+
+**Remote signer (production).** `--signer-url` / `AGGLAYER_SIGNER_URL` points at
+a Web3Signer-compatible service. Every account signature is produced by that
+service; the proxy generates, holds and stores no account secret. There is
+deliberately **no per-account fallback** — a key the signer does not hold is a
+hard error, never a silent local signature.
+
+**Local keystore (development and the e2e suite only).** `--insecure-local-keystore`
+/ `AGGLAYER_INSECURE_LOCAL_KEYSTORE=true` keeps account private keys on the
+host's disk. Refused by `--require-hardening`. Setting both this and
+`--signer-url` is refused at startup.
+
+One of the two must be chosen explicitly. There is no implicit default that
+silently writes a private key to disk.
+
+## What the proxy requires of the signer
+
+The proxy speaks a deliberately small HTTP contract, so any Web3Signer-compatible
+service works and no cloud-vendor SDK is linked into this binary:
+
+| | |
+|---|---|
+| List keys | `GET {signer}/api/v1/eth1/publicKeys` |
+| Sign | `POST {signer}/api/v1/eth1/sign/{identifier}` with `{"data": "0x…"}` |
+| Mode | Web3Signer **`eth1`** (secp256k1). `eth2` loads keys into memory and defeats vault custody |
+| Response | 65 bytes, `r (32) ‖ s (32) ‖ v (1)`; `v` is normalised from the 27/28 encoding |
+| Request timeout | `AGGLAYER_SIGNER_TIMEOUT_SECS`, default `30` |
+
+**Digest compatibility** is the load-bearing detail. Miden's `EcdsaK256Keccak`
+signs `keccak256(commitment_word_bytes)`. Web3Signer's eth1 endpoint computes
+`keccak256(data)` over whatever you post. The proxy therefore posts the raw
+32-byte commitment word as `data`, making the two digest constructions
+byte-identical — no re-hashing, no message prefix, no EIP-191 wrapper. A unit
+test pins remote signatures against a locally-computed one, so drift on either
+side breaks CI rather than on-chain verification.
+
+**Key identifiers** may be given in any encoding the signer publishes: 33-byte
+compressed SEC1, 65-byte tagged uncompressed (`0x04 ‖ x ‖ y`), or the 64-byte
+raw uncompressed point Ethereum tooling uses. All are normalised to compressed
+internally. This widens accepted *encodings*, not accepted *keys* — a value that
+is not a point on secp256k1 is rejected.
+
+## Roles: one key each
+
+Two roles exist, and each binds to its own key:
+
+| Role | Flag spelling | Account |
+|---|---|---|
+| `service` | `--signer-key service=<identifier>` | the service account |
+| `ger-manager` | `--signer-key ger-manager=<identifier>` (`ger_manager` also accepted) | the dedicated GER-injection account |
+
+Supply them via repeated `--signer-key` flags or a comma-separated
+`AGGLAYER_SIGNER_KEYS`:
+
+```
+AGGLAYER_SIGNER_KEYS=service=0x<pubkey>,ger-manager=0x<pubkey>
+```
+
+The proxy refuses to start if a role is unbound, if two roles name the same
+identifier, or if the signer does not actually expose a named key. One key per
+role is deliberate: a compromised or rotated key then takes out exactly one
+account instead of both. Key creation and IAM grants stay **outside** this
+process — the proxy never asks a signer to create a key.
+
+## Provisioning order
+
+The order matters. Keys exist before accounts, because an account is created
+*bound to* a key that must already be in the vault.
+
+**1. Create the account keys in your KMS/vault.** Two secp256k1 keys, one per
+role. Grant the signer's identity permission to *use* them for signing, not to
+export them.
+
+**2. Configure the signer to expose exactly those keys.** One key-config entry
+per key. This is the only file that differs between environments — see
+[KMS backends](#kms-backends) below.
+
+**3. Verify the signer serves the keys before pointing the proxy at it:**
+
+```bash
+curl -sf "$SIGNER_URL/upcheck"
+curl -sf "$SIGNER_URL/api/v1/eth1/publicKeys"
+```
+
+> A signer with an unreadable or empty key directory reports `/upcheck` as **UP**
+> while serving zero keys. Health-check on a **non-empty key list**, not on
+> `/upcheck` alone, or a broken custody setup looks exactly like a working
+> signer and only surfaces later as a confusing proxy boot error.
+
+**4. First boot of the proxy** with `--signer-url` and both `--signer-key`
+bindings. On a fresh store this creates the Miden accounts, each bound to the
+remote public key for its role; no secret is generated locally. Account ids are
+persisted to `bridge_accounts.toml` in the store directory.
+
+**5. Every subsequent boot re-verifies the bindings** (see below). Steady-state
+restarts do not re-create anything.
+
+## Startup verification (what "healthy" means)
+
+On every serving startup — not just the boot that created the accounts — the
+proxy, for each role:
+
+1. reads the **deployed on-chain account's** auth key out of its `AuthSingleSig`
+   storage slot (importing the account by id if the local store is cold),
+2. requires it to equal the key `--signer-key` names for that role, and
+3. requires the signer to **still hold** that key.
+
+All three must agree or the process aborts. The deployed account is the source
+of truth on purpose: inserting the configured commitment and then checking it
+would only prove the config agrees with itself.
+
+Success is published as a gauge rather than a log line, because log field
+rendering depends on the subscriber's formatter:
+
+```
+remote_signer_verified_accounts   # = number of roles verified (expect 2)
+remote_signer_signatures_total
+remote_signer_signature_failures_total
+```
+
+Alert on `remote_signer_verified_accounts` dropping below the configured role
+count, and on any sustained rate of `remote_signer_signature_failures_total`.
+
+## KMS backends
+
+The proxy is unaware of which vault backs the signer. Swapping backends is a
+change to the signer's key-config file and nothing else — the proxy flags, the
+network topology and this document's procedures are unchanged.
+
+Development (raw file, what the e2e suite generates):
+
+```yaml
+type: file-raw
+keyType: SECP256K1
+privateKey: "0x<32-byte hex>"
+```
+
+AWS KMS:
+
+```yaml
+type: aws-kms
+region: eu-west-1
+kmsKeyId: arn:aws:kms:eu-west-1:<account>:key/<uuid>   # kmsKeyId, not keyId
+```
+
+Azure Key Vault and HashiCorp Vault are configured with their respective
+`type: azure` / `type: hashicorp` entries per Web3Signer's documentation. In all
+cases the signer's identity needs **sign** permission only; it must not need
+export.
+
+Two operational notes that apply to the vault-backed setups:
+
+- The identifier you put in `AGGLAYER_SIGNER_KEYS` is the **public key** the
+  signer publishes, not the KMS key id or ARN. Read it back from
+  `/api/v1/eth1/publicKeys` after configuring the backend.
+- A KMS prevents key **extraction**. It does not prevent key **use** — see the
+  next section.
+
+## The loopback rule
+
+`--require-hardening` **refuses a non-loopback `--signer-url`.**
+
+This is not a formality. The proxy authenticates itself to the signer in no way
+at all: no client certificate, no token. `https` proves that *we* authenticated
+the *server*, not the reverse. So any caller with network reach to the signing
+API holds a signing oracle, and a KMS does not help — it stops key extraction,
+not key use.
+
+Until caller authentication (mTLS client certificate or token) is implemented,
+run the signer as a **sidecar on the same host/pod** and point `--signer-url` at
+`127.0.0.1`. If you must place the signer elsewhere, put an authenticated relay
+in front of it and point the proxy at the relay's loopback address.
+
+## Rotation
+
+There is **no in-place key rotation** for an existing account. An account's auth
+key is fixed in its on-chain storage slot at creation; changing which key a role
+binds to makes startup verification fail with "the deployed *role* account … is
+signed for by a DIFFERENT key than `--signer-key` configures for that role."
+
+That failure is correct behaviour — the deployment genuinely cannot sign for
+that account any more. Removing the old key from the signer produces the same
+abort from the other direction ("the remote signer does not hold the key(s)
+bound to *n* configured account(s)").
+
+So plan rotation as **provisioning a new account**, not as editing a binding.
+Keep the old key available in the signer until the replacement account is
+deployed and drained. Treat "rotate the ger-manager key" as a change/incident
+procedure with a migration plan, not a config edit.
+
+## Production checklist
+
+`--require-hardening` (`REQUIRE_HARDENING=true`) turns each of the following
+from a silent runtime exposure into a startup failure. Deployments should set
+it, and the list below is exactly what it enforces:
+
+| Requirement | Why |
+|---|---|
+| `--signer-url` is loopback | the client does not authenticate itself to the signer |
+| `--insecure-local-keystore` unset | account keys must not be on the host's disk |
+| `--admin-api-key` set | `admin_*` methods would otherwise be open |
+| `--allowed-signers` set | `eth_sendRawTransaction` fail-closed allow-list |
+| `--insecure-allow-any-signer` unset | legacy open mode, incompatible with the allow-list |
+| `--cors-allowed-origins` has no `*` | any browser origin could reach mutating endpoints |
+| `--miden-prover-url` set | the in-process prover is the documented OOM cause; also probed for reachability at startup |
+
+Setting it additionally implies **strict H6** (`--reject-unverified-ger-injection`),
+which refuses any GER not corroborated by the independent L1 InfoTree indexer,
+and requires `--l1-evidence-tag=safe` or `finalized` — `latest` may include
+reorgable L1 blocks and is not sufficient to authorize a GER.
+
+Beyond the flags: never expose the JSON-RPC port directly to the public
+internet, never run two service processes against one Miden store, and never
+delete `keystore/` or `bridge_accounts.toml` as part of a routine recovery.
+
+## Verifying a provisioned deployment
+
+The e2e suite exercises the same code path a KMS-backed deployment uses — proxy
+→ HTTP → signer → custody backend — differing only in the signer's key-config
+file:
+
+```bash
+./scripts/e2e-web3signer.sh
+```
+
+It asserts that the proxy holds no local secret, that a full L1→L2 deposit is
+signed remotely, that signing genuinely depends on the signer (stopping the
+signer must break signing, and restarting it must resume it), that a proxy
+restart re-verifies both role bindings against the deployed accounts, and that a
+role pointed at the wrong key is refused at startup and that the refusal is not
+sticky.
+
+Against a real deployment, the equivalent read-only checks are:
+
+```bash
+curl -sf "$SIGNER_URL/api/v1/eth1/publicKeys"          # signer serves both keys
+curl -sf "$PROXY_RPC/metrics" | grep remote_signer_    # verified_accounts == role count
+```
+
+## Related
+
+- [Runbook](runbook.md) — startup, shutdown, recovery procedures
+- [Monitoring](monitoring.md) — metrics and alerting
+- [Diagnostics](diagnostics.md) — symptom-to-cause investigation
+- [Upgrade guide](../UPGRADE.md) — in-place upgrade and rollback

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -1,8 +1,10 @@
 # Provisioning
 
 How to stand up a deployment of this service, with emphasis on key custody:
-where account keys live, who creates them, and the order operations must happen
-in so a broken custody setup fails at startup rather than mid-transaction.
+where account keys live, who creates them, and the order that validates key
+listing, binding, and signing authority before account creation. Serving
+startup rechecks key exposure and account bindings; it is not itself a signing
+canary.
 
 Like the rest of `docs/operations`, this document is deployment-neutral.
 Resolve `$NAMESPACE`, `$WORKLOAD`, `$SIGNER_URL`, `$DATABASE_URL` and secret
@@ -10,18 +12,24 @@ names from the deployment you are operating.
 
 ## The custody map
 
-Four distinct kinds of secret exist in a deployment. They are provisioned by
-different parties and must not be conflated:
+The following secret classes are relevant to this provisioning boundary. This
+is not a complete inventory of every deployment secret; in particular, the
+signer's cloud identity and the proxy's database credentials have different
+owners and must not be conflated with the account keys:
 
 | Secret | Owner | Provisioned by | Held by the proxy? |
 |---|---|---|---|
 | Miden **account** keys (`service`, `ger-manager`) | KMS / HSM / vault | your key-management process, **before** first boot | No — never, in remote custody |
+| Signer cloud credentials / workload identity | signer workload | deploy and IAM pipelines | No — never supplied to the proxy |
+| `DATABASE_URL` credentials | deployment secret store | database/deploy pipeline | Yes, as the proxy's database connection secret |
 | `--admin-api-key` | deployment secret store | deploy pipeline | Yes, in memory (compared constant-time) |
 | `--miden-api-key` | node gateway operator | node operator | Yes, in memory (redacted in logs) |
 | L1/aggkit EVM keys (aggoracle, aggsender, claimtxman) | those components' own config | the aggkit/bridge deployment | No — not this service's concern |
 
-Only the first row is what "remote signing" and "KMS" refer to. This document
-covers that row; the others are ordinary deployment secrets.
+The first two rows make up the remote-signing boundary. The proxy receives only
+the public key identifiers and the signer's loopback URL; cloud credentials
+belong to the signer workload. The remaining rows are separate deployment
+secrets.
 
 ## Two custody modes
 
@@ -50,17 +58,17 @@ service works and no cloud-vendor SDK is linked into this binary:
 |---|---|
 | List keys | `GET {signer}/api/v1/eth1/publicKeys` |
 | Sign | `POST {signer}/api/v1/eth1/sign/{identifier}` with `{"data": "0x…"}` |
-| Mode | Web3Signer **`eth1`** (secp256k1). `eth2` loads keys into memory and defeats vault custody |
-| Response | 65 bytes, `r (32) ‖ s (32) ‖ v (1)`; `v` is normalised from the 27/28 encoding |
+| Mode | Web3Signer **`eth1`**, the execution-layer secp256k1 API; the `eth2`/BLS API is incompatible |
+| Response | Plain `0x`-prefixed text encoding 65 bytes, `r (32) ‖ s (32) ‖ v (1)`; the client also tolerates optional JSON quotes, and normalises Ethereum-style `v` to Miden's recovery id |
 | Request timeout | `AGGLAYER_SIGNER_TIMEOUT_SECS`, default `30` |
 
 **Digest compatibility** is the load-bearing detail. Miden's `EcdsaK256Keccak`
 signs `keccak256(commitment_word_bytes)`. Web3Signer's eth1 endpoint computes
 `keccak256(data)` over whatever you post. The proxy therefore posts the raw
 32-byte commitment word as `data`, making the two digest constructions
-byte-identical — no re-hashing, no message prefix, no EIP-191 wrapper. A unit
-test pins remote signatures against a locally-computed one, so drift on either
-side breaks CI rather than on-chain verification.
+byte-identical — no extra application hash, message prefix, or EIP-191 wrapper.
+Unit tests pin the `r ‖ s ‖ v` decoder against a local signature; the
+`e2e-web3signer.sh` integration test is what exercises an actual Web3Signer.
 
 **Key identifiers** may be given in any encoding the signer publishes: 33-byte
 compressed SEC1, 65-byte tagged uncompressed (`0x04 ‖ x ‖ y`), or the 64-byte
@@ -84,76 +92,152 @@ Supply them via repeated `--signer-key` flags or a comma-separated
 AGGLAYER_SIGNER_KEYS=service=0x<pubkey>,ger-manager=0x<pubkey>
 ```
 
-The proxy refuses to start if a role is unbound, if two roles name the same
-identifier, or if the signer does not actually expose a named key. One key per
-role is deliberate: a compromised or rotated key then takes out exactly one
-account instead of both. Key creation and IAM grants stay **outside** this
-process — the proxy never asks a signer to create a key.
+The proxy refuses to start if a role is unbound, if two roles resolve to the
+same physical public key (even through different encodings), or if the signer
+does not expose a named key. One key per role is deliberate: a compromised key
+then affects exactly one account instead of both. Key creation and IAM grants
+stay **outside** this process — the proxy never asks a signer to create a key.
 
 ## Provisioning order
 
 The order matters. Keys exist before accounts, because an account is created
 *bound to* a key that must already be in the vault.
 
-**1. Create the account keys in your KMS/vault.** Two secp256k1 keys, one per
-role. Grant the signer's identity permission to *use* them for signing, not to
-export them.
+**1. Provision the durable stores and validate every non-custody startup
+input.** Before a boot that can initialize accounts:
 
-**2. Configure the signer to expose exactly those keys.** One key-config entry
-per key. This is the only file that differs between environments — see
-[KMS backends](#kms-backends) below.
+- provision PostgreSQL and set `DATABASE_URL`; the binary must include the
+  `postgres` feature and the database identity must be able to run the embedded
+  migrations under an advisory lock;
+- mount one persistent, exclusive `--miden-store-dir` for `store.sqlite3`, its
+  WAL/SHM files, `keystore/`, and `bridge_accounts.toml`; and
+- when using `--require-hardening`, validate the strict-H6 inputs described in
+  [Production checklist](#production-checklist), including the initial L1
+  indexer start block and catch-up budget.
 
-**3. Verify the signer serves the keys before pointing the proxy at it:**
+The service refuses to serve with the in-memory store unless
+`ALLOW_EPHEMERAL_STORE=1` explicitly accepts losing acknowledged future-nonce
+transactions on restart. That override is for development and tests only;
+never set it in production.
+
+Do these checks first. Account initialization happens before the serving-store
+and strict-H6 database gates, so a misconfigured first start can create Miden
+account identities and write `bridge_accounts.toml` before aborting later in
+startup.
+
+**2. Create the account keys in your KMS/vault.** Create two distinct
+secp256k1 signing keys, one per role. Grant only the backend-specific read/public
+key and signing operations described below; never grant private-key export or
+key administration to the signer workload.
+
+**3. Configure a dedicated signer to expose those two keys.** Use one
+key-config entry per key and supply cloud credentials only to the signer
+workload. The proxy receives no cloud credential. See
+[Signer backends](#signer-backends) below.
+
+**4. Verify both keys, exercise signing authority, and validate the response
+shape before pointing the proxy at the signer.** Set the expected identifiers
+to the exact public-key strings from the authenticated DevOps handoff, run this
+from the same network namespace the proxy will use, and then use those exact
+strings in `AGGLAYER_SIGNER_KEYS`:
 
 ```bash
-curl -sf "$SIGNER_URL/upcheck"
-curl -sf "$SIGNER_URL/api/v1/eth1/publicKeys"
+set -Eeuo pipefail
+: "${SIGNER_URL:?}"
+: "${EXPECTED_SERVICE_KEY:?}"
+: "${EXPECTED_GER_MANAGER_KEY:?}"
+
+curl -fsS "$SIGNER_URL/upcheck" >/dev/null
+signer_keys="$(curl -fsS "$SIGNER_URL/api/v1/eth1/publicKeys")"
+jq -e \
+  --arg service "$EXPECTED_SERVICE_KEY" \
+  --arg ger "$EXPECTED_GER_MANAGER_KEY" '
+    type == "array" and length == 2 and
+    $service != $ger and
+    index($service) != null and index($ger) != null
+  ' <<<"$signer_keys" >/dev/null
+
+sign_test_data="0x$(printf '%064d' 0)"
+for identifier in "$EXPECTED_SERVICE_KEY" "$EXPECTED_GER_MANAGER_KEY"; do
+  signature="$(
+    curl -fsS \
+      -H 'content-type: application/json' \
+      --data "$(jq -nc --arg data "$sign_test_data" '{data:$data}')" \
+      "$SIGNER_URL/api/v1/eth1/sign/$identifier"
+  )"
+  signature="${signature#\"}"
+  signature="${signature%\"}"
+  [[ "$signature" =~ ^0x[0-9a-fA-F]{130}$ ]]
+done
 ```
 
 > A signer with an unreadable or empty key directory reports `/upcheck` as **UP**
-> while serving zero keys. Health-check on a **non-empty key list**, not on
-> `/upcheck` alone, or a broken custody setup looks exactly like a working
-> signer and only surfaces later as a confusing proxy boot error.
+> while serving zero keys. `/upcheck` alone, or even a non-empty key list, does
+> not prove that both role keys are present or that the backend grants signing.
+> Require the exact two-key match and both sign-endpoint calls before any
+> account creation. Retain the provider-side audit events proving that both KMS
+> keys served them. The shell check proves authorization and the 65-byte wire
+> shape; it does **not** cryptographically validate the returned signatures or
+> digest compatibility. A real signed Miden operation and the Web3Signer e2e
+> test provide that proof.
 
-**4. First boot of the proxy** with `--signer-url` and both `--signer-key`
-bindings. On a fresh store this creates the Miden accounts, each bound to the
-remote public key for its role; no secret is generated locally. Account ids are
-persisted to `bridge_accounts.toml` in the store directory.
+**5. First boot of the proxy** with `--signer-url` and both `--signer-key`
+bindings. When `bridge_accounts.toml` is absent (or `--init` is explicitly
+used), this creates the Miden accounts, each bound to the remote public key for
+its role; no account secret is generated locally. Account ids are persisted to
+`bridge_accounts.toml` in the Miden store directory. `--init` forces this
+identity-creation path and exits; never use it against an existing deployment.
 
-**5. Every subsequent boot re-verifies the bindings** (see below). Steady-state
+**6. Every subsequent boot re-verifies the bindings** (see below). Steady-state
 restarts do not re-create anything.
 
 ## Startup verification (what "healthy" means)
 
 On every serving startup — not just the boot that created the accounts — the
-proxy, for each role:
+proxy, for each account role present in `bridge_accounts.toml`:
 
-1. reads the **deployed on-chain account's** auth key out of its `AuthSingleSig`
-   storage slot (importing the account by id if the local store is cold),
+1. reads the account record's auth key from its `AuthSingleSig` storage slot in
+   the local Miden store, importing the public account by id from the node only
+   when that local record is absent,
 2. requires it to equal the key `--signer-key` names for that role, and
 3. requires the signer to **still hold** that key.
 
-All three must agree or the process aborts. The deployed account is the source
-of truth on purpose: inserting the configured commitment and then checking it
-would only prove the config agrees with itself.
+All three must agree or the process aborts. The persisted or imported account
+record is the source of truth on purpose: inserting the configured commitment
+and then checking it would only prove the config agrees with itself. A newly
+created service account can still exist only in the local client store at this
+point; the check must not be described as an unconditional fresh on-chain read.
+
+This is a key-list and binding check, not a startup signing canary. For example,
+an AWS identity with `kms:GetPublicKey` but no `kms:Sign` can pass startup and
+then fail on the first transaction. That is why the provisioning preflight
+above invokes the signing endpoint for each key, and why deployment acceptance
+still requires a real signed operation plus runtime signature counters.
 
 Success is published as a gauge rather than a log line, because log field
 rendering depends on the subscriber's formatter:
 
 ```
-remote_signer_verified_accounts   # = number of roles verified (expect 2)
+remote_signer_verified_accounts   # account roles verified (expect 2 when newly provisioned)
 remote_signer_signatures_total
 remote_signer_signature_failures_total
 ```
 
-Alert on `remote_signer_verified_accounts` dropping below the configured role
-count, and on any sustained rate of `remote_signer_signature_failures_total`.
+`remote_signer_verified_accounts` is set during startup; it is not a continuous
+signer probe. Require it to equal `2` for a newly provisioned deployment, and
+alert if the process/target is absent as well as if that gauge is wrong. During
+runtime, alert on signature failures and on an expected workload producing no
+increase in `remote_signer_signatures_total`.
 
-## KMS backends
+## Signer backends
 
-The proxy is unaware of which vault backs the signer. Swapping backends is a
-change to the signer's key-config file and nothing else — the proxy flags, the
-network topology and this document's procedures are unchanged.
+The proxy is unaware of the signer's storage backend, but that does **not** make
+backend or key changes transparent. Existing Miden accounts remain bound to the
+same public keys. A backend change is proxy-neutral only if it preserves those
+exact keys and the loopback HTTP contract; moving away from a non-exportable
+KMS key normally requires the unsupported account-migration procedure described
+under [Rotation](#rotation). Backend credentials, IAM and signer configuration
+also differ even though the proxy flags do not.
 
 Development (raw file, what the e2e suite generates):
 
@@ -167,26 +251,46 @@ AWS KMS:
 
 ```yaml
 type: aws-kms
+authenticationMode: ENVIRONMENT
 region: eu-west-1
 kmsKeyId: arn:aws:kms:eu-west-1:<account>:key/<uuid>   # kmsKeyId, not keyId
 ```
 
-Azure Key Vault and HashiCorp Vault are configured with their respective
-`type: azure` / `type: hashicorp` entries per Web3Signer's documentation. In all
-cases the signer's identity needs **sign** permission only; it must not need
-export.
+Create each AWS key as `ECC_SECG_P256K1`, `SIGN_VERIFY`, and verify it is
+enabled. `authenticationMode: ENVIRONMENT` uses the AWS default credential
+provider chain; deliver a short-lived workload identity to Web3Signer rather
+than embedding `accessKeyId`, `secretAccessKey`, or `sessionToken` in the YAML.
+Restrict the signer identity to the two key ARNs using separate IAM statements:
+allow `kms:GetPublicKey` without signing-request conditions, and allow
+`kms:Sign` with `kms:SigningAlgorithm=ECDSA_SHA_256` and
+`kms:MessageType=DIGEST`. Do not put those conditions on the `GetPublicKey`
+statement: that request supplies neither field and would be denied. Web3Signer
+needs both operations, but startup key loading exercises only `GetPublicKey`;
+`kms:Sign` is proved only by a real signing request.
+
+For Azure Key Vault, `type: azure-key` performs signing inside Key Vault and is
+the non-export custody option. `type: azure-secret` instead downloads the key
+secret into Web3Signer. HashiCorp's `type: hashicorp` similarly reads private
+key material from the KV store. Those latter modes still keep secrets out of
+the proxy, but they do **not** provide the same non-export guarantee as AWS KMS
+or `azure-key`, and their signer identities require secret-read permission
+rather than only a signing operation. Follow Web3Signer's version-matched
+[key configuration reference](https://docs.web3signer.consensys.io/reference/key-config-file-params).
 
 Two operational notes that apply to the vault-backed setups:
 
 - The identifier you put in `AGGLAYER_SIGNER_KEYS` is the **public key** the
   signer publishes, not the KMS key id or ARN. Read it back from
   `/api/v1/eth1/publicKeys` after configuring the backend.
-- A KMS prevents key **extraction**. It does not prevent key **use** — see the
-  next section.
+- A non-export KMS backend prevents key **extraction**. It does not prevent key
+  **use** — see the next section.
 
 ## The loopback rule
 
-`--require-hardening` **refuses a non-loopback `--signer-url`.**
+`--require-hardening` accepts only a plaintext HTTP URL whose host is a literal
+loopback address (`127.0.0.0/8` or `::1`) or exactly `localhost`. It rejects
+service DNS names, non-loopback hosts, URL credentials, other schemes, and even
+a remote HTTPS signer.
 
 This is not a formality. The proxy authenticates itself to the signer in no way
 at all: no client certificate, no token. `https` proves that *we* authenticated
@@ -195,57 +299,100 @@ API holds a signing oracle, and a KMS does not help — it stops key extraction,
 not key use.
 
 Until caller authentication (mTLS client certificate or token) is implemented,
-run the signer as a **sidecar on the same host/pod** and point `--signer-url` at
-`127.0.0.1`. If you must place the signer elsewhere, put an authenticated relay
-in front of it and point the proxy at the relay's loopback address.
+run the signer in the proxy's **same network namespace**—for example, as a
+sidecar in the same Kubernetes pod—and point `--signer-url` at
+`http://127.0.0.1:<port>`. Merely placing two containers on the same host is not
+enough: each container normally has its own loopback namespace. If the signer
+must run elsewhere, put an authenticated relay beside the proxy and point the
+proxy at the relay's loopback listener.
+
+The signer or relay must also **listen only on loopback** in that namespace. For
+the pinned Web3Signer this means its version-matched equivalent of
+`--http-listen-host=127.0.0.1`; do not publish the signing port with a host-port
+mapping, Kubernetes Service, or Ingress. Verify the bound socket and confirm an
+adjacent workload cannot connect. `--require-hardening` inspects only the URL
+configured on the proxy—it cannot prove how the signer listener is bound or
+exposed.
 
 ## Rotation
 
-There is **no in-place key rotation** for an existing account. An account's auth
-key is fixed in its on-chain storage slot at creation; changing which key a role
-binds to makes startup verification fail with "the deployed *role* account … is
-signed for by a DIFFERENT key than `--signer-key` configures for that role."
+There is **no supported in-place key rotation or automated replacement-account
+workflow** in the current service. An account's persisted/imported auth slot
+remains the source of truth; changing a role binding to another key makes the
+next startup fail its account-versus-configured check.
 
-That failure is correct behaviour — the deployment genuinely cannot sign for
-that account any more. Removing the old key from the signer produces the same
-abort from the other direction ("the remote signer does not hold the key(s)
-bound to *n* configured account(s)").
+Removing a key while the process is already running is different: the signer
+key directory is a startup snapshot, so live transactions begin failing at the
+signing HTTP call and increment `remote_signer_signature_failures_total`. The
+next startup then fails because the configured role key is no longer exposed.
 
-So plan rotation as **provisioning a new account**, not as editing a binding.
-Keep the old key available in the signer until the replacement account is
-deployed and drained. Treat "rotate the ger-manager key" as a change/incident
-procedure with a migration plan, not a config edit.
+Do not edit a binding, remove the old key, or run `--init` as a rotation
+shortcut. Preserve the old key. Rotation requires an explicitly designed and
+tested migration that deploys the replacement account, transfers every
+affected on-chain bridge role and operational dependency, updates the account
+configuration, and proves the old account is drained before retiring its key.
+That migration is outside the current CLI and must be treated as a bespoke
+change/incident procedure.
 
 ## Production checklist
 
-`--require-hardening` (`REQUIRE_HARDENING=true`) turns each of the following
-from a silent runtime exposure into a startup failure. Deployments should set
-it, and the list below is exactly what it enforces:
+`--require-hardening` (`REQUIRE_HARDENING=true`) makes the following custody and
+request-policy predicates startup requirements. Deployments should set it.
+Some defaults are already fail-closed rather than exposed: without an admin key
+the admin methods are disabled, and without an allowed-signer list every signed
+submission is rejected. Hardening requires an explicit production-complete
+configuration instead of accepting those disabled defaults.
 
 | Requirement | Why |
 |---|---|
-| `--signer-url` is loopback | the client does not authenticate itself to the signer |
-| `--insecure-local-keystore` unset | account keys must not be on the host's disk |
-| `--admin-api-key` set | `admin_*` methods would otherwise be open |
-| `--allowed-signers` set | `eth_sendRawTransaction` fail-closed allow-list |
+| `--signer-url` is accepted loopback HTTP | the client does not authenticate itself to the signer |
+| `--insecure-local-keystore` unset | the proxy must not generate or persist account secrets in its own keystore |
+| `--admin-api-key` set | hardening requires authenticated admin operations; without it they are disabled |
+| non-empty `--allowed-signers` | hardening requires an explicit submitter policy; without it all signers are rejected |
 | `--insecure-allow-any-signer` unset | legacy open mode, incompatible with the allow-list |
 | `--cors-allowed-origins` has no `*` | any browser origin could reach mutating endpoints |
 | `--miden-prover-url` set | the in-process prover is the documented OOM cause; also probed for reachability at startup |
 
-Setting it additionally implies **strict H6** (`--reject-unverified-ger-injection`),
-which refuses any GER not corroborated by the independent L1 InfoTree indexer,
-and requires `--l1-evidence-tag=safe` or `finalized` — `latest` may include
-reorgable L1 blocks and is not sufficient to authorize a GER.
+This gate proves the proxy selected remote custody; it does not attest the
+signer's backend. A loopback Web3Signer using `file-raw` keys can satisfy
+hardening while keeping private material on the same host. Prove non-export KMS
+custody separately from the signer config, IAM policy, two-key preflight, and
+provider audit evidence.
 
-Beyond the flags: never expose the JSON-RPC port directly to the public
-internet, never run two service processes against one Miden store, and never
-delete `keystore/` or `bridge_accounts.toml` as part of a routine recovery.
+Setting it also implies **strict H6**
+(`--reject-unverified-ger-injection`). Current startup therefore additionally
+requires all of the following:
+
+- both `L1_RPC_URL` and `GER_L1_ADDRESS`, with a usable HTTP(S) RPC URL and a
+  syntactically valid EVM contract address;
+- `L1_EVIDENCE_TAG=safe` or `finalized`; `latest` may include reorgable L1
+  blocks and is rejected under hardening;
+- on a fresh PostgreSQL database, `L1_INDEXER_FROM_BLOCK` set at or before the
+  rollup deployment as a one-boot initial-backfill override; remove it after
+  successful catch-up because it outranks the persisted cursor and otherwise
+  rewinds that range on every restart; an existing database may instead supply
+  its non-zero, policy-matched evidence cursor; and
+- synchronous L1 evidence catch-up before the JSON-RPC listener serves. The
+  default ceiling is 300 seconds; size
+  `L1_EVIDENCE_CATCHUP_BUDGET_SECS` for the initial historical range. Startup
+  aborts rather than serving if the evidence index cannot converge in time.
+
+These H6 checks are part of the effective hardened startup contract even though
+they are evaluated separately from the core flag checklist.
+
+Independently of hardening, production serving requires `DATABASE_URL`; never
+use `ALLOW_EPHEMERAL_STORE=1`. Never expose the JSON-RPC port directly to the
+public internet, run two service processes against one Miden store, or delete
+`keystore/` or `bridge_accounts.toml` as part of routine recovery.
 
 ## Verifying a provisioned deployment
 
-The e2e suite exercises the same code path a KMS-backed deployment uses — proxy
-→ HTTP → signer → custody backend — differing only in the signer's key-config
-file:
+The e2e suite exercises the same proxy → HTTP → Web3Signer protocol and its
+negative controls, using `file-raw` keys. It does **not** validate production
+network topology, cloud credentials, IAM, or KMS audit evidence.
+
+The script destroys its Compose volumes and fixture data. Run it only against a
+disposable, isolated e2e project—never against a provisioned deployment:
 
 ```bash
 ./scripts/e2e-web3signer.sh
@@ -254,16 +401,30 @@ file:
 It asserts that the proxy holds no local secret, that a full L1→L2 deposit is
 signed remotely, that signing genuinely depends on the signer (stopping the
 signer must break signing, and restarting it must resume it), that a proxy
-restart re-verifies both role bindings against the deployed accounts, and that a
-role pointed at the wrong key is refused at startup and that the refusal is not
-sticky.
+restart re-verifies both role bindings against the persisted account records,
+and that a role pointed at the wrong key is refused at startup and that the
+refusal is not sticky.
 
-Against a real deployment, the equivalent read-only checks are:
+Against a real deployment, these are useful basic spot checks:
 
 ```bash
-curl -sf "$SIGNER_URL/api/v1/eth1/publicKeys"          # signer serves both keys
-curl -sf "$PROXY_RPC/metrics" | grep remote_signer_    # verified_accounts == role count
+curl -fsS "$SIGNER_URL/api/v1/eth1/publicKeys" | jq .
+expected_accounts="${EXPECTED_ACCOUNT_ROLE_COUNT:-2}"
+verified="$(
+  curl -fsS "$PROXY_RPC/metrics" |
+    awk '$1 == "remote_signer_verified_accounts" {print $2}'
+)"
+test "${verified%.*}" -eq "$expected_accounts"
 ```
+
+They are not equivalent to the e2e test and do not prove KMS signing authority.
+Set `EXPECTED_ACCOUNT_ROLE_COUNT` to the roles present in
+`bridge_accounts.toml`: `2` for a new deployment, or potentially `1` for a
+supported legacy file without `ger_manager`. For deployment acceptance, repeat
+the two-key signing-authority/response-shape preflight, execute a real signed
+operation, prove `remote_signer_signatures_total` increased without a
+failure-counter increase, and retain provider-side evidence that both expected
+KMS keys served the signing calls.
 
 ## Related
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -33,9 +33,11 @@ the service then enforces containment after symlink resolution.
 
 ### Durable synthetic store
 
-Set `DATABASE_URL` in production. Without it the service uses `InMemoryStore`,
-which loses synthetic logs, receipts, cursors, faucet routes, and admission
-state at restart.
+Set `DATABASE_URL` in production. A serving start without it is now refused.
+`ALLOW_EPHEMERAL_STORE=1` is an explicit development/test escape hatch that
+selects `InMemoryStore` and loses synthetic logs, receipts, cursors, faucet
+routes, admission state, and acknowledged future-nonce transactions at
+restart. Never set it in production.
 
 Postgres migrations are embedded into the binary and run automatically under
 an advisory lock before the pool opens. A previously applied file whose
@@ -45,17 +47,20 @@ container, edit an applied migration, or mark one applied manually.
 ### Rate-limit sizing vs the claim pipeline
 
 The per-IP rate limit (`RATE_LIMIT_PER_SECOND` / `RATE_LIMIT_BURST`, default
-500/500) MUST be sized above your claimtxman/aggkit burst rate. Measured on the
-N=30 loadtest: the stack's own infrastructure generates 400-1000 rate-limited
-requests per run at the default. The failure mode is not throttling — it is a
-PERMANENT wedge: claimtxman pre-assigns nonces to monitored claim txs and never
-re-nonces one it drops, so a 429-exhausted tx leaves a nonce gap that the R4
-anti-replay ledger then rejects everything behind (observed: `tx.nonce = 86-89,
-expected 11`, L1→L2 autoclaims stalled indefinitely). If autoclaims stall and
-the proxy log shows rate-limit hits alongside `nonce mismatch` errors from the
-claimtxman address, raise the limit for the infra network — the wedged
-claimtxman txs themselves need their sqlite state cleared (recreate the
-container) to re-nonce.
+500/500) must be sized above the claimtxman/aggkit burst rate. Measured on the
+N=30 loadtest, the stack's own infrastructure generates 400–1000 rate-limited
+requests per run at the default.
+
+Current nonce admission persists a valid future nonce in the Postgres-backed
+ephemeral txpool instead of rejecting everything behind a missing nonce. That
+removes the old immediate `nonce mismatch` wedge, but it does not make a
+rejected lower transaction optional: later transactions wait in the bounded
+future-nonce queue until promotion is possible, and non-recovery rows may
+eventually be evicted. If rate-limit hits correlate with
+`rpc_future_nonce_parked_total` or bound-exceeded events, raise the rate limit
+for the infrastructure boundary and have the sender retry the exact missing
+signed transaction. Diagnose its state before changing sender storage; do not
+clear proxy admission rows or invent a replacement transaction.
 
 ### Private listener and authentication
 
@@ -70,8 +75,10 @@ Current state-changing protections:
   `--require-hardening`;
 - no `ADMIN_API_KEY` means every `admin_*` call is disabled;
 - no CORS configuration means browsers receive no allow-origin header;
-- `--require-hardening` additionally requires admin key, signer allow-list,
-  non-wildcard CORS, and a configured/reachable remote prover.
+- `--require-hardening` additionally requires remote-only loopback signer
+  custody, an admin key, a signer allow-list, non-wildcard CORS, a
+  configured/reachable remote prover, and the strict-H6 L1 evidence contract
+  below.
 
 ### Remote prover
 
@@ -84,15 +91,23 @@ at startup and refuses local-only mode.
 ### L1 GER indexer
 
 Configure both `L1_RPC_URL` and `GER_L1_ADDRESS`. If either is missing, the
-InfoTree indexer is disabled; newly projected GER rows can remain unresolved
-and `zkevm_getExitRootsByGER` returns `null` for them. There is no safe
-latest-root fallback because a combined GER cannot be decomposed after the
-fact. Monitor `l1_indexer_state` and the indexer error metrics.
+InfoTree indexer is disabled in non-strict mode; strict H6 instead aborts
+startup. Newly projected GER rows can remain unresolved and
+`zkevm_getExitRootsByGER` returns `null` for them. There is no safe latest-root
+fallback because a combined GER cannot be decomposed after the fact. Monitor
+`l1_indexer_state` and the indexer error metrics.
 
 `L1_EVIDENCE_TAG=latest|safe|finalized` selects the indexer's only L1 frontier;
 the default is `latest`. `REJECT_UNVERIFIED_GER_INJECTION=true` makes GER
 admission wait for roots written by that scan. `REQUIRE_HARDENING=true` implies
 strict admission and requires `safe` or `finalized`.
+
+Strict startup also validates an HTTP(S) L1 URL and EVM GER address. On a fresh
+database it requires `L1_INDEXER_FROM_BLOCK` at or before rollup deployment; an
+existing database may use its non-zero, policy-matched cursor. Before serving,
+the indexer synchronously catches up to the selected frontier. The default
+budget is 300 seconds (`L1_EVIDENCE_CATCHUP_BUDGET_SECS`); size it for an
+initial historical backfill or startup aborts without binding the listener.
 
 The database binds its evidence marker and cursor to the exact selected tag.
 Changing it requires stopping the service, clearing the policy-derived marker,
@@ -320,6 +335,32 @@ than** `transaction_hash` differs. It also refuses to run against a store that i
 itself restore output (`service_state.nonce_ledger_rebuilt = true`), because such a
 run would only measure idempotence, not fidelity.
 
+### Nonce admission after full PostgreSQL loss
+
+The submitter nonce ledger is proxy-local and cannot be reconstructed from
+Miden. A restore into a fresh PostgreSQL database therefore records a durable
+rebuild marker. On the next serving boot, a signer with no nonce row may park
+its first observed transaction; after a three-projected-block settle margin,
+the lowest eligible parked nonce becomes that signer's baseline and the
+contiguous run is promoted. Ordinary nonce ordering applies after that
+first-contact seed.
+
+The global first-contact window defaults to six hours from the restore stamp
+and is configured with `NONCE_RECOVERY_WINDOW_SECS`. Restarts do not extend it.
+A transaction parked while the window is open carries
+`parked_during_recovery=true`; it remains eligible and is exempt from the normal
+3600-block txpool TTL even if the global window closes first. It remains until
+admission/reconciliation, or until an operator handles a surfaced stranded row.
+
+This policy intentionally treats **any signer first seen while the recovery
+window is open as continuing**, including a genuinely new signer. That is an
+accepted operational trade-off of recovering a nonce ledger with no chain
+source. Freeze signer onboarding and changes to `ALLOWED_SIGNERS` during the
+window, admit only the expected pre-loss identities, and verify
+`rpc_nonce_ledger_bootstrapped_total` against that inventory. The
+`rpc_nonce_recovery_mode_expired_total` counter records retirement of the
+global window; already stamped rows remain grandfathered until handled.
+
 ### Full Miden sqlite reset plus restore
 
 Use only when sqlite divergence cannot be repaired surgically and the managed
@@ -452,10 +493,11 @@ leaf). To detect it:
 
 ### Pending transaction or writer restart
 
-Look up the hash in `transactions`, `tx_note_links`, and
-`nonce_reservations` as shown in diagnostics.
+Look up the hash in `queued_txns`, `transactions`, `tx_note_links`, and
+`nonce_reservations` as shown in diagnostics. A parked future transaction has a
+`queued_txns` row but no `transactions` row until promotion.
 
-- Queue saturation returns JSON-RPC `-32005`; callers should back off and
+- Writer-queue saturation returns JSON-RPC `-32005`; callers should back off and
   rebroadcast the exact signed envelope.
 - Queue-wait TTL can fail a job only before dispatch when no durable handoff
   exists. The maintenance sweeper also evicts old terminal in-memory entries;
@@ -464,114 +506,80 @@ Look up the hash in `transactions`, `tx_note_links`, and
   pending. Only exact note observation/commit or authoritative expiration
   classification may resolve it.
 - A different transaction cannot replace the durable `(signer, nonce)` owner.
+- A valid nonce above the executable frontier is accepted into the bounded
+  Postgres-backed but ephemeral `queued_txns` pool. Filling the gap triggers an
+  ordered promotion attempt, with retained failures retried periodically;
+  same-hash rebroadcast is idempotent and a different same-nonce hash is
+  rejected.
+- A non-recovery parked row still resident at its 3600-projected-block TTL may
+  be evicted, including after a failed promotion attempt. Its hash then stops
+  resolving and its capacity is reclaimed; the sender must retain and
+  rebroadcast the signed envelope if it still needs it. Recovery-stamped rows
+  follow the exemption described above.
 - A lower nonce admitted without reaching handoff blocks higher nonces until
   the exact lower signed transaction is resubmitted.
 
 Recovery:
 
 1. Obtain the original raw signed transaction from the caller/transaction
-   manager or the durable `envelope_bytes` through an approved forensic path.
+   manager, `queued_txns.envelope`, or `transactions.envelope_bytes` through an
+   approved forensic path.
 2. Submit those exact bytes again; verify the returned EVM hash is unchanged.
 3. Observe handoff/receipt reconciliation and nonce progression.
 4. Never construct a new random Miden note or a new EVM transaction at the same
    nonce to "unstick" it.
 5. Never delete admission/handoff rows manually.
 
-### Stuck GER injection (interrupted `ger_insert`) — aggoracle deadlock
+### Interrupted GER or claim job: automatic orphan recovery
 
-Known failure mode (tracked as finding #70; recurred repeatedly under fault
-testing). If the proxy is restarted/paused while a `ger_insert` writer job is
-in flight, the aggoracle's `insertGlobalExitRoot` transaction can be left
-`status='pending', block_number=0` permanently: nothing resumes the job after
-restart. Two deadlocks then stack:
+The service automatically recovers acknowledged `pending` transactions after an
+interrupted writer job. A bounded background pass starts at boot and repeats
+every 30 seconds. It works from the stored signed envelope and authoritative
+Miden state, in nonce order per signer:
 
-- the aggoracle's ethtxmanager polls that hash forever ("waiting signedTx to
-  be mined"); and
-- its monitored-transaction ID is deterministic (hash of from/to/calldata, no
-  nonce), so even a recreated aggkit re-derives the same ID, logs
-  `inject GER transaction already exists in monitoring DB`, and never sends a
-  new injection.
+- an intent with no durable note handoff is re-enqueued with persistent,
+  exponential backoff;
+- a submitted handoff or recorded Miden transaction is polled and is never
+  blindly resubmitted;
+- a prepared-but-unconfirmed handoff is retained until the reconciliation
+  cursor proves its finite expiration has passed, then a fresh note is driven;
+  and
+- an effect already applied in Miden is reconciled to a terminal receipt for
+  the original proxy transaction hash.
 
-Blast radius: GER injection stops → deposits never turn `ready_for_claim`,
-L2↔L2 settlement stalls, and the store's UpdateHashChain/ClaimEvent counts
-freeze while the chain keeps advancing. There is no error anywhere — only
-silence.
+Do not delete `transactions`, `tx_note_links`, `nonce_reservations`, or `nonces`,
+and do not recreate a transaction at the same nonce. Those changes destroy the
+recovery source of truth and can violate admission ordering.
 
-**Diagnosis (in order):**
+**Diagnosis:** first rule out a silent ntx-builder using the next procedure. If
+note consumption is advancing, inspect the recovery backlog and its handoff
+state:
 
-1. Rule out the ntx-builder first (see the next procedure): if it is silent,
-   restart it and re-check before touching anything else — an unconsumed
-   UpdateGerNote resolves itself once consumption resumes.
-2. Stuck pending injection:
-
-   ```sql
-   SELECT tx_hash, status, block_number, created_at
-   FROM transactions
-   WHERE lower(signer) = '<aggoracle sender, lowercase>'
-     AND status = 'pending'
-     AND created_at < now() - interval '3 minutes';
-   ```
-
-   The aggoracle sender address is logged at aggkit startup
-   (`AggOracle sender address: 0x…`).
-3. Aggoracle deadlock confirmation: aggkit logs repeat
-   `inject GER transaction already exists in monitoring DB with ID 0x…` with
-   no interleaved `submitted`, and the proxy receives no
-   `eth_sendRawTransaction` from that sender.
-4. Corroborate the freeze: `ger_entries.is_injected` stops advancing;
-   `synthetic_logs` UpdateHashChain count is static while the Miden tip moves.
-
-**Recovery.** This is the one documented exception to "never delete
-admission rows / never replace a pending transaction". It is safe if and only
-if ALL of the following hold — verify each before proceeding:
-
-- the pending rows belong to the aggoracle sender only;
-- their GERs show `is_injected = false` in `ger_entries` (the injection never
-  landed — nothing external ever observed a receipt);
-- the only consumer of those hashes is the aggoracle itself, and it is reset
-  in the same procedure (fresh ethtxmanager state);
-- GER injection is content-idempotent: the same root is safely re-injected
-  under a new transaction.
-
-Procedure (order matters — client side must come back AFTER the proxy):
-
-```bash
-# 1. stop the aggoracle so it cannot re-send mid-surgery
-docker stop <aggkit-container>
-
-# 2. proxy store: remove the dead pending injection(s) + realign the nonce
-#    (psql into the proxy's PostgreSQL, agglayer_store)
-DELETE FROM tx_note_links WHERE tx_hash IN
-  (SELECT tx_hash FROM transactions
-   WHERE lower(signer)='<aggoracle>' AND status='pending');
-DELETE FROM transactions
-  WHERE lower(signer)='<aggoracle>' AND status='pending';
--- MINED := count of that signer's success/reverted rows
-DELETE FROM nonce_reservations
-  WHERE lower(signer)='<aggoracle>' AND nonce >= MINED;
-UPDATE nonces SET nonce = MINED WHERE lower(address)='<aggoracle>';
-
-# 3. restart the proxy; wait for healthy
-docker restart <proxy-container>
-
-# 4. recreate aggkit WITH A FRESH CONTAINER (its ethtxmanager sqlite lives in
-#    the container /tmp — a plain restart resumes the deadlocked state)
-docker rm -f <aggkit-container>
-docker compose up -d --no-deps aggkit
+```sql
+SELECT t.tx_hash, t.signer, t.miden_tx_id, t.status,
+       t.recovery_attempts, t.next_recovery_at,
+       l.handoff_state, l.note_id, l.prepared_expiration_block,
+       t.created_at, t.updated_at
+FROM transactions AS t
+LEFT JOIN tx_note_links AS l ON l.tx_hash = t.tx_hash
+WHERE t.status = 'pending'
+ORDER BY t.created_at;
 ```
 
-**Verify:** within ~1 minute the aggoracle logs `inject GER transaction
-submitted`, the proxy mines it (`transactions.status='success'`,
-`ger_entries.is_injected` flips true, UpdateHashChain count increments), and
-new deposits turn `ready_for_claim`.
+Watch `pending_unlinked_txns` and
+`pending_unlinked_oldest_age_seconds`; the backlog and oldest age should fall as
+dependencies recover. `orphan_recovery_successes_total`,
+`orphan_recovery_redrives_total`, and
+`orphan_recovery_already_claimed_total` identify forward progress. Page on any
+increase in `orphan_recovery_persistent_failures_total`, or on a persistently
+rising oldest-age gauge while the Miden node and writer are healthy. Correlate
+with `target=recovery` logs and dependency health.
 
-**Prevention / monitoring:** alert when
-`count(pending aggoracle txs older than 3 min) > 0` or when
-`ger_entries.is_injected` is static for >5 min while the Miden tip advances.
-A supervised auto-heal implementing exactly the procedure above is acceptable.
-The product fix — resuming interrupted `ger_insert` jobs on startup via the
-durable note handoff — is tracked as finding #70; until it ships, treat this
-procedure as the standing remediation.
+If recovery remains stuck, preserve the database, exact envelope, handoff row,
+and logs and escalate for code-level diagnosis. A legacy prepared handoff with
+`prepared_expiration_block = 4294967295` predates finite note expiry and cannot
+self-heal through expiration; resolve that bounded upgrade edge case out of
+band. It is not authorization for ad-hoc row deletion or nonce rewinding.
 
 ### ntx-builder silent death (network-note consumption halts)
 
@@ -580,8 +588,9 @@ Upstream Miden issue (finding #68). After all account actors log
 following the chain entirely — no further `apply_committed_block` lines, no
 error, process alive — while the tip advances. Because the bridge is a network
 account, ALL bridge note consumption (CLAIM, UpdateGerNote) halts with it:
-claims stop landing, GER injections stall (see the previous procedure — check
-this FIRST), and store event counts freeze silently.
+claims stop landing, GER injections stall, and store event counts freeze
+silently. Check this condition before treating an old pending transaction as an
+orphan-recovery failure.
 
 **Diagnosis:** compare the ntx-builder's last log timestamp against the Miden
 tip. Healthy operation logs `apply_committed_block` every few seconds; more


### PR DESCRIPTION
## Summary

- add a deployment-neutral provisioning guide for account-key custody and first boot
- document remote-signer requirements, role bindings, KMS backends, startup verification, rotation constraints, and production hardening
- link the guide from the operations documentation index

## Validation

- documentation-only change
- content verified against the current CLI, signer implementation, and deployment checks