### PR TITLE
chore: bump to the stable Miden 0.16 line (client 0.16.0, protocol 0.16.1, node v0.16.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69316dfc0c3d880aa328b6b13550c606ed607a5bc367a69b61c2f0303384b20e"
+checksum = "c9340d981c2aaefded2a28ca66f10169dd4170c912538d33fe8690ea549e468e"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -3765,9 +3765,9 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6039840fa65549acced4c65f9d2e3e938016b6ec2df2b608543e1eeee14d71"
+checksum = "3e34859c5f2005e95cfc5ba97ae0dffec15bb44460fc23262532e5e2aee49155"
 dependencies = [
  "miden-protocol",
  "thiserror 2.0.20",
@@ -3775,9 +3775,9 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.16.0-rc.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade7087c2961fb6b3a102987c6e9c0831ba4dd154e17b481f69ff2ff8cee0ad2"
+checksum = "c9862fde2ef60a6a1f1066834c9920f50973a2012465c451ec64381fea4654fc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3787,8 +3787,10 @@ dependencies = [
  "gloo-timers",
  "hex",
  "miden-agglayer",
+ "miden-assembly-syntax",
  "miden-node-proto-build",
  "miden-note-transport-proto-build",
+ "miden-processor",
  "miden-protocol",
  "miden-standards",
  "miden-testing",
@@ -3814,9 +3816,9 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.16.0-rc.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2378c4453ca0ac5d716174fcca9f024a831de8ff48c280152ffe8d12d6c3d1ab"
+checksum = "b1bdb490a10753418209cf9efcb8d923b3b0a39105b9cba987e9674dd1528b66"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4085,9 +4087,9 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.16.0-rc.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be898c22d3f1f398658925cb31d18871c239cc9b7004ee3d8099d74efc70e1e6"
+checksum = "724a79e7663157e73de1fc19fcd6e30c7cee4e4c4189d44477922a3969797acb"
 dependencies = [
  "build-rs",
  "codegen",
@@ -4099,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto-build"
-version = "0.5.0-alpha.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e600f9d0bcb8c7e052a0dff573bde5fb953cf29c26b8c5aa36d71166a17957"
+checksum = "5a9d736051a42941788c6534caf8cf779b388c0ae72c9d5f0d729d2a9872d833"
 dependencies = [
  "fs-err",
  "miette",
@@ -4197,9 +4199,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d0e83b841c75cababe1a9622872c71b693888e206574985aab67b24fcdb0bf"
+checksum = "89ccf181d3a4e90b9e6ac107547ce1db30f085dfe5696a7735b1de03ac02f6ba"
 dependencies = [
  "bech32",
  "fs-err",
@@ -4228,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol-build-utils"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e115c3886d07558c4ea0a375c84dbc233afff9d4cd8157d9470d2e95594f084"
+checksum = "9d16cdd96c1d0b3b2d57342d37eaadd15cc7c633bda965fc8c3b23ca249965b4"
 dependencies = [
  "fs-err",
  "miden-assembly",
@@ -4281,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f448c316cf5b1e3fe06374fd17f71af7b75b91e730695c37b17bf70a018f5178"
+checksum = "ee6fc2cdac6d1bb48ae4b0c2f0498e754490750283783b7a71b25c3017e68754"
 dependencies = [
  "bon",
  "miden-assembly",
@@ -4320,9 +4322,9 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b8ca42ab5ce2359a1e6f9f502fc24c6832816b11b9f782a6b1f2473a58ff2a"
+checksum = "697ea989c4553c1676dd740e41ad29d35fa6b1ac2ab20893c647fa4c7ec6d9dd"
 dependencies = [
  "anyhow",
  "itertools 0.15.0",
@@ -4341,9 +4343,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d6e37711034331959d11e66d5abf96a8cab07a40b94bed735b5d062e2cb841"
+checksum = "6d5e8e69cf0db2d2f37f16909fc17d0b28730e1d21a587580ec90f27e19e309f"
 dependencies = [
  "bon",
  "miden-agglayer",
@@ -4356,9 +4358,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92f7b08f6ee27fbd656ac8c3ff22bc77e735c46b2907d35d38492425ca09f16a"
+checksum = "06419d4c747d8e79674d2be1436f0a46abe70aa2598f1789e71a07c14106cfa9"
 dependencies = [
  "miden-processor",
  "miden-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = [".github/"]
 license = "MIT OR Apache-2.0"
 name = "miden-agglayer-service"
 readme = "README.md"
-rust-version = "1.98"
+rust-version = "1.98.1"
 version = "0.1.0"
 
 [[bin]]
@@ -32,8 +32,8 @@ path = "src/bin/bridge_autoclaim.rs"
 [dev-dependencies]
 # testing exposes the generated proto types — the ONLY public construction
 # path for rpc TransactionRecord fixtures (consumed_note_refs is pub(crate)
-# upstream in rc.5).
-miden-client = { version = "=0.16.0-rc.5", features = ["testing", "tonic"] }
+# upstream in 0.16.0).
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
 tempfile = "3.10"
 # test-util enables tokio's paused virtual clock (start_paused) — used by the
 # ger::poll_until_ready timing regression test to pin the exact sleep count
@@ -140,30 +140,31 @@ deadpool-postgres = { version = "0.14", optional = true }
 # pages, so it returns ALL matches with bounded memory. Only used on the pg path.
 futures-util = { version = "0.3", optional = true }
 
-# Release matrix (refreshed 2026-09-04: #180 node rc.5, #177 unvendor):
+# Release matrix (refreshed 2026-09-08: stable 0.16 line — node v0.16.0,
+# protocol 0.16.1, client 0.16.0):
 #   - protocol crates (miden-protocol / miden-standards / miden-agglayer /
-#     miden-tx) = 0.16.0-rc.9, exact pins kept aligned (never mix protocol
-#     releases). rc.9 is what miden-node v0.16.0-rc.5 and miden-client rc.5
-#     both build against, so the BURN/MINT/CLAIM/B2AGG MAST roots agree across
-#     the node/client boundary by construction. rc.7..rc.9 changed the bridge
-#     code commitment (priced fee policy, emergency pause, RBAC config notes)
-#     — see the protocol CHANGELOG; the e2e genesis is redeployed by the
-#     proxy's --init, so no committed account file needs regenerating.
-#   - miden-client / miden-client-sqlite-store = 0.16.0-rc.5, STOCK crates.io
-#     release, no [patch.crates-io], no vendor/ (closes #177). rc.5 ships the
-#     upstream fix for the submission retry (rust-sdk#2441 / #2489): the retry
-#     policy is endpoint-aware — SubmitProvenTx / SubmitProvenBatch no longer
-#     re-send on `Unavailable`, only on `ResourceExhausted` (the node's rate
-#     limiter rejects before the mempool sees the tx, so that re-send is
-#     safe). That is what the rc.1..rc.4 vendor patch existed to enforce; the
-#     caller-side backstop (`submit_is_indeterminate` in
-#     src/bin/bridge_out_tool.rs) stays.
+#     miden-tx) = 0.16.1 (stable), exact pins kept aligned (never mix protocol
+#     releases). 0.16.1 is what miden-node v0.16.0 (its Cargo.lock) and
+#     miden-client 0.16.0 build against, so the BURN/MINT/CLAIM/B2AGG MAST
+#     roots agree across the node/client boundary by construction. This is a
+#     rc.9 -> 0.16.1 stabilization on the SAME 0.16 line (no API train jump);
+#     the e2e genesis is redeployed by the proxy's --init, so no committed
+#     account file needs regenerating. Do NOT jump to 0.17.x (needs VM 0.32,
+#     breaking train).
+#   - miden-client / miden-client-sqlite-store = 0.16.0 (stable), STOCK
+#     crates.io release, no [patch.crates-io], no vendor/ (#177 stays closed).
+#     0.16.0 is rc.5 + the finalization; its submission-retry fix (endpoint-
+#     aware, rust-sdk#2441/#2489) is retained. Bumping the client forces the
+#     protocol bump: client 0.16.0 requires protocol ^0.16, which the rc.9
+#     prerelease does not satisfy. The caller-side backstop
+#     (`submit_is_indeterminate` in src/bin/bridge_out_tool.rs) stays.
 #   - VM train (miden-assembly / miden-core / miden-processor) = 0.29, lock
-#     cohort at 0.29.4 — protocol rc.9 still requires ^0.29.1; do not jump to
-#     0.30 (breaking train). The node rc.5 lock resolves 0.29.1.
-#   - services interact with a miden-node v0.16.0-rc.5 e2e stack; the Makefile
+#     cohort at 0.29.4 — protocol 0.16.1 still requires ^0.29.1; do not jump to
+#     0.30/0.32 (breaking trains). The node v0.16.0 lock resolves 0.29.4.
+#   - services interact with a miden-node v0.16.0 e2e stack; the Makefile
 #     (MIDEN_NODE_GIT_REF) is the single source of truth for the node ref.
-#   - Rust toolchain 1.98 (rust-version above; protocol rc.9 raised it).
+#   - Rust toolchain 1.98.1 (rust-version above; protocol 0.16.1 / client
+#     0.16.0 MSRV).
 # Headline API changes ported in the rc.6 migration: create_bridge_account grew a
 # GER-remover role (4 args), duplicate GER injection now aborts with
 # ERR_GER_ALREADY_REGISTERED (was silent success), B2AGG notes must be
@@ -173,16 +174,16 @@ futures-util = { version = "0.3", optional = true }
 # MAST-root consistency note (carried over from the 0.14/0.15 pins): the
 # proxy-side `BurnNote::script_root()` MUST match the miden-node binary's, or
 # every L2→L1 bridge-out fails in the node's NTX `before_created` handler with
-# "note script with root <X> not found". The rc.9 base crates resolve
+# "note script with root <X> not found". The 0.16.1 base crates resolve
 # miden-assembly/core 0.29.x; keep these in lockstep with the deployed
-# miden-node v0.16.0-rc.x release and tighten to an exact patch if a root
+# miden-node v0.16.0 release and tighten to an exact patch if a root
 # mismatch resurfaces during the e2e regression.
-miden-base-agglayer = { package = "miden-agglayer", version = "=0.16.0-rc.9" }
+miden-base-agglayer = { package = "miden-agglayer", version = "=0.16.1" }
 miden-protocol = { default-features = false, features = [
   "std",
-], version = "=0.16.0-rc.9" }
-miden-standards = { default-features = false, version = "=0.16.0-rc.9" }
-miden-tx = { default-features = false, version = "=0.16.0-rc.9" }
+], version = "=0.16.1" }
+miden-standards = { default-features = false, version = "=0.16.1" }
+miden-tx = { default-features = false, version = "=0.16.1" }
 
 miden-assembly = { default-features = false, version = "0.29" }
 miden-core = { default-features = false, version = "0.29" }
@@ -196,12 +197,12 @@ miden-processor = { default-features = false, features = [
   "std",
 ], version = "0.29" }
 
-# miden-client 0.16.0-rc.5 — stock crates.io release (see the release matrix
-# above for why no patch is needed any more). sqlite-store pinned in lockstep.
+# miden-client 0.16.0 — stock crates.io release (see the release matrix above
+# for why no patch is needed). sqlite-store pinned in lockstep.
 miden-client = { default-features = false, features = [
   "tonic",
-], version = "=0.16.0-rc.5" }
-miden-client-sqlite-store = { version = "=0.16.0-rc.5" }
+], version = "=0.16.0" }
+miden-client-sqlite-store = { version = "=0.16.0" }
 
 [features]
 default = []

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ install-tools: ## Install development tools
 # per-service `bootstrap`/`start` subcommands across separate binaries), and
 # the `02-with-account-files.toml` genesis sample no longer exists upstream —
 # the compose file mirrors the official rc.3+ runner (scripts/run-node.sh)
-# instead. We pin to the v0.16.0-rc.5 tag. E2E node images are built by
+# instead. We pin to the v0.16.0 tag. E2E node images are built by
 # run-all.sh FROM THE UPSTREAM CHECKOUT'S OWN Dockerfile — there is no
 # repo-local node Dockerfile — and the checkout is built UNMODIFIED: since
 # node v0.16.0-rc.4 the ntx-builder's remote-prover timeout is a CLI flag
@@ -222,14 +222,13 @@ install-tools: ## Install development tools
 # so the source patch #180 tracked is gone. run-all.sh fails setup if the
 # pinned checkout lacks that flag.
 #
-# COMPATIBILITY: node rc.5's official Cargo.lock resolves
-# miden-protocol/standards/tx/agglayer 0.16.0-rc.9 — the SAME protocol
-# release our proxy pins — and the VM train (miden-assembly/core/processor)
-# 0.29.1 vs our 0.29.4 (patch releases on the same minor). The BURN/MINT/
-# CLAIM/B2AGG note MAST roots therefore agree by construction on the protocol
-# side; cross-binary evidence from a live e2e run against rc.5 is still
-# PENDING for this bump. If a bridge-out fails with "note script with root <X>
-# not found", tighten the VM-train pin to the node's 0.29.1 first.
+# COMPATIBILITY: node v0.16.0's official Cargo.lock resolves
+# miden-protocol/standards/tx/agglayer 0.16.1 — the SAME protocol release our
+# proxy pins — and the VM train (miden-assembly/core/processor) 0.29.4, the
+# SAME as ours. The BURN/MINT/CLAIM/B2AGG note MAST roots therefore agree by
+# construction across the node/client boundary. Cross-binary evidence from a
+# live e2e run against v0.16.0 is pending for this bump. If a bridge-out fails
+# with "note script with root <X> not found", tighten the VM-train pin first.
 # Node-pin coordination: the Makefile and run-all.sh BOTH carry the pin
 # (run-all.sh reads plain constants — no make-in-shell plumbing) and each
 # drift-checks the other at setup time. Bump BOTH together: edit
@@ -239,15 +238,15 @@ install-tools: ## Install development tools
 #
 # Bumping checklist: Makefile (REF + COMMIT) and run-all.sh (URL/REF/COMMIT).
 MIDEN_NODE_GIT_URL := https://github.com/0xMiden/node.git
-# v0.16.0-rc.5. See the compatibility note above: its lock pins protocol rc.9
-# (ours too) + VM 0.29.1 (ours 0.29.4). No source patch, no vendor patch: the
-# prover timeout is a flag, the node-store callback-vault-key bug is fixed
-# upstream, and the AggLayer network id is a runtime storage slot.
-MIDEN_NODE_GIT_REF := v0.16.0-rc.5
+# v0.16.0 (stable). Its lock pins protocol 0.16.1 (ours too) + VM 0.29.4 (ours
+# too). No source patch, no vendor patch: the prover timeout is a flag, the
+# node-store callback-vault-key bug is fixed upstream, and the AggLayer network
+# id is a runtime storage slot.
+MIDEN_NODE_GIT_REF := v0.16.0
 # The exact commit the tag points at (verified by `git ls-remote` at pin
 # time). run-all.sh checks the checkout's HEAD against this so a fork cannot
 # shadow the tag. Bump BOTH together.
-MIDEN_NODE_GIT_COMMIT := 461ac961951c19543b3b2e6db99a0bf82349dbde
+MIDEN_NODE_GIT_COMMIT := d6ce8b14d4680e0187b877c1de5c1cdeea16e7e2
 
 # Remote-custody overlay. Applies to the BASE e2e stack too, not just l2l2:
 # without it `make e2e-up` can only run local-keystore custody, and every

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Operational deployment, recovery, and alert guidance lives in
 
 ## Prerequisites
 
-- Rust 1.98 or newer (matches `rust-version` in Cargo.toml — raised by protocol 0.16.0-rc.9; the release container currently builds with Rust nightly)
+- Rust 1.98.1 or newer (matches `rust-version` in Cargo.toml — raised by protocol 0.16.1 / client 0.16.0; the release container currently builds with Rust nightly)
 - Docker with Compose for the integration stack
 - Foundry (`cast`) for integration scripts
 - `jq`, Python 3, and Bash for the scripts

--- a/docs/RUNNING-E2E.md
+++ b/docs/RUNNING-E2E.md
@@ -24,14 +24,14 @@ state must be retained.
 ## Prerequisites
 
 The normal host needs Docker with Compose, Foundry (`cast`), Bash, `jq`, Python
-3, Node.js, and Rust 1.98 or newer. Fixture generation also needs Kurtosis.
+3, Node.js, and Rust 1.98.1 or newer. Fixture generation also needs Kurtosis.
 
 Compose expects four locally built Miden images and one patched bridge-service
 image:
 
 | Image | Source used by repository scripts |
 |---|---|
-| `miden-validator` | `https://github.com/0xMiden/node.git` at `v0.16.0-rc.5` |
+| `miden-validator` | `https://github.com/0xMiden/node.git` at `v0.16.0` |
 | `miden-node` | same checkout and ref |
 | `miden-ntx-builder` | same checkout and ref |
 | `miden-remote-prover` | same checkout and ref |

--- a/docs/development/code-health-tooling.md
+++ b/docs/development/code-health-tooling.md
@@ -14,7 +14,7 @@ not a tooling roadmap.
 4. `make test-unit`
 5. `make test-scripts`
 
-The crate declares Rust **1.98** as its minimum supported version in
+The crate declares Rust **1.98.1** as its minimum supported version in
 `Cargo.toml`. The repository does not pin a rustup toolchain, so developers and
 CI must select a compatible toolchain themselves.
 

--- a/run-all.sh
+++ b/run-all.sh
@@ -102,8 +102,8 @@ provision() {
   # Single source of truth is MIDEN_NODE_GIT_REF in the Makefile; this script
   # pins the same value and fails loudly if the two drift.
   MIDEN_NODE_GIT_URL="https://github.com/0xMiden/node.git"
-  MIDEN_NODE_GIT_REF="v0.16.0-rc.5"
-  MIDEN_NODE_GIT_COMMIT="461ac961951c19543b3b2e6db99a0bf82349dbde"
+  MIDEN_NODE_GIT_REF="v0.16.0"
+  MIDEN_NODE_GIT_COMMIT="d6ce8b14d4680e0187b877c1de5c1cdeea16e7e2"
   export MIDEN_NODE_GIT_URL MIDEN_NODE_GIT_REF MIDEN_NODE_GIT_COMMIT
   makefile_pin="$(git rev-parse --show-toplevel)/Makefile"
   grep -Fx "MIDEN_NODE_GIT_URL := $MIDEN_NODE_GIT_URL" "$makefile_pin" || \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+[toolchain]
+# Pin the toolchain to the workspace MSRV (Cargo.toml `rust-version`). The stable
+# Miden 0.16 crates (miden-protocol 0.16.1, miden-client 0.16.0) require rustc
+# 1.98.1; without this file CI falls back to the runner's default (1.98.0) and
+# clippy's MSRV check fails. Pinning keeps CI, local dev, and the e2e box aligned.
+channel = "1.98.1"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Stabilizes the whole Miden 0.16 cohort now that it went final. **Same 0.16 line, not an API-train jump** (0.17.x needs VM 0.32, deliberately not taken).

| Crate / pin | Before | After |
|---|---|---|
| `miden-client` / `-sqlite-store` | `=0.16.0-rc.5` | `=0.16.0` |
| `miden-protocol` / `-standards` / `-agglayer` / `-tx` | `=0.16.0-rc.9` | `=0.16.1` |
| VM (`miden-assembly`/`-core`/`-processor`) | 0.29 → 0.29.4 | unchanged (0.29.4) |
| miden-node (Makefile/run-all pin) | `v0.16.0-rc.5` (`461ac961`) | `v0.16.0` (`d6ce8b14`) |
| MSRV | 1.98 | 1.98.1 |

Bumping the client forces the protocol bump: client `0.16.0` requires protocol `^0.16`, which the rc.9 prerelease doesn't satisfy.

## Is this safe without a full e2e? — low risk, and MAST-root-safe by construction

The historical risk in a Miden bump is a note-script/MAST-root mismatch across the node/client boundary. That risk is **nil** here: node `v0.16.0`'s own `Cargo.lock` resolves protocol **0.16.1** + VM **0.29.4**, the **same** as this proxy, so both sides move together and the BURN/MINT/CLAIM/B2AGG/GER roots agree by construction.

The actual code delta is small (checked the git compares, the changelogs are cumulative and misleading):
- **protocol `rc.9..0.16.1` = 2 commits:** a version bump, and an `AuthMultisig` fee-payment bound (#3802). The bridge uses `AuthNetworkAccount`/RBAC, **not** `AuthMultisig`, so nothing the proxy depends on changes.
- **client `rc.5..0.16.0` = 12 commits:** robustness fixes (including *no-panic on a consumed input note without metadata*, #2354 — squarely on our resolved-input path), a distinct submit-unknown-outcome error, explicit input-note classification (#2437), and CLI-only changes. No SMT-forest/storage-map/fees-in-auth churn in this delta — those landed in earlier rc's and were already in rc.5.

**Recommendation:** mergeable on unit tests + build for a low-risk stabilization, but a **light** e2e (round-trip + one restore drill, ~1h) is cheap insurance for a client minor and the box is free. NOT the full multi-day battery.

## Verification
- `cargo test --lib --bins`: 630 passed, 0 failed, 1 ignored
- `cargo clippy --all-targets -D warnings`, `cargo fmt --check`: clean
- `cargo build --all-targets`: clean; single resolved cohort (client 0.16.0, protocol/agglayer/tx 0.16.1, VM 0.29.4)
- No source changes; no `[patch.crates-io]`, no `vendor/` (#177 stays closed)

**Operational note:** client 0.16.0's sqlite store format is not backward compatible — upgrade with `--reset-miden-store` (or a fresh store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGoAzmPkjYq85iADpZodwm
