### PR TITLE
fix: Dockerfile no longer copies the deleted vendor/ directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ WORKDIR /usr/src/app
 COPY src src
 COPY axum-jrpc axum-jrpc
 COPY migrations migrations
-# vendor/ carries the temporary miden-client [patch.crates-io] override —
-# the build cannot resolve the patch path without it.
-COPY vendor vendor
 COPY Cargo.* .
 
 # build


### PR DESCRIPTION
Follow-up to #181: `COPY vendor vendor` survived the unvendor, so every proxy image build on main fails with `/vendor: not found` (caught by the #176 e2e run at `make e2e-up`). One-line removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGoAzmPkjYq85iADpZodwm