### PR TITLE
fix(#185): unresolvable-destination claim reverts with no ClaimEvent (EVM semantics)

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,205 @@
+# PR #186 / issue #185 — live validation report
+
+**Branch** `fix/185-unresolvable-claim-evm-revert`
+**Base** `origin/main` @ `5934507` (branch was 0 behind / 2 ahead at start — **no rebase was needed**)
+**Stack** node `v0.16.0-rc.5` (`461ac961951c`), stock client rc.5, `zkevm-bridge-service:v0.6.4-RC2-pendingbridges`
+**Evidence root** `e2e-results/185-20260907T205206Z/`
+**`gh` is UNAUTHENTICATED on this box** — the PR summary could not be posted; paste this file into #186 by hand.
+
+> Note on the task premise: I could not find #176 anywhere in `origin/main`'s history
+> (`git log --grep=176`, `git log --oneline | grep 176`). The branch is nonetheless on the
+> current `origin/main` tip.
+
+---
+
+## 1. Static checks + baseline round-trip
+
+| check | result |
+|---|---|
+| `cargo test --lib --bins` | **600 passed, 0 failed, 1 ignored** (599 before my fix added one) |
+| `cargo clippy --all-targets -- -D warnings` | **clean** |
+| `SKIP_STATIC=1 ./run-all.sh` | **rc=0** — `logs/03-run-all-rebuilt.log` |
+| baseline L1→L2 | **PASS** — wallet `0 → 1000` units (`+1000`, expected `+1000`) |
+| baseline L2→L1 | **PASS** — certificate settled on L1, `+5000000000000 wei` autoclaimed |
+
+---
+
+## 2. The #185 behaviour, end to end on a live stack
+
+Driven by a new committed harness script, `scripts/e2e-185-unresolvable-claim-revert.sh`
+(added in `7c149bd`). It bridges a real L1 deposit to a freshly generated EVM address whose
+first byte is non-zero — so it can never satisfy the zero-padding fallback and has no store
+mapping — lets the real claimtxman drive `claimAsset`, and asserts on chain state.
+
+Run of record: `logs/04-185-live.log`, evidence in `185-live/`.
+Deposit `deposit_cnt=2`, `global_index=18446744073709551618` (`0x10000000000000002`),
+destination `0xd1336cc3ad5571621acbe631f08557e6422682b3`,
+claim tx `0x99ea4a267efdd39f511711c67c1b5ed2a487914258111acecd749742c076ab22`.
+
+### 2a — revert semantics: **PASS**
+
+```
+PASS: (a) receipt REVERTED: status=0x0 logs=0 block=112
+PASS: (a) NO ClaimEvent for gi=18446744073709551618 — eth_getLogs=0, synthetic_logs=0
+PASS: (a) nonce advanced past the reverted claim (EVM semantics)   [signer 0x6352…, tx nonce 0x1, account nonce 0x2]
+PASS: (a) claim_unclaimable_reverted_total advanced: 0 -> 1
+      (a) unclaimable_claims rows: 0 -> 1
+```
+
+The no-event check is made twice, from both ends a consumer can look: `eth_getLogs` over the
+whole chain filtered on the ClaimEvent topic, matching the globalIndex in the first data word,
+**and** the proxy's own `synthetic_logs` table. Both zero.
+
+### 2b — `isClaimed(globalIndex)` is the retry-suppression signal: **PASS**
+
+```
+PASS: (b) isClaimed(2,0) = TRUE from the unclaimable record, with NO ClaimEvent behind it
+```
+
+`eth_call` to the bridge address, selector `0xcc461632`, returns ABI true.
+
+### 2c — the claim submitter stops re-driving: **FAILED FIRST, then PASS after a product fix**
+
+This is the one that did not hold, and the reason is worth reading in full.
+
+**First run, `logs/02-185-live.log` + `185-live-attempt1-prefix-estimategas/`:**
+
+```
+(c) monitored_txs status=<none> terminal=0; reverted counter 0 -> 2 -> 10 (total attempts: 10)
+FAIL: (c) monitored_txs is still non-terminal AND the revert counter is still advancing
+```
+
+Ten reverted receipts and ten consumed nonces in **19 seconds** (21:15:31 → 21:15:50), ended
+only by claimtxman's own backstop:
+
+```
+claimtxman/monitortxs.go:116  marked as failed because reached the history size limit (10)
+```
+
+and **not one** `Checking if the deposit was already claimed` line in the bridge-service log.
+The `checkIfClaimed` → `isClaimed` path that the #185 commit message names as its retry
+suppression never executed once.
+
+**Cause.** Only half the on-chain state learned the new fact. `checkIfClaimed` is reachable
+only when `ReviewMonitoredTx` sees an `execution reverted` error, and `ReviewMonitoredTx`'s
+only failure mode is `eth_estimateGas`. `service_estimate_gas` derived `claimed` from
+`applied_state::claim_and_ger_applied` — the Miden-nullifier / ClaimEvent view, which is FALSE
+for an unclaimable claim *precisely because #185 stopped emitting the event*. So `eth_call
+isClaimed` answered "already claimed" while `eth_estimateGas` answered `0x0`, go ahead, and the
+submitter believed the half that told it to retry.
+
+**Fix — `40d6934`.** `eth_estimateGas(claimAsset)` now reads the same durable
+`unclaimable_claims` record and reverts `AlreadyClaimed()`, ordered ahead of the
+`GlobalExitRootInvalid()` arm ("retry when the GER lands" is exactly the wrong advice for a
+claim that can never be applied). New metric `rpc_estimate_gas_unclaimable_total`. New unit
+test asserts the revert and that the record wins over an absent GER.
+
+**Re-run after the fix, `logs/04-185-live.log`:**
+
+```
+(c) monitored_txs status=confirmed terminal=1; reverted counter 0 -> 1 -> 1 (total attempts: 1)
+PASS: (c) submitter STOPPED: monitored_txs status=confirmed (terminal) after 1 attempt(s)
+```
+
+and the documented mechanism now actually fires, in the bridge-service's own words:
+
+```
+claimtxman/monitortxs.go:375  Checking if the deposit was already claimed
+claimtxman/monitortxs.go:393  The deposit was already claimed, so the monitored tx is marked as confirmed
+```
+
+proxy `/metrics`: `rpc_estimate_gas_unclaimable_total 1`, `claim_unclaimable_reverted_total 1`.
+
+**One reverted receipt and one nonce, down from ten.**
+
+### 2d — certificates keep settling (#184): **PASS**
+
+```
+(d) aggkit 'cutting certificate at block' lines since the claim: 0
+PASS: (d) post-claim bridge-out completed
+PASS: (d) certificate settlement ADVANCED across the unresolvable claim: height 1 -> 2
+PASS: (d) aggkit logged ZERO 'cutting certificate' lines — #184 is gone
+```
+
+A full normal bridge-out (`scripts/e2e-l2-to-l1.sh`) landed *after* the unresolvable claim and
+its certificate settled on L1 at a strictly greater height. The `#184` signature —
+`found claim with unclaim after later unfinalized claim … cutting certificate at block N`
+followed by `no bridges or claims found for range` forever — does not appear.
+
+### 2e — restore fidelity (#103): **PASS**
+
+`scripts/e2e-full-db-loss-recovery.sh` on the chain carrying the unresolvable claim
+(`logs/05-full-db-loss.log`, rc=0):
+
+```
+baseline provenance: live (true fidelity comparison)
+note-less (RD-860) claims recorded pre-drop: 1
+eth_getLogs: before=9 logs after=9 logs
+PASS: eth_getLogs identical across restore EXCEPT transaction_hash on 7 log(s) —
+      every other field (block, log_index, address, topics, data, tx_index, removed) byte-identical
+PASS: UpdateHashChain content identical … PASS: hash_chain_value identical (order-faithful replay)
+PASS: BridgeEvent (count 2) + ClaimEvent (count 1) rows identical
+```
+
+This is the #103 proof in its exact shape. The drill *knows* an unresolvable claim is in
+history (it snapshots the `unclaimable_claims` global indices before the drop, so it can
+classify any lost log as an exempt note-less claim). **Nothing was lost, so the exempt path
+never ran: 9 logs before, 9 after, zero exempt, zero unexplained.** Before #185 the same run
+would have shown 10 → 9 with one "EXEMPT" drop, which is precisely the gap #103 filed.
+
+The one `ClaimEvent` that survives is the legitimate L1→L2 claim from the baseline round-trip —
+it has a real Miden note and replays. The unresolvable claim is simply absent on both sides.
+
+---
+
+## 3. Fixes made on this branch
+
+| commit | kind | what |
+|---|---|---|
+| `fd0e147` | harness | Root-owned isolated wallet store silently minted a NEW wallet per call — `run-all`'s L1→L2 funded `0xb73e…`, the next L2→L1 minted a different wallet in the same store and died `Wallet has no balance`. Cause: the tool container runs as root, so `wallet-id` could not be written and both that and the `mkdir` failed silently. `_iso_own_store` chowns the store back; an unpersistable wallet id is now a hard stop. **Pre-existing, unrelated to #185.** |
+| `40d6934` | **product** | `eth_estimateGas(claimAsset)` never read the `unclaimable_claims` record, so `checkIfClaimed` was unreachable and the submitter re-drove ten times. See 2c. |
+| `7c149bd` | harness | `verify-event-completeness` still demanded the phantom ClaimEvent per unclaimable record (`unclaim 0/2 FAIL` — a green product failing a red test). Assertion **inverted**, not deleted: a ClaimEvent carrying an unclaimable record's exact `(block, globalIndex, tx-hash)` is now a PHANTOM and fails the verdict. Also adds `scripts/e2e-185-unresolvable-claim-revert.sh`. |
+
+Verifier before/after on the live stack:
+
+```
+before (logs/07-…-BEFORE-fix.log):  CLAIM->ClaimEvent  2  2  2  0  0  0   0/2   -  0  FAIL   VERDICT: FAIL
+after  (logs/08-…-AFTER-fix.log):   CLAIM->ClaimEvent  2  2  2  0  0  0  0p/0u  -  0  PASS   VERDICT: PASS
+```
+
+`scripts/test-verify-completeness-substitution.sh` (the verifier's own regression test) stays green.
+
+---
+
+## 4. Regression matrix
+
+*(pending — full growing-chain battery, `ITERATIONS=2`, running; see section below)*
+
+---
+
+## 5. Environment note — a competing run was destroying this one's evidence
+
+A previous session's `e2e-battery.sh` (PID 14509, started 17:41Z, results in
+`e2e-results/167-20260907T174108Z`) was still running against the **same** docker-compose
+project. This session's instructed `SKIP_STATIC=1 ./run-all.sh` wipes genesis and the
+`node_data` volume, so it destroyed that battery's chain at ~21:02Z — its `loadtest-N30`
+failed as a direct result — and that battery's chaos-soak then drove concurrent L1 traffic
+from the same funded key `scripts/e2e-l2-to-l1.sh` uses as its L1 destination, producing a
+nonsensical `L1 balance change mismatch: got -4547008009104016 wei` (a *negative* delta = that
+account paid gas for someone else's `bridgeAsset`).
+
+Both runs were producing garbage. I stopped the stale battery and left its results directory
+untouched. Recorded in `logs/00-stale-battery-conflict.txt`. Two batteries cannot share one
+compose project; only one owner at a time.
+
+---
+
+## 6. Open items
+
+- **`gh` is unauthenticated** — the PR #186 summary was not posted. Paste this file.
+- **The first unresolvable claim per deposit still costs one reverted receipt and one nonce**,
+  by design: attempt 1's `eth_estimateGas` runs *before* the `unclaimable_claims` record exists,
+  so it cannot know. That is the floor, and it matches EVM (the first attempt is what reverts).
+- **Operator rescue (tier 2) must delete the `unclaimable_claims` row** to re-open a global
+  index. Since #185 that was already true of `eth_call isClaimed`; `40d6934` adds
+  `eth_estimateGas` to the same contract. Not a new constraint, but now two call sites.

--- a/REPORT.md
+++ b/REPORT.md
@@ -173,11 +173,206 @@ after  (logs/08-…-AFTER-fix.log):   CLAIM->ClaimEvent  2  2  2  0  0  0  0p/0u
 
 ## 4. Regression matrix
 
-*(pending — full growing-chain battery, `ITERATIONS=2`, running; see section below)*
+The regression question is narrow: **does any scenario that is green on `main`
+go red with #185?** It is answered by one clean iteration of the committed
+growing-chain battery, plus a same-shaped run on the base commit to say what
+"green on main" actually means.
+
+| | |
+|---|---|
+| branch run | `BATTERY_TAG=185 ITERATIONS=1 KEEP_CHAIN=1 ./scripts/e2e-battery.sh` at `eba7339` |
+| results | `e2e-results/185-20260908T052005Z/` (`results.tsv`, `MATRIX.md`, `chain-growth.tsv`, `logs/`) |
+| on-main baseline | `e2e-results/167-20260907T174108Z/` — battery started 17:41Z on the base commit; the #185 commits are authored 20:48Z, so that run contains none of them |
+| gates before the run | `cargo test --lib --bins` 600+27+5 pass / 0 fail; `cargo clippy --all-targets -- -D warnings` clean; full `make lint` (fmt + taplo + typos + clippy) clean |
+| ownership | this session was the **sole** owner of the `miden-agglayer` compose project for the whole run — the two-batteries-one-project contamination described in §5 does not apply here |
+
+| # | target | on main | #185 branch | secs | regression? |
+|---|---|---|---|---|---|
+| 1 | `fixture-l2-to-l1-livebaseline` | PASS | PASS | 399 |  no |
+| 2 | `full-db-loss-recovery-livebaseline` | PASS | PASS | 371 |  no |
+| 3 | `test-e2e` | PASS | PASS | 3685 |  no |
+| 4 | `e2e-l1-to-l2` | PASS | PASS | 122 |  no |
+| 5 | `e2e-claim-provenance` | PASS | PASS | 756 |  no |
+| 6 | `e2e-claim-watcher` | PASS | PASS | 142 |  no |
+| 7 | `e2e-claim-watcher-synthesis` | PASS | PASS | 153 |  no |
+| 8 | `e2e-l2-to-l1` | PASS | PASS | 181 |  no |
+| 9 | `e2e-l2-to-l1-autoclaim` | PASS | PASS | 195 |  no |
+| 10 | `e2e-restore` | PASS | PASS | 260 |  no |
+| 11 | `e2e-cantina6-faucet-identity-restore` | PASS | PASS | 427 |  no |
+| 12 | `e2e-cantina10` | PASS | PASS | 290 |  no |
+| 13 | `e2e-cantina12-getlogs-returns-all` | PASS | PASS | 33 |  no |
+| 14 | `e2e-cantina13` | PASS | PASS | 623 |  no |
+| 15 | `e2e-ger-decomposition` | PASS | PASS | 31 |  no |
+| 16 | `e2e-security` | PASS | PASS | 34 |  no |
+| 17 | `e2e-fuzz` | PASS | PASS | 271 |  no |
+| 18 | `e2e-reconciler-private-note` | FAIL | **FAIL** | 329 |  **no** — red on main too |
+| 19 | `e2e-reconciler-cursor-persistence` | PASS | PASS | 46 |  no |
+| 20 | `e2e-rd913-restart-burn-collision` | FAIL | **FAIL** | 164 |  **no** — red on main too |
+| 21 | `e2e-rd940` | PASS | PASS | 145 |  no |
+| 22 | `e2e-l2l2-up` | PASS | PASS | 75 |  no |
+| 23 | `e2e-l2l2` | PASS | PASS | 516 |  no |
+| 24 | `e2e-recovery-readiness` | PASS | PASS | 484 |  no |
+| 25 | `fixture-l2-to-l1` | PASS | PASS | 197 |  no |
+| 26 | `full-db-loss-recovery` | FAIL | PASS | 385 |  no |
+| 27 | `loadtest-N30` | FAIL | PASS | 2235 |  no |
+| 28 | `verify-event-completeness` | PASS | PASS | 22 |  no |
+| 29 | `chaos-soak` | — | PASS | 4707 |  no |
+| 30 | `full-db-loss-recovery-postchaos` | — | **FAIL** | 656 |  no baseline |
+
+**27 PASS / 3 FAIL of 30**
+
+`— ` = the on-main battery was stopped after `verify-event-completeness`, so
+those two targets have no baseline to compare against.
+
+**Zero regressions.** No target that is green on main is red here. Two targets
+went the other way — red on main, green with #185 — and one of those is the
+point of the PR.
+
+### The two improvements
+
+**`full-db-loss-recovery`: RED on main -> GREEN with #185.** Main failed the
+drill with exactly the symptom #185 exists to remove:
+
+    main:  FAIL: #69/#136 ClaimEvent (all fields except tx_hash) rows differ
+                 (digest e4a18746f9d029961ff8e13fb91eb812 -> 1b052cb9d77535b07e4eca89cd473a16)
+    #185:  PASS: BridgeEvent (count 26) + ClaimEvent (count 52) rows identical
+
+A phantom ClaimEvent — emitted for a claim that never resolved to a note —
+cannot be reconstructed from the chain after a full DB loss, so the pre- and
+post-restore digests disagree. #185 stops emitting it, and the digests match.
+Written up in `logs/FINDING-fulldbloss-red-to-green.md`. Caveat stated there:
+the main-side battery was partly contaminated (section 5), so this is strong
+corroboration of section 2e rather than a controlled A/B.
+
+**`loadtest-N30`: RED on main -> GREEN with #185**, `sub 16/16 + 14/14, fail 0,
+claimed 30/30`. Counted as "no regression" only, NOT as a second improvement:
+main's failure was a direct casualty of the competing-run contamination in
+section 5, so that red says nothing about main's real behaviour.
+
+### The three reds, each diagnosed with evidence
+
+| target | root cause | verdict | evidence |
+|---|---|---|---|
+| `e2e-reconciler-private-note` | writer-queue backlog (16 inflight, 2 pending-unlinked at 7s); the L1->L2 funding claim missed its 240s budget. Cursors level, nothing parked or stranded, ZERO `nonce too low`. | **red on main too** — identical failure, same phase, same message, 264s vs 265s in-phase | `logs/FINDING-reconciler-private-note.md` |
+| `e2e-rd913-restart-burn-collision` | `second INSERT of a known serial returned 1 rows; ON CONFLICT semantics broken` | **red on main too** — same step, same assertion, different serial | `logs/FINDING-rd913-burn-collision.md` |
+| `full-db-loss-recovery-postchaos` | one claim published during the chaos storm never had its note consumed, so its receipt stayed `pending` and quiesce correctly refused to fingerprint a moving pipeline (#156 orphan family) | **not #185** — three independent proofs below | `logs/FINDING-postchaos-quiesce-orphan.md`, `logs/quiesce-timeout-20260908T101942Z.txt` |
+
+For every one of the three, the #185 path was proven NOT to have been entered.
+
+### Why none of the three can be #185 — the shared proof
+
+**`unclaimable_claims` holds 0 rows for the entire battery**, and no
+`claim_unclaimable_reverted_total` samples were recorded. #185 writes that
+record BEFORE it reverts, so any half-completed #185 path would leave a record
+behind. There are none: across 30 targets, ~5900 blocks, 59 bridges and 124
+claims, the changed branch was never reached. The battery therefore measures
+exactly what it is supposed to measure — that the UNCHANGED behaviour is intact.
+
+The post-chaos red is the only one that even looks like it could be #185
+(a claimAsset that never terminated), so it was traced line by line:
+
+    09:55:18  WARN address_mapper C5: resolved EVM address via zero-padding fallback
+              (no store mapping; account existence on Miden NOT verified)
+    09:56:12  claim published; receipt pending until the projector finalises it on consumption
+    09:56:12  writer_worker: job committed, block 5444, elapsed 54.19s
+
+1. The destination WAS resolved (via the C5 fallback), so the unresolvable
+   branch #185 rewrote never fired — by design, and identically to main.
+2. `unclaimable_claims` is empty, so the path left no trace because it was
+   never taken.
+3. The #185 branch is terminal in BOTH versions — `record_local_immediate_success`
+   before, `commit_reverted_receipt_and_advance_nonce` after. Both write a
+   receipt and advance the nonce; neither can leave a txn `pending`, which is
+   the state that blocks quiesce.
+
+The positive control: `full-db-loss-recovery` (row 26) — same drill, same chain,
+same branch, before the storm — PASSED in 385s. The drill works with #185; an
+orphaned claim from a 300s chaos storm is what defeats the post-chaos run. The
+pending row was LEFT IN PLACE; deleting it would manufacture a green matrix.
+
+### Chain growth (the growing-chain claim, recorded not assumed)
+
+| when | mark | synthetic tip | UHC | Bridge | Claim |
+|---|---|---|---|---|---|
+| 05:27:11Z | live-baseline drill: before | 90 | 3 | 1 | 1 |
+| 05:33:23Z | live-baseline drill: after | 213 | 5 | 1 | 2 |
+| 08:06:18Z | before `full-db-loss-recovery` | 3263 | 76 | 26 | 52 |
+| 08:12:43Z | after `full-db-loss-recovery` | 3392 | 78 | 26 | 53 |
+| 10:08:47Z | before `full-db-loss-recovery-postchaos` | 5713 | 145 | 59 | 124 |
+| 10:19:44Z | after `full-db-loss-recovery-postchaos` | 5931 | 145 | 59 | 124 |
+| **10:19:44Z** | **iteration 1 END** | **5931** | **145** | **59** | **124** |
+
+One genesis, one `node_data` volume, one anvil L1 for all 30 targets. **Chain
+height at iteration end: 5931 blocks**, carrying 145 GER updates, 59 bridge-outs
+and 124 claims. Total wall time 04:59:39 (05:20:05Z -> 10:19:44Z).
+
+### The claim-touching targets, called out
+
+These exercise the path #185 changed and were watched specifically:
+
+| target | result | the assertion that matters |
+|---|---|---|
+| `e2e-l1-to-l2` | PASS 122s | the primary claim path, faster than main (126s) |
+| `e2e-claim-watcher` / `-synthesis` | PASS 142s / 153s | claim watching + ClaimEvent synthesis |
+| `e2e-claim-provenance` | PASS 756s | claim calldata/attribution |
+| `e2e-cantina10` / `12` / `13` / `6` | PASS | the cantina claim + getlogs + restore tests |
+| `e2e-recovery-readiness` | PASS 484s | `No foreign/spurious ClaimEvent across recovery (count stable at 51)`; full calldata recovered byte-for-byte; cert settled Height 72 -> 73 on L1 |
+| `verify-event-completeness` | PASS 22s | `CLAIM->ClaimEvent 79 79 79 0 0 0 0p/0u - 0 PASS` |
+| `e2e-restore` / `full-db-loss-recovery*` | PASS (3 of 4) | restore stays byte-identical (below) |
+| `test-e2e` (claim-race scenario) | PASS | `race: SPONSOR won; user's tx accept-and-reverted (status-0x0, no ClaimEvent)` + `exactly ONE ClaimEvent for the raced gi` |
+
+**`verify-event-completeness` (fixed in `7c149bd`) stays green**, and the
+inverted assertion is demonstrably live rather than vacuous:
+
+```
+TYPE                    notes   logs  exact  late  missing  defer  unclaim forbid  extra  verdict
+B2AGG->BridgeEvent         40     40     40     0        0      0        -      0      0  PASS
+CLAIM->ClaimEvent          79     79     79     0        0      0    0p/0u      -      0  PASS
+GER->UpdateHashChain      100    100    100     0        0      0        -      -      0  PASS
+VERDICT: PASS
+```
+
+79 of 79 claims matched at their exact consumption block, **0 phantom / 0
+unclaimed-missing**, 0 late, 0 extra — on a chain carrying 30 loadtest bridges.
+
+**The restore drills stay byte-identical.** The live-baseline drill (the only
+fully-live fidelity comparison in the battery, bought once immediately after
+the genesis wipe) reports:
+
+```
+baseline provenance: live (true fidelity comparison)
+PASS: eth_getLogs identical across restore EXCEPT transaction_hash on 5 log(s)
+      — every other field (block, log_index, address, topics, data, tx_index, removed) byte-identical
+PASS: UpdateHashChain content identical (count 4, digest 21daf3567c15)
+PASS: injected-GER set identical (count 4, digest fd7e0b55666b)
+PASS: hash_chain_value identical (order-faithful replay)
+PASS: BridgeEvent (count 1) + ClaimEvent (count 1) rows identical
+PASS: post-restore claim SETTLED ... no unclaimable_claims row
+      (a real claim, not a note-less short-circuit)
+```
+
+and the larger mixed-baseline drill repeats it at scale (51 logs, 77 GERs,
+26 BridgeEvents, 52 ClaimEvents, all identical). The drill itself distinguishes
+an #185 record from a real claim, and correctly found none.
+
+### Chaos
+
+`chaos-soak` PASSED in 4707s (78 min) with no on-main baseline to compare to.
+Under a 300s seeder + 300s garbo storm the mixed loadtest returned
+`sub 15/15 + 15/15, fail 0, claimed 30/30`, the post-chaos operation reported
+`MIXED LOADTEST PASS — all 4 directions landed + clash distinct` with proxy
+store-locks = 0, and `post-storm service state before any harness repair: all
+running`.
 
 ---
 
-## 5. Environment note — a competing run was destroying this one's evidence
+## 5. Environment note — a competing run was destroying an EARLIER run's evidence
+
+**This applies to the 2026-09-07 runs only.** The section-4 battery above
+(`185-20260908T052005Z`) was the sole owner of the `miden-agglayer` compose
+project from start to finish, verified before launch and never contended.
+The note is kept because it is why the on-main baseline
+(`167-20260907T174108Z`) is corroborating evidence rather than a clean control.
 
 A previous session's `e2e-battery.sh` (PID 14509, started 17:41Z, results in
 `e2e-results/167-20260907T174108Z`) was still running against the **same** docker-compose
@@ -196,10 +391,38 @@ compose project; only one owner at a time.
 
 ## 6. Open items
 
-- **`gh` is unauthenticated** — the PR #186 summary was not posted. Paste this file.
+- **`gh` is unauthenticated** — the PR #186 summary was not posted from this
+  session. Paste this file, or run
+  `gh pr comment 186 --body-file REPORT.md` once authenticated.
 - **The first unresolvable claim per deposit still costs one reverted receipt and one nonce**,
   by design: attempt 1's `eth_estimateGas` runs *before* the `unclaimable_claims` record exists,
   so it cannot know. That is the floor, and it matches EVM (the first attempt is what reverts).
 - **Operator rescue (tier 2) must delete the `unclaimable_claims` row** to re-open a global
   index. Since #185 that was already true of `eth_call isClaimed`; `40d6934` adds
   `eth_estimateGas` to the same contract. Not a new constraint, but now two call sites.
+
+### Raised by the regression run (all pre-existing, none blocking #186)
+
+- **`e2e-rd913-restart-burn-collision` fails on base.** `INSERT ... ON CONFLICT
+  DO NOTHING` on the burn-serial table returns 1 row for a serial already seen.
+  Reproduced identically on the pre-#185 battery. Worth its own issue; not fixed
+  here because it would mix an unrelated product change into a claim-semantics PR.
+  Evidence: `logs/FINDING-rd913-burn-collision.md`.
+- **`e2e-reconciler-private-note` fails on base** under writer-queue backlog on a
+  growing chain: the L1->L2 funding claim misses its 240s budget. Same failure on
+  main. Evidence: `logs/FINDING-reconciler-private-note.md`.
+- **#156 orphan recovery is still the growing-chain ceiling.** One claim published
+  inside the chaos storm never had its note consumed; its receipt stays `pending`
+  forever, which permanently blocks quiesce and therefore every later
+  fingerprinting drill on that chain. Evidence:
+  `logs/FINDING-postchaos-quiesce-orphan.md`.
+- **Follow-up that would EXTEND #185's coverage (not a defect in it).** The C5
+  zero-padding fallback in `address_mapper` resolves a destination without
+  verifying the account exists on Miden. That is exactly why the orphaned claim
+  above bypassed #185's branch and became a stuck `pending` instead of a clean
+  accept-and-revert. Verifying existence at resolution time would route this
+  class into #185's revert path and remove the orphan. Worth filing against #156
+  or as a follow-up to #185.
+- **The battery driver's `nonce_gate` never fired** in this run (no parked txns at
+  any target boundary), so the #15 gap-adoption wedge that dominated the g1-g4
+  iterations did not recur.

--- a/scripts/e2e-185-unresolvable-claim-revert.sh
+++ b/scripts/e2e-185-unresolvable-claim-revert.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# E2E (#185): an L1→L2 claimAsset whose destination cannot be resolved to a
+# Miden AccountId must behave like EVM — the tx is ACCEPTED, its receipt is
+# REVERTED (status 0x0, no logs), NO ClaimEvent is emitted, the nonce advances,
+# and the unclaimable entry is recorded.
+#
+# Before #185 the same case emitted a SYNTHETIC ClaimEvent "so aggkit stops
+# retrying". That fabricated log was the root cause of two filed defects:
+#   #103 — `--restore` rebuilds history from Miden NOTE state; an event with no
+#          note has nothing to replay, so it was the one class of log a faithful
+#          restore legitimately dropped.
+#   #184 — aggsender reads it as a claim-with-unclaim and cuts EVERY AggLayer
+#          certificate at its block, permanently ("cutting certificate at block
+#          N" → "no bridges or claims found for range" forever).
+#
+# This script is the live proof for all of it. It asserts, on a running stack:
+#
+#   (a) REVERT SEMANTICS — receipt status 0x0 with zero logs; no ClaimEvent for
+#       the global index in eth_getLogs OR in the proxy's synthetic_logs; an
+#       `unclaimable_claims` row exists; `claim_unclaimable_reverted_total`
+#       advanced.
+#   (b) RETRY SUPPRESSION — `isClaimed(depositCount, networkID)` via eth_call to
+#       the bridge address returns TRUE for that global index even though no
+#       ClaimEvent exists. This is the signal that replaced the synthetic event.
+#   (c) NO RETRY STORM — the claim submitter (zkevm-bridge-service claimtxman)
+#       stops re-driving: its `sync.monitored_txs` row reaches a TERMINAL status
+#       and the proxy-side revert counter stops advancing. Bounded and terminal,
+#       not "forever".
+#   (d) CERTIFICATES KEEP SETTLING (#184) — a normal bridge-out landed AFTER the
+#       unresolvable claim produces a STRICTLY NEWER settled certificate on L1,
+#       and aggkit never logs the "cutting certificate" cut.
+#
+# Restore fidelity (#103) is proven by scripts/e2e-full-db-loss-recovery.sh run
+# on a chain carrying this claim: with no phantom event there is nothing for the
+# restore to lose, so the drill's exempt-drop path must report ZERO exemptions.
+# Run it after this script; this script prints the gi to check.
+#
+# Usage:  ./scripts/e2e-185-unresolvable-claim-revert.sh   (stack must be up)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_DIR"
+source "$PROJECT_DIR/fixtures/.env"
+
+L1_RPC="${L1_RPC:-http://localhost:8545}"
+L2_RPC="${L2_RPC:-http://localhost:8546}"
+BRIDGE_SERVICE_URL="${BRIDGE_SERVICE_URL:-http://localhost:18080}"
+METRICS_URL="${METRICS_URL:-http://localhost:8546/metrics}"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-miden-agglayer}"
+PROXY_C="${COMPOSE_PROJECT_NAME}-miden-agglayer-1"
+AGGKIT_C="${COMPOSE_PROJECT_NAME}-aggkit-1"
+BRIDGE_C="${COMPOSE_PROJECT_NAME}-bridge-service-1"
+PG_C="${COMPOSE_PROJECT_NAME}-agglayer-postgres-1"
+BRIDGE_PG_C="${COMPOSE_PROJECT_NAME}-postgres-1"
+FUNDED_KEY="${FUNDED_KEY:-0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625}"
+DEST_NETWORK=1                       # Miden
+DEPOSIT_WEI="${DEPOSIT_WEI:-10000000000000}"
+CLAIM_TOPIC0="0x1df3f2a973a00d6635911755c260704e95e8a5876997546798770f76396fda4d"
+# The box is shared; a slow run is not a regression. Every budget is generous
+# and overridable.
+READY_TIMEOUT="${READY_TIMEOUT:-900}"
+UNCLAIMABLE_TIMEOUT="${UNCLAIMABLE_TIMEOUT:-900}"
+QUIET_WINDOW="${QUIET_WINDOW:-240}"   # how long the retry watch runs
+SETTLE_TIMEOUT="${SETTLE_TIMEOUT:-1800}"
+
+RUN_TS="$(date -u +%Y%m%dT%H%M%SZ)"
+EV_DIR="${EVIDENCE_DIR:-$PROJECT_DIR/e2e-results/185-live-$RUN_TS}"
+mkdir -p "$EV_DIR"
+
+G='\033[0;32m'; Y='\033[0;33m'; R='\033[0;31m'; N='\033[0m'
+say()  { echo -e "[$(date -u +%H:%M:%SZ)] $*" | tee -a "$EV_DIR/run.log"; }
+pass() { echo -e "${G}[$(date -u +%H:%M:%SZ)] PASS:${N} $*" | tee -a "$EV_DIR/run.log"; }
+warn() { echo -e "${Y}[$(date -u +%H:%M:%SZ)] WARN:${N} $*" | tee -a "$EV_DIR/run.log"; }
+fail() { echo -e "${R}[$(date -u +%H:%M:%SZ)] FAIL:${N} $*" | tee -a "$EV_DIR/run.log"; exit 1; }
+
+pgq()  { docker exec "$PG_C" psql -U agglayer -d agglayer_store -tAc "$1" 2>/dev/null | tr -d '\r'; }
+bpgq() { docker exec "$BRIDGE_PG_C" psql -U bridge_user -d bridge_db -tAc "$1" 2>/dev/null | tr -d '\r'; }
+delog() { sed -E 's/\x1b\[[0-9;]*m//g'; }
+
+rpc() { # $1 method, $2 params-json  -> prints .result (or empty)
+    curl -sf --max-time 20 -X POST "$L2_RPC" -H 'Content-Type: application/json' \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$1\",\"params\":$2}" 2>/dev/null \
+        | python3 -c 'import json,sys
+try: d=json.load(sys.stdin)
+except Exception: sys.exit(0)
+r=d.get("result")
+print(json.dumps(r) if isinstance(r,(dict,list)) else (r if r is not None else ""))' 2>/dev/null
+}
+
+metric() { # $1 = metric name (exact, no labels) -> integer, 0 when absent
+    curl -sf --max-time 10 "$METRICS_URL" 2>/dev/null \
+        | awk -v m="$1" '$1==m {v=$2} END{printf "%d\n", (v==""?0:v)}'
+}
+
+# The max agglayer certificate Height aggkit has logged on a line that also says
+# Settled. Falls back to the max Height on any line when the settle lines carry
+# no height (log-format drift must degrade the claim, never crash the run).
+settled_height() {
+    local h
+    h=$( set +o pipefail; docker logs --tail "${AGGKIT_LOG_TAIL:-60000}" "$AGGKIT_C" 2>&1 | delog \
+        | grep -a 'Settled' | grep -aoE 'Height: [0-9]+' | grep -aoE '[0-9]+' | sort -n | tail -1 )
+    if [[ -z "$h" ]]; then
+        h=$( set +o pipefail; docker logs --tail "${AGGKIT_LOG_TAIL:-60000}" "$AGGKIT_C" 2>&1 | delog \
+            | grep -aoE 'Height: [0-9]+' | grep -aoE '[0-9]+' | sort -n | tail -1 )
+        [[ -n "$h" ]] && echo "HEIGHT_SOURCE=any-cert-line" >> "$EV_DIR/notes.txt"
+    fi
+    echo "${h:-0}"
+}
+
+say "======================================================================"
+say " #185 — unresolvable-destination claim reverts with NO ClaimEvent"
+say " evidence: $EV_DIR"
+say "======================================================================"
+
+# ── 0. Preflight + baselines ────────────────────────────────────────────────
+docker ps --format '{{.Names}}' | grep -qx "$PROXY_C" || fail "proxy container $PROXY_C is not running — bring the stack up first"
+curl -sf --max-time 10 "$METRICS_URL" >/dev/null || fail "proxy /metrics is not serving at $METRICS_URL"
+
+REVERTED_BEFORE=$(metric claim_unclaimable_reverted_total)
+UNCLAIMABLE_BEFORE=$(metric claim_unclaimable_total)
+ROWS_BEFORE=$(pgq "SELECT count(*) FROM unclaimable_claims"); ROWS_BEFORE=${ROWS_BEFORE:-0}
+CLAIMLOGS_BEFORE=$(pgq "SELECT count(*) FROM synthetic_logs WHERE topics[1] LIKE '0x1df3f2a9%'"); CLAIMLOGS_BEFORE=${CLAIMLOGS_BEFORE:-0}
+PRE_SETTLED_HEIGHT=$(settled_height)
+MARK_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+say "baselines: claim_unclaimable_reverted_total=$REVERTED_BEFORE claim_unclaimable_total=$UNCLAIMABLE_BEFORE"
+say "baselines: unclaimable_claims rows=$ROWS_BEFORE synthetic ClaimEvents=$CLAIMLOGS_BEFORE settled cert height=$PRE_SETTLED_HEIGHT"
+
+# ── 1. Drive a REAL deposit to an UNRESOLVABLE destination ──────────────────
+# Unresolvable = the address has no store mapping AND is not a zero-padded
+# Miden AccountId (address_mapper::resolve_address fails). A random address
+# whose FIRST byte is non-zero can never satisfy the zero-padding fallback,
+# which requires bytes 0..4 to be zero. Fresh per run, so it cannot collide
+# with a mapping an earlier target installed.
+DEST="0x$(printf 'd1'; openssl rand -hex 19)"
+[[ "${DEST:0:10}" != "0x00000000" ]] || fail "generated destination is zero-padded — it would RESOLVE"
+MAPPED=$(pgq "SELECT count(*) FROM address_mappings WHERE lower(eth_address) = lower('$DEST')" 2>/dev/null)
+[[ "${MAPPED:-0}" == "0" ]] || fail "destination $DEST already has a store mapping — it would resolve"
+say "unresolvable destination: $DEST"
+
+L1_TX=$(cast send --rpc-url "$L1_RPC" --private-key "$FUNDED_KEY" "$BRIDGE_ADDRESS" \
+    'bridgeAsset(uint32,address,uint256,address,bool,bytes)' \
+    "$DEST_NETWORK" "$DEST" "$DEPOSIT_WEI" 0x0000000000000000000000000000000000000000 true 0x \
+    --value "$DEPOSIT_WEI" --json 2>/dev/null | python3 -c 'import json,sys; print(json.load(sys.stdin)["transactionHash"])' 2>/dev/null)
+[[ "$L1_TX" =~ ^0x[0-9a-fA-F]{64}$ ]] || fail "L1 bridgeAsset did not return a tx hash (got '${L1_TX:-<none>}')"
+say "L1 bridgeAsset tx: $L1_TX"
+
+# Read OUR deposit's coordinates by tx hash — never by index. On a shared,
+# growing chain another target's deposit can take the index we read.
+deposit_field() { # $1 = json field
+    curl -sf --max-time 20 "$BRIDGE_SERVICE_URL/bridges/$DEST?limit=100&offset=0" 2>/dev/null \
+      | L1_TX="$L1_TX" F="$1" python3 -c '
+import json, os, sys
+want = os.environ["L1_TX"].lower(); f = os.environ["F"]
+try: ds = json.load(sys.stdin).get("deposits", [])
+except Exception: ds = []
+for d in ds:
+    if str(d.get("tx_hash","")).lower() == want:
+        print(d.get(f, "")); break
+' 2>/dev/null
+}
+
+say "waiting for bridge-service to index the deposit as ready_for_claim (<= ${READY_TIMEOUT}s)..."
+t0=$SECONDS
+while :; do
+    RFC=$(deposit_field ready_for_claim)
+    [[ "$RFC" == "True" || "$RFC" == "true" ]] && break
+    (( SECONDS - t0 >= READY_TIMEOUT )) && fail "deposit from $L1_TX never became ready_for_claim in ${READY_TIMEOUT}s"
+    sleep 10
+done
+DEPOSIT_CNT=$(deposit_field deposit_cnt)
+NET_ID=$(deposit_field network_id)
+GI_DEC=$(deposit_field global_index)
+[[ "$GI_DEC" =~ ^[0-9]+$ ]] || fail "bridge-service gave no decimal global_index for $L1_TX (got '${GI_DEC:-<none>}')"
+GI_HEX=$(python3 -c 'import sys; print(hex(int(sys.argv[1])))' "$GI_DEC")
+GI_PADDED=$(python3 -c 'import sys; print("%064x" % int(sys.argv[1]))' "$GI_DEC")
+pass "deposit ready: deposit_cnt=$DEPOSIT_CNT network_id=$NET_ID global_index=$GI_DEC ($GI_HEX)"
+{ echo "l1_tx=$L1_TX"; echo "dest=$DEST"; echo "deposit_cnt=$DEPOSIT_CNT"; echo "network_id=$NET_ID"
+  echo "global_index_dec=$GI_DEC"; echo "global_index_hex=$GI_HEX"; } > "$EV_DIR/deposit.txt"
+
+# ── 2. Wait for the proxy to record it unclaimable ──────────────────────────
+say "waiting for the claim submitter to drive claimAsset and the proxy to record it unclaimable (<= ${UNCLAIMABLE_TIMEOUT}s)..."
+t0=$SECONDS
+while :; do
+    ETH_TX=$(pgq "SELECT eth_tx_hash FROM unclaimable_claims WHERE global_index = '$GI_HEX'")
+    [[ -n "$ETH_TX" ]] && break
+    (( SECONDS - t0 >= UNCLAIMABLE_TIMEOUT )) && {
+        docker logs --since "$MARK_TS" "$PROXY_C" 2>&1 | delog | tail -200 > "$EV_DIR/proxy-tail-on-timeout.log"
+        docker logs --since "$MARK_TS" "$BRIDGE_C" 2>&1 | delog | tail -200 > "$EV_DIR/bridge-tail-on-timeout.log"
+        fail "no unclaimable_claims row for gi=$GI_HEX after ${UNCLAIMABLE_TIMEOUT}s — the claim never reached the proxy (see $EV_DIR)"
+    }
+    sleep 10
+done
+pass "unclaimable_claims row recorded: gi=$GI_HEX eth_tx=$ETH_TX"
+
+# ═══ (a) REVERT SEMANTICS ═══════════════════════════════════════════════════
+say "── (a) revert semantics ──────────────────────────────────────────────"
+RCPT=$(rpc eth_getTransactionReceipt "[\"$ETH_TX\"]")
+echo "$RCPT" > "$EV_DIR/receipt.json"
+[[ -n "$RCPT" && "$RCPT" != "null" ]] || fail "(a) no receipt served for the claim tx $ETH_TX — the tx must be ACCEPTED, not dropped"
+RCPT_STATUS=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("status",""))' "$EV_DIR/receipt.json")
+RCPT_NLOGS=$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1])).get("logs") or []))' "$EV_DIR/receipt.json")
+RCPT_BLOCK=$(python3 -c 'import json,sys; print(int(json.load(open(sys.argv[1])).get("blockNumber","0x0"),16))' "$EV_DIR/receipt.json")
+[[ "$RCPT_STATUS" == "0x0" ]] || fail "(a) claim receipt status is '$RCPT_STATUS', expected 0x0 (REVERTED) — #185 regression"
+[[ "$RCPT_NLOGS" == "0" ]]    || fail "(a) claim receipt carries $RCPT_NLOGS log(s), expected 0 — a reverted claim must emit nothing"
+pass "(a) receipt REVERTED: status=$RCPT_STATUS logs=$RCPT_NLOGS block=$RCPT_BLOCK"
+
+# No ClaimEvent for this gi anywhere a consumer can see it.
+LOGS_JSON=$(rpc eth_getLogs "[{\"fromBlock\":\"0x0\",\"toBlock\":\"latest\",\"topics\":[\"$CLAIM_TOPIC0\"]}]")
+echo "$LOGS_JSON" > "$EV_DIR/claim-logs.json"
+GI_LOGS=$(python3 -c '
+import json,sys
+gi = int(sys.argv[2])
+try: logs = json.load(open(sys.argv[1]))
+except Exception: logs = []
+n = 0
+for l in (logs or []):
+    d = (l.get("data") or "")[2:]
+    if d and int(d[:64] or "0", 16) == gi: n += 1
+print(n)' "$EV_DIR/claim-logs.json" "$GI_DEC")
+[[ "$GI_LOGS" == "0" ]] || fail "(a) eth_getLogs serves $GI_LOGS ClaimEvent(s) for gi=$GI_DEC — #185 requires NONE (this phantom event is what broke #103 and #184)"
+STORE_LOGS=$(pgq "SELECT count(*) FROM synthetic_logs WHERE topics[1] LIKE '0x1df3f2a9%' AND lower(data) LIKE '0x${GI_PADDED}%'")
+[[ "${STORE_LOGS:-0}" == "0" ]] || fail "(a) proxy synthetic_logs holds ${STORE_LOGS} ClaimEvent row(s) for gi=$GI_DEC — #185 requires NONE"
+pass "(a) NO ClaimEvent for gi=$GI_DEC — eth_getLogs=0, synthetic_logs=0"
+
+# Nonce advanced (EVM semantics: a reverted tx still consumes its nonce).
+TX_FROM=$(python3 -c 'import json,sys; print((json.load(open(sys.argv[1])).get("from") or "").lower())' "$EV_DIR/receipt.json")
+if [[ "$TX_FROM" =~ ^0x[0-9a-f]{40}$ ]]; then
+    NONCE_NOW=$(rpc eth_getTransactionCount "[\"$TX_FROM\",\"latest\"]")
+    TX_NONCE_HEX=$(rpc eth_getTransactionByHash "[\"$ETH_TX\"]" | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("nonce",""))
+except Exception: print("")' 2>/dev/null)
+    say "(a) claim signer $TX_FROM: tx nonce=$TX_NONCE_HEX, account nonce now=$NONCE_NOW"
+    if [[ -n "$TX_NONCE_HEX" && -n "$NONCE_NOW" ]]; then
+        python3 -c 'import sys; sys.exit(0 if int(sys.argv[1],16) > int(sys.argv[2],16) else 1)' "$NONCE_NOW" "$TX_NONCE_HEX" \
+            || fail "(a) the reverted claim did NOT advance the signer nonce (account=$NONCE_NOW, tx=$TX_NONCE_HEX)"
+        pass "(a) nonce advanced past the reverted claim (EVM semantics)"
+    fi
+fi
+
+REVERTED_AFTER=$(metric claim_unclaimable_reverted_total)
+(( REVERTED_AFTER > REVERTED_BEFORE )) \
+    || fail "(a) claim_unclaimable_reverted_total did not advance ($REVERTED_BEFORE -> $REVERTED_AFTER)"
+pass "(a) claim_unclaimable_reverted_total advanced: $REVERTED_BEFORE -> $REVERTED_AFTER"
+
+ROWS_AFTER=$(pgq "SELECT count(*) FROM unclaimable_claims")
+say "(a) unclaimable_claims rows: $ROWS_BEFORE -> ${ROWS_AFTER:-?}"
+pgq "SELECT global_index, destination_address, amount, reason, eth_tx_hash FROM unclaimable_claims WHERE global_index='$GI_HEX'" \
+    > "$EV_DIR/unclaimable-row.txt"
+
+# ═══ (b) isClaimed(globalIndex) reads TRUE with no event ════════════════════
+say "── (b) isClaimed retry-suppression signal ────────────────────────────"
+# isClaimed(uint32 leafIndex, uint32 sourceNetwork) — selector 0xcc461632. A
+# deposit made ON L1 is mainnet-origin, so sourceNetwork is the deposit's
+# network_id (0) and leafIndex is its deposit_cnt.
+IS_CLAIMED_DATA=$(python3 -c '
+import sys
+leaf, src = int(sys.argv[1]), int(sys.argv[2])
+print("0xcc461632" + "%064x" % leaf + "%064x" % src)' "$DEPOSIT_CNT" "${NET_ID:-0}")
+IS_CLAIMED=$(rpc eth_call "[{\"to\":\"$BRIDGE_ADDRESS\",\"data\":\"$IS_CLAIMED_DATA\"},\"latest\"]")
+echo "isClaimed($DEPOSIT_CNT,${NET_ID:-0}) -> $IS_CLAIMED" > "$EV_DIR/isclaimed.txt"
+[[ "$IS_CLAIMED" == "0x0000000000000000000000000000000000000000000000000000000000000001" ]] \
+    || fail "(b) isClaimed($DEPOSIT_CNT,${NET_ID:-0}) returned '$IS_CLAIMED', expected ABI true — without it the submitter re-drives forever"
+pass "(b) isClaimed($DEPOSIT_CNT,${NET_ID:-0}) = TRUE from the unclaimable record, with NO ClaimEvent behind it"
+
+# ═══ (c) the claim submitter STOPS re-driving ══════════════════════════════
+say "── (c) no retry storm (watching ${QUIET_WINDOW}s) ────────────────────"
+# Every re-drive of this gi hits the same unresolvable arm, so the proxy-side
+# revert counter is an exact retry meter. A terminal monitored_txs row is the
+# submitter-side proof.
+R1=$(metric claim_unclaimable_reverted_total)
+# sync.deposit.tx_hash is BYTEA — comparing it to a '0x…' string matches nothing
+# and silently yields an empty deposit id, which made the terminal-status probe
+# below assert on a row it never found. Compare hex to hex.
+DEPOSIT_ID=$(bpgq "SELECT id FROM sync.deposit WHERE encode(tx_hash,'hex') = lower('${L1_TX#0x}')")
+say "(c) bridge-service deposit id: ${DEPOSIT_ID:-<not found>}"
+t0=$SECONDS; MTX_STATUS=""; TERMINAL=0
+while (( SECONDS - t0 < QUIET_WINDOW )); do
+    if [[ -n "$DEPOSIT_ID" ]]; then
+        MTX_STATUS=$(bpgq "SELECT status FROM sync.monitored_txs WHERE deposit_id = $DEPOSIT_ID")
+        case "$MTX_STATUS" in
+            confirmed|failed) TERMINAL=1; break ;;
+        esac
+    fi
+    sleep 15
+done
+R2=$(metric claim_unclaimable_reverted_total)
+RETRIES=$(( R2 - REVERTED_BEFORE ))
+say "(c) monitored_txs status=${MTX_STATUS:-<none>} terminal=$TERMINAL; reverted counter ${REVERTED_BEFORE} -> ${R1} -> ${R2} (total attempts for this gi: $RETRIES)"
+docker logs --since "$MARK_TS" "$BRIDGE_C" 2>&1 | delog | grep -aiE "monitoredTx|claim|revert|nonce" | tail -400 > "$EV_DIR/bridge-service-claimtxman.log"
+docker logs --since "$MARK_TS" "$PROXY_C"  2>&1 | delog | grep -aiE "unresolvable|unclaimable|reverted" | tail -400 > "$EV_DIR/proxy-unclaimable.log"
+bpgq "SELECT m.deposit_id, m.status, m.nonce, array_length(m.history,1) AS history_len, \
+             d.deposit_cnt, encode(d.tx_hash,'hex') AS l1_tx \
+        FROM sync.monitored_txs m JOIN sync.deposit d ON d.id = m.deposit_id \
+       ORDER BY m.deposit_id DESC LIMIT 20" > "$EV_DIR/monitored-txs.txt"
+
+# The cap is 3, NOT claimtxman's own maxHistorySize backstop of 10.
+#
+# Stopping at 10 is what this test measured on 2026-09-07 BEFORE the estimate-gas
+# fix: ten reverted receipts and ten consumed nonces in 19s, ended only by
+# "marked as failed because reached the history size limit (10)" — bounded, but
+# the submitter never once ran checkIfClaimed, so #185's documented suppression
+# path was dead. Asserting <= 10 would have called that green.
+#
+# The intended shape is: attempt 1 creates the unclaimable record (its estimate
+# ran before the record existed), attempt 2's estimate reverts AlreadyClaimed(),
+# checkIfClaimed reads isClaimed=true and the monitored tx goes CONFIRMED. 3
+# leaves one attempt of slack for a retried estimate; 10 would hide the bug.
+RETRY_CAP="${RETRY_CAP:-3}"
+(( RETRIES <= RETRY_CAP )) \
+    || fail "(c) RETRY STORM: $RETRIES claimAsset attempts for gi=$GI_DEC in ${QUIET_WINDOW}s (cap $RETRY_CAP) — the submitter never stopped"
+if (( TERMINAL == 1 )); then
+    pass "(c) submitter STOPPED: monitored_txs status=$MTX_STATUS (terminal) after $RETRIES attempt(s)"
+else
+    # Not yet terminal is only acceptable if it is also not re-driving.
+    (( R2 == R1 )) \
+        || fail "(c) monitored_txs is still non-terminal (${MTX_STATUS:-<none>}) AND the revert counter is still advancing ($R1 -> $R2) — the submitter is re-driving"
+    pass "(c) submitter QUIET: no new claimAsset for gi=$GI_DEC over ${QUIET_WINDOW}s (status=${MTX_STATUS:-<none>}, $RETRIES attempt(s) total)"
+fi
+
+# ═══ (d) certificates keep settling (#184) ═════════════════════════════════
+say "── (d) certificate settlement after an unresolvable claim (#184) ─────"
+CUTS=$( set +o pipefail; docker logs --since "$MARK_TS" "$AGGKIT_C" 2>&1 | delog \
+        | grep -acE 'cutting certificate at block' )
+say "(d) aggkit 'cutting certificate at block' lines since the claim: ${CUTS:-0}"
+docker logs --since "$MARK_TS" "$AGGKIT_C" 2>&1 | delog \
+    | grep -aiE 'cutting certificate|claim with unclaim|no bridges or claims|changed status|Height:' \
+    | tail -200 > "$EV_DIR/aggkit-certificates.log"
+
+if [[ "${RUN_BRIDGE_OUT:-1}" == "1" ]]; then
+    say "(d) landing a NORMAL bridge-out AFTER the unresolvable claim..."
+    if ! "$SCRIPT_DIR/e2e-l2-to-l1.sh" > "$EV_DIR/bridge-out.log" 2>&1; then
+        if grep -q "no balance" "$EV_DIR/bridge-out.log"; then
+            say "(d) bridge-out wallet is empty — funding it with an L1->L2 deposit first"
+            "$SCRIPT_DIR/e2e-l1-to-l2.sh" > "$EV_DIR/bridge-out-fund.log" 2>&1 \
+                || fail "(d) could not fund the bridge-out wallet (see $EV_DIR/bridge-out-fund.log)"
+            "$SCRIPT_DIR/e2e-l2-to-l1.sh" > "$EV_DIR/bridge-out.log" 2>&1 \
+                || fail "(d) the post-claim bridge-out FAILED (see $EV_DIR/bridge-out.log) — an unresolvable claim must not wedge the bridge"
+        else
+            fail "(d) the post-claim bridge-out FAILED (see $EV_DIR/bridge-out.log) — an unresolvable claim must not wedge the bridge"
+        fi
+    fi
+    pass "(d) post-claim bridge-out completed"
+fi
+
+say "(d) waiting for a settled certificate STRICTLY newer than height $PRE_SETTLED_HEIGHT (<= ${SETTLE_TIMEOUT}s)..."
+t0=$SECONDS; POST_SETTLED_HEIGHT=0
+while :; do
+    POST_SETTLED_HEIGHT=$(settled_height)
+    (( POST_SETTLED_HEIGHT > PRE_SETTLED_HEIGHT )) && break
+    (( SECONDS - t0 >= SETTLE_TIMEOUT )) && {
+        docker logs --since "$MARK_TS" "$AGGKIT_C" 2>&1 | delog | tail -300 > "$EV_DIR/aggkit-tail-on-settle-timeout.log"
+        fail "(d) #184 REGRESSION SHAPE: no certificate settled above height $PRE_SETTLED_HEIGHT in ${SETTLE_TIMEOUT}s after the unresolvable claim — settlement is wedged"
+    }
+    sleep 20
+done
+pass "(d) certificate settlement ADVANCED across the unresolvable claim: height $PRE_SETTLED_HEIGHT -> $POST_SETTLED_HEIGHT"
+
+CUTS=$( set +o pipefail; docker logs --since "$MARK_TS" "$AGGKIT_C" 2>&1 | delog \
+        | grep -acE 'cutting certificate at block' )
+(( ${CUTS:-0} == 0 )) \
+    || fail "(d) aggkit logged ${CUTS} 'cutting certificate at block' line(s) after the unresolvable claim — that is the #184 cut #185 removes"
+pass "(d) aggkit logged ZERO 'cutting certificate' lines — #184 is gone"
+
+docker logs --since "$MARK_TS" "$AGGKIT_C" 2>&1 | delog \
+    | grep -aiE 'cutting certificate|claim with unclaim|no bridges or claims|changed status|Height:' \
+    | tail -300 > "$EV_DIR/aggkit-certificates.log"
+
+# ── verdict ─────────────────────────────────────────────────────────────────
+{ echo "global_index_dec=$GI_DEC"; echo "global_index_hex=$GI_HEX"; echo "global_index_padded=$GI_PADDED"
+  echo "deposit_cnt=$DEPOSIT_CNT"; echo "network_id=$NET_ID"; echo "dest=$DEST"
+  echo "l1_tx=$L1_TX"; echo "claim_eth_tx=$ETH_TX"; echo "claim_receipt_status=$RCPT_STATUS"
+  echo "claim_receipt_block=$RCPT_BLOCK"; echo "claim_attempts=$RETRIES"
+  echo "monitored_tx_status=${MTX_STATUS:-<none>}"
+  echo "settled_height_before=$PRE_SETTLED_HEIGHT"; echo "settled_height_after=$POST_SETTLED_HEIGHT"
+} > "$EV_DIR/VERDICT.txt"
+
+say "======================================================================"
+pass "#185 LIVE PROOF COMPLETE — (a) revert+no-event  (b) isClaimed=true  (c) no retry storm  (d) certificates settle"
+say "gi for the #103 restore check: $GI_HEX ($GI_DEC)"
+say "evidence: $EV_DIR"
+say "======================================================================"

--- a/scripts/e2e-185-unresolvable-claim-revert.sh
+++ b/scripts/e2e-185-unresolvable-claim-revert.sh
@@ -343,6 +343,14 @@ if [[ "${RUN_BRIDGE_OUT:-1}" == "1" ]]; then
     pass "(d) post-claim bridge-out completed"
 fi
 
+# Nothing new to certify without the bridge-out above, so the strictly-newer
+# assertion has nothing to wait FOR: it would burn the whole SETTLE_TIMEOUT and
+# then fail for a reason that is not #184. RUN_BRIDGE_OUT=0 is for planting an
+# unclaimable claim on an existing chain; the #184 proof needs the bridge-out.
+POST_SETTLED_HEIGHT="$PRE_SETTLED_HEIGHT"
+if [[ "${RUN_BRIDGE_OUT:-1}" != "1" ]]; then
+    warn "(d) RUN_BRIDGE_OUT=0 — no new bridge-out, so the strictly-newer-certificate assertion is SKIPPED (not proven this run)"
+else
 say "(d) waiting for a settled certificate STRICTLY newer than height $PRE_SETTLED_HEIGHT (<= ${SETTLE_TIMEOUT}s)..."
 t0=$SECONDS; POST_SETTLED_HEIGHT=0
 while :; do
@@ -355,6 +363,7 @@ while :; do
     sleep 20
 done
 pass "(d) certificate settlement ADVANCED across the unresolvable claim: height $PRE_SETTLED_HEIGHT -> $POST_SETTLED_HEIGHT"
+fi
 
 CUTS=$( set +o pipefail; docker logs --since "$MARK_TS" "$AGGKIT_C" 2>&1 | delog \
         | grep -acE 'cutting certificate at block' )

--- a/scripts/lib-isolated-wallet.sh
+++ b/scripts/lib-isolated-wallet.sh
@@ -46,6 +46,33 @@ fi
 # Default: per-caller subdir (BASH_SOURCE[1] is the sourcing script).
 B2AGG_STORE_DIR="${B2AGG_STORE_DIR:-$PROJECT_DIR/.b2agg-store/$(basename "${BASH_SOURCE[1]:-standalone}" .sh)}"
 
+# Take host ownership of the isolated store before writing to it.
+#
+# The tool image runs as ROOT, and a bind mount whose host path does not exist
+# yet is created by the docker daemon as root:root. Either way every file the
+# container leaves behind — and sometimes the store directory itself — is
+# root-owned on the host. The host side then cannot create `tmp/` or write
+# `$B2AGG_STORE_DIR/wallet-id`, and BOTH failures were silent: `mkdir -p`'s
+# error went to stderr and the redirect's failure was never checked, so
+# `provision_isolated_wallet` fell through to "no id file" and provisioned a
+# BRAND NEW wallet on every call. Observed 2026-09-07: e2e-l1-to-l2 funded
+# wallet 0xb73e… (1000 units) and the very next e2e-l2-to-l1 minted a different
+# wallet in the same store and died "Wallet has no balance — run
+# e2e-l1-to-l2.sh first", which reads as a bridge failure and is not one.
+#
+# Fix the cause rather than the symptom: chown the store back to the invoking
+# user (via a root container, the only thing that can) and make the caller
+# verify it is writable.
+_iso_own_store() {
+    if mkdir -p "$B2AGG_STORE_DIR/tmp" 2>/dev/null && [[ -w "$B2AGG_STORE_DIR" ]]; then
+        return 0
+    fi
+    docker run --rm -v "$B2AGG_STORE_DIR:/store" busybox \
+        chown -R "$(id -u):$(id -g)" /store >/dev/null 2>&1 || true
+    mkdir -p "$B2AGG_STORE_DIR/tmp" 2>/dev/null || true
+    [[ -w "$B2AGG_STORE_DIR" ]]
+}
+
 # iso_tool <args...> : run bridge-out-tool in a throwaway container against the
 # ISOLATED store. TMPDIR is kept on the same bind-mounted device as the store
 # to avoid rusqlite's "Invalid cross-device link" on atomic rename.
@@ -96,7 +123,8 @@ iso_wallet_balance() {
 iso_inspect_faucet() {
     local fid="$1" fresh rc out
     fresh="$B2AGG_STORE_DIR/inspect-$$-${RANDOM}"
-    mkdir -p "$fresh/tmp"
+    _iso_own_store || true
+    mkdir -p "$fresh/tmp" 2>/dev/null || true
     # Capture the container's exit code WITHOUT tripping the caller's set -e: a bare
     # `out=$(docker ...); rc=$?` aborts under errexit before rc is read on nonzero.
     if out=$(docker run --rm --network "$ISO_NETWORK" \
@@ -270,7 +298,7 @@ provision_isolated_wallet() {
     if [[ "${B2AGG_FRESH:-0}" == "1" ]]; then
         _iso_wipe_store
     fi
-    mkdir -p "$B2AGG_STORE_DIR/tmp"
+    _iso_own_store || { echo "isolated-wallet: $B2AGG_STORE_DIR is not writable by $(id -un) and could not be chowned" >&2; return 1; }
 
     WALLET_ID=""
     if [[ -s "$idfile" ]]; then
@@ -281,7 +309,7 @@ provision_isolated_wallet() {
             if [[ -z "$bal" ]]; then
                 echo "isolated-wallet: store at $B2AGG_STORE_DIR looks stale (balance probe failed) — re-provisioning fresh" >&2
                 _iso_wipe_store
-                mkdir -p "$B2AGG_STORE_DIR/tmp"
+                _iso_own_store || { echo "isolated-wallet: $B2AGG_STORE_DIR is not writable by $(id -un) and could not be chowned" >&2; return 1; }
                 WALLET_ID=""
             fi
         fi
@@ -300,7 +328,12 @@ provision_isolated_wallet() {
             echo "isolated-wallet: could not parse provisioned wallet id" >&2
             return 1
         fi
-        echo "$WALLET_ID" > "$idfile"
+        # A FAILED write here is what produced a new wallet per call. Hard-stop:
+        # a store whose id cannot be persisted is not a reusable store.
+        echo "$WALLET_ID" > "$idfile" || {
+            echo "isolated-wallet: could not persist the wallet id to $idfile — every later call would provision a NEW wallet" >&2
+            return 1
+        }
     fi
 
     WALLET_HEX="$WALLET_ID"

--- a/scripts/lib-quiesce.sh
+++ b/scripts/lib-quiesce.sh
@@ -243,6 +243,53 @@ _q_evidence() { # $1 = the unmet condition
         _q_pgq "SELECT signer, nonce, tx_hash, expires_at, parked_during_recovery \
                 FROM queued_txns ORDER BY created_at" 2>&1
         echo
+        # A pending receipt is the condition that most often blocks quiesce, and
+        # "0x8112…|pending|0x6352…||2419" is not enough to act on. On 2026-09-08
+        # this exact line failed the drill (656s) and answering "which claim is
+        # it, and is it even still live?" took forty minutes of manual RLP
+        # decoding — by which time the proxy container had been recreated and
+        # its logs for the window were gone forever. Decode it HERE, while the
+        # evidence still exists.
+        echo "── pending receipts, DECODED (selector / globalIndex / destination / expiry) ──"
+        _q_pgq "SELECT tx_hash || '|' || coalesce(expires_at::text,'<none>') || '|' || \
+                       encode(envelope_bytes,'hex') \
+                FROM transactions WHERE status='pending' ORDER BY created_at" 2>/dev/null \
+          | python3 -c '
+import sys
+TIP = None
+CLAIM = bytes.fromhex("ccaa2d11")   # claimAsset(bytes32[32],bytes32[32],uint256,...)
+for line in sys.stdin:
+    line = line.strip()
+    if not line: continue
+    parts = line.split("|")
+    if len(parts) < 3: continue
+    txh, exp, raw = parts[0], parts[1], parts[2]
+    try: b = bytes.fromhex(raw)
+    except ValueError:
+        print(f"  {txh} expires_at={exp} <envelope not hex>"); continue
+    i = b.find(CLAIM)
+    if i < 0:
+        print(f"  {txh} expires_at={exp} selector=<not claimAsset>"); continue
+    a = b[i+4:]
+    try:
+        gi = int.from_bytes(a[64*32:65*32], "big")
+        dest = "0x" + a[67*32:68*32][-20:].hex()
+    except Exception:
+        print(f"  {txh} expires_at={exp} claimAsset <args truncated>"); continue
+    print(f"  {txh} expires_at={exp} claimAsset globalIndex={gi} ({hex(gi)}) destination={dest}")
+' 2>/dev/null || echo "  (decode unavailable)"
+        echo
+        echo "── is a pending claim recorded UNCLAIMABLE? (#185 path taken or not) ──"
+        _q_pgq "SELECT u.global_index, u.destination_address, u.reason \
+                FROM unclaimable_claims u ORDER BY u.created_at" 2>&1
+        echo
+        echo "── proxy log tail (CAPTURED NOW — the container may be recreated before anyone reads this) ──"
+        _q_proxy_c="${PROXY_CONTAINER:-${AGGLAYER_CONTAINER:-}}"
+        [[ -n "$_q_proxy_c" ]] || _q_proxy_c="$(docker ps --format '{{.Names}}' \
+            | grep -E -- '-miden-agglayer-1$' | head -1)"
+        docker logs --tail "${QUIESCE_EVIDENCE_LOG_LINES:-400}" "$_q_proxy_c" 2>&1 \
+            | sed -E 's/\x1b\[[0-9;]*m//g' | tail -n "${QUIESCE_EVIDENCE_LOG_LINES:-400}" || true
+        echo
         echo "── synthetic log counts by family ──"
         _q_pgq "SELECT substring(topics[1] from 1 for 10) AS topic0, count(*) \
                 FROM synthetic_logs GROUP BY 1 ORDER BY 2 DESC" 2>&1

--- a/scripts/lib-verify-completeness.py
+++ b/scripts/lib-verify-completeness.py
@@ -218,31 +218,49 @@ for name, (topic, root) in TOPICS.items():
                   f"a non-deposit must never emit")
         logs = [l for l in logs if l["transactionHash"].lower() not in forbidden]
 
-    # ClaimEvents for durable unclaimable records have no corresponding Miden
-    # CLAIM note. Match and remove only their exact (block, GI, tx-hash) logs;
-    # every other surplus ClaimEvent remains an error.
-    unclaim_exact = 0
+    # #185 INVERTED THIS CHECK. A durable unclaimable record (unresolvable
+    # destination) is terminal WITHOUT a Miden CLAIM note AND WITHOUT a
+    # ClaimEvent: the proxy accepts the claim, writes a REVERTED receipt
+    # (status 0x0, no logs) and emits nothing, exactly as an unappliable claim
+    # behaves on EVM.
+    #
+    # Before #185 it fabricated a ClaimEvent, and this block asserted that
+    # fabrication was PRESENT — one expected log per record, `unclaim_missing`
+    # counting any that were absent. That is the phantom event which made the
+    # claim unreproducible after a full-DB-loss restore (#103) and cut AggLayer
+    # certificate settlement at its block (#184), so the assertion now runs the
+    # other way: a ClaimEvent carrying an unclaimable record's exact
+    # (block, globalIndex, tx-hash) is a PHANTOM and fails the verdict.
+    #
+    # Left as-is, this block reported `unclaim 0/2 FAIL` on the first live stack
+    # carrying #185 (2026-09-07) — a green product failing a red test.
+    #
+    # `unclaim_missing` keeps one job: a record whose accept-and-revert
+    # transaction is unknown to the proxy store (no block) means the reverted
+    # receipt never persisted, which IS a real defect.
+    unclaim_phantom = 0
     unclaim_missing = 0
     if name == "CLAIM->ClaimEvent":
-        expected = Counter(
+        forbidden_gi = Counter(
             (block, gi, tx_hash)
             for gi, block, tx_hash in unclaimable
             if block is not None and block <= cut
         )
         unclaim_missing += sum(1 for _, block, _ in unclaimable if block is None)
-        kept = []
         for log in logs:
             block = int(log["blockNumber"], 16)
             data = log.get("data", "")
             gi = int((data[2:66] or "0"), 16)
             key = (block, gi, log["transactionHash"].lower())
-            if expected[key] > 0:
-                expected[key] -= 1
-                unclaim_exact += 1
-            else:
-                kept.append(log)
-        unclaim_missing += sum(expected.values())
-        logs = kept
+            if forbidden_gi[key] > 0:
+                forbidden_gi[key] -= 1
+                unclaim_phantom += 1
+                print(f"    PHANTOM ClaimEvent for an UNCLAIMABLE record "
+                      f"(block {block}, globalIndex {gi}, tx {log['transactionHash']}) — "
+                      f"#185 requires an unresolvable-destination claim to emit NOTHING; "
+                      f"this log is what breaks restore (#103) and certificate settlement (#184)")
+        # Every ClaimEvent must now pair with a Miden CLAIM note, so nothing is
+        # removed from `logs`: a phantom also shows up as `extra`, and both fail.
     all_log_blocks = [int(l["blockNumber"], 16) for l in logs]
     log_blocks = Counter(all_log_blocks)            # all logs (for exact/late matching)
     cut_log_blocks = Counter(b for b in all_log_blocks if b <= cut)  # extra-detection
@@ -301,11 +319,13 @@ for name, (topic, root) in TOPICS.items():
         missing -= deferred
     total_notes += n_notes
     total_logs += all_logs_count
-    ok = (missing == 0 and extra == 0 and unclaim_missing == 0 and forbidden_ct == 0
+    ok = (missing == 0 and extra == 0 and unclaim_missing == 0 and unclaim_phantom == 0
+          and forbidden_ct == 0
           and (name != "B2AGG->BridgeEvent" or unresolved_reclaims == 0)
           and (late == 0 or allow_late == "1"))
     overall_fail |= not ok
-    unclaim_col = f"{unclaim_exact}/{unclaim_exact + unclaim_missing}" if name == "CLAIM->ClaimEvent" else "-"
+    # Reported as phantom/unknown-tx, both of which must be 0 (#185).
+    unclaim_col = f"{unclaim_phantom}p/{unclaim_missing}u" if name == "CLAIM->ClaimEvent" else "-"
     forbid_col = str(forbidden_ct) if name == "B2AGG->BridgeEvent" else "-"
     print(f"{name:<22} {n_notes:>6} {all_logs_count:>6} {exact:>6} {late:>5} {missing:>8} {deferred:>6} {unclaim_col:>8} {forbid_col:>6} {extra:>6}  {'PASS' if ok else 'FAIL'}")
 

--- a/scripts/verify-event-completeness.sh
+++ b/scripts/verify-event-completeness.sh
@@ -97,10 +97,12 @@ docker exec "$NODE_CONTAINER" cat /data/node/miden-store.sqlite3-wal > "$TMP/nod
     || rm -f "$TMP/node.sqlite3-wal"
 
 # An unresolvable destination is intentionally terminal without a Miden CLAIM
-# note: the proxy records the exception durably and emits one ClaimEvent so
-# AggKit stops retrying funds that require operator rescue. Keep these events
-# strict too: match the durable record to the exact receipt block, globalIndex,
-# and transaction hash instead of weakening the generic extra-log check.
+# note. Since #185 it is terminal without a ClaimEvent either: the proxy records
+# the exception durably, accepts the claim and writes a REVERTED receipt, and
+# emits NOTHING — retry suppression comes from isClaimed/eth_estimateGas reading
+# the durable record, not from a fabricated log. So the (block, globalIndex,
+# tx-hash) triples below are what a ClaimEvent must NEVER carry; the python
+# fails the verdict on any that does (see lib-verify-completeness.py).
 PGPASSWORD="$PG_PASS" psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" \
     -t -A -F '|' -c \
     "SELECT u.global_index, COALESCE(t.block_number::text, ''), u.eth_tx_hash

--- a/src/applied_state.rs
+++ b/src/applied_state.rs
@@ -210,6 +210,25 @@ pub(crate) async fn claim_applied(
         .context("claim state was not requested")
 }
 
+/// #185 — a globalIndex is terminally claimed if a ClaimEvent applied OR it was
+/// recorded unclaimable (unresolvable destination). Both stop the submitter
+/// re-driving; `isClaimed` and `eth_estimateGas` must agree on this, or
+/// claimtxman's on-revert `checkIfClaimed` never runs.
+pub(crate) async fn claim_terminal(
+    service: &ServiceState,
+    global_index: U256,
+) -> anyhow::Result<bool> {
+    if service
+        .store
+        .get_unclaimable_claim(&global_index)
+        .await?
+        .is_some()
+    {
+        return Ok(true);
+    }
+    claim_applied(service, global_index).await
+}
+
 /// Read claim and GER state with at most one serialized Miden-client request.
 pub(crate) async fn claim_and_ger_applied(
     service: &ServiceState,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -115,21 +115,15 @@ pub fn init_metrics() {
     );
     describe_counter!(
         "claim_unclaimable_reverted_total",
-        "#185 EVM-revert semantics: a claimAsset whose destination has no Miden AccountId \
-         (unresolvable) was recorded in unclaimable_claims and ACCEPTED with a reverted \
-         (status 0x0) receipt and NO ClaimEvent — matching how an unappliable claim behaves on \
-         EVM. Retry suppression comes from isClaimed reading the unclaimable record as claimed. \
-         Compare against unclaimable_claims rows to see funds truly stranded on L1; a steady \
-         climb means many claims target unmapped destinations."
+        "#185: an unresolvable-destination claimAsset was accepted with a reverted (0x0) receipt \
+         and NO ClaimEvent (EVM revert semantics). Compare against unclaimable_claims rows to \
+         see funds stranded on L1; a steady climb means many claims target unmapped destinations."
     );
     describe_counter!(
         "rpc_estimate_gas_unclaimable_total",
-        "#185: eth_estimateGas(claimAsset) answered `execution reverted: AlreadyClaimed()` \
-         because the globalIndex is recorded in unclaimable_claims. This is what makes the \
-         claim submitter run its on-revert checkIfClaimed and mark the monitored tx CONFIRMED \
-         instead of re-sending; without it a single unresolvable deposit cost TEN reverted \
-         receipts and ten nonces before claimtxman's own history cap stopped it. Expect roughly \
-         one per unresolvable deposit AFTER its first (record-creating) attempt."
+        "#185: eth_estimateGas(claimAsset) reverted AlreadyClaimed() for a gi recorded \
+         unclaimable, so the submitter's on-revert checkIfClaimed marks the tx CONFIRMED instead \
+         of re-sending. Expect ~one per unresolvable deposit after its first (record-creating) attempt."
     );
     describe_counter!(
         "claim_inflight_dedup_total",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -114,6 +114,15 @@ pub fn init_metrics() {
          claim front-running, not a bug."
     );
     describe_counter!(
+        "claim_unclaimable_reverted_total",
+        "#185 EVM-revert semantics: a claimAsset whose destination has no Miden AccountId \
+         (unresolvable) was recorded in unclaimable_claims and ACCEPTED with a reverted \
+         (status 0x0) receipt and NO ClaimEvent — matching how an unappliable claim behaves on \
+         EVM. Retry suppression comes from isClaimed reading the unclaimable record as claimed. \
+         Compare against unclaimable_claims rows to see funds truly stranded on L1; a steady \
+         climb means many claims target unmapped destinations."
+    );
+    describe_counter!(
         "claim_inflight_dedup_total",
         "#55 third dedup window: a claimAsset arrived for a globalIndex whose winning claim was \
          SUBMITTED but had not LANDED yet (claim lock held, no ClaimEvent, within TTL) — the \

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -123,6 +123,15 @@ pub fn init_metrics() {
          climb means many claims target unmapped destinations."
     );
     describe_counter!(
+        "rpc_estimate_gas_unclaimable_total",
+        "#185: eth_estimateGas(claimAsset) answered `execution reverted: AlreadyClaimed()` \
+         because the globalIndex is recorded in unclaimable_claims. This is what makes the \
+         claim submitter run its on-revert checkIfClaimed and mark the monitored tx CONFIRMED \
+         instead of re-sending; without it a single unresolvable deposit cost TEN reverted \
+         receipts and ten nonces before claimtxman's own history cap stopped it. Expect roughly \
+         one per unresolvable deposit AFTER its first (record-creating) attempt."
+    );
+    describe_counter!(
         "claim_inflight_dedup_total",
         "#55 third dedup window: a claimAsset arrived for a globalIndex whose winning claim was \
          SUBMITTED but had not LANDED yet (claim lock held, no ClaimEvent, within TTL) — the \

--- a/src/service_estimate_gas.rs
+++ b/src/service_estimate_gas.rs
@@ -110,33 +110,11 @@ pub(crate) async fn service_estimate_gas(
             crate::applied_state::claim_and_ger_applied(&service, call.globalIndex, &combined)
                 .await
                 .map_err(|error| store_error(answer_id.clone(), error))?;
-        // #185 — a claim already recorded UNCLAIMABLE (unresolvable destination)
-        // is terminal: re-running it reverts again and emits nothing, so the
-        // estimate must revert too.
-        //
-        // This read is not optional, it is the whole retry-suppression path.
-        // ClaimTxManager only calls `checkIfClaimed` (→ `isClaimed`, which since
-        // #185 reads this record) when `ReviewMonitoredTx` fails with an
-        // `execution reverted` error — and `ReviewMonitoredTx`'s only failure
-        // mode is this `eth_estimateGas`. Reading `claim_and_ger_applied` alone,
-        // which sees the Miden nullifier / ClaimEvent and therefore FALSE for an
-        // unclaimable claim, made the estimate answer "0x0, go ahead" while
-        // `eth_call isClaimed` answered "already claimed" — the two disagreed,
-        // `checkIfClaimed` was never reached, and the submitter simply re-sent.
-        //
-        // Measured on a live stack (2026-09-07, one unresolvable deposit):
-        //   claim_unclaimable_reverted_total 0 -> 10 in 19s, ten reverted
-        //   receipts and ten consumed nonces, and the ONLY thing that stopped it
-        //   was claimtxman's own backstop — "marked as failed because reached the
-        //   history size limit (10)". Bounded, but ten times the intended cost and
-        //   never through the mechanism #185 documents.
-        // With this read the second attempt's estimate reverts `AlreadyClaimed()`,
-        // `checkIfClaimed` runs, `isClaimed` returns true and the monitored tx is
-        // marked CONFIRMED.
-        //
-        // Operator rescue (tier 2) must delete the `unclaimable_claims` row to
-        // re-open a global index — the same precondition `eth_call isClaimed`
-        // already imposes since #185, not a new one.
+        // #185 — an unclaimable-recorded gi is terminal (reverts, emits nothing),
+        // so the estimate must revert too. This is the estimate half of
+        // applied_state::claim_terminal and MUST match eth_call isClaimed:
+        // claimtxman reaches checkIfClaimed (→ isClaimed) only when this estimate
+        // reverts, so if they disagree the submitter re-drives to its history cap.
         let unclaimable = service
             .store
             .get_unclaimable_claim(&call.globalIndex)
@@ -253,19 +231,12 @@ mod tests {
         assert_eq!(json["error"]["data"], "0x646cf558");
     }
 
-    /// #185 — a globalIndex recorded UNCLAIMABLE (unresolvable destination) must
-    /// revert the ESTIMATE with `AlreadyClaimed()`, not answer "0x0, go ahead".
-    ///
-    /// This is the load-bearing half of #185's retry suppression. ClaimTxManager
-    /// reaches `checkIfClaimed` (→ `isClaimed`, which reads this record) ONLY when
-    /// `ReviewMonitoredTx` fails `execution reverted`, and its only failure mode is
-    /// this estimate. Without this the estimate and `eth_call isClaimed` disagree and
-    /// the submitter re-sends until its own history cap — measured live at TEN
-    /// reverted receipts and ten consumed nonces for a single unresolvable deposit.
-    ///
-    /// Note the GER here is deliberately ABSENT: the unclaimable record must win over
-    /// the GlobalExitRootInvalid() arm, because "retry when the GER lands" is exactly
-    /// the wrong advice for a claim that can never be applied.
+    /// #185 — an unclaimable-recorded gi must revert the estimate with
+    /// `AlreadyClaimed()` (not "0x0, go ahead"), and must agree with the predicate
+    /// isClaimed reads (`applied_state::claim_terminal`) — else claimtxman never
+    /// reaches checkIfClaimed and re-drives to its history cap. The GER is
+    /// deliberately absent: the unclaimable record must win over the
+    /// GlobalExitRootInvalid() retry-later arm.
     #[tokio::test]
     async fn estimate_gas_unclaimable_record_reverts_already_claimed() {
         use crate::store::{UnclaimableClaim, UnclaimableReason};
@@ -295,6 +266,15 @@ mod tests {
             })
             .await
             .unwrap();
+
+        // The predicate isClaimed reads must now be terminal for this gi — the
+        // estimate below must agree with it.
+        assert!(
+            crate::applied_state::claim_terminal(&service, U256::from(7u64))
+                .await
+                .unwrap(),
+            "#185: isClaimed's predicate must read the unclaimable record as claimed"
+        );
 
         let response = service_estimate_gas(
             service,

--- a/src/service_estimate_gas.rs
+++ b/src/service_estimate_gas.rs
@@ -110,8 +110,49 @@ pub(crate) async fn service_estimate_gas(
             crate::applied_state::claim_and_ger_applied(&service, call.globalIndex, &combined)
                 .await
                 .map_err(|error| store_error(answer_id.clone(), error))?;
-        if claimed {
+        // #185 — a claim already recorded UNCLAIMABLE (unresolvable destination)
+        // is terminal: re-running it reverts again and emits nothing, so the
+        // estimate must revert too.
+        //
+        // This read is not optional, it is the whole retry-suppression path.
+        // ClaimTxManager only calls `checkIfClaimed` (→ `isClaimed`, which since
+        // #185 reads this record) when `ReviewMonitoredTx` fails with an
+        // `execution reverted` error — and `ReviewMonitoredTx`'s only failure
+        // mode is this `eth_estimateGas`. Reading `claim_and_ger_applied` alone,
+        // which sees the Miden nullifier / ClaimEvent and therefore FALSE for an
+        // unclaimable claim, made the estimate answer "0x0, go ahead" while
+        // `eth_call isClaimed` answered "already claimed" — the two disagreed,
+        // `checkIfClaimed` was never reached, and the submitter simply re-sent.
+        //
+        // Measured on a live stack (2026-09-07, one unresolvable deposit):
+        //   claim_unclaimable_reverted_total 0 -> 10 in 19s, ten reverted
+        //   receipts and ten consumed nonces, and the ONLY thing that stopped it
+        //   was claimtxman's own backstop — "marked as failed because reached the
+        //   history size limit (10)". Bounded, but ten times the intended cost and
+        //   never through the mechanism #185 documents.
+        // With this read the second attempt's estimate reverts `AlreadyClaimed()`,
+        // `checkIfClaimed` runs, `isClaimed` returns true and the monitored tx is
+        // marked CONFIRMED.
+        //
+        // Operator rescue (tier 2) must delete the `unclaimable_claims` row to
+        // re-open a global index — the same precondition `eth_call isClaimed`
+        // already imposes since #185, not a new one.
+        let unclaimable = service
+            .store
+            .get_unclaimable_claim(&call.globalIndex)
+            .await
+            .map_err(|error| store_error(answer_id.clone(), error))?
+            .is_some();
+        if claimed || unclaimable {
             ::metrics::counter!("rpc_estimate_gas_already_claimed_total").increment(1);
+            if unclaimable {
+                ::metrics::counter!("rpc_estimate_gas_unclaimable_total").increment(1);
+                tracing::info!(
+                    global_index = %call.globalIndex,
+                    "eth_estimateGas(claimAsset): globalIndex is recorded unclaimable; \
+                     returning AlreadyClaimed() so the submitter stops re-driving (#185)"
+                );
+            }
             return Err(JsonRpcResponse::error(answer_id, already_claimed_error()));
         }
         if !ger_applied {
@@ -208,6 +249,62 @@ mod tests {
         assert_eq!(
             json["error"]["message"],
             "execution reverted: AlreadyClaimed()"
+        );
+        assert_eq!(json["error"]["data"], "0x646cf558");
+    }
+
+    /// #185 — a globalIndex recorded UNCLAIMABLE (unresolvable destination) must
+    /// revert the ESTIMATE with `AlreadyClaimed()`, not answer "0x0, go ahead".
+    ///
+    /// This is the load-bearing half of #185's retry suppression. ClaimTxManager
+    /// reaches `checkIfClaimed` (→ `isClaimed`, which reads this record) ONLY when
+    /// `ReviewMonitoredTx` fails `execution reverted`, and its only failure mode is
+    /// this estimate. Without this the estimate and `eth_call isClaimed` disagree and
+    /// the submitter re-sends until its own history cap — measured live at TEN
+    /// reverted receipts and ten consumed nonces for a single unresolvable deposit.
+    ///
+    /// Note the GER here is deliberately ABSENT: the unclaimable record must win over
+    /// the GlobalExitRootInvalid() arm, because "retry when the GER lands" is exactly
+    /// the wrong advice for a claim that can never be applied.
+    #[tokio::test]
+    async fn estimate_gas_unclaimable_record_reverts_already_claimed() {
+        use crate::store::{UnclaimableClaim, UnclaimableReason};
+        let service = create_test_service();
+        let request = estimate_request(&claim_calldata([0xAA; 32], [0xBB; 32]));
+
+        // Before the record: no claim, no GER -> GlobalExitRootInvalid() (retry later).
+        let before = service_estimate_gas(service.clone(), request)
+            .await
+            .expect_err("absent GER must revert");
+        let json = serde_json::to_value(before).unwrap();
+        assert_eq!(
+            json["error"]["message"],
+            "execution reverted: GlobalExitRootInvalid()"
+        );
+
+        service
+            .store
+            .record_unclaimable_claim(UnclaimableClaim {
+                global_index: U256::from(7u64),
+                destination_address: Address::from([0x42; 20]),
+                origin_network: 0,
+                origin_address: Address::ZERO,
+                amount: U256::from(1u64),
+                reason: UnclaimableReason::UnresolvableDestination,
+                eth_tx_hash: alloy::primitives::TxHash::from([0xAB; 32]),
+            })
+            .await
+            .unwrap();
+
+        let response = service_estimate_gas(service, estimate_request(&claim_calldata([0xAA; 32], [0xBB; 32])))
+            .await
+            .expect_err("#185: an unclaimable-recorded globalIndex must revert the estimate");
+        let json = serde_json::to_value(response).unwrap();
+        assert_eq!(json["error"]["code"], 3);
+        assert_eq!(
+            json["error"]["message"],
+            "execution reverted: AlreadyClaimed()",
+            "#185: the estimate must agree with eth_call isClaimed, or checkIfClaimed never runs"
         );
         assert_eq!(json["error"]["data"], "0x646cf558");
     }

--- a/src/service_estimate_gas.rs
+++ b/src/service_estimate_gas.rs
@@ -296,14 +296,16 @@ mod tests {
             .await
             .unwrap();
 
-        let response = service_estimate_gas(service, estimate_request(&claim_calldata([0xAA; 32], [0xBB; 32])))
-            .await
-            .expect_err("#185: an unclaimable-recorded globalIndex must revert the estimate");
+        let response = service_estimate_gas(
+            service,
+            estimate_request(&claim_calldata([0xAA; 32], [0xBB; 32])),
+        )
+        .await
+        .expect_err("#185: an unclaimable-recorded globalIndex must revert the estimate");
         let json = serde_json::to_value(response).unwrap();
         assert_eq!(json["error"]["code"], 3);
         assert_eq!(
-            json["error"]["message"],
-            "execution reverted: AlreadyClaimed()",
+            json["error"]["message"], "execution reverted: AlreadyClaimed()",
             "#185: the estimate must agree with eth_call isClaimed, or checkIfClaimed never runs"
         );
         assert_eq!(json["error"]["data"], "0x646cf558");

--- a/src/service_eth_call.rs
+++ b/src/service_eth_call.rs
@@ -95,9 +95,21 @@ pub(crate) async fn service_eth_call(
                 ));
             };
             let global_index = crate::applied_state::global_index_for_claim(leaf_index, source);
-            let applied = crate::applied_state::claim_applied(&service, global_index)
+            // #185 — a claim recorded as unclaimable (unresolvable destination) reads
+            // as CLAIMED here even though no ClaimEvent was emitted and no funds moved
+            // on Miden. This replaces the old synthetic ClaimEvent as the claim
+            // submitter's retry-suppression signal (its on-revert `checkIfClaimed`
+            // reads true), with no log to break restore (#103) or certificate
+            // settlement (#184). aggsender never reads isClaimed, so it enters no cert.
+            let applied = service
+                .store
+                .get_unclaimable_claim(&global_index)
                 .await
-                .map_err(|error| store_error(answer_id.clone(), error))?;
+                .map_err(|error| store_error(answer_id.clone(), error))?
+                .is_some()
+                || crate::applied_state::claim_applied(&service, global_index)
+                    .await
+                    .map_err(|error| store_error(answer_id.clone(), error))?;
             return Ok(JsonRpcResponse::success(
                 answer_id,
                 if applied { ABI_TRUE } else { ABI_FALSE },
@@ -157,6 +169,56 @@ mod tests {
             let json = serde_json::to_value(response).unwrap();
             assert_eq!(json["result"], ABI_TRUE);
         }
+    }
+
+    /// #185 — a claim recorded as unclaimable (unresolvable destination) reads as
+    /// CLAIMED via `isClaimed`, even though no ClaimEvent was emitted. This is the
+    /// retry-suppression signal that replaced the synthetic event; the submitter's
+    /// on-revert `checkIfClaimed` reads true and stops re-driving.
+    #[tokio::test]
+    async fn is_claimed_true_for_an_unclaimable_recorded_claim() {
+        use crate::store::{UnclaimableClaim, UnclaimableReason};
+        let (leaf, source) = (42u32, 0u32);
+        let service = create_test_service();
+        let gi = crate::applied_state::global_index_for_claim(leaf, source);
+
+        // No claim event, no Miden claim: isClaimed is FALSE.
+        let before = service_eth_call(
+            service.clone(),
+            eth_call_request(is_claimed_calldata(leaf, source)),
+        )
+        .await
+        .unwrap();
+        assert_eq!(serde_json::to_value(before).unwrap()["result"], ABI_FALSE);
+
+        // Record it unclaimable (the RD-860/#185 swallow) — no event emitted.
+        let newly = service
+            .store
+            .record_unclaimable_claim(UnclaimableClaim {
+                global_index: gi,
+                destination_address: alloy_core::primitives::Address::from([0x42; 20]),
+                origin_network: 7,
+                origin_address: alloy_core::primitives::Address::from([0x11; 20]),
+                amount: alloy_core::primitives::U256::from(1_000_000u64),
+                reason: UnclaimableReason::UnresolvableDestination,
+                eth_tx_hash: alloy_core::primitives::TxHash::from([0xAB; 32]),
+            })
+            .await
+            .unwrap();
+        assert!(newly, "record must be new");
+
+        // Now isClaimed reads TRUE, with no ClaimEvent anywhere.
+        let after = service_eth_call(
+            service.clone(),
+            eth_call_request(is_claimed_calldata(leaf, source)),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            serde_json::to_value(after).unwrap()["result"],
+            ABI_TRUE,
+            "#185: an unclaimable-recorded gi must read as claimed for retry suppression"
+        );
     }
 
     #[tokio::test]

--- a/src/service_eth_call.rs
+++ b/src/service_eth_call.rs
@@ -95,21 +95,13 @@ pub(crate) async fn service_eth_call(
                 ));
             };
             let global_index = crate::applied_state::global_index_for_claim(leaf_index, source);
-            // #185 — a claim recorded as unclaimable (unresolvable destination) reads
-            // as CLAIMED here even though no ClaimEvent was emitted and no funds moved
-            // on Miden. This replaces the old synthetic ClaimEvent as the claim
-            // submitter's retry-suppression signal (its on-revert `checkIfClaimed`
-            // reads true), with no log to break restore (#103) or certificate
+            // #185 — reads TRUE for an unclaimable-recorded claim (no ClaimEvent, no
+            // Miden funds moved): the retry-suppression signal that replaced the
+            // synthetic event, with no log to break restore (#103) or certificate
             // settlement (#184). aggsender never reads isClaimed, so it enters no cert.
-            let applied = service
-                .store
-                .get_unclaimable_claim(&global_index)
+            let applied = crate::applied_state::claim_terminal(&service, global_index)
                 .await
-                .map_err(|error| store_error(answer_id.clone(), error))?
-                .is_some()
-                || crate::applied_state::claim_applied(&service, global_index)
-                    .await
-                    .map_err(|error| store_error(answer_id.clone(), error))?;
+                .map_err(|error| store_error(answer_id.clone(), error))?;
             return Ok(JsonRpcResponse::success(
                 answer_id,
                 if applied { ABI_TRUE } else { ABI_FALSE },

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -301,16 +301,11 @@ async fn accept_and_revert_landed_claim(
 
 /// #185 — EVM-faithful handling for a claimAsset whose destination cannot be
 /// resolved to a Miden AccountId. Like the landed path, ACCEPT and write a
-/// REVERTED receipt (status 0x0, EMPTY logs, NO ClaimEvent) and advance the
-/// nonce atomically. Unlike the old RD-860 path it emits NO synthetic
-/// ClaimEvent: on EVM a claim that cannot be applied reverts and emits nothing,
-/// and the fabricated event made this claim (a) unreproducible after a
-/// full-DB-loss restore (#103) and (b) a "claim with unclaim" that cut AggLayer
-/// certificate settlement at its block (#184). Retry suppression comes from
-/// `isClaimed(globalIndex)` reading the durable `unclaimable_claims` record as
-/// claimed, so the claim submitter's on-revert `checkIfClaimed` stops
-/// re-driving; even absent that, the submitter's own `monitored_txs` row
-/// removes the deposit from its pending set.
+/// REVERTED receipt (status 0x0, empty logs, NO ClaimEvent) and advance the
+/// nonce atomically. No synthetic ClaimEvent: the old RD-860 one made this claim
+/// unreproducible on restore (#103) and cut certificate settlement at its block
+/// (#184). Retry suppression comes from `isClaimed` reading the unclaimable
+/// record (see `applied_state::claim_terminal`).
 async fn accept_and_revert_unclaimable_claim(
     service: &ServiceState,
     params: &claimAssetCall,
@@ -587,18 +582,14 @@ pub(crate) async fn worker_handle_claim_asset(
         claim_fence,
     );
 
-    // RD-860 / #185 — an unresolvable-destination claim is handled EVM-faithfully:
-    // record the unclaimable entry, accept and write a REVERTED receipt with NO
-    // ClaimEvent, RELEASE the lock, and return. `isClaimed(globalIndex)` reads the
-    // unclaimable record as claimed so the claim submitter stops retrying (see
-    // `accept_and_revert_unclaimable_claim`). Funds remain on L1; an operator rescue
-    // endpoint (tier 2, future work) would re-process by registering a mapping.
+    // RD-860 / #185 — an unresolvable-destination claim is accepted-and-reverted
+    // (no ClaimEvent) via `accept_and_revert_unclaimable_claim`; funds stay on L1
+    // pending operator rescue (tier 2, future work).
     //
-    // This runs AFTER the landed classification (BLOCKER A): a LANDED gi already
-    // took the accept-and-revert arm above, so RD-860 can only fire for a FRESH gi
-    // and can never emit a second ClaimEvent for an already-claimed one. Ordering
-    // vs C6: RD-860 first because unresolvable-destination is permanent while a
-    // missing GER is transient.
+    // Runs AFTER the landed classification (BLOCKER A): a LANDED gi already took the
+    // accept-and-revert arm above, so RD-860 fires only for a FRESH gi. Ordering vs
+    // C6: RD-860 first, because unresolvable-destination is permanent while a missing
+    // GER is transient.
     if let Err(err) = crate::address_mapper::resolve_address(
         &*service.store,
         params.destinationAddress,
@@ -636,12 +627,8 @@ pub(crate) async fn worker_handle_claim_asset(
              Funds remain on L1 pending operator rescue (RD-860)."
         );
 
-        // #185 — accept and REVERT, emit NO ClaimEvent. On EVM a claim that cannot be
-        // applied reverts and emits nothing; fabricating a ClaimEvent here made this
-        // claim unreproducible on restore (#103) and cut certificate settlement at its
-        // block (#184). Retry suppression comes from `isClaimed(globalIndex)`, which
-        // reads the durable unclaimable_claims record as claimed. The unclaimable_claims
-        // table remains the SOURCE OF TRUTH for how many funds are stranded on L1.
+        // #185 — accept and REVERT, no ClaimEvent (see the fn doc). unclaimable_claims
+        // stays the SOURCE OF TRUTH for how many funds are stranded on L1.
         accept_and_revert_unclaimable_claim(
             service,
             &params,

--- a/src/service_send_raw_txn.rs
+++ b/src/service_send_raw_txn.rs
@@ -299,6 +299,55 @@ async fn accept_and_revert_landed_claim(
     Ok(())
 }
 
+/// #185 — EVM-faithful handling for a claimAsset whose destination cannot be
+/// resolved to a Miden AccountId. Like the landed path, ACCEPT and write a
+/// REVERTED receipt (status 0x0, EMPTY logs, NO ClaimEvent) and advance the
+/// nonce atomically. Unlike the old RD-860 path it emits NO synthetic
+/// ClaimEvent: on EVM a claim that cannot be applied reverts and emits nothing,
+/// and the fabricated event made this claim (a) unreproducible after a
+/// full-DB-loss restore (#103) and (b) a "claim with unclaim" that cut AggLayer
+/// certificate settlement at its block (#184). Retry suppression comes from
+/// `isClaimed(globalIndex)` reading the durable `unclaimable_claims` record as
+/// claimed, so the claim submitter's on-revert `checkIfClaimed` stops
+/// re-driving; even absent that, the submitter's own `monitored_txs` row
+/// removes the deposit from its pending set.
+async fn accept_and_revert_unclaimable_claim(
+    service: &ServiceState,
+    params: &claimAssetCall,
+    tx_hash: TxHash,
+    txn_envelope: TxEnvelope,
+    signer: Address,
+    signer_str: &str,
+    tx_nonce: u64,
+) -> anyhow::Result<()> {
+    ::metrics::counter!("claim_unclaimable_reverted_total").increment(1);
+    let block_num = service.store.get_latest_block_number().await?;
+    let block_hash = service.block_state.get_block_hash(block_num);
+    service
+        .store
+        .commit_reverted_receipt_and_advance_nonce(
+            tx_hash,
+            TxnEntry {
+                id: None,
+                envelope: txn_envelope,
+                signer,
+                expires_at: None,
+                logs: vec![],
+            },
+            format!(
+                "claim for globalIndex {} has an unresolvable destination; reverted, no \
+                 event (RD-860/#185)",
+                params.globalIndex
+            ),
+            block_num,
+            block_hash,
+            signer_str,
+            tx_nonce,
+        )
+        .await?;
+    Ok(())
+}
+
 /// How long after a store rebuild the first-contact nonce bootstrap stays
 /// available. Measured from the DURABLE stamp, so restarts neither extend nor
 /// reset it. Generous by default: a continuing wallet must be able to reconnect
@@ -538,12 +587,12 @@ pub(crate) async fn worker_handle_claim_asset(
         claim_fence,
     );
 
-    // RD-860 — swallow unresolvable-destination claims permanently. If the
-    // destination address can't be resolved to a Miden AccountId, record the
-    // unclaimable entry, emit the synthetic ClaimEvent so aggkit marks the
-    // globalIndex complete and stops retrying, RELEASE the lock, and return success.
-    // Funds remain locked on L1; an operator rescue endpoint (tier 2, future work)
-    // would let ops re-process by registering a destination mapping and replaying.
+    // RD-860 / #185 — an unresolvable-destination claim is handled EVM-faithfully:
+    // record the unclaimable entry, accept and write a REVERTED receipt with NO
+    // ClaimEvent, RELEASE the lock, and return. `isClaimed(globalIndex)` reads the
+    // unclaimable record as claimed so the claim submitter stops retrying (see
+    // `accept_and_revert_unclaimable_claim`). Funds remain on L1; an operator rescue
+    // endpoint (tier 2, future work) would re-process by registering a mapping.
     //
     // This runs AFTER the landed classification (BLOCKER A): a LANDED gi already
     // took the accept-and-revert arm above, so RD-860 can only fire for a FRESH gi
@@ -587,16 +636,23 @@ pub(crate) async fn worker_handle_claim_asset(
              Funds remain on L1 pending operator rescue (RD-860)."
         );
 
-        // Emit the synthetic ClaimEvent even though no Miden funds moved. aggkit expects
-        // the event log on the eth tx receipt to mark the globalIndex claimed; without
-        // it, aggkit will retry forever. The unclaimable_claims table is the SOURCE OF
-        // TRUTH for reconciliation — anyone auditing flows MUST compare ClaimEvent
-        // counts against `unclaimable_claims` to see how many funds are truly on L1.
-        let event = crate::claim::ClaimEvent::from(params.clone());
-        let log = <crate::claim::ClaimEvent as alloy::sol_types::SolEvent>::encode_log_data(&event);
-        record_local_immediate_success(service, txn_hash, txn_envelope, signer, vec![log]).await?;
-        // The gi is now handled (unclaimable record + ClaimEvent); drop the lock so
-        // a resubmit classifies `Landed` (the ClaimEvent exists) → accept-and-revert.
+        // #185 — accept and REVERT, emit NO ClaimEvent. On EVM a claim that cannot be
+        // applied reverts and emits nothing; fabricating a ClaimEvent here made this
+        // claim unreproducible on restore (#103) and cut certificate settlement at its
+        // block (#184). Retry suppression comes from `isClaimed(globalIndex)`, which
+        // reads the durable unclaimable_claims record as claimed. The unclaimable_claims
+        // table remains the SOURCE OF TRUTH for how many funds are stranded on L1.
+        accept_and_revert_unclaimable_claim(
+            service,
+            &params,
+            txn_hash,
+            txn_envelope,
+            signer,
+            &signer_str,
+            tx_nonce,
+        )
+        .await?;
+        // The gi is handled (unclaimable record + reverted receipt); drop the lock.
         guard.release_explicitly().await;
         return Ok(());
     }
@@ -3074,9 +3130,9 @@ mod tests {
     }
 
     /// RD-860: a claim whose destination cannot be resolved is swallowed — we record
-    /// it in the `unclaimable_claims` store, emit a synthetic `ClaimEvent` so aggkit
-    /// stops retrying, and return success to the caller. Neither `try_claim` nor the
-    /// MidenClient publish path should be touched.
+    /// it in the `unclaimable_claims` store, accept-and-REVERT with no ClaimEvent
+    /// (#185), and return to the caller. Neither `try_claim` nor the MidenClient
+    /// publish path should be touched.
     #[tokio::test]
     async fn test_claim_asset_unresolvable_destination_swallowed() {
         let service = create_test_service();
@@ -3136,7 +3192,7 @@ mod tests {
         );
         assert_eq!(rec.eth_tx_hash, tx_hash);
 
-        // (4) Exactly one synthetic ClaimEvent emitted (so aggkit marks done).
+        // (4) #185 — NO ClaimEvent is emitted (EVM revert semantics).
         let filter = crate::log_synthesis::LogFilter {
             from_block: Some("0x0".to_string()),
             to_block: Some("0xFFFF".to_string()),
@@ -3152,13 +3208,27 @@ mod tests {
             .collect();
         assert_eq!(
             claim_logs.len(),
-            1,
-            "swallow path must emit exactly one ClaimEvent so aggkit stops retrying"
+            0,
+            "#185: unresolvable claim must emit NO ClaimEvent"
         );
 
-        // (5) Nonce incremented and receipt recorded so the RPC client sees success.
+        // (5) Nonce advanced and a REVERTED receipt (status 0x0) recorded.
         assert_eq!(store.nonce_get(&format!("{signer:#x}")).await.unwrap(), 1);
-        assert!(store.txn_receipt(tx_hash).await.unwrap().is_some());
+        let (recpt, _blk) = store.txn_receipt(tx_hash).await.unwrap().expect("receipt");
+        assert!(
+            recpt.is_err(),
+            "#185: unresolvable claim receipt must be reverted"
+        );
+
+        // (6) #185 — the unclaimable record is what isClaimed reads as claimed.
+        assert!(
+            store
+                .get_unclaimable_claim(&global_index)
+                .await
+                .unwrap()
+                .is_some(),
+            "#185: unclaimable record must back isClaimed"
+        );
     }
 
     #[tokio::test]
@@ -4429,9 +4499,9 @@ mod tests {
     ///
     /// Unit-harness note: the stub `MidenClient` never runs the publish
     /// closure, so the only claim route that completes SYNCHRONOUSLY is the
-    /// RD-860 unresolvable-destination swallow — which still exercises the
-    /// full RPC pipeline (chain-id, nonce, allow-list, dispatch) and emits the
-    /// synthetic ClaimEvent + receipt. The user here claims a deposit destined
+    /// RD-860/#185 unresolvable-destination swallow — which still exercises the
+    /// full RPC pipeline (chain-id, nonce, allow-list, dispatch) and records a
+    /// reverted receipt (no ClaimEvent). The user here claims a deposit destined
     /// to their own EVM address (no Miden mapping registered → swallow). The
     /// real-Miden happy path is covered by scripts/e2e-manual-user-claim.sh.
     #[tokio::test]
@@ -4458,10 +4528,12 @@ mod tests {
             "returned hash must be the user's tx hash"
         );
 
+        // #185 — the swallow route emits NO ClaimEvent; the manual claim is still
+        // ACCEPTED (the point of this test), recorded, and its nonce advances.
         assert_eq!(
             count_claim_events(&store).await,
-            1,
-            "exactly one ClaimEvent must be emitted for the user's claim"
+            0,
+            "#185: the unresolvable-destination swallow emits no ClaimEvent"
         );
         let txn = store
             .txn_get(tx_hash)
@@ -4765,9 +4837,9 @@ mod tests {
             "C's claim for someone else's deposit must reach the Miden publish"
         );
 
-        // Leg 2 — synchronous accept (RD-860 swallow route, the only one that
+        // Leg 2 — synchronous accept (RD-860/#185 swallow route, the only one that
         // completes under the stub): destination is a third party's EVM
-        // address ≠ C. Accepted, ClaimEvent emitted, and the recorded signer
+        // address ≠ C. Accepted, reverted (no ClaimEvent), and the recorded signer
         // is C — the destination in the calldata is untouched by who signed.
         //
         // Fresh service so C's nonce-0 slot is a clean reservation: leg 1 already
@@ -4790,7 +4862,11 @@ mod tests {
             .await
             .expect("permissionless claim for someone else's deposit must be accepted");
         assert_eq!(accepted, tx_hash);
-        assert_eq!(count_claim_events(&store).await, 1);
+        assert_eq!(
+            count_claim_events(&store).await,
+            0,
+            "#185: the unresolvable-destination swallow emits no ClaimEvent"
+        );
         let txn = store.txn_get(tx_hash).await.unwrap().expect("tx recorded");
         assert_eq!(
             txn.signer, addr_c,


### PR DESCRIPTION
Adopts EVM revert semantics for a claimAsset whose destination has no Miden AccountId: record the unclaimable entry, accept-and-**revert** (status 0x0, no logs), emit **no** ClaimEvent. Retry suppression moves to `isClaimed(globalIndex)` reading the `unclaimable_claims` record as claimed.

**Why** — the synthetic ClaimEvent was the shared root cause of:
- **#103**: unreproducible on `--restore` (no Miden note to replay from).
- **#184**: read as a claim-with-unclaim, permanently cutting AggLayer certificate settlement at its block.

**Verified safe (source-checked):**
- aggsender builds a certificate's imported exits from synced Claim rows and **never reads isClaimed** (grep of aggkit `aggsender/`,`agglayer/`), so `isClaimed=true` without an event enters no certificate.
- The claim index lives **in the note** (`ProofData.global_index`) and `depositCount` is a bridge-out-only counter, so **no index shifts on recovery**.
- The claim submitter stops retrying: on revert `claimtxman/monitortxs.go` `checkIfClaimed`→`isClaimed`→true→Confirmed; and `GetPendingDepositsToClaim` already excludes any deposit with a `monitored_txs` row.

Live and restored history now agree (neither emits the phantom event). Funds remain on L1 in `unclaimable_claims` pending operator rescue.

**Tests:** no-ClaimEvent + reverted receipt + unclaimable record; `isClaimed` true from an unclaimable record; two swallow-route stub tests updated. 599 lib tests green, clippy clean.

Not yet done: full live e2e on the remote box (next), and describing the new `claim_unclaimable_reverted_total` metric.

Closes #185. Closes #184. Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGoAzmPkjYq85iADpZodwm