### PR TITLE
docs: refresh the post-#167 projection-source description

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,7 +167,7 @@ sequenceDiagram
     P->>P: require body-sweep frontier >= current Miden tip
     P->>N: sync_transactions for bridge account and block window
     N-->>P: finalized bridge transactions and consumed nullifiers
-    P->>M: read locally consumed CLAIM and GER notes
+    P->>P: resolve B2AGG, CLAIM and GER consumption from those transactions (resolve_bridge_consumptions)
     loop Each block from cursor plus one to Miden tip
         P->>P: order notes by transaction and input-note position
         P->>S: reserve B2AGG LET indices in that exact order
@@ -177,14 +177,14 @@ sequenceDiagram
     end
 ```
 
-The note sources are deliberately different:
-
-- B2AGG bridge-outs are externally created. Their finalized consumption comes
-  from `sync_transactions` filtered to the bridge account. The tag-0
-  `sync_notes` sweep supplies their bodies and gates projection until those
-  bodies are available.
-- CLAIM and `UpdateGerNote` notes are created by this proxy. Their consumption
-  is read from the local miden-client consumed-note view.
+Every family is projected from the same source (#167). B2AGG, CLAIM and
+`UpdateGerNote` consumption is all attributed from the bridge account's
+`sync_transactions` feed for `[cursor + 1, Miden tip]`, resolved through the one
+`resolve_bridge_consumptions` pipeline (exact `NoteId`, body, and authoritative
+metadata). The tag-0 `sync_notes` sweep supplies note bodies and gates projection
+until they are available. The local miden-client consumed-note view is no longer a
+projection source — it is read only for the live claim-calldata backfill and the
+completeness auditor, so a client-store loss cannot erase CLAIM/GER events.
 
 Each event path validates provenance and fails closed:
 

--- a/docs/SYNTHETIC-INDEXER-REDESIGN.md
+++ b/docs/SYNTHETIC-INDEXER-REDESIGN.md
@@ -59,7 +59,8 @@ parent hash; they do not commit to the log set.
 
 ## Consumption sources
 
-One local feed cannot reliably serve every note type:
+Since #167, the bridge-account transaction feed serves every note type through
+one pipeline (`resolve_bridge_consumptions`):
 
 - B2AGG notes are made by external wallets and may be created and consumed
   between two proxy syncs. The projector reads bridge-account transactions for
@@ -68,7 +69,9 @@ One local feed cannot reliably serve every note type:
   canonical B2AGG body.
 - CLAIM and GER notes are made by the proxy, with their output metadata and
   durable EVM-transaction links recorded before those specific notes are
-  submitted. Their consumed records come from the local miden-client store.
+  submitted. Their consumption is attributed from that **same** bridge-account
+  transaction feed — not the local miden-client store, which is read only for the
+  claim-calldata backfill and the completeness audit.
 
 The note reconciler walks `sync_notes` for public tag-0 notes. Its persisted
 cursor means “all note bodies through this Miden block were swept,” not “all


### PR DESCRIPTION
Refreshes the outdated architecture docs the #167 recovery-as-projection refactor left behind.

## What was stale
`docs/ARCHITECTURE.md` and `docs/SYNTHETIC-INDEXER-REDESIGN.md` still described the **pre-#167** source split — that CLAIM/GER consumption is "read from the local miden-client store / consumed-note view", with a projection sequence diagram step `read locally consumed CLAIM and GER notes`. That contradicted the code and the sibling `docs/design/UNIFIED-PROJECTOR.md` (the #167 authority).

## Now
Both docs (and the ARCHITECTURE projection sequence diagram) state the post-#167 reality: **every family — B2AGG, CLAIM, GER — is attributed from the bridge account's `sync_transactions` feed through the one `resolve_bridge_consumptions` pipeline**; the local consumed-note view is no longer a projection source (read only for the claim-calldata backfill and the completeness auditor), so a client-store loss cannot erase CLAIM/GER events.

Cite: `src/synthetic_projector.rs` (`resolve_bridge_consumptions`; tick sources consumption from the bridge transaction feed).

## Scope
Corrects the genuinely stale descriptions only. The survey confirmed versions/vendoring docs are current (the tree is on the rc pins, not stable 0.16.1), so those are untouched. Net-new sequence diagrams (claim lifecycle, b2agg) are worth adding but left out of this refresh — happy to add them separately.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGoAzmPkjYq85iADpZodwm