### PR TITLE
ci(release): rebuild the OS-package layer so releases carry apt fixes (Aikido, unblocks 33 findings incl. 3 high)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,14 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          # Aikido: always rebuild the `runtime` stage, the one that runs
+          # `apt-get update && apt-get upgrade -y`. Its cache key is the
+          # instruction text (never changes) plus the debian:trixie-slim
+          # digest, so between base-image refreshes the gha cache restores a
+          # pre-advisory layer and the release republishes the SAME vulnerable
+          # packages. Only this stage is uncached; the Rust build stage — the
+          # expensive one — still hits the cache.
+          no-cache-filters: runtime
           outputs: type=image,name=gatewayfm/miden-agglayer,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,13 @@ RUN \
     && cp target/release/bridge-out-tool bin/bridge-out-tool \
     && cp target/release/bridge-autoclaim bin/bridge-autoclaim
 
-FROM debian:trixie-slim
+# Named so release.yml can mark this stage uncached (`no-cache-filters`). The
+# `apt-get upgrade` below is what carries Debian security updates into the
+# image, and its buildx cache key is the instruction text (never changes) plus
+# the debian:trixie-slim digest — so while the base digest sits still, every
+# release after the first restores this layer from the gha cache and reships
+# the same package versions.
+FROM debian:trixie-slim AS runtime
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
## What this changes

Two lines of intent, in the release path only:

- `Dockerfile` — the final stage is given a name: `FROM debian:trixie-slim AS runtime`.
- `.github/workflows/release.yml` — the multi-arch build step gains
  `no-cache-filters: runtime`, so that one stage is always rebuilt.

No dependency changes, no application code, no change to what the image contains
on a cold build.

## Why

`release.yml` builds with `cache-from`/`cache-to: type=gha,mode=max`. The stage
that carries Debian security updates into the image is the runtime stage:

```
RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends ...
```

Its buildx cache key is the instruction text — which never changes — plus the
`debian:trixie-slim` digest. So for as long as the base digest sits still, the
**second and every later** release restores that layer from the gha cache and
republishes exactly the package versions the first one happened to pick up. A
CVE published in that window cannot be fixed by cutting a release, which is the
one remediation Aikido offers for these findings ("Rebuild your docker image and
make sure you use the latest OS base image").

That window is not hypothetical here. The five releases from v0.15.5 (2026-07-06)
to v0.15.9 (2026-07-20) all landed inside a single base-image digest, so four of
the five could not have re-run `apt-get upgrade` at all.

This is the same fix, for the same reason, as
gateway-fm/open-privacy-suite#467 (merged 2026-09-07), which marked
`runtime-base` and `prod` uncached in that repo's release workflow.

## Aikido findings in scope

`gatewayfm/miden-agglayer` currently carries **33 open findings** (3 high 76, from
`GET /api/public/v1/containers`: last pushed 2026-07-20 at tag `0.15.9`, last
scanned 2026-09-07) across nine Debian packages — openssl, libssl3t64,
openssl-provider-legacy `3.5.6-1~deb13u2` → `3.5.7-1~deb13u2`, and
util-linux, bsdutils, libmount1, libsmartcols1, libuuid1, liblastlog2-2
`2.41-5` → `2.41.5-0+deb13u1`.

- <https://app.aikido.dev/issues/single/563266068?groupId=20439> — CVE-2026-63072 in libssl3t64, high 76
- <https://app.aikido.dev/issues/single/563266087?groupId=20439> — CVE-2026-63072 in openssl, high 76
- <https://app.aikido.dev/issues/single/563266101?groupId=20439> — CVE-2026-63072 in openssl-provider-legacy, high 76

## Do NOT wait for this PR before cutting the release

This PR is **preventive, not load-bearing for the next release**. Three dates say
so:

| date | what |
|---|---|
| 2026-07-20 | last `gatewayfm/miden-agglayer` build (tag `0.15.9`) |
| 2026-08-25 | `debian:trixie-slim` digest last refreshed on Docker Hub |
| 2026-08-26 | CVE-2026-63072 advisory |

Because the base digest moved *after* the last build, the runtime layer's cache
key has already changed and the next release will re-run `apt-get upgrade` on its
own. The nine patched versions are present in `trixie-security` today (checked
against `dists/trixie-security/main/binary-amd64/Packages.xz`: eight exact
matches, `bsdutils` differing only by its `1:` epoch), and the base image's apt
sources include that suite — so tagging clears all 33 findings with or without
this change:

```
git tag v0.15.10 && git push origin v0.15.10
```

What this PR buys is the release *after* that one, and every one after it.

## Verification

`no-cache-filters` needs buildx, which is what `docker/build-push-action` runs, so
there is nothing to execute locally here — and this repo has no PR-time image
build (`check.yml` runs `make lint`, `make build`, `cargo check`, `make test-unit`,
`make test-scripts` and `cargo-deny`; `release.yml` is the only workflow that
touches Docker and it only fires on a `v*` tag push). So the checks below are what
was actually run, via `work/validate_miden_0908.py`:

| check | result |
|---|---|
| diff vs `origin/main` is purely additive apart from the `FROM` rename | pass — 15 added, 1 removed, the removal being `FROM debian:trixie-slim` |
| `no-cache-filters` is a plain `key: value` at the same indent as its siblings inside the existing `with:` mapping | pass — indent 10, between `cache-to:` and `outputs:` |
| the filter value names a stage that exists | pass — `runtime`, against stages `builder` and `runtime` |
| no `--target` anywhere in the repo that a stage rename could break | pass — `grep -rn 'target:' .github/workflows/` returns nothing, and the runtime stage stays last, so it remains the default build target |

A YAML parser was **not** run: this runner has no PyYAML and both `ruby` and
`node` are unavailable to it, so the workflow edit was verified structurally as
above rather than by parsing. Please eyeball the eight added lines.

## Risk

Low, and confined to the release path. The runtime stage stops being cached, so
each release does one extra `apt-get update && apt-get upgrade` — tens of seconds
against a multi-arch Rust + RocksDB build, and the builder stage still hits the
cache untouched. The failure mode if the stage name were wrong is a failed release
build, not a bad image; that is what the third check above rules out.

## Closing this Aikido issue

`closes_on: release-required` — **this PR closes nothing on merge.** The 33
findings are in the published image, and only a rebuild-and-push clears them:

```
git tag v0.15.10 && git push origin v0.15.10   # release.yml fires on push of a v* tag
```

republishes `gatewayfm/miden-agglayer`, after which Aikido's next image scan
clears the findings. Merging this PR is not a precondition for that (see the
three dates above) and does not on its own change any finding's state.
