### PR TITLE
fix(#201): fee-charging chains — fund only the KMS keys, cascade the rest; fees ON in e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,8 +444,14 @@ e2e-claim-watcher-synthesis: e2e-claim-watcher ## After watcher happy path, simu
 	$(COMPOSE_ENV) ./scripts/e2e-claim-watcher-synthesis.sh
 
 .PHONY: e2e-claim-provenance
+# Each scenario bakes a starved account into its own chain; in the battery every later
+# target shares whatever chain is up, so the target hands back a default-budget stack,
+# pass or fail — otherwise the whole tail of the run inherits a service with no reserve.
 e2e-fee-exhaustion: ## #201: service, ger_manager and the bridge each run out of fee asset mid-flow and must recover when topped up (fee-charging chain; brings its own stacks)
-	for a in service ger_manager bridge; do $(COMPOSE_ENV) ./scripts/e2e-fee-exhaustion.sh $$a || exit 1; done
+	rc=0; for a in service ger_manager bridge; do $(COMPOSE_ENV) ./scripts/e2e-fee-exhaustion.sh $$a || { rc=1; break; }; done; \
+	echo "e2e-fee-exhaustion: handing back a default-budget stack (rc=$$rc)"; \
+	KEEP_CHAIN=0 $(MAKE) e2e-down >/dev/null 2>&1; KEEP_CHAIN=0 $(MAKE) e2e-clean-data >/dev/null 2>&1; $(MAKE) e2e-up >/dev/null 2>&1 || echo "WARN: default-budget bring-up failed"; \
+	exit $$rc
 
 e2e-claim-provenance: ## Deploy a FOREIGN bridge on the same chain, drive a claim through it, assert zero ClaimEvent leakage (stack must be up)
 	$(COMPOSE_ENV) ./scripts/e2e-claim-provenance.sh

--- a/Makefile
+++ b/Makefile
@@ -96,13 +96,12 @@ test-scripts: ## Syntax-check + run the shell guard test harnesses (no docker ne
 	bash scripts/test-quiesce-predicate.sh
 
 .PHONY: test-e2e
-test-e2e: ## Spin up docker stack, run E2E tests, tear down (fully self-contained)
+test-e2e: ## Spin up the stack WITH the L2B overlay, run ALL E2E tiers (incl. L2<->L2 + Miden-origin), tear down (fully self-contained)
 	@echo "╔══════════════════════════════════════════════════════════════╗"
-	@echo "║  Starting E2E stack (Anvil, Miden node, PG, bridge, aggkit) ║"
+	@echo "║  Starting E2E stack + L2B overlay (rollup #2)                ║"
 	@echo "╚══════════════════════════════════════════════════════════════╝"
-	@$(MAKE) --no-print-directory e2e-clean-data
 	@./scripts/ensure-e2e-secrets.sh
-	$(E2E_COMPOSE) up -d --build --wait
+	@$(MAKE) --no-print-directory e2e-l2l2-up
 	@echo ""
 	@echo "Stack is up — running E2E tests..."
 	@echo ""
@@ -112,7 +111,7 @@ test-e2e: ## Spin up docker stack, run E2E tests, tear down (fully self-containe
 			echo "KEEP_CHAIN=1 — leaving the stack UP (the chain must survive this target)"; \
 		else \
 			echo "Tearing down stack..."; \
-			$(E2E_COMPOSE) down -v; \
+			$(L2L2_COMPOSE) down -v; \
 		fi; \
 		exit $$EXIT_CODE
 

--- a/Makefile
+++ b/Makefile
@@ -412,6 +412,10 @@ e2e-l2l2: ## Run the L2<->L2 group (preflight + forward L2B->Miden + back Miden-
 e2e-loadtest-isolated: e2e-up ## Isolated bridge-out reliability loadtest (N=30, 1 ETH + 9 ERC-20) on a fresh stack
 	$(COMPOSE_ENV) env N=$${N:-30} ./scripts/e2e-bridge-loadtest-isolated.sh
 
+.PHONY: e2e-miden-origin-fresh
+e2e-miden-origin-fresh: e2e-l2l2-up ## Fresh stack + L2B overlay, then the three Miden-origin round-trips
+	$(MAKE) --no-print-directory e2e-miden-origin
+
 .PHONY: e2e-miden-origin
 e2e-miden-origin: ## Miden-originated token round-trips (->L2B, ->L1, permissionless ->L2B). L2B overlay must be up (make e2e-l2l2-up).
 	for v in "DEST=l2b" "DEST=l1" "REGISTER_MODE=permissionless DEST=l2b"; do env $$v $(COMPOSE_ENV) ./scripts/e2e-miden-origin.sh || exit 1; done

--- a/Makefile
+++ b/Makefile
@@ -409,6 +409,10 @@ e2e-l2l2-up: e2e-clean-data gen-l2b-configs ## Bring up base stack + L2B overlay
 e2e-l2l2: ## Run the L2<->L2 group (preflight + forward L2B->Miden + back Miden->L2B + evidence). Stack must be up (make e2e-l2l2-up).
 	$(COMPOSE_ENV) ./scripts/e2e-test.sh l2l2
 
+.PHONY: e2e-miden-origin
+e2e-miden-origin: ## Miden-originated token round-trips (->L2B, ->L1, permissionless ->L2B). L2B overlay must be up (make e2e-l2l2-up).
+	for v in "DEST=l2b" "DEST=l1" "REGISTER_MODE=permissionless DEST=l2b"; do env $$v $(COMPOSE_ENV) ./scripts/e2e-miden-origin.sh || exit 1; done
+
 .PHONY: e2e-recovery-readiness
 e2e-recovery-readiness: e2e-l2l2-up ## #148: fresh stack -> land a claim -> run the DESTRUCTIVE recovery-readiness test 3x (retained-PG + reset-Miden-store). DEDICATED gate, NOT in e2e-test.sh all: it drops bridge_db + force-recreates aggkit, which would degrade later suite tiers.
 	# Land a real ClaimEvent (with calldata) for the recovery test to blank + repair.

--- a/Makefile
+++ b/Makefile
@@ -408,6 +408,10 @@ e2e-l2l2-up: e2e-clean-data gen-l2b-configs ## Bring up base stack + L2B overlay
 e2e-l2l2: ## Run the L2<->L2 group (preflight + forward L2B->Miden + back Miden->L2B + evidence). Stack must be up (make e2e-l2l2-up).
 	$(COMPOSE_ENV) ./scripts/e2e-test.sh l2l2
 
+.PHONY: e2e-loadtest-isolated
+e2e-loadtest-isolated: e2e-up ## Isolated bridge-out reliability loadtest (N=30, 1 ETH + 9 ERC-20) on a fresh stack
+	$(COMPOSE_ENV) env N=$${N:-30} ./scripts/e2e-bridge-loadtest-isolated.sh
+
 .PHONY: e2e-miden-origin
 e2e-miden-origin: ## Miden-originated token round-trips (->L2B, ->L1, permissionless ->L2B). L2B overlay must be up (make e2e-l2l2-up).
 	for v in "DEST=l2b" "DEST=l1" "REGISTER_MODE=permissionless DEST=l2b"; do env $$v $(COMPOSE_ENV) ./scripts/e2e-miden-origin.sh || exit 1; done

--- a/Makefile
+++ b/Makefile
@@ -433,6 +433,9 @@ e2e-claim-watcher-synthesis: e2e-claim-watcher ## After watcher happy path, simu
 	$(COMPOSE_ENV) ./scripts/e2e-claim-watcher-synthesis.sh
 
 .PHONY: e2e-claim-provenance
+e2e-fee-exhaustion: ## #201: service, ger_manager and the bridge each run out of fee asset mid-flow and must recover when topped up (fee-charging chain; brings its own stacks)
+	for a in service ger_manager bridge; do $(COMPOSE_ENV) ./scripts/e2e-fee-exhaustion.sh $$a || exit 1; done
+
 e2e-claim-provenance: ## Deploy a FOREIGN bridge on the same chain, drive a claim through it, assert zero ClaimEvent leakage (stack must be up)
 	$(COMPOSE_ENV) ./scripts/e2e-claim-provenance.sh
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -317,7 +317,10 @@ services:
       FEE_TXN_BUDGET_SERVICE: "${FEE_TXN_BUDGET_SERVICE:-4096}"
       FEE_TXN_BUDGET_GER_MANAGER: "${FEE_TXN_BUDGET_GER_MANAGER:-4096}"
       FEE_TXN_BUDGET_CASCADE: "${FEE_TXN_BUDGET_CASCADE:-1024}"
-      FEE_TXN_BUDGET_CASCADE_TARGETS: "${FEE_TXN_BUDGET_CASCADE_TARGETS:-}"
+      # Every token the battery bridges in costs `service` one cascade; test-e2e
+      # alone creates nine, loadtest and chaos more. 12 reserve cascades ran out
+      # 1.7 h into final6 (service 3.44M → 1.07M), so reserve for the whole run.
+      FEE_TXN_BUDGET_CASCADE_TARGETS: "${FEE_TXN_BUDGET_CASCADE_TARGETS:-64}"
       # Regression requirement: offload ALL proxy tx proving (CLAIM / GER /
       # faucet / bridge-out / init) to an EXTERNAL Miden tx-prover instead of
       # the in-process LocalTransactionProver. Fallback-to-local stays OFF

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -308,9 +308,15 @@ services:
       DATABASE_URL: "host=agglayer-postgres user=agglayer password=agglayer dbname=agglayer_store"
       RUST_LOG: "info"
       # #201 e2e-fee-exhaustion: start one account nearly dry (unset = production defaults).
-      FEE_TXN_BUDGET_SERVICE: "${FEE_TXN_BUDGET_SERVICE:-}"
-      FEE_TXN_BUDGET_GER_MANAGER: "${FEE_TXN_BUDGET_GER_MANAGER:-}"
-      FEE_TXN_BUDGET_CASCADE: "${FEE_TXN_BUDGET_CASCADE:-}"
+      # The production defaults are runway for a manual top-up (hours); the
+      # battery runs unattended on ONE growing chain for half a day and nobody
+      # tops up, so e2e budgets are sized for the whole run (the bridge alone
+      # burned a 64-transaction cascade in 2.5 h). The genesis operator holds
+      # 1e9 units, so the ~4.3M this costs is nothing. The exhaustion e2e still
+      # overrides these to tiny values through the same variables.
+      FEE_TXN_BUDGET_SERVICE: "${FEE_TXN_BUDGET_SERVICE:-4096}"
+      FEE_TXN_BUDGET_GER_MANAGER: "${FEE_TXN_BUDGET_GER_MANAGER:-4096}"
+      FEE_TXN_BUDGET_CASCADE: "${FEE_TXN_BUDGET_CASCADE:-1024}"
       FEE_TXN_BUDGET_CASCADE_TARGETS: "${FEE_TXN_BUDGET_CASCADE_TARGETS:-}"
       # Regression requirement: offload ALL proxy tx proving (CLAIM / GER /
       # faucet / bridge-out / init) to an EXTERNAL Miden tx-prover instead of

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -456,7 +456,45 @@ services:
       # longer than a bare RPC bind; with the --init account redeploy + external-prover
       # handshake, give the first healthy check headroom so `up --wait` does not abort
       # dependents prematurely.
-      start_period: 240s
+      # #201: --init now also waits for the fee-funder's notes before it can
+      # deploy (fees are enabled in the e2e genesis), so give it more room.
+      start_period: 600s
+
+  # #201 — the e2e stand-in for the OPERATOR's funding step. Fees are ENABLED in
+  # the e2e genesis (verification_base_fee = 7, matching the live testnet), so
+  # every account the proxy deploys must hold the native fee asset. The proxy's
+  # --init writes funding.toml (the two KMS-keyed accounts + amounts) and waits;
+  # this one-shot sidecar mints from the genesis native faucet — LOCAL custody,
+  # exactly as an operator would, and independent of whether the proxy itself
+  # runs with remote/KMS keys — to just those two accounts. The proxy then
+  # consumes the notes as its deploys and cascade-funds the keyless bridge and
+  # faucets from `service`. No production analogue: operators fund by hand.
+  fee-funder:
+    image: miden-agglayer-e2e:latest
+    restart: "no"
+    volumes:
+      - node_data:/data:ro
+      - ./.miden-agglayer-data:/var/lib/miden-agglayer-service
+    entrypoint: ["/bin/sh", "-c"]
+    depends_on:
+      miden-node:
+        condition: service_started
+    command:
+      - |
+        set -e
+        M=/var/lib/miden-agglayer-service/funding.toml
+        echo "[fee-funder] waiting for $$M (written by the proxy's --init)"
+        i=0
+        until [ -f "$$M" ]; do
+          i=$$((i+1))
+          if [ "$$i" -gt 600 ]; then echo "[fee-funder] TIMEOUT waiting for $$M"; exit 1; fi
+          sleep 2
+        done
+        echo "[fee-funder] funding the accounts in $$M from the genesis native faucet"
+        bridge-out-tool --store-dir /tmp/fee-funder --node-url http://miden-node:57291 \
+          --fund-fee-asset --native-faucet-mac /data/accounts/native_faucet.mac \
+          --funding-manifest "$$M"
+        echo "[fee-funder] done"
 
   # ── Bridge Service ─────────────────────────────────────────────────────────
   bridge-service:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -505,8 +505,10 @@ services:
           --fund-fee-asset --faucet-operator-mac /data/accounts/faucet_operator.mac \
           --funding-manifest "$$M"; }
         # Retry until it lands: a single failed attempt would leave --init waiting for
-        # notes that never come and the healthcheck to give up.
-        until fund; do echo "[fee-funder] funding failed — retrying in 10s"; sleep 10; done
+        # notes that never come and the healthcheck to give up. Not on a restart after
+        # --init already finished: the accounts are funded, and a spurious send from the
+        # operator races other funders spending the same account ("conflicts with mempool").
+        if [ ! -f "$$C" ]; then until fund; do echo "[fee-funder] funding failed — retrying in 10s"; sleep 10; done; fi
         # Stay alive: `compose up --wait` treats an exited one-shot as a failed wait, and a
         # test that wipes the proxy's data dir makes --init write a NEW manifest — fund that too.
         last=$$(md5sum "$$M")

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -504,13 +504,15 @@ services:
         fund() { bridge-out-tool --store-dir /tmp/fee-funder --node-url http://miden-node:57291 \
           --fund-fee-asset --faucet-operator-mac /data/accounts/faucet_operator.mac \
           --funding-manifest "$$M"; }
-        fund
+        # Retry until it lands: a single failed attempt would leave --init waiting for
+        # notes that never come and the healthcheck to give up.
+        until fund; do echo "[fee-funder] funding failed — retrying in 10s"; sleep 10; done
         # Stay alive: `compose up --wait` treats an exited one-shot as a failed wait, and a
         # test that wipes the proxy's data dir makes --init write a NEW manifest — fund that too.
         last=$$(md5sum "$$M")
         while sleep 10; do
           cur=$$(md5sum "$$M" 2>/dev/null) || continue
-          [ "$$cur" != "$$last" ] && { echo "[fee-funder] new manifest — funding again"; fund; last=$$cur; }
+          [ "$$cur" != "$$last" ] && { echo "[fee-funder] new manifest — funding again"; until fund; do sleep 10; done; last=$$cur; }
         done
 
   # ── Bridge Service ─────────────────────────────────────────────────────────

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -376,6 +376,9 @@ services:
       # but inherits environment; restore/recovery must therefore retain the
       # exact policy already bound to this database.
       L1_RPC_URL: "http://anvil:8545"
+      # Origin-network RPCs for ERC-20 metadata recovery on --restore (finding #62): one-shot
+      # `compose run … --restore` replaces the command args, so this must come from the env.
+      NETWORK_RPC_URLS: "2=http://anvil-l2b:8545"
       GER_L1_ADDRESS: "0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674"
       L1_INDEXER_FROM_BLOCK: "1"
       L1_EVIDENCE_TAG: "${L1_EVIDENCE_TAG:-latest}"

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -307,6 +307,10 @@ services:
       NETWORK_ID: "${NETWORK_ID:-1}"
       DATABASE_URL: "host=agglayer-postgres user=agglayer password=agglayer dbname=agglayer_store"
       RUST_LOG: "info"
+      # #201 e2e-fee-exhaustion: start one account nearly dry (unset = production defaults).
+      FEE_TXN_BUDGET_SERVICE: "${FEE_TXN_BUDGET_SERVICE:-}"
+      FEE_TXN_BUDGET_GER_MANAGER: "${FEE_TXN_BUDGET_GER_MANAGER:-}"
+      FEE_TXN_BUDGET_CASCADE: "${FEE_TXN_BUDGET_CASCADE:-}"
       # Regression requirement: offload ALL proxy tx proving (CLAIM / GER /
       # faucet / bridge-out / init) to an EXTERNAL Miden tx-prover instead of
       # the in-process LocalTransactionProver. Fallback-to-local stays OFF

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -464,7 +464,8 @@ services:
   # the e2e genesis (verification_base_fee = 7, matching the live testnet), so
   # every account the proxy deploys must hold the native fee asset. The proxy's
   # --init writes funding.toml (the two KMS-keyed accounts + amounts) and waits;
-  # this one-shot sidecar mints from the genesis native faucet — LOCAL custody,
+  # this one-shot sidecar sends from the genesis FAUCET OPERATOR's pre-funded
+  # vault (the fee faucet's owner; the faucet itself is keyless) — LOCAL custody,
   # exactly as an operator would, and independent of whether the proxy itself
   # runs with remote/KMS keys — to just those two accounts. The proxy then
   # consumes the notes as its deploys and cascade-funds the keyless bridge and
@@ -490,9 +491,12 @@ services:
           if [ "$$i" -gt 600 ]; then echo "[fee-funder] TIMEOUT waiting for $$M"; exit 1; fi
           sleep 2
         done
-        echo "[fee-funder] funding the accounts in $$M from the genesis native faucet"
+        echo "[fee-funder] funding the accounts in $$M from the genesis faucet operator's vault"
+        # faucet_operator.mac, NOT native_faucet.mac: the fee faucet is a network
+        # account with an owner-only mint policy and no key; its OWNER (the
+        # operator) is a plain wallet pre-funded with the fee asset at genesis.
         bridge-out-tool --store-dir /tmp/fee-funder --node-url http://miden-node:57291 \
-          --fund-fee-asset --native-faucet-mac /data/accounts/native_faucet.mac \
+          --fund-fee-asset --faucet-operator-mac /data/accounts/faucet_operator.mac \
           --funding-manifest "$$M"
         echo "[fee-funder] done"
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -311,6 +311,7 @@ services:
       FEE_TXN_BUDGET_SERVICE: "${FEE_TXN_BUDGET_SERVICE:-}"
       FEE_TXN_BUDGET_GER_MANAGER: "${FEE_TXN_BUDGET_GER_MANAGER:-}"
       FEE_TXN_BUDGET_CASCADE: "${FEE_TXN_BUDGET_CASCADE:-}"
+      FEE_TXN_BUDGET_CASCADE_TARGETS: "${FEE_TXN_BUDGET_CASCADE_TARGETS:-}"
       # Regression requirement: offload ALL proxy tx proving (CLAIM / GER /
       # faucet / bridge-out / init) to an EXTERNAL Miden tx-prover instead of
       # the in-process LocalTransactionProver. Fallback-to-local stays OFF

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -484,13 +484,15 @@ services:
       - |
         set -e
         M=/var/lib/miden-agglayer-service/funding.toml
-        echo "[fee-funder] waiting for $$M (written by the proxy's --init)"
+        C=/var/lib/miden-agglayer-service/bridge_accounts.toml
+        echo "[fee-funder] waiting for $$M (written by a fee-charging --init) or $$C (a zero-fee --init finished)"
         i=0
-        until [ -f "$$M" ]; do
+        until [ -f "$$M" ] || [ -f "$$C" ]; do
           i=$$((i+1))
-          if [ "$$i" -gt 600 ]; then echo "[fee-funder] TIMEOUT waiting for $$M"; exit 1; fi
+          if [ "$$i" -gt 600 ]; then echo "[fee-funder] TIMEOUT waiting for $$M / $$C"; exit 1; fi
           sleep 2
         done
+        if [ ! -f "$$M" ]; then echo "[fee-funder] zero-fee chain: init completed without needing funding — nothing to do"; exit 0; fi
         echo "[fee-funder] funding the accounts in $$M from the genesis faucet operator's vault"
         # faucet_operator.mac, NOT native_faucet.mac: the fee faucet is a network
         # account with an owner-only mint policy and no key; its OWNER (the

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -497,10 +497,17 @@ services:
         # faucet_operator.mac, NOT native_faucet.mac: the fee faucet is a network
         # account with an owner-only mint policy and no key; its OWNER (the
         # operator) is a plain wallet pre-funded with the fee asset at genesis.
-        bridge-out-tool --store-dir /tmp/fee-funder --node-url http://miden-node:57291 \
+        fund() { bridge-out-tool --store-dir /tmp/fee-funder --node-url http://miden-node:57291 \
           --fund-fee-asset --faucet-operator-mac /data/accounts/faucet_operator.mac \
-          --funding-manifest "$$M"
-        echo "[fee-funder] done"
+          --funding-manifest "$$M"; }
+        fund
+        # Stay alive: `compose up --wait` treats an exited one-shot as a failed wait, and a
+        # test that wipes the proxy's data dir makes --init write a NEW manifest — fund that too.
+        last=$$(md5sum "$$M")
+        while sleep 10; do
+          cur=$$(md5sum "$$M" 2>/dev/null) || continue
+          [ "$$cur" != "$$last" ] && { echo "[fee-funder] new manifest — funding again"; fund; last=$$cur; }
+        done
 
   # ── Bridge Service ─────────────────────────────────────────────────────────
   bridge-service:

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -270,7 +270,7 @@ ger_manager   = "0x…"      # KMS-keyed — fund this
 fee_faucet_id = "0x…"      # the chain's native fee asset
 verification_base_fee = 7
 max_fee_per_txn       = 210
-fund_service     = 215040  # bigger: its own budget + cascades for the bridge, the ETH faucet and 10 runtime faucets
+fund_service     = 698880  # bigger: its own budget + cascades for the bridge, the ETH faucet and 10 runtime faucets
 fund_ger_manager = 53760
 ```
 
@@ -309,9 +309,10 @@ asset; send it and init continues.
 `bridge_fee_vault_txns_left < 32`. A top-up P2ID is consumed by the proxy on its next
 monitor tick (the note pays for its own consume, so an empty vault recovers without a
 restart). Measured at base fee 7: network transactions
-(bridge, faucets) cost ~40–50 units, signed client transactions the 210 cap; a
-busy bridge ran 27 network transactions in ten minutes, so the 13,440-unit
-cascade is hours of runway — top up from the metric, not on a schedule.
+(bridge, faucets) cost ~105–112 units, signed client transactions the 210 cap; a
+busy bridge ran 27 network transactions in ten minutes, so the 53,760-unit
+cascade (~480 of them) is hours of runway — top up from the metric, not on a
+schedule. (A 13,440-unit cascade ran a bridge dry in 2.5 h of e2e traffic.)
 
 Fees are per-transaction and continuous, so this is a **balance to maintain**,
 not a one-time deposit — `ger_manager` pays on every GER injection, `service` on
@@ -328,7 +329,7 @@ bridge-out-tool --fund-fee-asset \
   --fund <service-or-bridge-or-faucet-id>=<amount>
 ```
 
-**Every new token costs `service` one cascade** (13,440 units at base fee 7): the
+**Every new token costs `service` one cascade** (53,760 units at base fee 7): the
 recommended `fund_service` reserves ten of them; past that the proxy logs "fee
 vault too low to fund another faucet" and new tokens' claims fail until `service`
 is topped up.

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -308,7 +308,18 @@ asset; send it and init continues.
 `--fee-vault-warn-txns` (default 32) and ERROR at 0. Alert on
 `bridge_fee_vault_txns_left < 32`. A top-up P2ID is consumed by the proxy on its next
 monitor tick (the note pays for its own consume, so an empty vault recovers without a
-restart). Measured at base fee 7: network transactions
+restart).
+
+**What a dry `service` / `ger_manager` does to in-flight work.** A claim or GER
+insert whose signer cannot pay the fee is NOT failed: the proxy holds the accepted
+transaction pending (receipt `null`), logs `fee vault EMPTY — holding the transaction
+pending` and re-tries it every 30 s; `agglayer_writer_jobs_parked` counts the held
+transactions. The first retry after the top-up lands them, so deposits that arrived
+while the vault was empty complete on their own. This matters because the claim
+sponsor (bridge-service's ClaimTxManager) gives up on a deposit after ten reverted
+claim transactions — a hard-coded limit — and a reverted receipt per attempt would
+strand every deposit touched by a dry vault until someone re-drove it by hand.
+Measured at base fee 7: network transactions
 (bridge, faucets) cost ~105–112 units, signed client transactions the 210 cap; a
 busy bridge ran 27 network transactions in ten minutes, so the 53,760-unit
 cascade (~480 of them) is hours of runway — top up from the metric, not on a

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -229,6 +229,47 @@ alert if the process/target is absent as well as if that gauge is wrong. During
 runtime, alert on signature failures and on an expected workload producing no
 increase in `remote_signer_signatures_total`.
 
+## Funding the accounts on a fee-charging chain (#201)
+
+Protocol 0.16 charges `verification_base_fee × (ilog2(cycles) + 1)` on **every**
+transaction, paid by the **executing account from its own vault** in the chain's
+native fee asset. Miden has no gas-paying EOA: a signing key only *authorizes*;
+the account pays. So every account that executes needs the fee asset in its
+vault — including the **keyless** bridge and faucets that only the two KMS keys
+authorize. (Our dev genesis sets `verification_base_fee = 0`, which is why a
+local stack never shows this; a real chain — e.g. the live testnet, base fee 7,
+fee asset `0x18101fa522c174b165efd4f70a0385` — fails at the first deploy with
+"amount in the vault is less than the amount to remove".)
+
+**You fund only the two KMS-keyed accounts; the proxy cascades the rest.**
+
+1. **Print what to fund.** With the signer configured exactly as for a normal
+   boot, run once with `--print-funding`. It builds and *persists*
+   `service`/`ger_manager` (their ids are random-seeded, so they exist only once
+   persisted), reads the chain's fee parameters, writes `funding.toml` beside
+   `bridge_accounts.toml`, prints the two addresses, the fee asset and the
+   recommended amounts, and exits **without deploying**. Re-running it re-prints
+   and never rebuilds.
+2. **Send the fee asset** to those two addresses as P2ID notes (your treasury /
+   the chain's faucet). `fund_service` is larger: it includes what `service`
+   cascades to the bridge and faucets.
+3. **Start the proxy normally.** `--init` *resumes* the recorded accounts, waits
+   (up to `--funding-wait-secs`, default 900) for each funding note, deploys
+   each account by **consuming** that note — the vault is filled before the fee
+   is charged, so the deploy pays for itself — then `service` cascade-funds the
+   bridge and every faucet (at init and as new tokens appear at runtime).
+
+Nothing changes in custody: the cascade sends are `service`'s own transactions,
+signed by its (remote) key like its claims. The proxy never mints the fee asset
+and never holds a local secret for it. For dev/e2e the operator step is played
+by `bridge-out-tool --fund-fee-asset --native-faucet-mac <genesis
+native_faucet.mac> --funding-manifest <funding.toml>` (local custody, hence a
+separate tool), which the e2e `fee-funder` sidecar runs automatically. Fees
+are **enabled** in the e2e genesis so the battery exercises this path.
+
+Watch the vaults: `ger_manager` pays on every GER injection and `service` on
+every claim, so this is an ongoing balance, not a one-time deposit.
+
 ## Signer backends
 
 The proxy is unaware of the signer's storage backend, but that does **not** make

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -270,22 +270,28 @@ wallet pre-funded with the fee asset and written with its key — because the fe
 faucet itself is a network account with an owner-only mint policy and no key,
 so nothing can mint from it directly.
 
-**The keyless network accounts are funded differently.** The bridge and every
-faucet are `AuthNetworkAccount` network accounts: they pay fees like everything
-else, but they have no `receive_asset`, so a P2ID cannot fund them, and an empty
-"deploy" transaction cannot pay from an empty vault. The protocol funds a
-network account through a **`FeeSponsorshipNote`** — one asset, bound to one
-feature note the account accepts, consumed in the same transaction: the
-account's auth collects it into the vault and the kernel fee is then paid from
-the vault. So `service` bootstraps each of them by emitting a harmless feature
-note (a `ConstantFeePolicyConfigNote` re-scheduling the zero fee the account
-already has) plus a sponsorship bound to it carrying the cascade amount, and the
-account's **first transaction consumes both** — funding, fee payment and deploy
-in one. After that, because the proxy's per-note fee policy is zero, ordinary
-notes (CLAIM, B2AGG, UpdateGer, MINT) need no sponsorship: the vault pays. Keep
-those vaults topped up (a sponsorship can be bound to any routine note, e.g.
-`UpdateGer`); an empty network-account vault stalls every network transaction
-against it.
+**The keyless network accounts are funded the same way — by construction.** The
+bridge and every faucet are `AuthNetworkAccount` network accounts and pay fees
+like everything else. As built upstream they could not be funded at all after
+genesis: they had no `receive_asset` (a P2ID aborts in the kernel), and every
+feature note they accept carries a `NetworkAccountTarget`, which the sender can
+only create once the target is on-chain — while the account cannot get on-chain
+without a funded vault. The proxy therefore builds them the way Miden builds its
+own post-genesis network accounts (the testnet network-monitor's counter): the
+upstream component set **plus a `BasicWallet`**, with the **P2ID script
+allowlisted at zero fee** (`src/network_accounts.rs`). A P2ID carries no
+attachment, so `service` can send one to the not-yet-created account, and the
+account's **first transaction consumes it** — funding the vault, paying the
+kernel fee from it, and deploying the account in one. `--init` cascades this to
+the bridge and the ETH faucet; each later faucet gets it at creation. After
+that, because the per-note fee policy is zero, ordinary notes (CLAIM, B2AGG,
+UpdateGer, MINT) need no sponsorship — the vault pays — and a top-up is just
+another P2ID from `service`. Keep those vaults topped up: an empty
+network-account vault stalls every network transaction against it. (Safety: a
+network account runs only allowlisted note scripts, and its tx-script allowlist
+holds only the network builder's expiration script, so `BasicWallet`'s send
+procedures are reachable through no path; the P2ID script calls
+`receive_asset` alone.)
 
 Watch the vaults: `ger_manager` pays on every GER injection and `service` on
 every claim, so this is an ongoing balance, not a one-time deposit.

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -306,7 +306,9 @@ asset; send it and init continues.
 `bridge_fee_vault_balance` (units of the fee asset), `bridge_fee_vault_txns_left`
 (balance ÷ the per-transaction cap `bridge_fee_max_per_txn`), and logs WARN below
 `--fee-vault-warn-txns` (default 32) and ERROR at 0. Alert on
-`bridge_fee_vault_txns_left < 32`. Measured at base fee 7: network transactions
+`bridge_fee_vault_txns_left < 32`. A top-up P2ID is consumed by the proxy on its next
+monitor tick (the note pays for its own consume, so an empty vault recovers without a
+restart). Measured at base fee 7: network transactions
 (bridge, faucets) cost ~40–50 units, signed client transactions the 210 cap; a
 busy bridge ran 27 network transactions in ten minutes, so the 13,440-unit
 cascade is hours of runway — top up from the metric, not on a schedule.

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -270,7 +270,7 @@ ger_manager   = "0x…"      # KMS-keyed — fund this
 fee_faucet_id = "0x…"      # the chain's native fee asset
 verification_base_fee = 7
 max_fee_per_txn       = 210
-fund_service     = 80640   # bigger: covers what service cascades to bridge/faucets
+fund_service     = 215040  # bigger: its own budget + cascades for the bridge, the ETH faucet and 10 runtime faucets
 fund_ger_manager = 53760
 ```
 
@@ -327,6 +327,11 @@ bridge-out-tool --fund-fee-asset \
   --fee-faucet-id <fee_faucet_id from funding.toml> \
   --fund <service-or-bridge-or-faucet-id>=<amount>
 ```
+
+**Every new token costs `service` one cascade** (13,440 units at base fee 7): the
+recommended `fund_service` reserves ten of them; past that the proxy logs "fee
+vault too low to fund another faucet" and new tokens' claims fail until `service`
+is topped up.
 
 **Recipients (bridged-in claimants) pay to consume their mint.** The MINT the
 faucet produces is a P2ID to the claimant, and consuming it is a transaction the

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -243,21 +243,78 @@ fee asset `0x18101fa522c174b165efd4f70a0385` — fails at the first deploy with
 
 **You fund only the two KMS-keyed accounts; the proxy cascades the rest.**
 
-1. **Print what to fund.** With the signer configured exactly as for a normal
-   boot, run once with `--print-funding`. It builds and *persists*
-   `service`/`ger_manager` (their ids are random-seeded, so they exist only once
-   persisted), reads the chain's fee parameters, writes `funding.toml` beside
-   `bridge_accounts.toml`, prints the two addresses, the fee asset and the
-   recommended amounts, and exits **without deploying**. Re-running it re-prints
-   and never rebuilds.
-2. **Send the fee asset** to those two addresses as P2ID notes (your treasury /
-   the chain's faucet). `fund_service` is larger: it includes what `service`
-   cascades to the bridge and faucets.
-3. **Start the proxy normally.** `--init` *resumes* the recorded accounts, waits
-   (up to `--funding-wait-secs`, default 900) for each funding note, deploys
-   each account by **consuming** that note — the vault is filled before the fee
-   is charged, so the deploy pays for itself — then `service` cascade-funds the
-   bridge and every faucet (at init and as new tokens appear at runtime).
+### Manual procedure (DevOps)
+
+Run these by hand, in order. `$STORE`, `$NODE`, and `$SIGNER_FLAGS` are the same
+`--miden-store-dir`, `--miden-node`, and signer flags (`--signer-url`,
+`--signer-key …`) you boot the proxy with.
+
+**1. Print what to fund** — with the signer configured exactly as for a normal
+boot, run once with `--print-funding` and stop. It builds and *persists*
+`service`/`ger_manager` (their ids are random-seeded — they exist only once
+persisted), reads the chain's fee parameters, writes `funding.toml` beside
+`bridge_accounts.toml`, and exits **without deploying** (re-running re-prints and
+never rebuilds):
+
+```sh
+miden-agglayer-service --print-funding \
+  --miden-store-dir "$STORE" --miden-node "$NODE" $SIGNER_FLAGS
+cat "$STORE/funding.toml"
+```
+
+`funding.toml` gives you everything you need:
+
+```toml
+service       = "0x…"      # KMS-keyed — fund this
+ger_manager   = "0x…"      # KMS-keyed — fund this
+fee_faucet_id = "0x…"      # the chain's native fee asset
+verification_base_fee = 7
+max_fee_per_txn       = 210
+fund_service     = 80640   # bigger: covers what service cascades to bridge/faucets
+fund_ger_manager = 53760
+```
+
+**2. Send the fee asset** — from whatever account holds the native fee asset
+(your treasury; on the testnet, the genesis faucet operator), send **`fund_*`
+units to each address as a P2ID note**. Two addresses only. With the operator
+tool that means (`--faucet-operator-mac` is the *source-of-funds* account file
+that holds the fee asset and its key — the treasury/faucet-operator wallet, NOT
+the proxy's KMS accounts):
+
+```sh
+bridge-out-tool --fund-fee-asset \
+  --store-dir /tmp/funder --node-url "$NODE" \
+  --faucet-operator-mac /path/to/treasury.mac \
+  --funding-manifest "$STORE/funding.toml"
+```
+
+Or, from any Miden wallet you control, send two P2ID notes of the fee asset:
+`fund_service` → `service`, `fund_ger_manager` → `ger_manager`.
+
+**3. Start the proxy normally.** `--init` *resumes* the recorded accounts, waits
+(up to `--funding-wait-secs`, default 900) for each funding note, deploys each
+account by **consuming** it — the vault is filled before the fee is charged, so
+the deploy pays for itself — then `service` cascade-funds the bridge and every
+faucet (at init, and each new faucet as a token is first bridged). If a funding
+note is missing, the log says exactly which address to send how much of which
+asset; send it and init continues.
+
+### Ongoing top-ups
+
+Fees are per-transaction and continuous, so this is a **balance to maintain**,
+not a one-time deposit — `ger_manager` pays on every GER injection, `service` on
+every claim, the bridge on every network transaction, each faucet on every mint.
+Watch the vaults (an empty vault stalls that account) and top up with more P2IDs
+of the fee asset. `service` is the simplest single point: top it up and it keeps
+cascading, or fund any account directly by id:
+
+```sh
+bridge-out-tool --fund-fee-asset \
+  --store-dir /tmp/funder --node-url "$NODE" \
+  --faucet-operator-mac /path/to/treasury.mac \
+  --fee-faucet-id <fee_faucet_id from funding.toml> \
+  --fund <service-or-bridge-or-faucet-id>=<amount>
+```
 
 Nothing changes in custody: the cascade sends are `service`'s own transactions,
 signed by its (remote) key like its claims. The proxy never mints the fee asset
@@ -292,9 +349,6 @@ network account runs only allowlisted note scripts, and its tx-script allowlist
 holds only the network builder's expiration script, so `BasicWallet`'s send
 procedures are reachable through no path; the P2ID script calls
 `receive_asset` alone.)
-
-Watch the vaults: `ger_manager` pays on every GER injection and `service` on
-every claim, so this is an ongoing balance, not a one-time deposit.
 
 ## Signer backends
 

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -316,6 +316,20 @@ bridge-out-tool --fund-fee-asset \
   --fund <service-or-bridge-or-faucet-id>=<amount>
 ```
 
+**Recipients (bridged-in claimants) pay to consume their mint.** The MINT the
+faucet produces is a P2ID to the claimant, and consuming it is a transaction the
+*claimant's* account executes — so on a fee-charging chain it pays
+`verification_base_fee × …` from the claimant's own vault, in the native fee
+asset, before the bridged tokens land. A fresh wallet has none and the consume
+aborts in the kernel ("failed to remove the fungible asset from the vault …"):
+the mint is on-chain and waiting, the balance just never shows. This is standard
+Miden UX (users get the native asset from a faucet first), not a bridge
+concern — but tell your users, and give any test/relayer wallet the fee asset
+before it claims. The e2e does exactly that: `lib-isolated-wallet.sh` funds its
+isolated recipient wallet from the genesis faucet operator whenever the chain
+charges fees, and the wallet's next consume takes the fee P2ID together with the
+mint, paying for itself.
+
 Nothing changes in custody: the cascade sends are `service`'s own transactions,
 signed by its (remote) key like its claims. The proxy never mints the fee asset
 and never holds a local secret for it. For dev/e2e the operator step is played

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -268,8 +268,24 @@ separate tool), which the e2e `fee-funder` sidecar runs automatically. It sends
 from the genesis **faucet operator** — the native fee faucet's owner, a plain
 wallet pre-funded with the fee asset and written with its key — because the fee
 faucet itself is a network account with an owner-only mint policy and no key,
-so nothing can mint from it directly. Fees are **enabled** in the e2e genesis
-so the battery exercises this path.
+so nothing can mint from it directly.
+
+**The keyless network accounts are funded differently.** The bridge and every
+faucet are `AuthNetworkAccount` network accounts: they pay fees like everything
+else, but they have no `receive_asset`, so a P2ID cannot fund them, and an empty
+"deploy" transaction cannot pay from an empty vault. The protocol funds a
+network account through a **`FeeSponsorshipNote`** — one asset, bound to one
+feature note the account accepts, consumed in the same transaction: the
+account's auth collects it into the vault and the kernel fee is then paid from
+the vault. So `service` bootstraps each of them by emitting a harmless feature
+note (a `ConstantFeePolicyConfigNote` re-scheduling the zero fee the account
+already has) plus a sponsorship bound to it carrying the cascade amount, and the
+account's **first transaction consumes both** — funding, fee payment and deploy
+in one. After that, because the proxy's per-note fee policy is zero, ordinary
+notes (CLAIM, B2AGG, UpdateGer, MINT) need no sponsorship: the vault pays. Keep
+those vaults topped up (a sponsorship can be bound to any routine note, e.g.
+`UpdateGer`); an empty network-account vault stalls every network transaction
+against it.
 
 Watch the vaults: `ger_manager` pays on every GER injection and `service` on
 every claim, so this is an ongoing balance, not a one-time deposit.

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -329,7 +329,11 @@ Fees are per-transaction and continuous, so this is a **balance to maintain**,
 not a one-time deposit — `ger_manager` pays on every GER injection, `service` on
 every claim, the bridge on every network transaction, each faucet on every mint.
 Watch the vaults (an empty vault stalls that account) and top up with more P2IDs
-of the fee asset. `service` is the simplest single point: top it up and it keeps
+of the fee asset. For a **deployed network account** (the bridge, every faucet) the
+P2ID must carry a `NetworkAccountTarget` attachment naming it — only the ntx-builder
+can execute such an account, and it only sees notes with that attachment (the node
+rejects user-submitted transactions for network accounts). `bridge-out-tool
+--fund-fee-asset` does this automatically when the target is already on chain. `service` is the simplest single point: top it up and it keeps
 cascading, or fund any account directly by id:
 
 ```sh

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -301,6 +301,16 @@ asset; send it and init continues.
 
 ### Ongoing top-ups
 
+**Watch the vaults in metrics.** The proxy exports, every `--fee-vault-poll-secs`
+(default 60 s), per account (`account="service"|"ger_manager"|"bridge"|"faucet:<SYMBOL>"`):
+`bridge_fee_vault_balance` (units of the fee asset), `bridge_fee_vault_txns_left`
+(balance ÷ the per-transaction cap `bridge_fee_max_per_txn`), and logs WARN below
+`--fee-vault-warn-txns` (default 32) and ERROR at 0. Alert on
+`bridge_fee_vault_txns_left < 32`. Measured at base fee 7: network transactions
+(bridge, faucets) cost ~40–50 units, signed client transactions the 210 cap; a
+busy bridge ran 27 network transactions in ten minutes, so the 13,440-unit
+cascade is hours of runway — top up from the metric, not on a schedule.
+
 Fees are per-transaction and continuous, so this is a **balance to maintain**,
 not a one-time deposit — `ger_manager` pays on every GER injection, `service` on
 every claim, the bridge on every network transaction, each faucet on every mint.

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -262,10 +262,14 @@ fee asset `0x18101fa522c174b165efd4f70a0385` — fails at the first deploy with
 Nothing changes in custody: the cascade sends are `service`'s own transactions,
 signed by its (remote) key like its claims. The proxy never mints the fee asset
 and never holds a local secret for it. For dev/e2e the operator step is played
-by `bridge-out-tool --fund-fee-asset --native-faucet-mac <genesis
-native_faucet.mac> --funding-manifest <funding.toml>` (local custody, hence a
-separate tool), which the e2e `fee-funder` sidecar runs automatically. Fees
-are **enabled** in the e2e genesis so the battery exercises this path.
+by `bridge-out-tool --fund-fee-asset --faucet-operator-mac <genesis
+faucet_operator.mac> --funding-manifest <funding.toml>` (local custody, hence a
+separate tool), which the e2e `fee-funder` sidecar runs automatically. It sends
+from the genesis **faucet operator** — the native fee faucet's owner, a plain
+wallet pre-funded with the fee asset and written with its key — because the fee
+faucet itself is a network account with an owner-only mint policy and no key,
+so nothing can mint from it directly. Fees are **enabled** in the e2e genesis
+so the battery exercises this path.
 
 Watch the vaults: `ger_manager` pays on every GER injection and `service` on
 every claim, so this is an ongoing balance, not a one-time deposit.

--- a/docs/operations/provisioning.md
+++ b/docs/operations/provisioning.md
@@ -306,9 +306,10 @@ asset; send it and init continues.
 `bridge_fee_vault_balance` (units of the fee asset), `bridge_fee_vault_txns_left`
 (balance ÷ the per-transaction cap `bridge_fee_max_per_txn`), and logs WARN below
 `--fee-vault-warn-txns` (default 32) and ERROR at 0. Alert on
-`bridge_fee_vault_txns_left < 32`. A top-up P2ID is consumed by the proxy on its next
-monitor tick (the note pays for its own consume, so an empty vault recovers without a
-restart).
+`bridge_fee_vault_txns_left < 32`. A top-up P2ID to `service` or `ger_manager` is
+consumed by the proxy on its next monitor tick; one to the bridge or a faucet by the
+ntx-builder (see below). Either way the note pays for its own consume, so an empty
+vault recovers without a restart.
 
 **What a dry `service` / `ger_manager` does to in-flight work.** A claim or GER
 insert whose signer cannot pay the fee is NOT failed: the proxy holds the accepted

--- a/fixtures/genesis/02-with-account-files.toml
+++ b/fixtures/genesis/02-with-account-files.toml
@@ -26,5 +26,6 @@ version = 1
 # account pays its own tx fee from its vault). The two KMS-keyed wallets are
 # funded by the `fee-funder` sidecar (from the genesis faucet operator) and
 # deploy by consuming those notes; the keyless network accounts (bridge,
-# faucets) are bootstrapped by `service` with a sponsored config note.
+# faucets) are built P2ID-fundable (BasicWallet + P2ID allowlisted, as Miden's
+# own network accounts are) and deploy the same way, cascade-funded by service.
 verification_base_fee = 7

--- a/fixtures/genesis/02-with-account-files.toml
+++ b/fixtures/genesis/02-with-account-files.toml
@@ -20,4 +20,9 @@ timestamp = 1717344256
 version = 1
 
 [fee_parameters]
-verification_base_fee = 0
+# #201: fees are ENABLED in e2e, matching the live testnet (base fee 7), so the
+# battery exercises the real funding path — every deployed account must hold the
+# native fee asset, cascade-funded from the two KMS-keyed accounts. `0` hid a
+# deploy failure on every real chain ("amount in the vault is less than the
+# amount to remove"). The e2e `fee-funder` sidecar mints the initial funding.
+verification_base_fee = 7

--- a/fixtures/genesis/02-with-account-files.toml
+++ b/fixtures/genesis/02-with-account-files.toml
@@ -20,9 +20,11 @@ timestamp = 1717344256
 version = 1
 
 [fee_parameters]
-# #201: fees are ENABLED in e2e, matching the live testnet (base fee 7), so the
-# battery exercises the real funding path — every deployed account must hold the
-# native fee asset, cascade-funded from the two KMS-keyed accounts. `0` hid a
-# deploy failure on every real chain ("amount in the vault is less than the
-# amount to remove"). The e2e `fee-funder` sidecar mints the initial funding.
+# #201: fees are ENABLED in e2e, mirroring the live testnet (base fee 7), so the
+# battery exercises the real funding path. `0` hid a deploy failure on every
+# real chain ("amount in the vault is less than the amount to remove" — every
+# account pays its own tx fee from its vault). The two KMS-keyed wallets are
+# funded by the `fee-funder` sidecar (from the genesis faucet operator) and
+# deploy by consuming those notes; the keyless network accounts (bridge,
+# faucets) are bootstrapped by `service` with a sponsored config note.
 verification_base_fee = 7

--- a/scripts/chaos-garbo.sh
+++ b/scripts/chaos-garbo.sh
@@ -166,8 +166,15 @@ garbo_foreign_claim() {
     B2AGG_STORE_DIR="$FOREIGN_STORE"
     FOREIGN_ATTEMPTS=$((FOREIGN_ATTEMPTS + 1)); echo x >> "$STATE/foreign_attempts"
     _iso_wipe_store; mkdir -p "$B2AGG_STORE_DIR/tmp"
+    # The foreign deployment is funded from a creator wallet that must live in THIS
+    # (fresh) store: on a fee-charging chain --create-foreign-bridge pays the foreign
+    # service/ger_manager from it, and the garbo wallet is in another store. Provision
+    # one here and keep the garbo wallet's globals for the private-note class.
+    local saved_id="$WALLET_ID" saved_hex="${WALLET_HEX:-}" saved_dest="${DEST_ADDR:-}" creator
+    provision_isolated_wallet || { glog "GARBO foreign-claim: creator wallet provisioning FAILED"; return 1; }
+    creator="$WALLET_ID"; WALLET_ID="$saved_id"; WALLET_HEX="$saved_hex"; DEST_ADDR="$saved_dest"
     local fb_out fs fg fbid ffaucet
-    fb_out=$(iso_tool --create-foreign-bridge --foreign-network-id "$FOREIGN_NETWORK_ID" --wallet-id "$WALLET_ID" 2>&1) || {
+    fb_out=$(iso_tool --create-foreign-bridge --foreign-network-id "$FOREIGN_NETWORK_ID" --wallet-id "$creator" 2>&1) || {
         glog "GARBO foreign-claim: --create-foreign-bridge FAILED — $(echo "$fb_out" | tail -2)"; return 1; }
     fs=$(echo "$fb_out" | grep "service-id:" | awk '{print $NF}')
     fg=$(echo "$fb_out" | grep "ger-manager-id:" | awk '{print $NF}')

--- a/scripts/chaos-garbo.sh
+++ b/scripts/chaos-garbo.sh
@@ -170,7 +170,7 @@ garbo_foreign_claim() {
     # (fresh) store: on a fee-charging chain --create-foreign-bridge pays the foreign
     # service/ger_manager from it, and the garbo wallet is in another store. Provision
     # one here and keep the garbo wallet's globals for the private-note class.
-    local saved_id="$WALLET_ID" saved_hex="${WALLET_HEX:-}" saved_dest="${DEST_ADDR:-}" creator
+    local saved_id="${WALLET_ID:-}" saved_hex="${WALLET_HEX:-}" saved_dest="${DEST_ADDR:-}" creator
     provision_isolated_wallet || { glog "GARBO foreign-claim: creator wallet provisioning FAILED"; return 1; }
     creator="$WALLET_ID"; WALLET_ID="$saved_id"; WALLET_HEX="$saved_hex"; DEST_ADDR="$saved_dest"
     local fb_out fs fg fbid ffaucet

--- a/scripts/chaos-garbo.sh
+++ b/scripts/chaos-garbo.sh
@@ -167,7 +167,7 @@ garbo_foreign_claim() {
     FOREIGN_ATTEMPTS=$((FOREIGN_ATTEMPTS + 1)); echo x >> "$STATE/foreign_attempts"
     _iso_wipe_store; mkdir -p "$B2AGG_STORE_DIR/tmp"
     local fb_out fs fg fbid ffaucet
-    fb_out=$(iso_tool --create-foreign-bridge --foreign-network-id "$FOREIGN_NETWORK_ID" 2>&1) || {
+    fb_out=$(iso_tool --create-foreign-bridge --foreign-network-id "$FOREIGN_NETWORK_ID" --wallet-id "$WALLET_ID" 2>&1) || {
         glog "GARBO foreign-claim: --create-foreign-bridge FAILED — $(echo "$fb_out" | tail -2)"; return 1; }
     fs=$(echo "$fb_out" | grep "service-id:" | awk '{print $NF}')
     fg=$(echo "$fb_out" | grep "ger-manager-id:" | awk '{print $NF}')

--- a/scripts/e2e-battery.sh
+++ b/scripts/e2e-battery.sh
@@ -254,6 +254,8 @@ for iter in $(seq "${ITER_START:-1}" "${ITERATIONS:-4}"); do
   # l2l2 group: bring up its own stack, then run the group
   run "$iter" "e2e-l2l2-up" fresh make e2e-l2l2-up
   run "$iter" "e2e-l2l2"    keep  make e2e-l2l2
+  # Miden-originated round-trips need the L2B overlay; test-e2e SKIPs them on the base stack.
+  run "$iter" "e2e-miden-origin" keep make e2e-miden-origin
   # recovery-readiness is DESTRUCTIVE and provisions via e2e-l2l2-up
   run "$iter" "e2e-recovery-readiness" fresh make e2e-recovery-readiness
 

--- a/scripts/e2e-battery.sh
+++ b/scripts/e2e-battery.sh
@@ -198,6 +198,7 @@ FRESH_TARGETS=(
   e2e-cantina12-getlogs-returns-all e2e-cantina13
   e2e-ger-decomposition e2e-security e2e-fuzz
   e2e-reconciler-private-note e2e-reconciler-cursor-persistence
+  e2e-fee-exhaustion
   e2e-rd913-restart-burn-collision e2e-rd940
 )
 

--- a/scripts/e2e-claim-provenance.sh
+++ b/scripts/e2e-claim-provenance.sh
@@ -179,7 +179,9 @@ log "  synthetic tip                     = $BASE_TIP"
 
 # ── Step 2: Deploy the FOREIGN deployment on the same chain ─────────────────
 step "Deploying foreign deployment (service, ger_manager, bridge net=$FOREIGN_NETWORK_ID, ETH faucet)"
-FB_OUT=$(iso_tool --create-foreign-bridge --foreign-network-id "$FOREIGN_NETWORK_ID" 2>&1) \
+# #201: on a fee-charging chain the foreign deployment is funded by a creator wallet.
+provision_isolated_wallet || fail "could not provision the creator wallet"
+FB_OUT=$(iso_tool --create-foreign-bridge --foreign-network-id "$FOREIGN_NETWORK_ID" --wallet-id "$WALLET_ID" 2>&1) \
     || { echo "$FB_OUT" | tail -30 >&2; fail "--create-foreign-bridge failed"; }
 FOREIGN_SERVICE_ID=$(echo "$FB_OUT" | grep "service-id:" | awk '{print $NF}')
 FOREIGN_GER_MANAGER_ID=$(echo "$FB_OUT" | grep "ger-manager-id:" | awk '{print $NF}')

--- a/scripts/e2e-fee-exhaustion.sh
+++ b/scripts/e2e-fee-exhaustion.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# e2e-fee-exhaustion <service|ger_manager|bridge> (#201)
+#
+# On a fee-charging chain every account pays its own transaction fees from its
+# vault, so an operator who under-funds one gets a silent stall. This test
+# starts ONE account with a deliberately tiny budget (FEE_TXN_BUDGET_*), runs
+# deposits until it is dry, asserts the stall is VISIBLE (metric at 0, ERROR in
+# the log, the flow stuck), tops the account up the way the runbook says, and
+# asserts the flow recovers on its own — including the deposits that got stuck.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"; cd "$PROJECT_DIR"
+ACCOUNT="${1:?usage: $0 service|ger_manager|bridge}"
+METRICS="${METRICS_URL:-http://127.0.0.1:8546/metrics}"
+DATA="$PROJECT_DIR/.miden-agglayer-data"
+ts(){ date -u +%H:%M:%S; }; log(){ echo "[$(ts)] $*"; }; pass(){ echo "[$(ts)] PASS: $*"; }; fail(){ echo "[$(ts)] FAIL: $*" >&2; exit 1; }
+
+# Tiny budgets: enough to deploy and serve a deposit or two, then dry mid-flow.
+case "$ACCOUNT" in
+  service)     export FEE_TXN_BUDGET_SERVICE=2 ;;
+  ger_manager) export FEE_TXN_BUDGET_GER_MANAGER=3 ;;
+  bridge)      export FEE_TXN_BUDGET_CASCADE=3 ;;   # the bridge burns fastest (a network tx per GER update)
+  *) fail "unknown account $ACCOUNT" ;;
+esac
+
+log "fresh stack with a tiny fee budget for $ACCOUNT"
+make e2e-down >/dev/null 2>&1 || true; make e2e-clean-data >/dev/null 2>&1 || true
+make e2e-up >/tmp/e2e-fee-exhaustion-up.log 2>&1 || { tail -20 /tmp/e2e-fee-exhaustion-up.log; fail "stack bring-up"; }
+[[ -f "$DATA/funding.toml" ]] || fail "no funding.toml — this test needs a fee-charging chain (base fee > 0)"
+MAX_FEE=$(sed -n 's/^max_fee_per_txn *= *\([0-9]*\).*/\1/p' "$DATA/funding.toml")
+ACCOUNT_ID=$(sed -n "s/^$ACCOUNT *= *\"\(.*\)\"/\1/p" "$DATA/bridge_accounts.toml")
+[[ -n "$ACCOUNT_ID" && -n "$MAX_FEE" ]] || fail "could not read $ACCOUNT id / max fee"
+log "$ACCOUNT = $ACCOUNT_ID, fee cap $MAX_FEE/tx"
+
+txns_left(){ curl -sf "$METRICS" | awk -v a="$ACCOUNT" -F'[ }]' '$0 ~ "^bridge_fee_vault_txns_left\\{account=\"" a "\"" {print $NF}' | tail -1; }
+proxy_log(){ docker logs miden-agglayer-miden-agglayer-1 2>&1 | sed -E 's/\x1b\[[0-9;]*m//g'; }
+deposit(){ ./scripts/e2e-l1-to-l2.sh >"/tmp/e2e-fee-exhaustion-dep$1.log" 2>&1; }
+
+# ── run it dry ────────────────────────────────────────────────────────────────
+passed=0; stuck=0; last_rc=0
+for i in $(seq 1 8); do
+  if deposit "$i"; then passed=$((passed+1)); last_rc=0; else last_rc=1; fi
+  left=$(txns_left); log "deposit $i rc=$last_rc — $ACCOUNT txns_left=${left:-?}"
+  (( last_rc != 0 )) && stuck=$((stuck+1))
+  [[ "${left:-1}" == "0" && $last_rc -ne 0 ]] && break
+done
+[[ "$(txns_left)" == "0" ]] || fail "$ACCOUNT never ran dry after 8 deposits (txns_left=$(txns_left)) — budget too generous"
+(( stuck > 0 )) || fail "$ACCOUNT is dry but no deposit stalled — the stall is not visible in the flow"
+proxy_log | grep -q "fee vault EMPTY.*account=\"$ACCOUNT\"\|account=\"$ACCOUNT\".*fee vault EMPTY" \
+  || proxy_log | grep -qE "fee vault EMPTY" || fail "no 'fee vault EMPTY' ERROR for $ACCOUNT in the proxy log"
+pass "$ACCOUNT ran dry after $passed deposit(s): txns_left=0, ERROR logged, $stuck deposit(s) stuck"
+
+# ── top up (the runbook's way) and expect self-recovery ───────────────────────
+export B2AGG_STORE_DIR="$PROJECT_DIR/.b2agg-store/e2e-suite"; source "$SCRIPT_DIR/lib-isolated-wallet.sh"
+iso_fund_fee_asset "$ACCOUNT_ID" $(( MAX_FEE * 64 )) || fail "top-up of $ACCOUNT failed"
+for _ in $(seq 1 30); do [[ "$(txns_left)" != "0" && -n "$(txns_left)" ]] && break; sleep 5; done
+[[ "$(txns_left)" != "0" ]] || fail "metric did not recover after the top-up"
+pass "$ACCOUNT topped up: txns_left=$(txns_left)"
+deposit recover || { tail -15 /tmp/e2e-fee-exhaustion-deprecover.log; fail "deposit after the top-up did not complete — $ACCOUNT did not recover"; }
+pass "a new deposit completes after the top-up (no restart)"
+
+# The deposits that stalled must land too: their notes / GERs were only waiting for fees.
+BRIDGE_ID=$(sed -n 's/^bridge *= *"\(.*\)"/\1/p' "$DATA/bridge_accounts.toml"); FAUCET_ID=$(sed -n 's/^faucet_eth *= *"\(.*\)"/\1/p' "$DATA/bridge_accounts.toml")
+WALLET_ID=$(cat "$B2AGG_STORE_DIR/wallet-id"); expected=$(( (passed + stuck + 1) * 1000 ))
+for _ in $(seq 1 30); do bal=$(iso_wallet_balance "$BRIDGE_ID" "$FAUCET_ID"); [[ "${bal:-0}" -ge "$expected" ]] && break; sleep 10; done
+[[ "${bal:-0}" -ge "$expected" ]] || fail "stuck deposits did not recover: wallet balance ${bal:-0} < expected $expected ($stuck stuck)"
+pass "all $((passed + stuck + 1)) deposits landed (balance $bal) — $ACCOUNT recovered fully when funded"

--- a/scripts/e2e-fee-exhaustion.sh
+++ b/scripts/e2e-fee-exhaustion.sh
@@ -24,7 +24,11 @@ esac
 
 log "fresh stack with a tiny fee budget for $ACCOUNT"
 make e2e-down >/dev/null 2>&1 || true; make e2e-clean-data >/dev/null 2>&1 || true
-make e2e-up >/tmp/e2e-fee-exhaustion-up.log 2>&1 || { tail -20 /tmp/e2e-fee-exhaustion-up.log; fail "stack bring-up"; }
+make e2e-up >/tmp/e2e-fee-exhaustion-up.log 2>&1 || {
+  tail -5 /tmp/e2e-fee-exhaustion-up.log
+  echo "--- proxy log (why --init did not come up healthy) ---"
+  docker logs miden-agglayer-miden-agglayer-1 2>&1 | sed -E 's/\x1b\[[0-9;]*m//g' | grep -E "WARN|ERROR|Error|deploy|cascade|funding|panick" | tail -25
+  fail "stack bring-up"; }
 [[ -f "$DATA/funding.toml" ]] || fail "no funding.toml — this test needs a fee-charging chain (base fee > 0)"
 MAX_FEE=$(sed -n 's/^max_fee_per_txn *= *\([0-9]*\).*/\1/p' "$DATA/funding.toml")
 ACCOUNT_ID=$(sed -n "s/^$ACCOUNT *= *\"\(.*\)\"/\1/p" "$DATA/bridge_accounts.toml")

--- a/scripts/e2e-fee-exhaustion.sh
+++ b/scripts/e2e-fee-exhaustion.sh
@@ -16,7 +16,7 @@ ts(){ date -u +%H:%M:%S; }; log(){ echo "[$(ts)] $*"; }; pass(){ echo "[$(ts)] P
 
 # Tiny budgets: enough to deploy and serve a deposit or two, then dry mid-flow.
 case "$ACCOUNT" in
-  service)     export FEE_TXN_BUDGET_SERVICE=4 ;;   # init itself costs ~3 (deploy, cascade sends, registration)
+  service)     export FEE_TXN_BUDGET_SERVICE=4 FEE_TXN_BUDGET_CASCADE_TARGETS=2 ;;   # own budget ~3 spent by init; no runtime-faucet reserve
   ger_manager) export FEE_TXN_BUDGET_GER_MANAGER=3 ;;
   bridge)      export FEE_TXN_BUDGET_CASCADE=3 ;;   # the bridge burns fastest (a network tx per GER update)
   *) fail "unknown account $ACCOUNT" ;;

--- a/scripts/e2e-fee-exhaustion.sh
+++ b/scripts/e2e-fee-exhaustion.sh
@@ -52,7 +52,9 @@ for i in $(seq 1 8); do
 done
 [[ "$(txns_left)" == "0" ]] || fail "$ACCOUNT never ran dry after 8 deposits (txns_left=$(txns_left)) — budget too generous"
 (( stuck > 0 )) || fail "$ACCOUNT is dry but no deposit stalled — the stall is not visible in the flow"
-proxy_log | grep "fee vault EMPTY" | grep -qE "account[:=] *\"?$ACCOUNT\b" || fail "no 'fee vault EMPTY' ERROR for $ACCOUNT in the proxy log"
+# No `grep -q` here: under pipefail it can exit before `docker logs` finishes writing
+# and the SIGPIPE fails the pipeline even though the line was found.
+proxy_log | grep "fee vault EMPTY" | grep -E "account[:=] *\"?$ACCOUNT\b" >/dev/null || fail "no 'fee vault EMPTY' ERROR for $ACCOUNT in the proxy log"
 pass "$ACCOUNT ran dry after $passed deposit(s): txns_left=0, ERROR logged, $stuck deposit(s) stuck"
 
 # ── top up (the runbook's way) and expect self-recovery ───────────────────────

--- a/scripts/e2e-fee-exhaustion.sh
+++ b/scripts/e2e-fee-exhaustion.sh
@@ -23,6 +23,9 @@ case "$ACCOUNT" in
 esac
 
 log "fresh stack with a tiny fee budget for $ACCOUNT"
+# Budgets apply at --init, so the chain AND the proxy store must be reset together: under the
+# battery's KEEP_CHAIN=1 a wipe of one but not the other leaves a store from another genesis.
+export KEEP_CHAIN=0
 make e2e-down >/dev/null 2>&1 || true; make e2e-clean-data >/dev/null 2>&1 || true
 make e2e-up >/tmp/e2e-fee-exhaustion-up.log 2>&1 || {
   tail -5 /tmp/e2e-fee-exhaustion-up.log

--- a/scripts/e2e-fee-exhaustion.sh
+++ b/scripts/e2e-fee-exhaustion.sh
@@ -16,7 +16,7 @@ ts(){ date -u +%H:%M:%S; }; log(){ echo "[$(ts)] $*"; }; pass(){ echo "[$(ts)] P
 
 # Tiny budgets: enough to deploy and serve a deposit or two, then dry mid-flow.
 case "$ACCOUNT" in
-  service)     export FEE_TXN_BUDGET_SERVICE=2 ;;
+  service)     export FEE_TXN_BUDGET_SERVICE=4 ;;   # init itself costs ~3 (deploy, cascade sends, registration)
   ger_manager) export FEE_TXN_BUDGET_GER_MANAGER=3 ;;
   bridge)      export FEE_TXN_BUDGET_CASCADE=3 ;;   # the bridge burns fastest (a network tx per GER update)
   *) fail "unknown account $ACCOUNT" ;;

--- a/scripts/e2e-fee-exhaustion.sh
+++ b/scripts/e2e-fee-exhaustion.sh
@@ -45,8 +45,7 @@ for i in $(seq 1 8); do
 done
 [[ "$(txns_left)" == "0" ]] || fail "$ACCOUNT never ran dry after 8 deposits (txns_left=$(txns_left)) — budget too generous"
 (( stuck > 0 )) || fail "$ACCOUNT is dry but no deposit stalled — the stall is not visible in the flow"
-proxy_log | grep -q "fee vault EMPTY.*account=\"$ACCOUNT\"\|account=\"$ACCOUNT\".*fee vault EMPTY" \
-  || proxy_log | grep -qE "fee vault EMPTY" || fail "no 'fee vault EMPTY' ERROR for $ACCOUNT in the proxy log"
+proxy_log | grep "fee vault EMPTY" | grep -q "account=$ACCOUNT" || fail "no 'fee vault EMPTY' ERROR for $ACCOUNT in the proxy log"
 pass "$ACCOUNT ran dry after $passed deposit(s): txns_left=0, ERROR logged, $stuck deposit(s) stuck"
 
 # ── top up (the runbook's way) and expect self-recovery ───────────────────────

--- a/scripts/e2e-fee-exhaustion.sh
+++ b/scripts/e2e-fee-exhaustion.sh
@@ -45,7 +45,7 @@ for i in $(seq 1 8); do
 done
 [[ "$(txns_left)" == "0" ]] || fail "$ACCOUNT never ran dry after 8 deposits (txns_left=$(txns_left)) — budget too generous"
 (( stuck > 0 )) || fail "$ACCOUNT is dry but no deposit stalled — the stall is not visible in the flow"
-proxy_log | grep "fee vault EMPTY" | grep -q "account=$ACCOUNT" || fail "no 'fee vault EMPTY' ERROR for $ACCOUNT in the proxy log"
+proxy_log | grep "fee vault EMPTY" | grep -qE "account[:=] *\"?$ACCOUNT\b" || fail "no 'fee vault EMPTY' ERROR for $ACCOUNT in the proxy log"
 pass "$ACCOUNT ran dry after $passed deposit(s): txns_left=0, ERROR logged, $stuck deposit(s) stuck"
 
 # ── top up (the runbook's way) and expect self-recovery ───────────────────────

--- a/scripts/e2e-rd913-restart-burn-collision.sh
+++ b/scripts/e2e-rd913-restart-burn-collision.sh
@@ -108,6 +108,23 @@ step "Driving an L1→L2 deposit to populate monitor_burn_serials..."
 }
 pass "L1→L2 deposit succeeded; bridge-in path has emitted observation events"
 
+# The counts are compared exactly across the restart, so the chain must be
+# quiet first: the deposit above keeps landing notes (mint, P2ID, fee top-ups)
+# for a while, and a row observed between the two snapshots is not a
+# restart-survival regression (final7: twin_notes 9 → 10 in the 15 s window).
+# Wait until all three counts hold still for 30 s before each snapshot.
+counts() { echo "$(pgquery "SELECT COUNT(*) FROM monitor_burn_serials")/$(pgquery "SELECT COUNT(*) FROM monitor_twin_notes")/$(pgquery "SELECT COUNT(*) FROM monitor_expected_mints")"; }
+settle_counts() {
+    local last="" cur stable=0 i
+    for i in $(seq 1 60); do
+        cur="$(counts)"
+        if [[ "$cur" == "$last" ]]; then stable=$((stable+1)); [[ $stable -ge 3 ]] && { log "monitor counts settled at $cur"; return 0; }; else stable=0; fi
+        last="$cur"; sleep 10
+    done
+    warn "monitor counts still moving after 10 min ($cur) — snapshotting anyway"
+}
+settle_counts
+
 # ── Step 2: snapshot pre-restart serial count.
 PRE_COUNT="$(pgquery "SELECT COUNT(*) FROM monitor_burn_serials")"
 log "Pre-restart monitor_burn_serials count: $PRE_COUNT"
@@ -136,6 +153,7 @@ wait_for "miden-agglayer back up" \
      -d '{\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":[],\"id\":1}' >/dev/null" \
     90 3
 pass "miden-agglayer restarted and responsive"
+settle_counts
 
 # ── Step 4: re-snapshot. Pre-RD-913 these counts would all be either
 #            unchanged in PG but UNUSED by the proxy (i.e. the in-memory

--- a/scripts/e2e-reconciler-private-note.sh
+++ b/scripts/e2e-reconciler-private-note.sh
@@ -210,14 +210,18 @@ else
     STATUS=$(printf '%s\n' "$TX" | awk '$1=="status"{print $2; exit}')
     [[ "$STATUS" == "1" ]] || fail "L1 deposit tx failed (status=$STATUS)"
     log "L1 deposit sent; waiting for auto-claim + P2ID delivery..."
-    for attempt in $(seq 1 24); do
+    # Up to 10 min, not 4: right after the battery's nonce-gap heal the GER
+    # pipeline lags for minutes (#205 — funding landed at poll 5 after a long
+    # gate and never within 240 s after a 30 s one); the same lib flow passes
+    # elsewhere, so the window is the only thing this Phase 0 gets wrong.
+    for attempt in $(seq 1 60); do
         sleep 10
         BAL=$(iso_wallet_balance "$BRIDGE_ID" "$FAUCET_ID")
         BAL="${BAL:-0}"
-        log "  attempt $attempt/24: balance = $BAL"
+        log "  attempt $attempt/60: balance = $BAL"
         [[ "$BAL" -gt 0 ]] && break
     done
-    [[ "$BAL" -gt 0 ]] || fail "wallet not funded after 240s"
+    [[ "$BAL" -gt 0 ]] || fail "wallet not funded after 600s"
 fi
 pass "isolated wallet funded (balance $BAL)"
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -121,7 +121,8 @@ case "$test_filter" in
             # COORDINATED proxy + bridge-service drop+restore (PR #150 re-review — no
             # separate destructive proxy-only reset that would wedge cantina13).
         else
-            echo "SKIP L2<->L2 + native tiers — L2B overlay not up (base stack). Run 'make e2e-l2l2-up' to include them."
+            # No silent skip: L2<->L2 and the Miden-origin round-trips are part of the suite.
+            echo "FAIL: L2B overlay not up — test-e2e requires it (make e2e-l2l2-up)" >&2; exit 1
         fi
         echo ""
         # cantina13 recovery — runs AFTER the L2<->L2 + native tiers so its from-scratch

--- a/scripts/e2e-web3signer.sh
+++ b/scripts/e2e-web3signer.sh
@@ -77,8 +77,13 @@ for _ in $(seq 1 60); do
     sleep 2
 done
 [[ "$KEYS" == \[\"0x* ]] || fail "the signer never served a public key (got: ${KEYS:-<nothing>})"
-SIGNER_KEY="$(echo "$KEYS" | sed 's/\[\"//;s/\".*//')"
-pass "signer holds key $SIGNER_KEY"
+# Report the key the proxy is actually BOUND to for `service` (the signer may
+# serve several — e.g. raw-file keys next to cloud-KMS ones — and its list order
+# is not meaningful), and assert the signer serves that exact key.
+SIGNER_KEY="$(printf '%s' "$AGGLAYER_SIGNER_KEYS" | tr ',' '\n' | grep '^service=' | cut -d= -f2)"
+[[ -n "$SIGNER_KEY" ]] || SIGNER_KEY="$(echo "$KEYS" | sed 's/\[\"//;s/\".*//')"
+echo "$KEYS" | grep -qi "$SIGNER_KEY" || fail "the signer does not serve the bound service key $SIGNER_KEY (serves: $KEYS)"
+pass "signer holds the bound service key $SIGNER_KEY"
 
 log "waiting for the proxy to become healthy with remote signing enabled"
 for _ in $(seq 1 90); do

--- a/scripts/e2e-web3signer.sh
+++ b/scripts/e2e-web3signer.sh
@@ -30,7 +30,12 @@ export MIDEN_NODE_GIT_URL MIDEN_NODE_GIT_REF
 # or it silently starts with zero keys loaded. See docker-compose.web3signer.yml.
 WEB3SIGNER_UID="$(id -u)"; WEB3SIGNER_GID="$(id -g)"
 export WEB3SIGNER_UID WEB3SIGNER_GID
-COMPOSE=(docker compose -f docker-compose.e2e.yml -f docker-compose.web3signer.yml --env-file fixtures/.env)
+# EXTRA_COMPOSE_FILES layers a site overlay (e.g. the cloud-KMS credentials for
+# the signer: `-f docker-compose.kms-local.yml`) exactly as lib-compose.sh and
+# `make` do — without it this test could only ever exercise raw-file signer keys.
+# Unquoted on purpose: it is a pre-split "-f a -f b" list.
+# shellcheck disable=SC2206
+COMPOSE=(docker compose -f docker-compose.e2e.yml -f docker-compose.web3signer.yml ${EXTRA_COMPOSE_FILES:-} --env-file fixtures/.env)
 PROXY="${PROJECT}-miden-agglayer-1"
 SIGNER="${PROJECT}-web3signer-1"
 SIGNER_URL="${SIGNER_URL:-http://127.0.0.1:9000}"
@@ -45,8 +50,16 @@ fail() { echo -e "${RED}[$(ts)] FAIL:${NC} $*"; exit 1; }
 # ── 0. provision the signer's key + bring the stack up ───────────────────────
 log "provisioning the signer key"
 ./scripts/gen-web3signer-keys.sh || fail "could not provision the signer keys"
-# Per-role bindings (AGGLAYER_SIGNER_KEYS) for the compose overlay.
-set -a; . ./fixtures/web3signer-keys.env; set +a
+# Per-role bindings (AGGLAYER_SIGNER_KEYS) for the compose overlay. The generated
+# env binds the roles to the RAW-FILE keys; a caller that already exported
+# AGGLAYER_SIGNER_KEYS (e.g. bound to cloud-KMS keys the signer serves via
+# EXTRA_COMPOSE_FILES) keeps its binding — sourcing would silently clobber it
+# and turn a KMS run back into a file-key run.
+if [[ -n "${AGGLAYER_SIGNER_KEYS:-}" ]]; then
+    echo "[$(ts)] using pre-set AGGLAYER_SIGNER_KEYS (not the generated file-key bindings)"
+else
+    set -a; . ./fixtures/web3signer-keys.env; set +a
+fi
 
 log "bringing up the stack with the web3signer overlay"
 "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1

--- a/scripts/lib-isolated-wallet.sh
+++ b/scripts/lib-isolated-wallet.sh
@@ -98,7 +98,8 @@ iso_tool() {
 # (`/data/accounts/faucet_operator.mac` on the node_data volume), exactly as the
 # e2e `fee-funder` sidecar uses for the proxy's own accounts. The wallet's next
 # consume takes the fee P2ID together with whatever else is pending and pays for
-# itself. 1024× the fee cap: a creator wallet also funds native-faucet / foreign-bridge deployments.
+# itself. 2048× the fee cap: a creator wallet also funds native-faucet / foreign-bridge
+# deployments, and a foreign service is funded with the full recommended amount (12 cascades).
 iso_fund_fee_asset() {
     local wallet="$1" want="${2:-}" manifest="$PROJECT_DIR/.miden-agglayer-data/funding.toml"
     [[ -f "$manifest" ]] || return 0   # zero-fee chain: nothing to do
@@ -106,7 +107,7 @@ iso_fund_fee_asset() {
     fee_faucet=$(sed -n 's/^fee_faucet_id *= *"\(.*\)"/\1/p' "$manifest")
     max_fee=$(sed -n 's/^max_fee_per_txn *= *\([0-9]*\).*/\1/p' "$manifest")
     [[ -n "$fee_faucet" && -n "$max_fee" ]] || { echo "isolated-wallet: $manifest lacks fee_faucet_id/max_fee_per_txn" >&2; return 1; }
-    amount=${want:-$(( max_fee * 1024 ))}
+    amount=${want:-$(( max_fee * 2048 ))}
     echo "isolated-wallet: fee-charging chain — funding $wallet with $amount units of the fee asset $fee_faucet (from the genesis faucet operator)" >&2
     # The operator account is shared with other funders (the fee-funder sidecar); a send
     # can lose a mempool race ("conflicts with current mempool state") — retry. A fresh

--- a/scripts/lib-isolated-wallet.sh
+++ b/scripts/lib-isolated-wallet.sh
@@ -87,6 +87,44 @@ iso_tool() {
         --miden-prover-url "$ISO_PROVER_URL" "$@"
 }
 
+# iso_fund_fee_asset <wallet_id> : on a FEE-CHARGING chain, give a freshly
+# provisioned isolated wallet the native fee asset (#201). Every transaction an
+# account executes pays the kernel fee from its own vault — including the
+# claimant's consume of its minted P2ID — so a fresh recipient with an empty
+# vault aborts in the kernel ("failed to remove the fungible asset from the
+# vault …") and the deposit's balance never shows although the mint is on-chain.
+# The proxy writes `funding.toml` only when the chain charges fees, so its
+# presence is the guard; the source of funds is the genesis faucet operator
+# (`/data/accounts/faucet_operator.mac` on the node_data volume), exactly as the
+# e2e `fee-funder` sidecar uses for the proxy's own accounts. The wallet's next
+# consume takes the fee P2ID together with whatever else is pending and pays for
+# itself. 64 × the per-transaction fee bound covers a whole suite run.
+iso_fund_fee_asset() {
+    local wallet="$1" manifest="$PROJECT_DIR/.miden-agglayer-data/funding.toml"
+    [[ -f "$manifest" ]] || return 0   # zero-fee chain: nothing to do
+    local fee_faucet max_fee amount
+    fee_faucet=$(sed -n 's/^fee_faucet_id *= *"\(.*\)"/\1/p' "$manifest")
+    max_fee=$(sed -n 's/^max_fee_per_txn *= *\([0-9]*\).*/\1/p' "$manifest")
+    [[ -n "$fee_faucet" && -n "$max_fee" ]] || { echo "isolated-wallet: $manifest lacks fee_faucet_id/max_fee_per_txn" >&2; return 1; }
+    amount=$(( max_fee * 64 ))
+    echo "isolated-wallet: fee-charging chain — funding $wallet with $amount units of the fee asset $fee_faucet (from the genesis faucet operator)" >&2
+    local out
+    if ! out=$(docker run --rm --network "$ISO_NETWORK" \
+            -v "$B2AGG_STORE_DIR:/store" \
+            -v "${ISO_NODE_DATA_VOLUME:-miden-agglayer_node_data}:/data:ro" \
+            -e "MIDEN_PROVER_URL=$ISO_PROVER_URL" -e "TMPDIR=/store/tmp" \
+            --entrypoint bridge-out-tool "$ISO_IMAGE" \
+            --store-dir /store/funder --node-url "$ISO_NODE_URL" \
+            --miden-prover-url "$ISO_PROVER_URL" \
+            --fund-fee-asset --faucet-operator-mac /data/accounts/faucet_operator.mac \
+            --fee-faucet-id "$fee_faucet" --fund "$wallet=$amount" 2>&1); then
+        echo "$out" | tail -15 >&2
+        echo "isolated-wallet: fee-asset funding of $wallet FAILED — on this chain its consumes cannot pay their fee" >&2
+        return 1
+    fi
+    echo "$out" | grep -E "\[fund\]|sent|committed" | tail -3 >&2 || true
+}
+
 # Remove the isolated store. Container-created files inside it are root-owned
 # on the host, so fall back to a root busybox container when plain rm fails.
 _iso_wipe_store() {
@@ -334,6 +372,7 @@ provision_isolated_wallet() {
             echo "isolated-wallet: could not persist the wallet id to $idfile — every later call would provision a NEW wallet" >&2
             return 1
         }
+        iso_fund_fee_asset "$WALLET_ID" || return 1
     fi
 
     WALLET_HEX="$WALLET_ID"

--- a/scripts/lib-isolated-wallet.sh
+++ b/scripts/lib-isolated-wallet.sh
@@ -98,8 +98,9 @@ iso_tool() {
 # (`/data/accounts/faucet_operator.mac` on the node_data volume), exactly as the
 # e2e `fee-funder` sidecar uses for the proxy's own accounts. The wallet's next
 # consume takes the fee P2ID together with whatever else is pending and pays for
-# itself. 2048× the fee cap: a creator wallet also funds native-faucet / foreign-bridge
-# deployments, and a foreign service is funded with the full recommended amount (12 cascades).
+# itself. 8192× the fee cap: a creator wallet also funds native-faucet / foreign-bridge
+# deployments, and a foreign service is funded with the full recommended amount (its
+# own budget + 12 cascades of 256 = 698,880 at base fee 7; 2048× no longer covered it).
 iso_fund_fee_asset() {
     local wallet="$1" want="${2:-}" manifest="$PROJECT_DIR/.miden-agglayer-data/funding.toml"
     [[ -f "$manifest" ]] || return 0   # zero-fee chain: nothing to do
@@ -107,7 +108,7 @@ iso_fund_fee_asset() {
     fee_faucet=$(sed -n 's/^fee_faucet_id *= *"\(.*\)"/\1/p' "$manifest")
     max_fee=$(sed -n 's/^max_fee_per_txn *= *\([0-9]*\).*/\1/p' "$manifest")
     [[ -n "$fee_faucet" && -n "$max_fee" ]] || { echo "isolated-wallet: $manifest lacks fee_faucet_id/max_fee_per_txn" >&2; return 1; }
-    amount=${want:-$(( max_fee * 2048 ))}
+    amount=${want:-$(( max_fee * 8192 ))}
     echo "isolated-wallet: fee-charging chain — funding $wallet with $amount units of the fee asset $fee_faucet (from the genesis faucet operator)" >&2
     # The operator account is shared with other funders (the fee-funder sidecar); a send
     # can lose a mempool race ("conflicts with current mempool state") — retry. A fresh

--- a/scripts/lib-isolated-wallet.sh
+++ b/scripts/lib-isolated-wallet.sh
@@ -100,13 +100,13 @@ iso_tool() {
 # consume takes the fee P2ID together with whatever else is pending and pays for
 # itself. 1024× the fee cap: a creator wallet also funds native-faucet / foreign-bridge deployments.
 iso_fund_fee_asset() {
-    local wallet="$1" manifest="$PROJECT_DIR/.miden-agglayer-data/funding.toml"
+    local wallet="$1" want="${2:-}" manifest="$PROJECT_DIR/.miden-agglayer-data/funding.toml"
     [[ -f "$manifest" ]] || return 0   # zero-fee chain: nothing to do
     local fee_faucet max_fee amount
     fee_faucet=$(sed -n 's/^fee_faucet_id *= *"\(.*\)"/\1/p' "$manifest")
     max_fee=$(sed -n 's/^max_fee_per_txn *= *\([0-9]*\).*/\1/p' "$manifest")
     [[ -n "$fee_faucet" && -n "$max_fee" ]] || { echo "isolated-wallet: $manifest lacks fee_faucet_id/max_fee_per_txn" >&2; return 1; }
-    amount=$(( max_fee * 1024 ))
+    amount=${want:-$(( max_fee * 1024 ))}
     echo "isolated-wallet: fee-charging chain — funding $wallet with $amount units of the fee asset $fee_faucet (from the genesis faucet operator)" >&2
     local out
     if ! out=$(docker run --rm --network "$ISO_NETWORK" \

--- a/scripts/lib-isolated-wallet.sh
+++ b/scripts/lib-isolated-wallet.sh
@@ -98,7 +98,7 @@ iso_tool() {
 # (`/data/accounts/faucet_operator.mac` on the node_data volume), exactly as the
 # e2e `fee-funder` sidecar uses for the proxy's own accounts. The wallet's next
 # consume takes the fee P2ID together with whatever else is pending and pays for
-# itself. 64 × the per-transaction fee bound covers a whole suite run.
+# itself. 1024× the fee cap: a creator wallet also funds native-faucet / foreign-bridge deployments.
 iso_fund_fee_asset() {
     local wallet="$1" manifest="$PROJECT_DIR/.miden-agglayer-data/funding.toml"
     [[ -f "$manifest" ]] || return 0   # zero-fee chain: nothing to do
@@ -106,7 +106,7 @@ iso_fund_fee_asset() {
     fee_faucet=$(sed -n 's/^fee_faucet_id *= *"\(.*\)"/\1/p' "$manifest")
     max_fee=$(sed -n 's/^max_fee_per_txn *= *\([0-9]*\).*/\1/p' "$manifest")
     [[ -n "$fee_faucet" && -n "$max_fee" ]] || { echo "isolated-wallet: $manifest lacks fee_faucet_id/max_fee_per_txn" >&2; return 1; }
-    amount=$(( max_fee * 64 ))
+    amount=$(( max_fee * 1024 ))
     echo "isolated-wallet: fee-charging chain — funding $wallet with $amount units of the fee asset $fee_faucet (from the genesis faucet operator)" >&2
     local out
     if ! out=$(docker run --rm --network "$ISO_NETWORK" \

--- a/scripts/lib-isolated-wallet.sh
+++ b/scripts/lib-isolated-wallet.sh
@@ -109,7 +109,8 @@ iso_fund_fee_asset() {
     amount=${want:-$(( max_fee * 1024 ))}
     echo "isolated-wallet: fee-charging chain — funding $wallet with $amount units of the fee asset $fee_faucet (from the genesis faucet operator)" >&2
     # The operator account is shared with other funders (the fee-funder sidecar); a send
-    # can lose a mempool race ("conflicts with current mempool state") — retry.
+    # can lose a mempool race ("conflicts with current mempool state") — retry. A fresh
+    # store per call: a reused one carries the operator from another chain / nonce.
     local out attempt
     for attempt in 1 2 3 4; do
         if out=$(docker run --rm --network "$ISO_NETWORK" \
@@ -117,7 +118,7 @@ iso_fund_fee_asset() {
             -v "${ISO_NODE_DATA_VOLUME:-miden-agglayer_node_data}:/data:ro" \
             -e "MIDEN_PROVER_URL=$ISO_PROVER_URL" -e "TMPDIR=/store/tmp" \
             --entrypoint bridge-out-tool "$ISO_IMAGE" \
-            --store-dir /store/funder --node-url "$ISO_NODE_URL" \
+            --store-dir "/store/tmp/funder-$$-$RANDOM" --node-url "$ISO_NODE_URL" \
             --miden-prover-url "$ISO_PROVER_URL" \
             --fund-fee-asset --faucet-operator-mac /data/accounts/faucet_operator.mac \
             --fee-faucet-id "$fee_faucet" --fund "$wallet=$amount" 2>&1); then break; fi

--- a/scripts/lib-isolated-wallet.sh
+++ b/scripts/lib-isolated-wallet.sh
@@ -108,8 +108,11 @@ iso_fund_fee_asset() {
     [[ -n "$fee_faucet" && -n "$max_fee" ]] || { echo "isolated-wallet: $manifest lacks fee_faucet_id/max_fee_per_txn" >&2; return 1; }
     amount=${want:-$(( max_fee * 1024 ))}
     echo "isolated-wallet: fee-charging chain — funding $wallet with $amount units of the fee asset $fee_faucet (from the genesis faucet operator)" >&2
-    local out
-    if ! out=$(docker run --rm --network "$ISO_NETWORK" \
+    # The operator account is shared with other funders (the fee-funder sidecar); a send
+    # can lose a mempool race ("conflicts with current mempool state") — retry.
+    local out attempt
+    for attempt in 1 2 3 4; do
+        if out=$(docker run --rm --network "$ISO_NETWORK" \
             -v "$B2AGG_STORE_DIR:/store" \
             -v "${ISO_NODE_DATA_VOLUME:-miden-agglayer_node_data}:/data:ro" \
             -e "MIDEN_PROVER_URL=$ISO_PROVER_URL" -e "TMPDIR=/store/tmp" \
@@ -117,8 +120,10 @@ iso_fund_fee_asset() {
             --store-dir /store/funder --node-url "$ISO_NODE_URL" \
             --miden-prover-url "$ISO_PROVER_URL" \
             --fund-fee-asset --faucet-operator-mac /data/accounts/faucet_operator.mac \
-            --fee-faucet-id "$fee_faucet" --fund "$wallet=$amount" 2>&1); then
-        echo "$out" | tail -15 >&2
+            --fee-faucet-id "$fee_faucet" --fund "$wallet=$amount" 2>&1); then break; fi
+        echo "isolated-wallet: fee-asset send attempt $attempt failed — retrying in 10s" >&2; sleep 10; out=""
+    done
+    if [[ -z "$out" ]]; then
         echo "isolated-wallet: fee-asset funding of $wallet FAILED — on this chain its consumes cannot pay their fee" >&2
         return 1
     fi

--- a/scripts/lib-l2l2.sh
+++ b/scripts/lib-l2l2.sh
@@ -166,7 +166,19 @@ aggkit_settled_count() {
 # and error-free for the whole 19-minute cold start, and during it every
 # readiness wait is guaranteed to fail. Producing a certificate is the first
 # moment it can answer the question the suite is about to ask.
-aggkit_ready() { [[ "$(aggkit_settled_count)" -gt 0 ]]; }
+#
+# After a RECREATE mid-run there may be nothing to certify yet: aggsender comes
+# up, evaluates the range and says "no bridges or claims found … so no
+# certificate will be built" — the exits that would produce one come from the
+# back-operations that run AFTER this gate, so waiting for a settlement here
+# deadlocks until the timeout (both standalone chaos soaks on 2026-09-12). An
+# evaluated range proves the same thing a settlement does — aggsender is synced
+# and answering — so accept either.
+aggkit_evaluated_count() {
+    docker logs "${AGGKIT_CONTAINER:-l2l2-aggkit-1}" 2>&1 \
+        | grep -c "no bridges or claims found" || echo 0
+}
+aggkit_ready() { [[ "$(aggkit_settled_count)" -gt 0 || "$(aggkit_evaluated_count)" -gt 0 ]]; }
 
 # Gate a timed wait behind aggkit being able to answer. Call after anything that
 # recreates it (restore drill, chaos fault, compose recreate).

--- a/src/accounts_config.rs
+++ b/src/accounts_config.rs
@@ -208,6 +208,127 @@ pub fn config_path_exists(miden_store_dir: Option<PathBuf>) -> anyhow::Result<bo
     Ok(fs::exists(&config_path)?)
 }
 
+// ── #201: fee-asset funding manifest ──────────────────────────────────────────
+//
+// Written by `--print-funding` (or by a fee-charging `--init` that found no
+// manifest) so an operator knows WHICH accounts to fund with HOW MUCH of WHICH
+// asset — and so a later `--init` RESUMES those exact accounts instead of
+// rebuilding them behind a fresh random seed, which would orphan the funded
+// ones. Ids are hex `AccountId`s: unambiguous, HRP-free, and what
+// `bridge-out-tool --fund-fee-asset` parses.
+
+/// Sibling of `bridge_accounts.toml` in the same (sanitized) store directory.
+pub fn funding_manifest_path(miden_store_dir: Option<PathBuf>) -> anyhow::Result<PathBuf> {
+    Ok(config_path(miden_store_dir)?.with_file_name("funding.toml"))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct FundingManifest {
+    pub service: String,
+    pub ger_manager: String,
+    pub fee_faucet_id: String,
+    pub verification_base_fee: u32,
+    pub max_fee_per_txn: u64,
+    pub fund_service: u64,
+    pub fund_ger_manager: u64,
+}
+
+impl FundingManifest {
+    pub fn new(
+        service: AccountId,
+        ger_manager: AccountId,
+        fee: &crate::fee_funding::FeeSnapshot,
+    ) -> Self {
+        Self {
+            service: service.to_hex(),
+            ger_manager: ger_manager.to_hex(),
+            fee_faucet_id: fee.fee_faucet_id.to_hex(),
+            verification_base_fee: fee.verification_base_fee,
+            max_fee_per_txn: crate::fee_funding::max_fee_per_txn(fee.verification_base_fee),
+            fund_service: crate::fee_funding::recommended_service(fee),
+            fund_ger_manager: crate::fee_funding::recommended_ger_manager(fee),
+        }
+    }
+
+    fn parse_id(field: &str, what: &str) -> anyhow::Result<AccountId> {
+        AccountId::from_hex(field)
+            .map_err(|e| anyhow::anyhow!("funding.toml: bad {what} id {field}: {e:?}"))
+    }
+
+    pub fn service_id(&self) -> anyhow::Result<AccountId> {
+        Self::parse_id(&self.service, "service")
+    }
+
+    pub fn ger_manager_id(&self) -> anyhow::Result<AccountId> {
+        Self::parse_id(&self.ger_manager, "ger_manager")
+    }
+
+    pub fn fee_faucet(&self) -> anyhow::Result<AccountId> {
+        Self::parse_id(&self.fee_faucet_id, "fee_faucet_id")
+    }
+
+    /// Operator-facing instructions — what `--print-funding` prints.
+    pub fn instructions(&self, path: &Path) -> String {
+        if self.verification_base_fee == 0 {
+            return format!(
+                "this chain charges no transaction fees (verification_base_fee = 0): nothing to \
+                 fund. manifest: {}",
+                path.display()
+            );
+        }
+        format!(
+            "FUND THESE ACCOUNTS BEFORE THEY DEPLOY (#201)\n\
+             chain fee:   verification_base_fee = {bf}  (at most {mx} units per transaction)\n\
+             fee asset:   {fa}  (the chain's native fee faucet)\n\
+             \n\
+             send, as P2ID notes of the fee asset:\n\
+             service      {svc}  ->  {fs} units   (own budget + what it cascades to bridge/faucets)\n\
+             ger_manager  {ger}  ->  {fg} units\n\
+             \n\
+             Only these two (the KMS-keyed accounts) need funding: the proxy cascade-funds the\n\
+             keyless bridge and faucets from `service`. Then start the proxy normally — --init\n\
+             resumes these exact accounts from {p} and deploys each by consuming its note.\n\
+             dev/e2e: bridge-out-tool --fund-fee-asset --native-faucet-mac <native_faucet.mac> \
+             --funding-manifest {p}",
+            bf = self.verification_base_fee,
+            mx = self.max_fee_per_txn,
+            fa = self.fee_faucet_id,
+            svc = self.service,
+            fs = self.fund_service,
+            ger = self.ger_manager,
+            fg = self.fund_ger_manager,
+            p = path.display(),
+        )
+    }
+}
+
+pub fn save_funding_manifest(
+    manifest: &FundingManifest,
+    miden_store_dir: Option<PathBuf>,
+) -> anyhow::Result<PathBuf> {
+    let path = funding_manifest_path(miden_store_dir)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    // Write-then-rename so a crash never leaves a truncated manifest that a
+    // resuming --init would misread as "no manifest" and rebuild (orphaning).
+    let tmp = path.with_extension("toml.tmp");
+    fs::write(&tmp, toml::to_string(manifest)?)?;
+    fs::rename(&tmp, &path)?;
+    Ok(path)
+}
+
+pub fn load_funding_manifest(
+    miden_store_dir: Option<PathBuf>,
+) -> anyhow::Result<Option<FundingManifest>> {
+    let path = funding_manifest_path(miden_store_dir)?;
+    if !fs::exists(&path)? {
+        return Ok(None);
+    }
+    let manifest: FundingManifest = toml::from_str(&fs::read_to_string(&path)?)?;
+    Ok(Some(manifest))
+}
+
 pub fn save_config(
     config: AccountsConfig,
     net_id: &NetworkId,
@@ -292,6 +413,70 @@ pub fn load_config(miden_store_dir: Option<PathBuf>) -> anyhow::Result<AccountsC
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    /// #201: the manifest round-trips through disk (hex ids parse back to the
+    /// same `AccountId`s), the amounts follow the fee formula for the live
+    /// testnet's base fee 7, a missing file is `None` (not an error), and a
+    /// zero-fee chain yields a "nothing to fund" instruction.
+    #[test]
+    fn funding_manifest_roundtrip_and_amounts() {
+        let dir = tempdir().unwrap();
+        let store = Some(dir.path().to_path_buf());
+        assert!(load_funding_manifest(store.clone()).unwrap().is_none());
+
+        let service = AccountId::from_hex("0x18101fa522c174b165efd4f70a0385").unwrap();
+        let ger = AccountId::from_hex("0x367b10dc6b0a7251202dbf4de2b76e").unwrap();
+        let fee = crate::fee_funding::FeeSnapshot {
+            verification_base_fee: 7,
+            fee_faucet_id: service,
+        };
+        let manifest = FundingManifest::new(service, ger, &fee);
+        let path = save_funding_manifest(&manifest, store.clone()).unwrap();
+        assert_eq!(path.file_name().unwrap(), "funding.toml");
+        assert!(
+            !path.with_extension("toml.tmp").exists(),
+            "atomic rename left no tmp"
+        );
+
+        let loaded = load_funding_manifest(store)
+            .unwrap()
+            .expect("manifest exists");
+        assert_eq!(loaded, manifest);
+        assert_eq!(loaded.service_id().unwrap(), service);
+        assert_eq!(loaded.ger_manager_id().unwrap(), ger);
+        assert_eq!(loaded.fee_faucet().unwrap(), service);
+        assert_eq!(loaded.verification_base_fee, 7);
+        assert_eq!(
+            loaded.max_fee_per_txn,
+            crate::fee_funding::max_fee_per_txn(7)
+        );
+        assert_eq!(
+            loaded.fund_ger_manager,
+            crate::fee_funding::recommended_ger_manager(&fee)
+        );
+        assert_eq!(
+            loaded.fund_service,
+            crate::fee_funding::recommended_service(&fee)
+        );
+        assert!(
+            loaded.fund_service > loaded.fund_ger_manager,
+            "service also funds the cascade"
+        );
+
+        let text = loaded.instructions(&path);
+        assert!(text.contains(&service.to_hex()) && text.contains(&ger.to_hex()));
+        assert!(text.contains("verification_base_fee = 7"));
+
+        let zero = FundingManifest::new(
+            service,
+            ger,
+            &crate::fee_funding::FeeSnapshot {
+                verification_base_fee: 0,
+                fee_faucet_id: service,
+            },
+        );
+        assert!(zero.instructions(&path).contains("nothing to fund"));
+    }
 
     // Valid protocol-0.15 (version-1) account id; the 0.14 v0 encoding is
     // rejected by the 0.15 codec (`UnknownAccountIdVersion`).

--- a/src/accounts_config.rs
+++ b/src/accounts_config.rs
@@ -288,7 +288,7 @@ impl FundingManifest {
              Only these two (the KMS-keyed accounts) need funding: the proxy cascade-funds the\n\
              keyless bridge and faucets from `service`. Then start the proxy normally — --init\n\
              resumes these exact accounts from {p} and deploys each by consuming its note.\n\
-             dev/e2e: bridge-out-tool --fund-fee-asset --native-faucet-mac <native_faucet.mac> \
+             dev/e2e: bridge-out-tool --fund-fee-asset --faucet-operator-mac <faucet_operator.mac> \
              --funding-manifest {p}",
             bf = self.verification_base_fee,
             mx = self.max_fee_per_txn,

--- a/src/applied_state.rs
+++ b/src/applied_state.rs
@@ -106,7 +106,7 @@ async fn bridge_snapshot_with_client(
 
     let ger_applied = ger
         .map(|root| {
-            AggLayerBridge::is_ger_registered(ExitRoot::new(root), &bridge)
+            crate::network_accounts::is_ger_registered(ExitRoot::new(root), &bridge)
                 .context("reading bridge GER map")
         })
         .transpose()?;

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -759,7 +759,7 @@ async fn fund_fee_asset(
                 .build()
                 .map_err(|e| anyhow!("building fee-asset P2ID to {}: {e:?}", target.to_hex()))?;
             TransactionRequestBuilder::new()
-                .own_output_notes(vec![miden_protocol::note::Note::from(note).into()])
+                .own_output_notes(vec![miden_protocol::note::Note::from(note)])
                 .foreign_accounts([miden_client::transaction::ForeignAccount::public(
                     target,
                     miden_client::rpc::domain::account::AccountStorageRequirements::default(),

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -584,6 +584,31 @@ async fn consume_pending_notes(
 /// pre-funded with 1e9 units of the fee asset — and writes it as
 /// `faucet_operator.mac` WITH its signing key. Funding is therefore a plain
 /// P2ID send from the operator's vault: no minting, no faucet interface needed.
+/// The creator wallet's own fee funding is a P2ID that lands only once consumed;
+/// consume it and wait, or the cascade below fails with "asset error" (#201).
+async fn settle_fee_notes(
+    client: &mut miden_agglayer_service::miden_client::MidenClientLib,
+    wallet: AccountId,
+    fee: &miden_agglayer_service::fee_funding::FeeSnapshot,
+) -> anyhow::Result<()> {
+    if miden_agglayer_service::fee_funding::consume_fee_notes(client, wallet, fee).await? == 0 {
+        return Ok(());
+    }
+    for _ in 0..30 {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        client.sync_state().await?;
+        if let Some(a) = client.get_account(wallet).await?
+            && miden_agglayer_service::fee_vault_monitor::fee_balance(&a, fee.fee_faucet_id) > 0
+        {
+            return Ok(());
+        }
+    }
+    anyhow::bail!(
+        "fee funding note of {} did not land within 60s",
+        wallet.to_hex()
+    )
+}
+
 async fn fund_fee_asset(
     client: &mut miden_agglayer_service::miden_client::MidenClientLib,
     keystore: Arc<miden_agglayer_service::proxy_keystore::ProxyKeystore>,
@@ -1019,6 +1044,7 @@ async fn main() -> anyhow::Result<()> {
             let funder = args.wallet_id.as_deref().map(AccountId::from_hex).transpose()
                 .map_err(|e| anyhow!("bad --wallet-id: {e:?}"))?
                 .ok_or_else(|| anyhow!("--create-foreign-bridge on a fee-charging chain needs --wallet-id <funded creator wallet> (#201)"))?;
+            settle_fee_notes(&mut client, funder, &fee).await?;
             fund_from_service(
                 &mut client,
                 funder,
@@ -1213,6 +1239,9 @@ async fn main() -> anyhow::Result<()> {
         }
         client.add_account(&faucet, false).await?;
         let fee = miden_agglayer_service::fee_funding::fee_snapshot(&mut client).await?;
+        if fee.charges_fees() {
+            settle_fee_notes(&mut client, wallet_id, &fee).await?;
+        }
         miden_agglayer_service::fee_funding::deploy_account(
             &mut client,
             faucet.id(),

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -263,6 +263,15 @@ struct Args {
     #[arg(long)]
     inspect_faucet: Option<String>,
 
+    /// Print the fungible vault balances of one or more PUBLIC accounts (hex or
+    /// bech32 ids), read-only — imports each account by id from the node. The
+    /// operator's view of "how much fee asset does my bridge / faucet / service
+    /// hold" for top-ups (#201). Output: one `vault-balance: account=<hex>
+    /// faucet=<hex> amount=<n>` line per asset (`(empty)` when the vault holds
+    /// nothing). Requires only --store-dir + --node-url.
+    #[arg(long = "vault-balance", num_args = 1..)]
+    vault_balance: Vec<String>,
+
     /// Received-asset linkage mode (#147 / PR#152). Enumerate the fungible faucets the
     /// RECEIVING wallet (--wallet-id) actually holds, derived from its ON-CHAIN vault
     /// after syncing + consuming any pending P2ID notes — so the e2e can identify the
@@ -750,6 +759,7 @@ async fn main() -> anyhow::Result<()> {
         || args.create_native_faucet
         || args.fund_fee_asset
         || args.inspect_faucet.is_some()
+        || !args.vault_balance.is_empty()
     {
         // Provision / read-only modes: the store/keystore may not exist yet (a fresh
         // temp dir for --inspect-faucet) — create them.
@@ -828,6 +838,55 @@ async fn main() -> anyhow::Result<()> {
     // faucet (the wallet's `Unknown`) or an RPC failure is a non-zero exit.
     if args.fund_fee_asset {
         return fund_fee_asset(&mut client, keystore.clone(), &args).await;
+    }
+    if !args.vault_balance.is_empty() {
+        sync_with_retry(&mut client, "vault-balance").await?;
+        let mut failures = 0;
+        for id_str in &args.vault_balance {
+            let id = match parse_account_id(id_str) {
+                Ok(id) => id,
+                Err(e) => {
+                    eprintln!("vault-balance: ERROR bad account id {id_str}: {e:?}");
+                    failures += 1;
+                    continue;
+                }
+            };
+            // Already-tracked accounts (the wallet, a previously imported id) make
+            // the import a no-op / benign error; the read below is what matters.
+            if let Err(e) = client.import_account_by_id(id).await {
+                eprintln!(
+                    "vault-balance: note: import of {} returned {e:?} (reading tracked state)",
+                    id.to_hex()
+                );
+            }
+            let Some(record) = client.get_account(id).await? else {
+                eprintln!(
+                    "vault-balance: ERROR account {} not found on the node",
+                    id.to_hex()
+                );
+                failures += 1;
+                continue;
+            };
+            let mut any = false;
+            for asset in record.vault().assets() {
+                if let miden_protocol::asset::Asset::Fungible(f) = asset {
+                    any = true;
+                    println!(
+                        "vault-balance: account={} faucet={} amount={}",
+                        id.to_hex(),
+                        f.faucet_id().to_hex(),
+                        f.amount().as_u64()
+                    );
+                }
+            }
+            if !any {
+                println!("vault-balance: account={} (empty)", id.to_hex());
+            }
+        }
+        if failures > 0 {
+            std::process::exit(2);
+        }
+        return Ok(());
     }
     if let Some(fid_hex) = args.inspect_faucet.as_deref() {
         let faucet_id = parse_account_id(fid_hex)

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -188,19 +188,23 @@ struct Args {
     #[arg(long)]
     create_native_faucet: bool,
 
-    /// #201: mint the chain's NATIVE FEE ASSET to the proxy's accounts so they can
-    /// pay transaction fees, using the genesis native faucet's account file
-    /// (`--native-faucet-mac`). Operator tooling — local custody by design, so it
+    /// #201: send the chain's NATIVE FEE ASSET to the proxy's accounts so they can
+    /// pay transaction fees, from the genesis FAUCET OPERATOR's pre-funded vault
+    /// (`--faucet-operator-mac`). Operator tooling — local custody by design, so it
     /// works unchanged when the proxy itself runs with remote/KMS keys. Targets
     /// come from a proxy `funding.toml` (`--funding-manifest`, written by the
     /// proxy's `--print-funding`) and/or explicit `--fund <account-hex>=<amount>`.
     #[arg(long)]
     fund_fee_asset: bool,
 
-    /// Path to the genesis `native_faucet.mac` (the account file `miden-validator
-    /// genesis --accounts-directory` writes for the chain's fee faucet).
+    /// Path to the genesis `faucet_operator.mac` — the account file
+    /// `miden-validator genesis --accounts-directory` writes for the native fee
+    /// faucet's OWNER: a plain wallet, pre-funded with the fee asset at genesis,
+    /// carrying its own signing key. (NOT `native_faucet.mac`: the fee faucet is
+    /// a network account with an owner-only mint policy and no key of its own,
+    /// so it cannot be minted from directly.)
     #[arg(long)]
-    native_faucet_mac: Option<PathBuf>,
+    faucet_operator_mac: Option<PathBuf>,
 
     /// A proxy `funding.toml` naming the KMS-keyed accounts and amounts to fund.
     #[arg(long)]
@@ -209,6 +213,11 @@ struct Args {
     /// Extra targets, repeatable: `<account-id-hex>=<amount>`.
     #[arg(long = "fund", num_args = 1..)]
     fund: Vec<String>,
+
+    /// The chain's fee faucet id (hex). Taken from `--funding-manifest` when
+    /// given; required only for `--fund`-only invocations.
+    #[arg(long)]
+    fee_faucet_id: Option<String>,
 
     /// Custom token symbol for --create-native-faucet (Miden TokenSymbol: <= 6 chars).
     #[arg(long, default_value = "MDN")]
@@ -553,10 +562,19 @@ async fn consume_pending_notes(
     }
 }
 
-/// #201: mint the chain's native fee asset to the proxy's accounts so they can
+/// #201: send the chain's native fee asset to the proxy's accounts so they can
 /// pay transaction fees. Operator tooling with LOCAL custody by design: the
 /// proxy's remote/KMS keystore rightly refuses to hold any local secret, so the
-/// one key this needs — the genesis native faucet's — lives here, not there.
+/// one key this needs lives here, not there.
+///
+/// Why the OPERATOR and not the faucet: the genesis native fee faucet is a
+/// network `FungibleFaucet` with an owner-only mint policy and NO key of its
+/// own (`native_faucet.mac` carries none; the client can't even build a mint
+/// against it — "does not contain the … fungible faucet interface"). Genesis
+/// also creates the faucet OPERATOR — a plain wallet, the faucet's owner,
+/// pre-funded with 1e9 units of the fee asset — and writes it as
+/// `faucet_operator.mac` WITH its signing key. Funding is therefore a plain
+/// P2ID send from the operator's vault: no minting, no faucet interface needed.
 async fn fund_fee_asset(
     client: &mut miden_agglayer_service::miden_client::MidenClientLib,
     keystore: Arc<miden_agglayer_service::proxy_keystore::ProxyKeystore>,
@@ -567,53 +585,68 @@ async fn fund_fee_asset(
         submit_new_transaction, wait_for_transaction_commit,
     };
     use miden_client::keystore::Keystore as _;
-    use miden_client::transaction::TransactionRequestBuilder;
+    use miden_client::transaction::{PaymentNoteDescription, TransactionRequestBuilder};
     use miden_protocol::account::AccountFile;
-    use miden_protocol::asset::FungibleAsset;
+    use miden_protocol::asset::{Asset, FungibleAsset};
     use miden_protocol::note::NoteType;
 
-    let mac = args.native_faucet_mac.as_ref().ok_or_else(|| {
-        anyhow!("--fund-fee-asset requires --native-faucet-mac <genesis native_faucet.mac>")
+    let mac = args.faucet_operator_mac.as_ref().ok_or_else(|| {
+        anyhow!("--fund-fee-asset requires --faucet-operator-mac <genesis faucet_operator.mac>")
     })?;
     let file = AccountFile::read(mac)
-        .with_context(|| format!("reading native faucet account file {}", mac.display()))?;
-    let faucet_id = file.account.id();
-    // The faucet must SIGN its mint transactions: load its secret(s) into this
-    // tool's local keystore.
+        .with_context(|| format!("reading faucet operator account file {}", mac.display()))?;
+    let operator_id = file.account.id();
+    if file.auth_secret_keys.is_empty() {
+        return Err(anyhow!(
+            "{} carries no signing key — is this native_faucet.mac instead of \
+             faucet_operator.mac? The operator (the faucet's owner) is the funding source",
+            mac.display()
+        ));
+    }
+    // The operator must SIGN its sends: load its secret(s) into this tool's
+    // local keystore.
     for key in &file.auth_secret_keys {
         keystore
-            .add_key(key, faucet_id)
+            .add_key(key, operator_id)
             .await
-            .map_err(|e| anyhow!("loading the native faucet key: {e}"))?;
+            .map_err(|e| anyhow!("loading the faucet operator key: {e}"))?;
     }
     client
         .add_account(&file.account, true)
         .await
-        .map_err(|e| anyhow!("importing native faucet {}: {e:?}", faucet_id.to_hex()))?;
+        .map_err(|e| anyhow!("importing faucet operator {}: {e:?}", operator_id.to_hex()))?;
     client
         .sync_state()
         .await
-        .map_err(|e| anyhow!("sync after native faucet import: {e:?}"))?;
+        .map_err(|e| anyhow!("sync after faucet operator import: {e:?}"))?;
 
     let mut targets: Vec<(AccountId, u64)> = Vec::new();
+    let mut fee_faucet_id: Option<AccountId> = None;
     if let Some(path) = args.funding_manifest.as_ref() {
         let text =
             std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
         let manifest: FundingManifest =
             toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))?;
-        let expected = manifest.fee_faucet()?;
-        if expected != faucet_id {
-            return Err(anyhow!(
-                "{} names fee asset {} but {} is faucet {} — wrong chain or wrong account file",
-                path.display(),
-                expected.to_hex(),
-                mac.display(),
-                faucet_id.to_hex()
-            ));
-        }
+        fee_faucet_id = Some(manifest.fee_faucet()?);
         targets.push((manifest.service_id()?, manifest.fund_service));
         targets.push((manifest.ger_manager_id()?, manifest.fund_ger_manager));
     }
+    if let Some(hex) = args.fee_faucet_id.as_deref() {
+        let given = parse_account_id(hex).context("--fee-faucet-id")?;
+        if let Some(from_manifest) = fee_faucet_id
+            && from_manifest != given
+        {
+            return Err(anyhow!(
+                "--fee-faucet-id {} disagrees with the manifest's fee asset {}",
+                given.to_hex(),
+                from_manifest.to_hex()
+            ));
+        }
+        fee_faucet_id = Some(given);
+    }
+    let fee_faucet_id = fee_faucet_id.ok_or_else(|| {
+        anyhow!("--fund-fee-asset needs the fee asset: give --funding-manifest or --fee-faucet-id")
+    })?;
     for spec in &args.fund {
         let (id, amount) = spec
             .split_once('=')
@@ -628,21 +661,50 @@ async fn fund_fee_asset(
             "--fund-fee-asset: nothing to fund (give --funding-manifest and/or --fund)"
         ));
     }
+
+    // Self-check before spending: the operator's genesis vault must cover the
+    // total, in the SAME fee asset the manifest names (wrong chain otherwise).
+    let have: u64 = file
+        .account
+        .vault()
+        .assets()
+        .filter_map(|a| match a {
+            Asset::Fungible(f) if f.faucet_id() == fee_faucet_id => Some(f.amount().as_u64()),
+            _ => None,
+        })
+        .sum();
+    let need: u64 = targets.iter().map(|(_, a)| *a).sum();
+    if have < need {
+        return Err(anyhow!(
+            "faucet operator {} holds {have} units of fee asset {} but {need} are needed — \
+             wrong chain/account file, or the genesis operator balance is too small",
+            operator_id.to_hex(),
+            fee_faucet_id.to_hex()
+        ));
+    }
+
     for (target, amount) in targets {
-        let asset = FungibleAsset::new(faucet_id, amount)
-            .map_err(|e| anyhow!("fee asset amount {amount}: {e:?}"))?;
+        let asset = Asset::Fungible(
+            FungibleAsset::new(fee_faucet_id, amount)
+                .map_err(|e| anyhow!("fee asset amount {amount}: {e:?}"))?,
+        );
         let req = TransactionRequestBuilder::new()
-            .build_mint_fungible_asset(asset, target, NoteType::Public, client.rng())
-            .map_err(|e| anyhow!("building fee-asset mint to {}: {e:?}", target.to_hex()))?;
-        let txn = submit_new_transaction(client, faucet_id, req)
+            .build_pay_to_id(
+                PaymentNoteDescription::new(vec![asset], operator_id, target),
+                NoteType::Public,
+                client.rng(),
+            )
+            .map_err(|e| anyhow!("building fee-asset P2ID to {}: {e:?}", target.to_hex()))?;
+        let txn = submit_new_transaction(client, operator_id, req)
             .await
-            .map_err(|e| anyhow!("fee-asset mint to {} failed: {e:?}", target.to_hex()))?;
+            .map_err(|e| anyhow!("fee-asset send to {} failed: {e:?}", target.to_hex()))?;
         wait_for_transaction_commit(client, txn, 30, std::time::Duration::from_secs(2))
             .await
-            .map_err(|e| anyhow!("fee-asset mint commit wait: {e:?}"))?;
+            .map_err(|e| anyhow!("fee-asset send commit wait: {e:?}"))?;
         println!(
-            "[fund-fee-asset] minted {amount} units of fee asset {} to {}",
-            faucet_id.to_hex(),
+            "[fund-fee-asset] sent {amount} units of fee asset {} from faucet operator {} to {}",
+            fee_faucet_id.to_hex(),
+            operator_id.to_hex(),
             target.to_hex()
         );
     }

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -726,13 +726,58 @@ async fn fund_fee_asset(
             FungibleAsset::new(fee_faucet_id, amount)
                 .map_err(|e| anyhow!("fee asset amount {amount}: {e:?}"))?,
         );
-        let req = TransactionRequestBuilder::new()
-            .build_pay_to_id(
-                PaymentNoteDescription::new(vec![asset], operator_id, target),
-                NoteType::Public,
-                client.rng(),
-            )
-            .map_err(|e| anyhow!("building fee-asset P2ID to {}: {e:?}", target.to_hex()))?;
+        // A DEPLOYED network account (bridge, faucet) is executed only by the
+        // ntx-builder — the node refuses user-submitted transactions for it
+        // ("Network transactions may not be submitted by users yet") — and the
+        // ntx-builder only picks up notes carrying a NetworkAccountTarget. So a
+        // top-up for one must carry the attachment, and the sender declares the
+        // target as a foreign account because the fee policy is read from it.
+        // Before deployment the plain P2ID is right: the account's creation
+        // transaction consumes it (see fee_funding::deploy_account).
+        let deployed_network = {
+            if client.get_account(target).await?.is_none() {
+                let _ = client.import_account_by_id(target).await; // not on chain yet ⇒ Err
+            }
+            client.get_account(target).await?.is_some_and(|account| {
+                miden_standards::account::auth::NetworkAccount::new(account).is_ok()
+            })
+        };
+        let req = if deployed_network {
+            let note = miden_standards::note::P2idNote::builder()
+                .sender(operator_id)
+                .target(target)
+                .asset(asset)
+                .note_type(NoteType::Public)
+                .attachment(miden_protocol::note::NoteAttachment::from(
+                    miden_standards::note::NetworkAccountTarget::new(
+                        target,
+                        miden_standards::note::NoteExecutionHint::Always,
+                    )
+                    .map_err(|e| anyhow!("network target for {}: {e:?}", target.to_hex()))?,
+                ))
+                .generate_serial_number(client.rng())
+                .build()
+                .map_err(|e| anyhow!("building fee-asset P2ID to {}: {e:?}", target.to_hex()))?;
+            TransactionRequestBuilder::new()
+                .own_output_notes(vec![miden_protocol::note::Note::from(note).into()])
+                .foreign_accounts([miden_client::transaction::ForeignAccount::public(
+                    target,
+                    miden_client::rpc::domain::account::AccountStorageRequirements::default(),
+                )
+                .map_err(|e| {
+                    anyhow!("declaring {} as a foreign account: {e:?}", target.to_hex())
+                })?])
+                .build()
+                .map_err(|e| anyhow!("building fee-asset P2ID to {}: {e:?}", target.to_hex()))?
+        } else {
+            TransactionRequestBuilder::new()
+                .build_pay_to_id(
+                    PaymentNoteDescription::new(vec![asset], operator_id, target),
+                    NoteType::Public,
+                    client.rng(),
+                )
+                .map_err(|e| anyhow!("building fee-asset P2ID to {}: {e:?}", target.to_hex()))?
+        };
         let txn = submit_new_transaction(client, operator_id, req)
             .await
             .map_err(|e| anyhow!("fee-asset send to {} failed: {e:?}", target.to_hex()))?;

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -989,10 +989,7 @@ async fn main() -> anyhow::Result<()> {
     // bridge account, ETH faucet registered in the FOREIGN bridge. All keys
     // live in this isolated store — the proxy's store is never touched.
     if args.create_foreign_bridge {
-        use miden_agglayer_service::miden_client::{
-            submit_new_transaction, wait_for_transaction_commit,
-        };
-        use miden_base_agglayer::{AggLayerBridge, BridgeRoles, MetadataHash};
+        use miden_base_agglayer::{BridgeRoles, MetadataHash};
         use miden_client::crypto::FeltRng;
 
         println!(
@@ -1010,15 +1007,53 @@ async fn main() -> anyhow::Result<()> {
             miden_agglayer_service::init::create_standalone_wallet(&mut client, keystore.clone())
                 .await
                 .map_err(|e| anyhow!("foreign ger_manager wallet creation failed: {e:?}"))?;
-
-        // Deploy ger_manager via dummy txn (mirrors init.rs::deploy_account).
-        let dummy = TransactionRequestBuilder::new().build()?;
-        let txn_id = submit_new_transaction(&mut client, ger_manager.id(), dummy)
+        // #201: every account pays its own fees, so the creator wallet (--wallet-id) funds
+        // the foreign service/ger_manager like the operator funds the proxy's.
+        use miden_agglayer_service::fee_funding::{
+            DeployKind, deploy_account, fee_snapshot, fund_from_service, recommended_ger_manager,
+            recommended_service,
+        };
+        let fee = fee_snapshot(&mut client).await?;
+        let wait = std::time::Duration::from_secs(180);
+        if fee.charges_fees() {
+            let funder = args.wallet_id.as_deref().map(AccountId::from_hex).transpose()
+                .map_err(|e| anyhow!("bad --wallet-id: {e:?}"))?
+                .ok_or_else(|| anyhow!("--create-foreign-bridge on a fee-charging chain needs --wallet-id <funded creator wallet> (#201)"))?;
+            fund_from_service(
+                &mut client,
+                funder,
+                service.id(),
+                "foreign service",
+                recommended_service(&fee),
+                &fee,
+            )
+            .await?;
+            fund_from_service(
+                &mut client,
+                funder,
+                ger_manager.id(),
+                "foreign ger_manager",
+                recommended_ger_manager(&fee),
+                &fee,
+            )
+            .await?;
+        }
+        for (id, name) in [
+            (service.id(), "foreign service"),
+            (ger_manager.id(), "foreign ger_manager"),
+        ] {
+            deploy_account(
+                &mut client,
+                id,
+                name,
+                DeployKind::Wallet,
+                miden_agglayer_service::metrics::ProofKind::BridgeOut,
+                &fee,
+                wait,
+            )
             .await
-            .map_err(|e| anyhow!("foreign ger_manager deploy failed: {e:?}"))?;
-        wait_for_transaction_commit(&mut client, txn_id, 30, std::time::Duration::from_secs(2))
-            .await
-            .map_err(|e| anyhow!("foreign ger_manager deploy commit wait failed: {e:?}"))?;
+            .map_err(|e| anyhow!("{name} deploy failed: {e:?}"))?;
+        }
 
         // Foreign bridge (mirrors init.rs::add_bridge). rc.4: role-based
         // creation — the foreign service is ADMIN + faucet manager, the
@@ -1032,29 +1067,32 @@ async fn main() -> anyhow::Result<()> {
             std::collections::BTreeSet::from([ger_manager.id()]),
         )
         .map_err(|e| anyhow!("foreign bridge role construction failed: {e}"))?;
-        let bridge = AggLayerBridge::account_builder(
+        let bridge = miden_agglayer_service::network_accounts::bridge_account_builder(
             client.rng().draw_word(),
             service.id(),
             roles,
             args.foreign_network_id,
-            miden_agglayer_service::fee_policy::zero_fee_policy_manager_for(
-                AggLayerBridge::allowed_notes(),
-                fee_faucet_id,
-            ),
-        )
+            fee_faucet_id,
+        )?
         .build()
         .map_err(|e| anyhow!("foreign bridge account build failed: {e}"))?;
         client
             .add_account(&bridge, false)
             .await
             .map_err(|e| anyhow!("adding foreign bridge account failed: {e:?}"))?;
-        let dummy = TransactionRequestBuilder::new().build()?;
-        let txn_id = submit_new_transaction(&mut client, bridge.id(), dummy)
-            .await
-            .map_err(|e| anyhow!("foreign bridge deploy failed: {e:?}"))?;
-        wait_for_transaction_commit(&mut client, txn_id, 30, std::time::Duration::from_secs(2))
-            .await
-            .map_err(|e| anyhow!("foreign bridge deploy commit wait failed: {e:?}"))?;
+        deploy_account(
+            &mut client,
+            bridge.id(),
+            "foreign bridge",
+            DeployKind::NetworkAccount {
+                funder: service.id(),
+            },
+            miden_agglayer_service::metrics::ProofKind::BridgeOut,
+            &fee,
+            wait,
+        )
+        .await
+        .map_err(|e| anyhow!("foreign bridge deploy failed: {e:?}"))?;
 
         // Settle accounts before the faucet registration note targets the bridge
         // (mirrors init.rs's NTX-builder settlement wait).
@@ -1166,19 +1204,26 @@ async fn main() -> anyhow::Result<()> {
             .with_component(faucet_component)
             .with_components(policy_manager)
             .with_component(auth_component)
+            // #201: P2ID-fundable — on a fee-charging chain the creator wallet funds the vault.
+            .with_component(miden_standards::account::wallets::BasicWallet)
             .build_with_schema_commitment()
             .map_err(|e| anyhow!("faucet account build failed: {e:?}"))?;
         if let Some(key_pair) = key_pair.as_ref() {
             keystore.add_key(key_pair, faucet.id()).await?;
         }
         client.add_account(&faucet, false).await?;
-        let dummy = TransactionRequestBuilder::new().build()?;
-        let txn_id = submit_new_transaction(&mut client, faucet.id(), dummy)
-            .await
-            .map_err(|e| anyhow!("faucet deploy failed: {e:?}"))?;
-        wait_for_transaction_commit(&mut client, txn_id, 30, std::time::Duration::from_secs(2))
-            .await
-            .map_err(|e| anyhow!("faucet deploy commit wait failed: {e:?}"))?;
+        let fee = miden_agglayer_service::fee_funding::fee_snapshot(&mut client).await?;
+        miden_agglayer_service::fee_funding::deploy_account(
+            &mut client,
+            faucet.id(),
+            "native faucet",
+            miden_agglayer_service::fee_funding::DeployKind::NetworkAccount { funder: wallet_id },
+            miden_agglayer_service::metrics::ProofKind::BridgeOut,
+            &fee,
+            std::time::Duration::from_secs(180),
+        )
+        .await
+        .map_err(|e| anyhow!("faucet deploy failed: {e:?}"))?;
         println!(
             "[native-faucet] deployed operator faucet {}",
             faucet.id().to_hex()

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -645,10 +645,14 @@ async fn fund_fee_asset(
             .await
             .map_err(|e| anyhow!("loading the faucet operator key: {e}"))?;
     }
-    client
-        .add_account(&file.account, true)
-        .await
-        .map_err(|e| anyhow!("importing faucet operator {}: {e:?}", operator_id.to_hex()))?;
+    // A store that already tracks the operator holds its CURRENT state; re-importing
+    // the genesis file over it fails with AccountNonceTooLow.
+    if client.get_account(operator_id).await?.is_none() {
+        client
+            .add_account(&file.account, false)
+            .await
+            .map_err(|e| anyhow!("importing faucet operator {}: {e:?}", operator_id.to_hex()))?;
+    }
     client
         .sync_state()
         .await

--- a/src/bin/bridge_out_tool.rs
+++ b/src/bin/bridge_out_tool.rs
@@ -188,6 +188,28 @@ struct Args {
     #[arg(long)]
     create_native_faucet: bool,
 
+    /// #201: mint the chain's NATIVE FEE ASSET to the proxy's accounts so they can
+    /// pay transaction fees, using the genesis native faucet's account file
+    /// (`--native-faucet-mac`). Operator tooling — local custody by design, so it
+    /// works unchanged when the proxy itself runs with remote/KMS keys. Targets
+    /// come from a proxy `funding.toml` (`--funding-manifest`, written by the
+    /// proxy's `--print-funding`) and/or explicit `--fund <account-hex>=<amount>`.
+    #[arg(long)]
+    fund_fee_asset: bool,
+
+    /// Path to the genesis `native_faucet.mac` (the account file `miden-validator
+    /// genesis --accounts-directory` writes for the chain's fee faucet).
+    #[arg(long)]
+    native_faucet_mac: Option<PathBuf>,
+
+    /// A proxy `funding.toml` naming the KMS-keyed accounts and amounts to fund.
+    #[arg(long)]
+    funding_manifest: Option<PathBuf>,
+
+    /// Extra targets, repeatable: `<account-id-hex>=<amount>`.
+    #[arg(long = "fund", num_args = 1..)]
+    fund: Vec<String>,
+
     /// Custom token symbol for --create-native-faucet (Miden TokenSymbol: <= 6 chars).
     #[arg(long, default_value = "MDN")]
     native_symbol: String,
@@ -531,6 +553,102 @@ async fn consume_pending_notes(
     }
 }
 
+/// #201: mint the chain's native fee asset to the proxy's accounts so they can
+/// pay transaction fees. Operator tooling with LOCAL custody by design: the
+/// proxy's remote/KMS keystore rightly refuses to hold any local secret, so the
+/// one key this needs — the genesis native faucet's — lives here, not there.
+async fn fund_fee_asset(
+    client: &mut miden_agglayer_service::miden_client::MidenClientLib,
+    keystore: Arc<miden_agglayer_service::proxy_keystore::ProxyKeystore>,
+    args: &Args,
+) -> anyhow::Result<()> {
+    use miden_agglayer_service::accounts_config::FundingManifest;
+    use miden_agglayer_service::miden_client::{
+        submit_new_transaction, wait_for_transaction_commit,
+    };
+    use miden_client::keystore::Keystore as _;
+    use miden_client::transaction::TransactionRequestBuilder;
+    use miden_protocol::account::AccountFile;
+    use miden_protocol::asset::FungibleAsset;
+    use miden_protocol::note::NoteType;
+
+    let mac = args.native_faucet_mac.as_ref().ok_or_else(|| {
+        anyhow!("--fund-fee-asset requires --native-faucet-mac <genesis native_faucet.mac>")
+    })?;
+    let file = AccountFile::read(mac)
+        .with_context(|| format!("reading native faucet account file {}", mac.display()))?;
+    let faucet_id = file.account.id();
+    // The faucet must SIGN its mint transactions: load its secret(s) into this
+    // tool's local keystore.
+    for key in &file.auth_secret_keys {
+        keystore
+            .add_key(key, faucet_id)
+            .await
+            .map_err(|e| anyhow!("loading the native faucet key: {e}"))?;
+    }
+    client
+        .add_account(&file.account, true)
+        .await
+        .map_err(|e| anyhow!("importing native faucet {}: {e:?}", faucet_id.to_hex()))?;
+    client
+        .sync_state()
+        .await
+        .map_err(|e| anyhow!("sync after native faucet import: {e:?}"))?;
+
+    let mut targets: Vec<(AccountId, u64)> = Vec::new();
+    if let Some(path) = args.funding_manifest.as_ref() {
+        let text =
+            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+        let manifest: FundingManifest =
+            toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))?;
+        let expected = manifest.fee_faucet()?;
+        if expected != faucet_id {
+            return Err(anyhow!(
+                "{} names fee asset {} but {} is faucet {} — wrong chain or wrong account file",
+                path.display(),
+                expected.to_hex(),
+                mac.display(),
+                faucet_id.to_hex()
+            ));
+        }
+        targets.push((manifest.service_id()?, manifest.fund_service));
+        targets.push((manifest.ger_manager_id()?, manifest.fund_ger_manager));
+    }
+    for spec in &args.fund {
+        let (id, amount) = spec
+            .split_once('=')
+            .ok_or_else(|| anyhow!("--fund expects <account-id-hex>=<amount>, got {spec}"))?;
+        let amount: u64 = amount
+            .parse()
+            .with_context(|| format!("--fund amount {amount:?} is not a number"))?;
+        targets.push((parse_account_id(id)?, amount));
+    }
+    if targets.is_empty() {
+        return Err(anyhow!(
+            "--fund-fee-asset: nothing to fund (give --funding-manifest and/or --fund)"
+        ));
+    }
+    for (target, amount) in targets {
+        let asset = FungibleAsset::new(faucet_id, amount)
+            .map_err(|e| anyhow!("fee asset amount {amount}: {e:?}"))?;
+        let req = TransactionRequestBuilder::new()
+            .build_mint_fungible_asset(asset, target, NoteType::Public, client.rng())
+            .map_err(|e| anyhow!("building fee-asset mint to {}: {e:?}", target.to_hex()))?;
+        let txn = submit_new_transaction(client, faucet_id, req)
+            .await
+            .map_err(|e| anyhow!("fee-asset mint to {} failed: {e:?}", target.to_hex()))?;
+        wait_for_transaction_commit(client, txn, 30, std::time::Duration::from_secs(2))
+            .await
+            .map_err(|e| anyhow!("fee-asset mint commit wait: {e:?}"))?;
+        println!(
+            "[fund-fee-asset] minted {amount} units of fee asset {} to {}",
+            faucet_id.to_hex(),
+            target.to_hex()
+        );
+    }
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
@@ -568,6 +686,7 @@ async fn main() -> anyhow::Result<()> {
     if args.create_wallet
         || args.create_foreign_bridge
         || args.create_native_faucet
+        || args.fund_fee_asset
         || args.inspect_faucet.is_some()
     {
         // Provision / read-only modes: the store/keystore may not exist yet (a fresh
@@ -645,6 +764,9 @@ async fn main() -> anyhow::Result<()> {
     // way a receiving wallet does — purely from on-chain account state, on a fresh
     // client with no preloaded token map. Machine-readable output; a NON-resolving
     // faucet (the wallet's `Unknown`) or an RPC failure is a non-zero exit.
+    if args.fund_fee_asset {
+        return fund_fee_asset(&mut client, keystore.clone(), &args).await;
+    }
     if let Some(fid_hex) = args.inspect_faucet.as_deref() {
         let faucet_id = parse_account_id(fid_hex)
             .with_context(|| format!("inspect-faucet: bad faucet id {fid_hex}"))?;

--- a/src/bridge_out.rs
+++ b/src/bridge_out.rs
@@ -1142,11 +1142,15 @@ impl BridgeOutScanner {
                 // register-faucet CONFIG (public since 0.16, which is why the
                 // pre-0.16 two-root allowlist started false-alerting on init),
                 // UPDATE_GER, and the new REMOVE_GER / DEREGISTER_AGG_FAUCET.
-                let admin_roots: [[u8; 32]; 4] = [
+                // #201: on a fee-charging chain the bridge is P2ID-fundable and
+                // consumes its fee-asset funding note (creation + top-ups) —
+                // canonical, not a wrapper; it advances no LET.
+                let admin_roots: [[u8; 32]; 5] = [
                     miden_base_agglayer::ConfigAggBridgeNote::script_root().as_bytes(),
                     miden_base_agglayer::UpdateGerNote::script_root().as_bytes(),
                     miden_base_agglayer::RemoveGerNote::script_root().as_bytes(),
                     miden_base_agglayer::DeregisterAggFaucetNote::script_root().as_bytes(),
+                    miden_standards::note::P2idNote::script_root().as_bytes(),
                 ];
                 let observed_bytes = note.details().script().root().as_bytes();
                 use crate::unknown_wrapper_detector::{
@@ -1708,26 +1712,26 @@ impl BridgeOutScanner {
             // The Ownable2Step component stores the owner AccountId at a
             // named slot. Upstream exposes `owner_account_id` returning
             // `Err(OwnershipRenounced)` for the renounced case.
-            let observed: Option<AccountId> =
-                match miden_base_agglayer::AggLayerFaucet::owner_account_id(&acct) {
-                    Ok(id) => Some(id),
-                    Err(miden_base_agglayer::AgglayerFaucetError::OwnershipRenounced) => None,
-                    Err(e) => {
-                        // Classification already proved this IS an AggLayer
-                        // faucet, so a decode failure here means the monitor
-                        // cannot see a faucet it is responsible for. Loud.
-                        Self::count_ownership_unchecked(entry.faucet_id, "undecodable");
-                        tracing::error!(
-                            target: "bridge_out::ownership",
-                            faucet_id = %entry.faucet_id,
-                            error = ?e,
-                            "Cantina #4: AggLayer faucet owner failed to decode — the ownership \
-                             monitor is BLIND for this faucet (upstream storage layout or code \
-                             commitment change?)"
-                        );
-                        continue;
-                    }
-                };
+            let observed: Option<AccountId> = match crate::network_accounts::owner_account_id(&acct)
+            {
+                Ok(id) => Some(id),
+                Err(miden_base_agglayer::AgglayerFaucetError::OwnershipRenounced) => None,
+                Err(e) => {
+                    // Classification already proved this IS an AggLayer
+                    // faucet, so a decode failure here means the monitor
+                    // cannot see a faucet it is responsible for. Loud.
+                    Self::count_ownership_unchecked(entry.faucet_id, "undecodable");
+                    tracing::error!(
+                        target: "bridge_out::ownership",
+                        faucet_id = %entry.faucet_id,
+                        error = ?e,
+                        "Cantina #4: AggLayer faucet owner failed to decode — the ownership \
+                         monitor is BLIND for this faucet (upstream storage layout or code \
+                         commitment change?)"
+                    );
+                    continue;
+                }
+            };
             metrics::counter!("bridge_faucet_ownership_checked_total").increment(1);
             match crate::faucet_ownership_monitor::check_faucet_owner(
                 self.bridge_account_id,

--- a/src/faucet_ops.rs
+++ b/src/faucet_ops.rs
@@ -107,17 +107,23 @@ pub async fn create_and_register_faucet(
     .map_err(|e| anyhow::anyhow!("faucet account build failed: {e}"))?;
     client.add_account(&account, false).await?;
 
-    // Deploy (#201): on a fee-charging chain the faucet is a keyless account
-    // that pays its own deploy fee, so `service` cascade-funds it first and the
-    // deploy CONSUMES that note; a zero-fee chain keeps the empty-txn deploy.
+    // Deploy (#201): a zero-fee chain keeps the empty-txn deploy. On a
+    // fee-charging chain a faucet is a keyless NETWORK account: it cannot pay an
+    // empty deploy from an empty vault, nor consume a P2ID (no receive_asset) —
+    // its vault is funded only by a FeeSponsorshipNote paired with a feature
+    // note it accepts, which is the #201 follow-up; until then this fails loudly
+    // with that reason instead of aborting in the kernel.
     let fee = crate::fee_funding::fee_snapshot(client).await?;
     crate::fee_funding::deploy_account(
         client,
         account.id(),
         symbol,
+        crate::fee_funding::DeployKind::NetworkAccount {
+            funder: service_id,
+            feature_script_root: miden_standards::note::MintNote::script_root(),
+        },
         crate::metrics::ProofKind::Faucet,
         &fee,
-        Some(service_id),
         std::time::Duration::from_secs(120),
     )
     .await?;

--- a/src/faucet_ops.rs
+++ b/src/faucet_ops.rs
@@ -107,30 +107,20 @@ pub async fn create_and_register_faucet(
     .map_err(|e| anyhow::anyhow!("faucet account build failed: {e}"))?;
     client.add_account(&account, false).await?;
 
-    // Deploy
-    tracing::info!(
-        "deploying {} faucet {} ...",
-        symbol,
-        AccountIdBech32(account.id())
-    );
-    let dummy_txn = TransactionRequestBuilder::new().build()?;
-    let txn_id = crate::metrics::meter_proof(
-        crate::metrics::ProofKind::Faucet,
-        crate::miden_client::submit_new_transaction(client, account.id(), dummy_txn),
-    )
-    .await?;
-    tracing::info!("deployed {symbol} faucet with txn_id {txn_id}");
-
-    let committed = crate::miden_client::wait_for_transaction_commit(
+    // Deploy (#201): on a fee-charging chain the faucet is a keyless account
+    // that pays its own deploy fee, so `service` cascade-funds it first and the
+    // deploy CONSUMES that note; a zero-fee chain keeps the empty-txn deploy.
+    let fee = crate::fee_funding::fee_snapshot(client).await?;
+    crate::fee_funding::deploy_account(
         client,
-        txn_id,
-        20,
-        std::time::Duration::from_secs(1),
+        account.id(),
+        symbol,
+        crate::metrics::ProofKind::Faucet,
+        &fee,
+        Some(service_id),
+        std::time::Duration::from_secs(120),
     )
     .await?;
-    if committed {
-        tracing::info!("deploy tx {txn_id} committed");
-    }
 
     // Register in bridge
     register_faucet_in_bridge(

--- a/src/faucet_ops.rs
+++ b/src/faucet_ops.rs
@@ -8,7 +8,7 @@ use crate::metadata_recovery::{EmitMetadata, FaucetConversion, recover_bridge_ou
 use crate::miden_client::MidenClientLib;
 use crate::store::FaucetEntry;
 use alloy::primitives::{Address, Bytes};
-use miden_base_agglayer::{AggLayerFaucet, ConfigAggBridgeNote, ConversionMetadata, MetadataHash};
+use miden_base_agglayer::{ConfigAggBridgeNote, ConversionMetadata, MetadataHash};
 use miden_client::Felt;
 use miden_client::asset::FungibleAsset;
 use miden_client::crypto::FeltRng;
@@ -40,7 +40,7 @@ pub fn classify_faucet_account(
     faucet_account: &Account,
 ) -> anyhow::Result<(FaucetKind, FungibleFaucet)> {
     // Supported #1: bridge-owned AggLayer wrapped faucet (foreign-origin tokens).
-    if let Ok(faucet) = AggLayerFaucet::try_faucet_from_account(faucet_account) {
+    if let Ok(faucet) = crate::network_accounts::try_faucet_from_account(faucet_account) {
         return Ok((FaucetKind::AggLayerOwned, faucet));
     }
     // Supported #2: native operator BasicFungibleFaucet (Miden-originated tokens). It lacks

--- a/src/faucet_ops.rs
+++ b/src/faucet_ops.rs
@@ -90,7 +90,7 @@ pub async fn create_and_register_faucet(
     // carries the mandatory zero-fee components against the chain's real fee
     // faucet.
     let fee_faucet_id = crate::fee_policy::fee_faucet_id_from_chain(client).await?;
-    let account = AggLayerFaucet::account_builder(
+    let account = crate::network_accounts::faucet_account_builder(
         client.rng().draw_word(),
         symbol,
         miden_decimals,
@@ -98,11 +98,8 @@ pub async fn create_and_register_faucet(
         Felt::new(0).expect("zero is a valid field element"),
         service_id,
         bridge_id,
-        crate::fee_policy::zero_fee_policy_manager_for(
-            AggLayerFaucet::allowed_notes(),
-            fee_faucet_id,
-        ),
-    )
+        fee_faucet_id,
+    )?
     .build()
     .map_err(|e| anyhow::anyhow!("faucet account build failed: {e}"))?;
     client.add_account(&account, false).await?;
@@ -118,10 +115,7 @@ pub async fn create_and_register_faucet(
         client,
         account.id(),
         symbol,
-        crate::fee_funding::DeployKind::NetworkAccount {
-            funder: service_id,
-            feature_script_root: miden_standards::note::MintNote::script_root(),
-        },
+        crate::fee_funding::DeployKind::NetworkAccount { funder: service_id },
         crate::metrics::ProofKind::Faucet,
         &fee,
         std::time::Duration::from_secs(120),

--- a/src/fee_funding.rs
+++ b/src/fee_funding.rs
@@ -87,7 +87,10 @@ pub fn max_fee_per_txn(verification_base_fee: u32) -> u64 {
 /// A transaction budget, overridable per account through the environment so the
 /// fee-exhaustion e2e can start an account nearly dry (`FEE_TXN_BUDGET_<NAME>`).
 fn budget(env: &str, default: u64) -> u64 {
-    std::env::var(env).ok().and_then(|v| v.parse().ok()).unwrap_or(default)
+    std::env::var(env)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
 }
 
 /// Recommended fee-asset funding for `ger_manager`.
@@ -106,7 +109,8 @@ pub fn recommended_service(fee: &FeeSnapshot) -> u64 {
 
 /// What `service` sends each keyless account it funds.
 pub fn cascade_amount(fee: &FeeSnapshot) -> u64 {
-    max_fee_per_txn(fee.verification_base_fee) * budget("FEE_TXN_BUDGET_CASCADE", CASCADE_TXN_BUDGET)
+    max_fee_per_txn(fee.verification_base_fee)
+        * budget("FEE_TXN_BUDGET_CASCADE", CASCADE_TXN_BUDGET)
 }
 
 fn carries_fee_asset(note: &Note, fee: &FeeSnapshot) -> bool {
@@ -118,6 +122,31 @@ fn carries_fee_asset(note: &Note, fee: &FeeSnapshot) -> bool {
 /// Poll until `account_id` has at least one consumable note carrying the fee
 /// asset, syncing between polls. The first miss logs the exact funding
 /// instruction so an operator watching the log knows what to send where.
+/// Consume every pending fee-asset note addressed to `account_id` (a top-up).
+/// Nobody else would: the ntx-builder only executes network notes, and a
+/// wallet's proxy-side transactions never look for stray P2IDs. The consumed
+/// note pays for its own consume, so this works on an empty vault too.
+pub async fn consume_fee_notes(
+    client: &mut MidenClientLib,
+    account_id: AccountId,
+    fee: &FeeSnapshot,
+) -> anyhow::Result<usize> {
+    let mut notes = Vec::new();
+    for (record, _) in client.get_consumable_notes(Some(account_id)).await? {
+        if let Ok(note) = Note::try_from(record)
+            && carries_fee_asset(&note, fee)
+        {
+            notes.push(note);
+        }
+    }
+    let n = notes.len();
+    if n > 0 {
+        let request = TransactionRequestBuilder::new().build_consume_notes(notes)?;
+        crate::miden_client::submit_new_transaction(client, account_id, request).await?;
+    }
+    Ok(n)
+}
+
 pub async fn wait_for_funding_notes(
     client: &mut MidenClientLib,
     account_id: AccountId,

--- a/src/fee_funding.rs
+++ b/src/fee_funding.rs
@@ -1,0 +1,300 @@
+//! Fee-asset funding for the proxy's on-chain accounts (#201).
+//!
+//! Protocol 0.16 charges `verification_base_fee × (ilog2(cycles) + 1)` on EVERY
+//! transaction, paid by the EXECUTING account from ITS OWN vault in the chain's
+//! native fee asset. Miden has no gas-paying EOA: a signing key only
+//! *authorizes*; the account pays. So every account that executes — `service`,
+//! `ger_manager`, the bridge, every faucet — needs the fee asset in its vault,
+//! including the keyless ones that only the two KMS keys authorize.
+//!
+//! Model — fund only the KMS keys, cascade the rest:
+//!   1. `--print-funding` builds + persists `service`/`ger_manager`, writes
+//!      `funding.toml` (their addresses, the fee asset, recommended amounts) and
+//!      exits without deploying.
+//!   2. The operator funds JUST those two (fee asset sent as P2ID notes).
+//!   3. `--init` resumes from the manifest. Each account's deploy CONSUMES its
+//!      funding note — the vault is populated before the fee is deducted, so the
+//!      deploy pays for itself — and `service` then cascade-funds the keyless
+//!      bridge and faucets the same way. A zero-fee chain keeps the old
+//!      empty-transaction deploy, unchanged.
+//!
+//! Custody is untouched: the cascade sends are signed by `service`'s (possibly
+//! remote/KMS) key exactly like its claims. Minting the fee asset is NOT done
+//! here — that is the operator's job (or, in e2e, `bridge-out-tool
+//! --fund-fee-asset`, local custody by design).
+
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, anyhow};
+use miden_client::transaction::{PaymentNoteDescription, TransactionRequestBuilder};
+use miden_protocol::MAX_TX_EXECUTION_CYCLES;
+use miden_protocol::account::AccountId;
+use miden_protocol::asset::{Asset, FungibleAsset};
+use miden_protocol::block::BlockNumber;
+use miden_protocol::note::{Note, NoteType};
+
+use crate::accounts_config::AccountIdBech32;
+use crate::metrics::ProofKind;
+use crate::miden_client::MidenClientLib;
+
+/// Transactions of fee headroom recommended per KMS-keyed account
+/// (`ger_manager` pays on every GER injection, `service` on every claim).
+pub const KMS_ACCOUNT_TXN_BUDGET: u64 = 256;
+/// Fee headroom cascaded to each keyless account (bridge, faucet) at deploy.
+pub const CASCADE_TXN_BUDGET: u64 = 64;
+/// Keyless accounts `--init` cascade-funds from `service`: the bridge and the
+/// ETH faucet. Later faucets are cascade-funded at runtime as tokens appear.
+pub const INIT_CASCADE_TARGETS: u64 = 2;
+const FUNDING_POLL: Duration = Duration::from_secs(5);
+
+/// The chain's fee parameters, read from the genesis header (constant for the
+/// chain's lifetime; the sync-height header is the fallback, as in `fee_policy`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FeeSnapshot {
+    pub verification_base_fee: u32,
+    pub fee_faucet_id: AccountId,
+}
+
+impl FeeSnapshot {
+    pub fn charges_fees(&self) -> bool {
+        self.verification_base_fee > 0
+    }
+}
+
+pub async fn fee_snapshot(client: &mut MidenClientLib) -> anyhow::Result<FeeSnapshot> {
+    for block in [BlockNumber::GENESIS, client.get_sync_height().await?] {
+        if let Some((header, _)) = client.get_block_header_by_num(block).await? {
+            let p = header.fee_parameters();
+            return Ok(FeeSnapshot {
+                verification_base_fee: p.verification_base_fee(),
+                fee_faucet_id: p.fee_faucet_id(),
+            });
+        }
+    }
+    anyhow::bail!(
+        "no block header available locally (genesis or sync height) — cannot read the chain \
+         fee parameters; sync the client first"
+    )
+}
+
+/// Worst-case fee of ONE transaction. The kernel charges
+/// `verification_base_fee × (ilog2(total_cycles) + 1)` and cycles are bounded by
+/// `MAX_TX_EXECUTION_CYCLES`, so this bounds any single transaction's fee.
+pub fn max_fee_per_txn(verification_base_fee: u32) -> u64 {
+    u64::from(verification_base_fee) * u64::from(MAX_TX_EXECUTION_CYCLES.ilog2() + 1)
+}
+
+/// Recommended fee-asset funding for `ger_manager`.
+pub fn recommended_ger_manager(fee: &FeeSnapshot) -> u64 {
+    max_fee_per_txn(fee.verification_base_fee) * KMS_ACCOUNT_TXN_BUDGET
+}
+
+/// Recommended fee-asset funding for `service`: its own budget PLUS everything
+/// it cascades to the keyless accounts at init.
+pub fn recommended_service(fee: &FeeSnapshot) -> u64 {
+    let per = max_fee_per_txn(fee.verification_base_fee);
+    per * KMS_ACCOUNT_TXN_BUDGET + per * CASCADE_TXN_BUDGET * INIT_CASCADE_TARGETS
+}
+
+/// What `service` sends each keyless account it funds.
+pub fn cascade_amount(fee: &FeeSnapshot) -> u64 {
+    max_fee_per_txn(fee.verification_base_fee) * CASCADE_TXN_BUDGET
+}
+
+fn carries_fee_asset(note: &Note, fee: &FeeSnapshot) -> bool {
+    note.assets()
+        .iter()
+        .any(|a| matches!(a, Asset::Fungible(f) if f.faucet_id() == fee.fee_faucet_id))
+}
+
+/// Poll until `account_id` has at least one consumable note carrying the fee
+/// asset, syncing between polls. The first miss logs the exact funding
+/// instruction so an operator watching the log knows what to send where.
+pub async fn wait_for_funding_notes(
+    client: &mut MidenClientLib,
+    account_id: AccountId,
+    name: &str,
+    fee: &FeeSnapshot,
+    wait: Duration,
+) -> anyhow::Result<Vec<Note>> {
+    let deadline = Instant::now() + wait;
+    let mut announced = false;
+    loop {
+        client.sync_state().await?;
+        let mut notes = Vec::new();
+        for (record, _) in client.get_consumable_notes(Some(account_id)).await? {
+            let note: Note = record
+                .try_into()
+                .map_err(|e| anyhow!("consumable note for {name} is not a full note: {e:?}"))?;
+            if carries_fee_asset(&note, fee) {
+                notes.push(note);
+            }
+        }
+        if !notes.is_empty() {
+            tracing::info!(
+                account = name,
+                account_id = %AccountIdBech32(account_id),
+                notes = notes.len(),
+                "fee-asset funding note(s) found; deploying by consuming them (#201)"
+            );
+            return Ok(notes);
+        }
+        let instruction = format!(
+            "{name} account {} holds no fee-asset funding note. This chain charges fees \
+             (verification_base_fee = {}); send it at least {} units of the native fee asset \
+             {} as a P2ID note (see funding.toml / --print-funding, #201)",
+            AccountIdBech32(account_id),
+            fee.verification_base_fee,
+            max_fee_per_txn(fee.verification_base_fee) * CASCADE_TXN_BUDGET,
+            fee.fee_faucet_id.to_hex(),
+        );
+        if Instant::now() >= deadline {
+            anyhow::bail!("{instruction}; gave up after {wait:?} (--funding-wait-secs)");
+        }
+        if !announced {
+            tracing::warn!("{instruction}; waiting up to {wait:?}");
+            announced = true;
+        }
+        tokio::time::sleep(FUNDING_POLL).await;
+    }
+}
+
+/// `service` sends `amount` of the fee asset to `target` as a public P2ID note
+/// — the cascade step. Signed by `service`'s key like any of its transactions.
+pub async fn fund_from_service(
+    client: &mut MidenClientLib,
+    service_id: AccountId,
+    target: AccountId,
+    name: &str,
+    amount: u64,
+    fee: &FeeSnapshot,
+) -> anyhow::Result<()> {
+    let asset = Asset::Fungible(
+        FungibleAsset::new(fee.fee_faucet_id, amount)
+            .map_err(|e| anyhow!("fee asset {amount} for {name}: {e:?}"))?,
+    );
+    let request = TransactionRequestBuilder::new()
+        .build_pay_to_id(
+            PaymentNoteDescription::new(vec![asset], service_id, target),
+            NoteType::Public,
+            client.rng(),
+        )
+        .map_err(|e| anyhow!("building fee-asset P2ID from service to {name}: {e:?}"))?;
+    tracing::info!(
+        target = name,
+        target_id = %AccountIdBech32(target),
+        amount,
+        "cascade-funding from service (#201)"
+    );
+    let txn_id = crate::metrics::meter_proof(
+        ProofKind::Init,
+        crate::miden_client::submit_new_transaction(client, service_id, request),
+    )
+    .await
+    .with_context(|| format!("service could not fund {name} (is service itself funded?)"))?;
+    crate::miden_client::wait_for_transaction_commit(client, txn_id, 30, Duration::from_secs(2))
+        .await?;
+    client.sync_state().await?;
+    Ok(())
+}
+
+/// Deploy `account_id` on-chain.
+///
+/// Zero-fee chain: an empty transaction anchors the account (the historical
+/// behaviour, unchanged). Fee-charging chain: the deploy CONSUMES the account's
+/// fee-asset funding note(s) — cascaded from `funder` (`service`) first when
+/// given — so the very transaction that deploys the account also funds it.
+pub async fn deploy_account(
+    client: &mut MidenClientLib,
+    account_id: AccountId,
+    name: &str,
+    kind: ProofKind,
+    fee: &FeeSnapshot,
+    funder: Option<AccountId>,
+    wait: Duration,
+) -> anyhow::Result<()> {
+    tracing::info!(
+        "deploying {} account {} ...",
+        name,
+        AccountIdBech32(account_id)
+    );
+    let request = if !fee.charges_fees() {
+        TransactionRequestBuilder::new().build()?
+    } else {
+        if let Some(service_id) = funder {
+            fund_from_service(
+                client,
+                service_id,
+                account_id,
+                name,
+                cascade_amount(fee),
+                fee,
+            )
+            .await?;
+        }
+        let notes = wait_for_funding_notes(client, account_id, name, fee, wait).await?;
+        TransactionRequestBuilder::new()
+            .build_consume_notes(notes)
+            .map_err(|e| anyhow!("building funding-note consumption for {name}: {e:?}"))?
+    };
+    let txn_id = crate::metrics::meter_proof(
+        kind,
+        crate::miden_client::submit_new_transaction(client, account_id, request),
+    )
+    .await?;
+    tracing::info!("deployed {name} account with txn_id {txn_id}");
+
+    let committed = crate::miden_client::wait_for_transaction_commit(
+        client,
+        txn_id,
+        20,
+        Duration::from_secs(1),
+    )
+    .await?;
+    if committed {
+        tracing::info!("deploy tx {txn_id} committed");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fee(base: u32) -> FeeSnapshot {
+        FeeSnapshot {
+            verification_base_fee: base,
+            fee_faucet_id: AccountId::from_hex("0x18101fa522c174b165efd4f70a0385").unwrap(),
+        }
+    }
+
+    #[test]
+    fn zero_base_fee_means_no_funding() {
+        assert!(!fee(0).charges_fees());
+        assert_eq!(max_fee_per_txn(0), 0);
+        assert_eq!(recommended_service(&fee(0)), 0);
+        assert_eq!(recommended_ger_manager(&fee(0)), 0);
+    }
+
+    /// The live testnet charges base fee 7. The kernel fee is
+    /// `base × (ilog2(cycles)+1)`, bounded by MAX_TX_EXECUTION_CYCLES, so the
+    /// per-txn bound is `7 × (ilog2(MAX)+1)` and the budgets scale from it.
+    #[test]
+    fn testnet_base_fee_7_amounts() {
+        let f = fee(7);
+        let per = 7 * u64::from(MAX_TX_EXECUTION_CYCLES.ilog2() + 1);
+        assert_eq!(max_fee_per_txn(7), per);
+        assert_eq!(recommended_ger_manager(&f), per * KMS_ACCOUNT_TXN_BUDGET);
+        assert_eq!(cascade_amount(&f), per * CASCADE_TXN_BUDGET);
+        assert_eq!(
+            recommended_service(&f),
+            per * KMS_ACCOUNT_TXN_BUDGET + per * CASCADE_TXN_BUDGET * INIT_CASCADE_TARGETS
+        );
+        // service must be able to fund every init cascade target out of its own
+        // recommendation and still keep its full personal budget.
+        assert!(
+            recommended_service(&f)
+                >= recommended_ger_manager(&f) + cascade_amount(&f) * INIT_CASCADE_TARGETS
+        );
+    }
+}

--- a/src/fee_funding.rs
+++ b/src/fee_funding.rs
@@ -26,15 +26,12 @@
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, anyhow};
-use miden_client::crypto::FeltRng;
-use miden_client::note::NoteScriptRoot;
 use miden_client::transaction::{PaymentNoteDescription, TransactionRequestBuilder};
 use miden_protocol::MAX_TX_EXECUTION_CYCLES;
 use miden_protocol::account::AccountId;
 use miden_protocol::asset::{Asset, FungibleAsset};
 use miden_protocol::block::BlockNumber;
 use miden_protocol::note::{Note, NoteType};
-use miden_standards::note::{ConstantFeePolicyConfigNote, FeeSponsorshipNote};
 
 use crate::accounts_config::AccountIdBech32;
 use crate::metrics::ProofKind;
@@ -201,115 +198,18 @@ pub async fn fund_from_service(
     Ok(())
 }
 
-/// What kind of account is being deployed — it decides how its deploy can pay
-/// its fee on a fee-charging chain.
-#[derive(Debug, Clone)]
+/// What kind of account is being deployed — it decides who funds its
+/// creation on a fee-charging chain. Both kinds are P2ID-fundable and deploy
+/// by consuming that note (see `network_accounts` for why the bridge and the
+/// faucets can be).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeployKind {
-    /// A `BasicWallet` (service, ger_manager): can consume a P2ID funding note,
-    /// so the deploy IS the consumption of that note.
+    /// A `BasicWallet` (service, ger_manager): funded by the OPERATOR (the
+    /// `fee-funder` in e2e); the deploy waits for that note.
     Wallet,
-    /// A network account (bridge, faucet: `AuthNetworkAccount`). It has no
-    /// `receive_asset`, so it can NOT consume a P2ID (kernel: "procedure root …
-    /// is not in the account procedure index map"); its vault is filled only by
-    /// a `FeeSponsorshipNote` bound to a feature note it accepts, consumed in the
-    /// same transaction. So `funder` (service) emits a harmless feature note —
-    /// a `ConstantFeePolicyConfigNote` re-scheduling the zero fee the account
-    /// already has for `feature_script_root` — plus a sponsorship bound to it,
-    /// and the account's first transaction consumes both: that transaction
-    /// funds the vault, pays its own kernel fee from it, and deploys the
-    /// account.
-    NetworkAccount {
-        funder: AccountId,
-        feature_script_root: NoteScriptRoot,
-    },
-}
-
-/// Bootstrap a NETWORK account on a fee-charging chain (#201): see
-/// [`DeployKind::NetworkAccount`]. The target is deliberately NOT declared as a
-/// foreign account on the funder's request — it is not deployed yet, so there
-/// is no on-chain state to pin; the sponsorship note carries no attachment and
-/// needs none, the config note carries the `NetworkAccountTarget` the account's
-/// script checks on consumption.
-pub async fn bootstrap_network_account(
-    client: &mut MidenClientLib,
-    funder: AccountId,
-    target: AccountId,
-    name: &str,
-    feature_script_root: NoteScriptRoot,
-    proof: ProofKind,
-    fee: &FeeSnapshot,
-) -> anyhow::Result<()> {
-    let amount = cascade_amount(fee);
-    let zero_fee = FungibleAsset::new(fee.fee_faucet_id, 0)
-        .map_err(|e| anyhow!("zero fee asset for {name}: {e:?}"))?;
-    let config: Note = ConstantFeePolicyConfigNote::builder()
-        .sender(funder)
-        .target(target)
-        .note_script_root(feature_script_root)
-        .fee_asset(zero_fee)
-        .serial_number(client.rng().draw_word())
-        .build()
-        .map_err(|e| anyhow!("building the bootstrap config note for {name}: {e:?}"))?
-        .into();
-    let sponsorship: Note = FeeSponsorshipNote::builder()
-        .sender(funder)
-        .target_account(target)
-        .feature_note_id(config.id())
-        .asset(Asset::Fungible(
-            FungibleAsset::new(fee.fee_faucet_id, amount)
-                .map_err(|e| anyhow!("sponsorship asset {amount} for {name}: {e:?}"))?,
-        ))
-        .generate_serial_number(client.rng())
-        .build()
-        .map_err(|e| anyhow!("building the sponsorship note for {name}: {e:?}"))?
-        .into();
-    tracing::info!(
-        target = name,
-        target_id = %AccountIdBech32(target),
-        amount,
-        config_note = %config.id(),
-        sponsorship_note = %sponsorship.id(),
-        "bootstrapping network account: funder emits config + sponsorship notes (#201)"
-    );
-    let request = TransactionRequestBuilder::new()
-        .own_output_notes(vec![config.clone(), sponsorship.clone()])
-        .build()
-        .map_err(|e| anyhow!("building the bootstrap send for {name}: {e:?}"))?;
-    let txn_id = crate::metrics::meter_proof(
-        proof,
-        crate::miden_client::submit_new_transaction(client, funder, request),
-    )
-    .await
-    .with_context(|| format!("funder could not emit the bootstrap notes for {name}"))?;
-    crate::miden_client::wait_for_transaction_commit(client, txn_id, 30, Duration::from_secs(2))
-        .await?;
-    client.sync_state().await?;
-
-    tracing::info!(
-        "deploying {} account {} by consuming its bootstrap notes ...",
-        name,
-        AccountIdBech32(target)
-    );
-    let request = TransactionRequestBuilder::new()
-        .build_consume_notes(vec![config, sponsorship])
-        .map_err(|e| anyhow!("building the bootstrap consumption for {name}: {e:?}"))?;
-    let txn_id = crate::metrics::meter_proof(
-        proof,
-        crate::miden_client::submit_new_transaction(client, target, request),
-    )
-    .await?;
-    tracing::info!("deployed {name} account with txn_id {txn_id}");
-    let committed = crate::miden_client::wait_for_transaction_commit(
-        client,
-        txn_id,
-        20,
-        Duration::from_secs(1),
-    )
-    .await?;
-    if committed {
-        tracing::info!("deploy tx {txn_id} committed");
-    }
-    Ok(())
+    /// A network account (bridge, faucet): `funder` (service) cascade-sends
+    /// the P2ID first, then the deploy consumes it.
+    NetworkAccount { funder: AccountId },
 }
 
 /// Deploy `account_id` on-chain.
@@ -317,9 +217,9 @@ pub async fn bootstrap_network_account(
 /// Zero-fee chain: an empty transaction anchors the account (the historical
 /// behaviour, unchanged, for every kind). Fee-charging chain: a wallet's deploy
 /// CONSUMES its fee-asset funding note(s), so the very transaction that
-/// deploys the account also funds it; a network account cannot be deployed
-/// that way (see [`DeployKind::NetworkAccount`]) and this fails loudly with the
-/// reason rather than aborting inside the kernel. An account that is already
+/// deploys the account also funds it — for a network account after `funder`
+/// cascade-sends that note (see [`DeployKind::NetworkAccount`]). An account
+/// that is already
 /// on-chain (a resumed `--init`) is skipped: its funding note was consumed by
 /// the deploy that put it there.
 pub async fn deploy_account(
@@ -347,21 +247,8 @@ pub async fn deploy_account(
             );
             return Ok(());
         }
-        if let DeployKind::NetworkAccount {
-            funder,
-            feature_script_root,
-        } = &kind
-        {
-            return bootstrap_network_account(
-                client,
-                *funder,
-                account_id,
-                name,
-                *feature_script_root,
-                proof,
-                fee,
-            )
-            .await;
+        if let DeployKind::NetworkAccount { funder } = kind {
+            fund_from_service(client, funder, account_id, name, cascade_amount(fee), fee).await?;
         }
     }
     tracing::info!(

--- a/src/fee_funding.rs
+++ b/src/fee_funding.rs
@@ -45,6 +45,11 @@ pub const CASCADE_TXN_BUDGET: u64 = 64;
 /// Keyless accounts `--init` cascade-funds from `service`: the bridge and the
 /// ETH faucet. Later faucets are cascade-funded at runtime as tokens appear.
 pub const INIT_CASCADE_TARGETS: u64 = 2;
+/// How many cascades `service` is funded for up front: the two init targets plus
+/// runtime faucets (one per new token bridged in). Loadtest N=30 (9 new tokens)
+/// ran `service` dry after four; the real answer for an unbounded token count is
+/// the fee-vault monitor and top-ups, this just makes the common case not stall.
+pub const CASCADE_RESERVE_TARGETS: u64 = INIT_CASCADE_TARGETS + 10;
 const FUNDING_POLL: Duration = Duration::from_secs(5);
 
 /// The chain's fee parameters, read from the genesis header (constant for the
@@ -104,7 +109,7 @@ pub fn recommended_ger_manager(fee: &FeeSnapshot) -> u64 {
 pub fn recommended_service(fee: &FeeSnapshot) -> u64 {
     let per = max_fee_per_txn(fee.verification_base_fee);
     per * budget("FEE_TXN_BUDGET_SERVICE", KMS_ACCOUNT_TXN_BUDGET)
-        + cascade_amount(fee) * INIT_CASCADE_TARGETS
+        + cascade_amount(fee) * CASCADE_RESERVE_TARGETS
 }
 
 /// What `service` sends each keyless account it funds.

--- a/src/fee_funding.rs
+++ b/src/fee_funding.rs
@@ -84,21 +84,29 @@ pub fn max_fee_per_txn(verification_base_fee: u32) -> u64 {
     u64::from(verification_base_fee) * u64::from(MAX_TX_EXECUTION_CYCLES.ilog2() + 1)
 }
 
+/// A transaction budget, overridable per account through the environment so the
+/// fee-exhaustion e2e can start an account nearly dry (`FEE_TXN_BUDGET_<NAME>`).
+fn budget(env: &str, default: u64) -> u64 {
+    std::env::var(env).ok().and_then(|v| v.parse().ok()).unwrap_or(default)
+}
+
 /// Recommended fee-asset funding for `ger_manager`.
 pub fn recommended_ger_manager(fee: &FeeSnapshot) -> u64 {
-    max_fee_per_txn(fee.verification_base_fee) * KMS_ACCOUNT_TXN_BUDGET
+    max_fee_per_txn(fee.verification_base_fee)
+        * budget("FEE_TXN_BUDGET_GER_MANAGER", KMS_ACCOUNT_TXN_BUDGET)
 }
 
 /// Recommended fee-asset funding for `service`: its own budget PLUS everything
 /// it cascades to the keyless accounts at init.
 pub fn recommended_service(fee: &FeeSnapshot) -> u64 {
     let per = max_fee_per_txn(fee.verification_base_fee);
-    per * KMS_ACCOUNT_TXN_BUDGET + per * CASCADE_TXN_BUDGET * INIT_CASCADE_TARGETS
+    per * budget("FEE_TXN_BUDGET_SERVICE", KMS_ACCOUNT_TXN_BUDGET)
+        + cascade_amount(fee) * INIT_CASCADE_TARGETS
 }
 
 /// What `service` sends each keyless account it funds.
 pub fn cascade_amount(fee: &FeeSnapshot) -> u64 {
-    max_fee_per_txn(fee.verification_base_fee) * CASCADE_TXN_BUDGET
+    max_fee_per_txn(fee.verification_base_fee) * budget("FEE_TXN_BUDGET_CASCADE", CASCADE_TXN_BUDGET)
 }
 
 fn carries_fee_asset(note: &Note, fee: &FeeSnapshot) -> bool {

--- a/src/fee_funding.rs
+++ b/src/fee_funding.rs
@@ -26,12 +26,15 @@
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, anyhow};
+use miden_client::crypto::FeltRng;
+use miden_client::note::NoteScriptRoot;
 use miden_client::transaction::{PaymentNoteDescription, TransactionRequestBuilder};
 use miden_protocol::MAX_TX_EXECUTION_CYCLES;
 use miden_protocol::account::AccountId;
 use miden_protocol::asset::{Asset, FungibleAsset};
 use miden_protocol::block::BlockNumber;
 use miden_protocol::note::{Note, NoteType};
+use miden_standards::note::{ConstantFeePolicyConfigNote, FeeSponsorshipNote};
 
 use crate::accounts_config::AccountIdBech32;
 use crate::metrics::ProofKind;
@@ -198,21 +201,169 @@ pub async fn fund_from_service(
     Ok(())
 }
 
+/// What kind of account is being deployed — it decides how its deploy can pay
+/// its fee on a fee-charging chain.
+#[derive(Debug, Clone)]
+pub enum DeployKind {
+    /// A `BasicWallet` (service, ger_manager): can consume a P2ID funding note,
+    /// so the deploy IS the consumption of that note.
+    Wallet,
+    /// A network account (bridge, faucet: `AuthNetworkAccount`). It has no
+    /// `receive_asset`, so it can NOT consume a P2ID (kernel: "procedure root …
+    /// is not in the account procedure index map"); its vault is filled only by
+    /// a `FeeSponsorshipNote` bound to a feature note it accepts, consumed in the
+    /// same transaction. So `funder` (service) emits a harmless feature note —
+    /// a `ConstantFeePolicyConfigNote` re-scheduling the zero fee the account
+    /// already has for `feature_script_root` — plus a sponsorship bound to it,
+    /// and the account's first transaction consumes both: that transaction
+    /// funds the vault, pays its own kernel fee from it, and deploys the
+    /// account.
+    NetworkAccount {
+        funder: AccountId,
+        feature_script_root: NoteScriptRoot,
+    },
+}
+
+/// Bootstrap a NETWORK account on a fee-charging chain (#201): see
+/// [`DeployKind::NetworkAccount`]. The target is deliberately NOT declared as a
+/// foreign account on the funder's request — it is not deployed yet, so there
+/// is no on-chain state to pin; the sponsorship note carries no attachment and
+/// needs none, the config note carries the `NetworkAccountTarget` the account's
+/// script checks on consumption.
+pub async fn bootstrap_network_account(
+    client: &mut MidenClientLib,
+    funder: AccountId,
+    target: AccountId,
+    name: &str,
+    feature_script_root: NoteScriptRoot,
+    proof: ProofKind,
+    fee: &FeeSnapshot,
+) -> anyhow::Result<()> {
+    let amount = cascade_amount(fee);
+    let zero_fee = FungibleAsset::new(fee.fee_faucet_id, 0)
+        .map_err(|e| anyhow!("zero fee asset for {name}: {e:?}"))?;
+    let config: Note = ConstantFeePolicyConfigNote::builder()
+        .sender(funder)
+        .target(target)
+        .note_script_root(feature_script_root)
+        .fee_asset(zero_fee)
+        .serial_number(client.rng().draw_word())
+        .build()
+        .map_err(|e| anyhow!("building the bootstrap config note for {name}: {e:?}"))?
+        .into();
+    let sponsorship: Note = FeeSponsorshipNote::builder()
+        .sender(funder)
+        .target_account(target)
+        .feature_note_id(config.id())
+        .asset(Asset::Fungible(
+            FungibleAsset::new(fee.fee_faucet_id, amount)
+                .map_err(|e| anyhow!("sponsorship asset {amount} for {name}: {e:?}"))?,
+        ))
+        .generate_serial_number(client.rng())
+        .build()
+        .map_err(|e| anyhow!("building the sponsorship note for {name}: {e:?}"))?
+        .into();
+    tracing::info!(
+        target = name,
+        target_id = %AccountIdBech32(target),
+        amount,
+        config_note = %config.id(),
+        sponsorship_note = %sponsorship.id(),
+        "bootstrapping network account: funder emits config + sponsorship notes (#201)"
+    );
+    let request = TransactionRequestBuilder::new()
+        .own_output_notes(vec![config.clone(), sponsorship.clone()])
+        .build()
+        .map_err(|e| anyhow!("building the bootstrap send for {name}: {e:?}"))?;
+    let txn_id = crate::metrics::meter_proof(
+        proof,
+        crate::miden_client::submit_new_transaction(client, funder, request),
+    )
+    .await
+    .with_context(|| format!("funder could not emit the bootstrap notes for {name}"))?;
+    crate::miden_client::wait_for_transaction_commit(client, txn_id, 30, Duration::from_secs(2))
+        .await?;
+    client.sync_state().await?;
+
+    tracing::info!(
+        "deploying {} account {} by consuming its bootstrap notes ...",
+        name,
+        AccountIdBech32(target)
+    );
+    let request = TransactionRequestBuilder::new()
+        .build_consume_notes(vec![config, sponsorship])
+        .map_err(|e| anyhow!("building the bootstrap consumption for {name}: {e:?}"))?;
+    let txn_id = crate::metrics::meter_proof(
+        proof,
+        crate::miden_client::submit_new_transaction(client, target, request),
+    )
+    .await?;
+    tracing::info!("deployed {name} account with txn_id {txn_id}");
+    let committed = crate::miden_client::wait_for_transaction_commit(
+        client,
+        txn_id,
+        20,
+        Duration::from_secs(1),
+    )
+    .await?;
+    if committed {
+        tracing::info!("deploy tx {txn_id} committed");
+    }
+    Ok(())
+}
+
 /// Deploy `account_id` on-chain.
 ///
 /// Zero-fee chain: an empty transaction anchors the account (the historical
-/// behaviour, unchanged). Fee-charging chain: the deploy CONSUMES the account's
-/// fee-asset funding note(s) — cascaded from `funder` (`service`) first when
-/// given — so the very transaction that deploys the account also funds it.
+/// behaviour, unchanged, for every kind). Fee-charging chain: a wallet's deploy
+/// CONSUMES its fee-asset funding note(s), so the very transaction that
+/// deploys the account also funds it; a network account cannot be deployed
+/// that way (see [`DeployKind::NetworkAccount`]) and this fails loudly with the
+/// reason rather than aborting inside the kernel. An account that is already
+/// on-chain (a resumed `--init`) is skipped: its funding note was consumed by
+/// the deploy that put it there.
 pub async fn deploy_account(
     client: &mut MidenClientLib,
     account_id: AccountId,
     name: &str,
-    kind: ProofKind,
+    kind: DeployKind,
+    proof: ProofKind,
     fee: &FeeSnapshot,
-    funder: Option<AccountId>,
     wait: Duration,
 ) -> anyhow::Result<()> {
+    if fee.charges_fees() {
+        // Resume: --init reuses the accounts funding.toml records. One that was
+        // already deployed (nonce > 0) must not wait for a second funding note
+        // that will never come — its note was consumed by the first deploy.
+        client.sync_state().await?;
+        if let Some(account) = client.get_account(account_id).await?
+            && !account.is_new()
+        {
+            tracing::info!(
+                account = name,
+                account_id = %AccountIdBech32(account_id),
+                nonce = %account.nonce(),
+                "already deployed on-chain — skipping deploy (#201)"
+            );
+            return Ok(());
+        }
+        if let DeployKind::NetworkAccount {
+            funder,
+            feature_script_root,
+        } = &kind
+        {
+            return bootstrap_network_account(
+                client,
+                *funder,
+                account_id,
+                name,
+                *feature_script_root,
+                proof,
+                fee,
+            )
+            .await;
+        }
+    }
     tracing::info!(
         "deploying {} account {} ...",
         name,
@@ -221,24 +372,13 @@ pub async fn deploy_account(
     let request = if !fee.charges_fees() {
         TransactionRequestBuilder::new().build()?
     } else {
-        if let Some(service_id) = funder {
-            fund_from_service(
-                client,
-                service_id,
-                account_id,
-                name,
-                cascade_amount(fee),
-                fee,
-            )
-            .await?;
-        }
         let notes = wait_for_funding_notes(client, account_id, name, fee, wait).await?;
         TransactionRequestBuilder::new()
             .build_consume_notes(notes)
             .map_err(|e| anyhow!("building funding-note consumption for {name}: {e:?}"))?
     };
     let txn_id = crate::metrics::meter_proof(
-        kind,
+        proof,
         crate::miden_client::submit_new_transaction(client, account_id, request),
     )
     .await?;

--- a/src/fee_funding.rs
+++ b/src/fee_funding.rs
@@ -41,7 +41,11 @@ use crate::miden_client::MidenClientLib;
 /// (`ger_manager` pays on every GER injection, `service` on every claim).
 pub const KMS_ACCOUNT_TXN_BUDGET: u64 = 256;
 /// Fee headroom cascaded to each keyless account (bridge, faucet) at deploy.
-pub const CASCADE_TXN_BUDGET: u64 = 64;
+/// Counted in worst-case (210-unit) transactions, but a bridge network
+/// transaction really costs ~112 units, so 256 is ~480 of them: several hours
+/// at a busy bridge's 27 per ten minutes — enough for a human to act on the
+/// `txns_left` alert. 64 (≈120 transactions) ran a bridge dry in 2.5 h of e2e.
+pub const CASCADE_TXN_BUDGET: u64 = 256;
 /// Keyless accounts `--init` cascade-funds from `service`: the bridge and the
 /// ETH faucet. Later faucets are cascade-funded at runtime as tokens appear.
 pub const INIT_CASCADE_TARGETS: u64 = 2;

--- a/src/fee_funding.rs
+++ b/src/fee_funding.rs
@@ -133,9 +133,10 @@ pub async fn consume_fee_notes(
 ) -> anyhow::Result<usize> {
     let mut notes = Vec::new();
     for (record, _) in client.get_consumable_notes(Some(account_id)).await? {
-        if let Ok(note) = Note::try_from(record)
-            && carries_fee_asset(&note, fee)
-        {
+        let Ok(note) = <_ as TryInto<Note>>::try_into(record) else {
+            continue;
+        };
+        if carries_fee_asset(&note, fee) {
             notes.push(note);
         }
     }

--- a/src/fee_funding.rs
+++ b/src/fee_funding.rs
@@ -49,7 +49,10 @@ pub const INIT_CASCADE_TARGETS: u64 = 2;
 /// runtime faucets (one per new token bridged in). Loadtest N=30 (9 new tokens)
 /// ran `service` dry after four; the real answer for an unbounded token count is
 /// the fee-vault monitor and top-ups, this just makes the common case not stall.
-pub const CASCADE_RESERVE_TARGETS: u64 = INIT_CASCADE_TARGETS + 10;
+/// Env-tunable so the exhaustion e2e can leave `service` with only its own budget.
+pub fn cascade_reserve_targets() -> u64 {
+    budget("FEE_TXN_BUDGET_CASCADE_TARGETS", INIT_CASCADE_TARGETS + 10)
+}
 const FUNDING_POLL: Duration = Duration::from_secs(5);
 
 /// The chain's fee parameters, read from the genesis header (constant for the
@@ -109,7 +112,7 @@ pub fn recommended_ger_manager(fee: &FeeSnapshot) -> u64 {
 pub fn recommended_service(fee: &FeeSnapshot) -> u64 {
     let per = max_fee_per_txn(fee.verification_base_fee);
     per * budget("FEE_TXN_BUDGET_SERVICE", KMS_ACCOUNT_TXN_BUDGET)
-        + cascade_amount(fee) * CASCADE_RESERVE_TARGETS
+        + cascade_amount(fee) * cascade_reserve_targets()
 }
 
 /// What `service` sends each keyless account it funds.
@@ -358,7 +361,7 @@ mod tests {
         assert_eq!(cascade_amount(&f), per * CASCADE_TXN_BUDGET);
         assert_eq!(
             recommended_service(&f),
-            per * KMS_ACCOUNT_TXN_BUDGET + per * CASCADE_TXN_BUDGET * CASCADE_RESERVE_TARGETS
+            per * KMS_ACCOUNT_TXN_BUDGET + per * CASCADE_TXN_BUDGET * cascade_reserve_targets()
         );
         // service must be able to fund every init cascade target out of its own
         // recommendation and still keep its full personal budget.

--- a/src/fee_funding.rs
+++ b/src/fee_funding.rs
@@ -358,13 +358,13 @@ mod tests {
         assert_eq!(cascade_amount(&f), per * CASCADE_TXN_BUDGET);
         assert_eq!(
             recommended_service(&f),
-            per * KMS_ACCOUNT_TXN_BUDGET + per * CASCADE_TXN_BUDGET * INIT_CASCADE_TARGETS
+            per * KMS_ACCOUNT_TXN_BUDGET + per * CASCADE_TXN_BUDGET * CASCADE_RESERVE_TARGETS
         );
         // service must be able to fund every init cascade target out of its own
         // recommendation and still keep its full personal budget.
         assert!(
             recommended_service(&f)
-                >= recommended_ger_manager(&f) + cascade_amount(&f) * INIT_CASCADE_TARGETS
+                >= recommended_ger_manager(&f) + cascade_amount(&f) * CASCADE_RESERVE_TARGETS
         );
     }
 }

--- a/src/fee_funding.rs
+++ b/src/fee_funding.rs
@@ -367,7 +367,7 @@ mod tests {
         // recommendation and still keep its full personal budget.
         assert!(
             recommended_service(&f)
-                >= recommended_ger_manager(&f) + cascade_amount(&f) * CASCADE_RESERVE_TARGETS
+                >= recommended_ger_manager(&f) + cascade_amount(&f) * cascade_reserve_targets()
         );
     }
 }

--- a/src/fee_vault_monitor.rs
+++ b/src/fee_vault_monitor.rs
@@ -51,11 +51,7 @@ pub fn fee_balance(account: &Account, fee_faucet_id: AccountId) -> u64 {
 
 /// Conservative "transactions before empty" at the per-transaction fee cap.
 pub fn txns_left(balance: u64, max_fee: u64) -> u64 {
-    if max_fee == 0 {
-        u64::MAX
-    } else {
-        balance / max_fee
-    }
+    balance.checked_div(max_fee).unwrap_or(u64::MAX)
 }
 
 pub struct FeeVaultMonitor {

--- a/src/fee_vault_monitor.rs
+++ b/src/fee_vault_monitor.rs
@@ -153,7 +153,15 @@ impl FeeVaultMonitor {
                         // Sweep top-ups: a P2ID of the fee asset sent to this account
                         // lands only once consumed. Not for an account still being
                         // created — its cascade note is the deploy's to consume.
-                        match if account.is_new() {
+                        // Deployed network accounts (bridge, faucets) cannot be swept
+                        // from here: the node refuses user-submitted transactions for
+                        // them, the ntx-builder consumes their top-ups (the funding
+                        // tool attaches the network target). Only wallets are swept.
+                        let network = miden_standards::account::auth::NetworkAccount::new(
+                            account.clone(),
+                        )
+                        .is_ok();
+                        match if account.is_new() || network {
                             Ok(0)
                         } else {
                             crate::fee_funding::consume_fee_notes(client, id, &snap).await

--- a/src/fee_vault_monitor.rs
+++ b/src/fee_vault_monitor.rs
@@ -149,6 +149,13 @@ impl FeeVaultMonitor {
                             tracing::warn!(account = %name, id = %id.to_hex(), "fee-vault monitor: account not in the client store");
                             continue;
                         };
+                        // Sweep top-ups: a P2ID of the fee asset sent to this account
+                        // (runbook top-up, cascade, exhaustion recovery) lands only once consumed.
+                        match crate::fee_funding::consume_fee_notes(client, id, &snap).await {
+                            Ok(n) if n > 0 => tracing::info!(account = %name, notes = n, "consuming fee-asset top-up note(s) (#201)"),
+                            Ok(_) => {}
+                            Err(e) => tracing::warn!(account = %name, error = %format!("{e:#}"), "could not consume a fee-asset top-up"),
+                        }
                         let balance = fee_balance(&account, snap.fee_faucet_id);
                         let left = txns_left(balance, max_fee);
                         metrics::gauge!("bridge_fee_vault_balance", "account" => name.clone())

--- a/src/fee_vault_monitor.rs
+++ b/src/fee_vault_monitor.rs
@@ -180,6 +180,13 @@ impl FeeVaultMonitor {
                         if balance == 0 {
                             tracing::error!(account = %name, id = %id.to_hex(),
                                 "fee vault EMPTY — every transaction of this account will abort until it is topped up (#201)");
+                        } else if name == "service"
+                            && balance < crate::fee_funding::cascade_amount(&snap) + max_fee
+                        {
+                            // A cascade is a 64-tx-sized spend: service can look healthy per
+                            // transaction and still be unable to fund the next new faucet.
+                            tracing::warn!(account = %name, id = %id.to_hex(), balance,
+                                "fee vault too low to fund another faucet — the next new token's claims will fail until topped up (#201)");
                         } else if left < warn_txns {
                             tracing::warn!(account = %name, id = %id.to_hex(), balance, txns_left = left,
                                 "fee vault low — top up with a P2ID of the fee asset (#201)");

--- a/src/fee_vault_monitor.rs
+++ b/src/fee_vault_monitor.rs
@@ -1,0 +1,198 @@
+//! Fee-vault monitor (#201): exports the native fee-asset balance of every
+//! account the proxy depends on, so an operator can alert before one hits 0.
+//!
+//! On a fee-charging chain every account pays its own transaction fees from
+//! its vault — `service` on every claim, `ger_manager` on every GER injection,
+//! the bridge on every network transaction (UpdateGer, CLAIM, B2AGG…), each
+//! faucet on every MINT/BURN. An empty vault silently stalls that account
+//! (its transactions abort in the kernel). Measured at base fee 7: network
+//! transactions cost ~40–50 units, signed client transactions the 210 cap; a
+//! busy bridge ran 27 network transactions in ten minutes — so the cascade
+//! amounts are hours, not weeks, of runway, and the balance has to be watched.
+//!
+//! Gauges (labelled `account="service"|"ger_manager"|"bridge"|"faucet:<SYMBOL>"`):
+//! - `bridge_fee_vault_balance` — units of the fee asset in the vault;
+//! - `bridge_fee_vault_txns_left` — balance ÷ the per-transaction fee cap
+//!   (`verification_base_fee × (ilog2(MAX_TX_EXECUTION_CYCLES)+1)`): a
+//!   conservative "transactions before empty"; alert on this one;
+//! - `bridge_fee_max_per_txn` — that cap (0 on a zero-fee chain, where the
+//!   monitor reports once and idles).
+//!
+//! Logs WARN when an account has fewer than `warn_txns` transactions left and
+//! ERROR at 0. Read-only; the proxy's tracked client state is what is read.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use miden_protocol::account::{Account, AccountId};
+use miden_protocol::asset::Asset;
+use tokio::sync::oneshot;
+
+use crate::fee_funding::{fee_snapshot, max_fee_per_txn};
+use crate::miden_client::MidenClient;
+use crate::store::Store;
+
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(60);
+/// Default WARN threshold: transactions left at the fee cap.
+pub const DEFAULT_WARN_TXNS: u64 = 32;
+
+/// Fee-asset balance of `account`'s vault, in units (0 when absent).
+pub fn fee_balance(account: &Account, fee_faucet_id: AccountId) -> u64 {
+    account
+        .vault()
+        .assets()
+        .find_map(|asset| match asset {
+            Asset::Fungible(f) if f.faucet_id() == fee_faucet_id => Some(f.amount().as_u64()),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+/// Conservative "transactions before empty" at the per-transaction fee cap.
+pub fn txns_left(balance: u64, max_fee: u64) -> u64 {
+    if max_fee == 0 {
+        u64::MAX
+    } else {
+        balance / max_fee
+    }
+}
+
+pub struct FeeVaultMonitor {
+    miden_client: Arc<MidenClient>,
+    store: Arc<dyn Store>,
+    service: AccountId,
+    ger_manager: Option<AccountId>,
+    bridge: AccountId,
+    poll_interval: Duration,
+    warn_txns: u64,
+    /// Last observed balance per account, to log what was withdrawn between ticks.
+    last: Arc<Mutex<HashMap<String, u64>>>,
+}
+
+impl FeeVaultMonitor {
+    pub fn new(
+        miden_client: Arc<MidenClient>,
+        store: Arc<dyn Store>,
+        service: AccountId,
+        ger_manager: Option<AccountId>,
+        bridge: AccountId,
+    ) -> Self {
+        Self {
+            miden_client,
+            store,
+            service,
+            ger_manager,
+            bridge,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            warn_txns: DEFAULT_WARN_TXNS,
+            last: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn with_poll_interval(mut self, interval: Duration) -> Self {
+        self.poll_interval = interval;
+        self
+    }
+
+    pub fn with_warn_txns(mut self, warn_txns: u64) -> Self {
+        self.warn_txns = warn_txns;
+        self
+    }
+
+    /// Spawn as a tokio task; returns a oneshot sender for graceful shutdown.
+    pub fn spawn(self) -> oneshot::Sender<()> {
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            loop {
+                match self.tick().await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        tracing::info!("fee-vault monitor: zero-fee chain — nothing to watch");
+                        return;
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %format!("{e:#}"), "fee-vault monitor tick failed")
+                    }
+                }
+                tokio::select! {
+                    _ = tokio::time::sleep(self.poll_interval) => {}
+                    _ = &mut shutdown_rx => return,
+                }
+            }
+        });
+        shutdown_tx
+    }
+
+    /// One pass. Returns `Ok(false)` on a zero-fee chain (nothing to monitor).
+    async fn tick(&self) -> anyhow::Result<bool> {
+        let mut targets: Vec<(String, AccountId)> = vec![("service".to_string(), self.service)];
+        if let Some(ger) = self.ger_manager {
+            targets.push(("ger_manager".to_string(), ger));
+        }
+        targets.push(("bridge".to_string(), self.bridge));
+        for f in self.store.list_faucets().await? {
+            targets.push((format!("faucet:{}", f.symbol), f.faucet_id));
+        }
+        let warn_txns = self.warn_txns;
+        let last = self.last.clone();
+        let charges = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let charges_inner = charges.clone();
+        self.miden_client
+            .with(move |client| {
+                Box::new(async move {
+                    let snap = fee_snapshot(client).await?;
+                    let max_fee = max_fee_per_txn(snap.verification_base_fee);
+                    metrics::gauge!("bridge_fee_max_per_txn").set(max_fee as f64);
+                    if !snap.charges_fees() {
+                        charges_inner.store(false, std::sync::atomic::Ordering::Relaxed);
+                        return Ok(());
+                    }
+                    for (name, id) in targets {
+                        let Some(account) = client.get_account(id).await? else {
+                            tracing::warn!(account = %name, id = %id.to_hex(), "fee-vault monitor: account not in the client store");
+                            continue;
+                        };
+                        let balance = fee_balance(&account, snap.fee_faucet_id);
+                        let left = txns_left(balance, max_fee);
+                        metrics::gauge!("bridge_fee_vault_balance", "account" => name.clone())
+                            .set(balance as f64);
+                        metrics::gauge!("bridge_fee_vault_txns_left", "account" => name.clone())
+                            .set(left as f64);
+                        // Where did fees go: log every decrease since the last tick
+                        // (an increase is a top-up / cascade landing).
+                        let prev = last.lock().expect("fee-vault last-balance map").insert(name.clone(), balance);
+                        match prev {
+                            Some(p) if p > balance => tracing::info!(account = %name, spent = p - balance, balance, txns_left = left,
+                                "fee vault spent since last check (#201)"),
+                            Some(p) if p < balance => tracing::info!(account = %name, received = balance - p, balance,
+                                "fee vault topped up (#201)"),
+                            _ => {}
+                        }
+                        if balance == 0 {
+                            tracing::error!(account = %name, id = %id.to_hex(),
+                                "fee vault EMPTY — every transaction of this account will abort until it is topped up (#201)");
+                        } else if left < warn_txns {
+                            tracing::warn!(account = %name, id = %id.to_hex(), balance, txns_left = left,
+                                "fee vault low — top up with a P2ID of the fee asset (#201)");
+                        }
+                    }
+                    Ok(())
+                })
+            })
+            .await?;
+        Ok(charges.load(std::sync::atomic::Ordering::Relaxed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn txns_left_is_conservative_and_zero_fee_safe() {
+        assert_eq!(txns_left(13_440, 210), 64);
+        assert_eq!(txns_left(209, 210), 0);
+        assert_eq!(txns_left(5, 0), u64::MAX);
+    }
+}

--- a/src/fee_vault_monitor.rs
+++ b/src/fee_vault_monitor.rs
@@ -150,8 +150,13 @@ impl FeeVaultMonitor {
                             continue;
                         };
                         // Sweep top-ups: a P2ID of the fee asset sent to this account
-                        // (runbook top-up, cascade, exhaustion recovery) lands only once consumed.
-                        match crate::fee_funding::consume_fee_notes(client, id, &snap).await {
+                        // lands only once consumed. Not for an account still being
+                        // created — its cascade note is the deploy's to consume.
+                        match if account.is_new() {
+                            Ok(0)
+                        } else {
+                            crate::fee_funding::consume_fee_notes(client, id, &snap).await
+                        } {
                             Ok(n) if n > 0 => tracing::info!(account = %name, notes = n, "consuming fee-asset top-up note(s) (#201)"),
                             Ok(_) => {}
                             Err(e) => tracing::warn!(account = %name, error = %format!("{e:#}"), "could not consume a fee-asset top-up"),

--- a/src/fee_vault_monitor.rs
+++ b/src/fee_vault_monitor.rs
@@ -6,9 +6,10 @@
 //! the bridge on every network transaction (UpdateGer, CLAIM, B2AGG…), each
 //! faucet on every MINT/BURN. An empty vault silently stalls that account
 //! (its transactions abort in the kernel). Measured at base fee 7: network
-//! transactions cost ~40–50 units, signed client transactions the 210 cap; a
-//! busy bridge ran 27 network transactions in ten minutes — so the cascade
-//! amounts are hours, not weeks, of runway, and the balance has to be watched.
+//! transactions cost ~105–112 units (the bridge burned 13,440 in 120 of them),
+//! signed client transactions the 210 cap; a busy bridge ran 27 network
+//! transactions in ten minutes — so the cascade amounts are hours, not weeks,
+//! of runway, and the balance has to be watched.
 //!
 //! Gauges (labelled `account="service"|"ger_manager"|"bridge"|"faucet:<SYMBOL>"`):
 //! - `bridge_fee_vault_balance` — units of the fee asset in the vault;

--- a/src/fee_vault_monitor.rs
+++ b/src/fee_vault_monitor.rs
@@ -178,8 +178,12 @@ impl FeeVaultMonitor {
                                 "fee vault topped up (#201)"),
                             _ => {}
                         }
-                        if balance == 0 {
-                            tracing::error!(account = %name, id = %id.to_hex(),
+                        // Same threshold as the gauge operators alert on: below one
+                        // worst-case fee the next transaction can already abort (the
+                        // bridge stalled at 77 units, a 105-unit note in the queue), so
+                        // "empty" is txns_left == 0, not a literal zero balance.
+                        if left == 0 {
+                            tracing::error!(account = %name, id = %id.to_hex(), balance,
                                 "fee vault EMPTY — every transaction of this account will abort until it is topped up (#201)");
                         } else if name == "service"
                             && balance < crate::fee_funding::cascade_amount(&snap) + max_fee

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,6 +1,9 @@
 use crate::accounts_config;
 use crate::accounts_config::{AccountIdBech32, AccountsConfig};
+use crate::accounts_config::{FundingManifest, load_funding_manifest, save_funding_manifest};
 use crate::faucet_ops;
+use crate::fee_funding::{self, FeeSnapshot};
+use crate::metrics::ProofKind;
 use crate::miden_client::MidenClient;
 use crate::miden_client::MidenClientLib;
 use crate::proxy_keystore::ProxyKeystore;
@@ -9,7 +12,6 @@ use anyhow::Context;
 use miden_base_agglayer::{AggLayerBridge, BridgeRoles, MetadataHash};
 use miden_client::crypto::FeltRng;
 use miden_client::keystore::Keystore;
-use miden_client::transaction::TransactionRequestBuilder;
 use miden_protocol::account::auth::{AuthSecretKey, PublicKeyCommitment};
 use miden_protocol::account::{Account, AccountId, AccountType};
 use miden_protocol::address::NetworkId;
@@ -112,36 +114,19 @@ pub async fn create_auth_component(
     Ok((auth_component, Some(key_pair)))
 }
 
-async fn deploy_account(
-    client: &mut MidenClientLib,
-    account_id: AccountId,
-    name: &str,
-) -> anyhow::Result<()> {
-    tracing::info!(
-        "deploying {} account {} ...",
-        name,
-        AccountIdBech32(account_id)
-    );
-    let dummy_txn = TransactionRequestBuilder::new().build()?;
-    let txn_id = crate::metrics::meter_proof(
-        crate::metrics::ProofKind::Init,
-        crate::miden_client::submit_new_transaction(client, account_id, dummy_txn),
-    )
-    .await?;
-    tracing::info!("deployed {name} account with txn_id {txn_id}");
-
-    // Wait for the transaction to be committed (like ajl test's wait_for_tx)
-    let committed = crate::miden_client::wait_for_transaction_commit(
-        client,
-        txn_id,
-        20,
-        std::time::Duration::from_secs(1),
-    )
-    .await?;
-    if committed {
-        tracing::info!("deploy tx {txn_id} committed");
-    }
-    Ok(())
+/// Options for `--init` (#201). Account deployment itself lives in
+/// `fee_funding::deploy_account`, which is fee-aware (empty-txn deploy on a
+/// zero-fee chain; consume-the-funding-note deploy on a fee-charging one).
+#[derive(Debug, Clone)]
+pub struct InitOptions {
+    /// Build + persist `service`/`ger_manager`, write `funding.toml` and exit
+    /// WITHOUT deploying anything — the operator funds those two, then starts
+    /// the proxy normally and `--init` resumes them.
+    pub print_funding: bool,
+    /// On a fee-charging chain, how long a deploy waits for its funding note.
+    pub funding_wait: std::time::Duration,
+    /// Where `funding.toml` lives (beside `bridge_accounts.toml`).
+    pub miden_store_dir: Option<PathBuf>,
 }
 
 async fn add_bridge(
@@ -150,6 +135,8 @@ async fn add_bridge(
     service_id: AccountId,
     ger_manager_id: AccountId,
     network_id: u32,
+    fee: &FeeSnapshot,
+    funding_wait: std::time::Duration,
 ) -> anyhow::Result<Account> {
     // 0.16.0-alpha.5: the AggLayer network id is a per-bridge storage slot
     // again (agglayer::bridge::network_id, written once at account creation —
@@ -185,7 +172,19 @@ async fn add_bridge(
     .map_err(|e| anyhow::anyhow!("bridge account build failed: {e}"))?;
     client.add_account(&account, false).await?;
 
-    deploy_account(client, account.id(), "bridge").await?;
+    // #201: on a fee-charging chain `service` cascade-funds the keyless bridge
+    // and the deploy consumes that note; a zero-fee chain keeps the empty-txn
+    // deploy.
+    fee_funding::deploy_account(
+        client,
+        account.id(),
+        "bridge",
+        ProofKind::Init,
+        fee,
+        Some(service_id),
+        funding_wait,
+    )
+    .await?;
 
     Ok(account)
 }
@@ -301,20 +300,103 @@ pub async fn create_standalone_wallet(
     Ok(account)
 }
 
+/// Build — or, after `--print-funding` (or a fee-charging `--init` that timed
+/// out waiting for funding), RELOAD — the two KMS-keyed accounts (#201).
+async fn kms_accounts(
+    client: &mut MidenClientLib,
+    keystore: Arc<ProxyKeystore>,
+    opts: &InitOptions,
+    fee: &FeeSnapshot,
+) -> anyhow::Result<(Account, Account)> {
+    if let Some(manifest) = load_funding_manifest(opts.miden_store_dir.clone())? {
+        let service = reload_account(client, manifest.service_id()?, "service").await?;
+        let ger_manager = reload_account(client, manifest.ger_manager_id()?, "ger_manager").await?;
+        tracing::info!(
+            service = %AccountIdBech32(service.id()),
+            ger_manager = %AccountIdBech32(ger_manager.id()),
+            "resuming --init from funding.toml: reusing the accounts it records (#201)"
+        );
+        return Ok((service, ger_manager));
+    }
+    let service = add_wallet(client, keystore.clone(), Some(SignerRole::Service)).await?;
+    let ger_manager = add_wallet(client, keystore, Some(SignerRole::GerManager)).await?;
+    if fee.charges_fees() {
+        // Fee-charging chain and nobody ran --print-funding first: persist the
+        // manifest NOW so whoever is watching (operator, e2e fee-funder) can fund
+        // the accounts this init is about to wait on. A re-run after a funding
+        // timeout then RESUMES these accounts instead of orphaning them behind
+        // a fresh random seed.
+        let manifest = FundingManifest::new(service.id(), ger_manager.id(), fee);
+        let path = save_funding_manifest(&manifest, opts.miden_store_dir.clone())?;
+        tracing::warn!("{}", manifest.instructions(&path));
+    }
+    Ok((service, ger_manager))
+}
+
+/// Reload an account `funding.toml` records; import it from the node if the
+/// local row is gone (the same recovery path `verify_remote_bindings` uses).
+async fn reload_account(
+    client: &mut MidenClientLib,
+    id: AccountId,
+    name: &str,
+) -> anyhow::Result<Account> {
+    if client.get_account(id).await?.is_none() {
+        client.import_account_by_id(id).await.map_err(|e| {
+            anyhow::anyhow!("cannot reload the {name} account {id} recorded in funding.toml: {e}")
+        })?;
+    }
+    client.get_account(id).await?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "the {name} account {id} recorded in funding.toml is unavailable locally and on the node"
+        )
+    })
+}
+
 async fn add_accounts(
     client: &mut MidenClientLib,
     keystore: Arc<ProxyKeystore>,
     network_id: u32,
+    opts: &InitOptions,
+    fee: &FeeSnapshot,
 ) -> anyhow::Result<Accounts> {
-    let service = add_wallet(client, keystore.clone(), Some(SignerRole::Service)).await?;
-    let ger_manager = add_wallet(client, keystore.clone(), Some(SignerRole::GerManager)).await?;
-    deploy_account(client, ger_manager.id(), "ger_manager").await?;
+    let (service, ger_manager) = kms_accounts(client, keystore.clone(), opts, fee).await?;
+    let wait = opts.funding_wait;
+    fee_funding::deploy_account(
+        client,
+        ger_manager.id(),
+        "ger_manager",
+        ProofKind::Init,
+        fee,
+        None,
+        wait,
+    )
+    .await?;
+    if fee.charges_fees() {
+        // Historically `service` deployed lazily on its first claim. On a
+        // fee-charging chain it must consume its operator funding note FIRST:
+        // the cascade sends below are its own transactions, and it pays them.
+        fee_funding::deploy_account(
+            client,
+            service.id(),
+            "service",
+            ProofKind::Init,
+            fee,
+            None,
+            wait,
+        )
+        .await?;
+    }
+    // The bridge is keyless (service administers it) and deploys via its own
+    // transaction inside add_bridge, which on a fee-charging chain cascade-funds
+    // it from service and consumes that note as the deploy.
     let bridge = add_bridge(
         client,
         keystore.clone(),
         service.id(),
         ger_manager.id(),
         network_id,
+        fee,
+        wait,
     )
     .await?;
     // ETH: 18 origin decimals → 8 miden decimals (scale=10). Native ETH has empty metadata on
@@ -346,6 +428,7 @@ async fn init_internal(
     net_id: NetworkId,
     network_id: u32,
     miden_store_dir: Option<PathBuf>,
+    opts: InitOptions,
 ) -> anyhow::Result<PathBuf> {
     client.sync_state().await?;
     // PREFLIGHT before ANY init side effect (PR #162 review). Roles were
@@ -378,7 +461,33 @@ async fn init_internal(
             "signer key preflight passed — every role resolves to a distinct key the signer holds"
         );
     }
-    let accounts = add_accounts(client, keystore, network_id).await?;
+    let fee = fee_funding::fee_snapshot(client).await?;
+    if fee.charges_fees() {
+        tracing::info!(
+            verification_base_fee = fee.verification_base_fee,
+            fee_faucet_id = %fee.fee_faucet_id.to_hex(),
+            "chain charges transaction fees: every deployed account must hold the native fee \
+             asset (#201)"
+        );
+    }
+    if opts.print_funding {
+        let path = accounts_config::funding_manifest_path(miden_store_dir.clone())?;
+        if let Some(existing) = load_funding_manifest(miden_store_dir.clone())? {
+            // Re-printing must never rebuild: a second --print-funding after the
+            // operator already funded the recorded accounts would orphan them.
+            tracing::info!("funding.toml already exists — re-printing it, accounts NOT rebuilt");
+            println!("{}", existing.instructions(&path));
+            return Ok(path);
+        }
+        let service = add_wallet(client, keystore.clone(), Some(SignerRole::Service)).await?;
+        let ger_manager = add_wallet(client, keystore, Some(SignerRole::GerManager)).await?;
+        let manifest = FundingManifest::new(service.id(), ger_manager.id(), &fee);
+        let path = save_funding_manifest(&manifest, miden_store_dir)?;
+        // Operator-facing: this IS the deliverable of --print-funding.
+        println!("{}", manifest.instructions(&path));
+        return Ok(path);
+    }
+    let accounts = add_accounts(client, keystore, network_id, &opts, &fee).await?;
 
     // Wait for the NTX builder to process account creation transactions
     // before submitting notes that target those accounts.
@@ -408,6 +517,7 @@ pub async fn init(
     net_id: NetworkId,
     network_id: u32,
     miden_store_dir: Option<PathBuf>,
+    opts: InitOptions,
 ) -> anyhow::Result<PathBuf> {
     let result = Arc::new(OnceLock::<PathBuf>::new());
     let result_internal = result.clone();
@@ -416,7 +526,7 @@ pub async fn init(
     let future = client.with(move |client| {
         Box::new(async move {
             let result =
-                init_internal(client, keystore, net_id, network_id, miden_store_dir).await?;
+                init_internal(client, keystore, net_id, network_id, miden_store_dir, opts).await?;
             result_internal.set(result).unwrap();
             Ok(())
         })

--- a/src/init.rs
+++ b/src/init.rs
@@ -9,7 +9,7 @@ use crate::miden_client::MidenClientLib;
 use crate::proxy_keystore::ProxyKeystore;
 use crate::remote_signer::SignerRole;
 use anyhow::Context;
-use miden_base_agglayer::{AggLayerBridge, BridgeRoles, MetadataHash};
+use miden_base_agglayer::{BridgeRoles, MetadataHash};
 use miden_client::crypto::FeltRng;
 use miden_client::keystore::Keystore;
 use miden_protocol::account::auth::{AuthSecretKey, PublicKeyCommitment};
@@ -158,16 +158,13 @@ async fn add_bridge(
         std::collections::BTreeSet::from([ger_manager_id]),
     )
     .map_err(|e| anyhow::anyhow!("bridge role construction failed: {e}"))?;
-    let account = AggLayerBridge::account_builder(
+    let account = crate::network_accounts::bridge_account_builder(
         client.rng().draw_word(),
         service_id,
         roles,
         network_id,
-        crate::fee_policy::zero_fee_policy_manager_for(
-            AggLayerBridge::allowed_notes(),
-            fee_faucet_id,
-        ),
-    )
+        fee_faucet_id,
+    )?
     .build()
     .map_err(|e| anyhow::anyhow!("bridge account build failed: {e}"))?;
     client.add_account(&account, false).await?;
@@ -178,10 +175,7 @@ async fn add_bridge(
         client,
         account.id(),
         "bridge",
-        fee_funding::DeployKind::NetworkAccount {
-            funder: service_id,
-            feature_script_root: miden_base_agglayer::ClaimNote::script_root(),
-        },
+        fee_funding::DeployKind::NetworkAccount { funder: service_id },
         ProofKind::Init,
         fee,
         funding_wait,

--- a/src/init.rs
+++ b/src/init.rs
@@ -172,16 +172,18 @@ async fn add_bridge(
     .map_err(|e| anyhow::anyhow!("bridge account build failed: {e}"))?;
     client.add_account(&account, false).await?;
 
-    // #201: on a fee-charging chain `service` cascade-funds the keyless bridge
-    // and the deploy consumes that note; a zero-fee chain keeps the empty-txn
-    // deploy.
+    // #201: zero-fee chain → empty-txn deploy (unchanged). Fee-charging chain →
+    // fails loudly (network account; see fee_funding::DeployKind).
     fee_funding::deploy_account(
         client,
         account.id(),
         "bridge",
+        fee_funding::DeployKind::NetworkAccount {
+            funder: service_id,
+            feature_script_root: miden_base_agglayer::ClaimNote::script_root(),
+        },
         ProofKind::Init,
         fee,
-        Some(service_id),
         funding_wait,
     )
     .await?;
@@ -365,9 +367,9 @@ async fn add_accounts(
         client,
         ger_manager.id(),
         "ger_manager",
+        fee_funding::DeployKind::Wallet,
         ProofKind::Init,
         fee,
-        None,
         wait,
     )
     .await?;
@@ -379,16 +381,18 @@ async fn add_accounts(
             client,
             service.id(),
             "service",
+            fee_funding::DeployKind::Wallet,
             ProofKind::Init,
             fee,
-            None,
             wait,
         )
         .await?;
     }
     // The bridge is keyless (service administers it) and deploys via its own
-    // transaction inside add_bridge, which on a fee-charging chain cascade-funds
-    // it from service and consumes that note as the deploy.
+    // transaction inside add_bridge. It is a NETWORK account: on a fee-charging
+    // chain it cannot consume a P2ID, so its vault must come from a
+    // FeeSponsorshipNote paired with a feature note it accepts (the #201
+    // follow-up); until then a fee-charging init fails loudly there.
     let bridge = add_bridge(
         client,
         keystore.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod metadata_recovery;
 pub mod metrics;
 pub mod miden_client;
 pub mod mint_target_monitor;
+pub mod network_accounts;
 pub mod orphan_recovery;
 pub mod projection;
 pub mod projection_order;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod faucet_ownership_monitor;
 pub mod faucet_registry_reconciler;
 pub mod fee_funding;
 pub mod fee_policy;
+pub mod fee_vault_monitor;
 pub mod forged_mint_detector;
 pub mod ger;
 pub mod hex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod faucet_bootstrap;
 pub mod faucet_ops;
 pub mod faucet_ownership_monitor;
 pub mod faucet_registry_reconciler;
+pub mod fee_funding;
 pub mod fee_policy;
 pub mod forged_mint_detector;
 pub mod ger;

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,10 @@ struct Command {
     #[arg(long, env = "FAUCET_RECONCILER_POLL_SECS", default_value_t = 30)]
     faucet_reconciler_poll_secs: u64,
 
+    fee_vault_poll_secs: 60,
+
+    fee_vault_warn_txns: 32,
+
     /// #201: how often to export the fee-asset vault balances of service,
     /// ger_manager, the bridge and every faucet (`bridge_fee_vault_balance`,
     /// `bridge_fee_vault_txns_left`). `0` disables. Default 60s.
@@ -1892,6 +1896,10 @@ mod hardening_tests {
             l1_indexer_from_block: None,
             l1_evidence_tag: "latest".to_string(),
             faucet_reconciler_poll_secs: 30,
+
+            fee_vault_poll_secs: 60,
+
+            fee_vault_warn_txns: 32,
             faucet_reconciler_grace_ticks: 3,
             miden_debug: false,
             cors_allowed_origins: cors,

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,19 @@ struct Command {
     #[arg(long)]
     init: bool,
 
+    /// #201: build + persist the two KMS-keyed accounts (service, ger_manager),
+    /// write `funding.toml` — their addresses, the chain's native fee asset and
+    /// the recommended amounts — and exit WITHOUT deploying. Fund those two,
+    /// then start normally: --init resumes them and deploys each by consuming
+    /// its funding note, cascade-funding the keyless bridge/faucets from service.
+    #[arg(long)]
+    print_funding: bool,
+
+    /// #201: on a fee-charging chain, how long a deploy waits for the account's
+    /// fee-asset funding note before failing with the exact funding instruction.
+    #[arg(long, env = "FUNDING_WAIT_SECS", default_value_t = 900)]
+    funding_wait_secs: u64,
+
     /// PostgreSQL connection URL (enables PgStore instead of InMemoryStore)
     #[arg(long, env = "DATABASE_URL")]
     database_url: Option<String>,
@@ -848,7 +861,8 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    let needs_init = command.init || !config_path_exists(miden_store_dir.clone())?;
+    let needs_init =
+        command.init || command.print_funding || !config_path_exists(miden_store_dir.clone())?;
 
     // Phase 1: Run init if needed (with a minimal client, no BridgeOutScanner)
     if needs_init {
@@ -895,13 +909,25 @@ async fn main() -> anyhow::Result<()> {
             init_net_id,
             init_network_id,
             miden_store_dir.clone(),
+            init::InitOptions {
+                print_funding: command.print_funding,
+                funding_wait: std::time::Duration::from_secs(command.funding_wait_secs),
+                miden_store_dir: miden_store_dir.clone(),
+            },
         )
         .await?;
-        tracing::info!("new config created at {config_path:?}");
+        if command.print_funding {
+            tracing::info!(
+                "funding manifest written to {config_path:?}; fund the listed accounts, then \
+                 start the proxy normally (--init resumes them)"
+            );
+        } else {
+            tracing::info!("new config created at {config_path:?}");
+        }
 
         init_client.shutdown()?;
 
-        if command.init {
+        if command.init || command.print_funding {
             return Ok(());
         }
     }
@@ -1821,6 +1847,8 @@ mod hardening_tests {
             chain_id: 1,
             network_id: 1,
             init: false,
+            print_funding: false,
+            funding_wait_secs: 900,
             database_url: None,
             restore: false,
             reset_miden_store: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,10 +152,6 @@ struct Command {
     #[arg(long, env = "FAUCET_RECONCILER_POLL_SECS", default_value_t = 30)]
     faucet_reconciler_poll_secs: u64,
 
-    fee_vault_poll_secs: 60,
-
-    fee_vault_warn_txns: 32,
-
     /// #201: how often to export the fee-asset vault balances of service,
     /// ger_manager, the bridge and every faucet (`bridge_fee_vault_balance`,
     /// `bridge_fee_vault_txns_left`). `0` disables. Default 60s.

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,17 @@ struct Command {
     #[arg(long, env = "FAUCET_RECONCILER_POLL_SECS", default_value_t = 30)]
     faucet_reconciler_poll_secs: u64,
 
+    /// #201: how often to export the fee-asset vault balances of service,
+    /// ger_manager, the bridge and every faucet (`bridge_fee_vault_balance`,
+    /// `bridge_fee_vault_txns_left`). `0` disables. Default 60s.
+    #[arg(long, env = "FEE_VAULT_POLL_SECS", default_value_t = 60)]
+    fee_vault_poll_secs: u64,
+
+    /// #201: WARN when an account can pay for fewer than this many transactions
+    /// at the fee cap (ERROR at 0). Default 32.
+    #[arg(long, env = "FEE_VAULT_WARN_TXNS", default_value_t = 32)]
+    fee_vault_warn_txns: u64,
+
     /// Consecutive reconciler scans an unknown bridge faucet must survive before it
     /// halts the proxy. The grace window (poll_secs × grace_ticks) tolerates the brief
     /// gap between the proxy's own on-chain registration note and its store-row commit,
@@ -1510,6 +1521,25 @@ async fn main() -> anyhow::Result<()> {
         // as the L1 indexer above — no graceful-shutdown path holds it).
         std::mem::forget(reconciler.spawn());
         tracing::info!("FaucetRegistryReconciler spawned");
+    }
+
+    // #201: fee-vault balances → metrics (every account pays its own tx fees).
+    if command.fee_vault_poll_secs == 0 {
+        tracing::warn!(
+            "fee-vault monitor DISABLED (--fee-vault-poll-secs 0): an empty fee vault will not be visible in metrics"
+        );
+    } else {
+        let monitor = miden_agglayer_service::fee_vault_monitor::FeeVaultMonitor::new(
+            state.miden_client.clone(),
+            state.store.clone(),
+            state.accounts.0.service.0,
+            state.accounts.0.ger_manager.as_ref().map(|g| g.0),
+            state.accounts.0.bridge.0,
+        )
+        .with_poll_interval(std::time::Duration::from_secs(command.fee_vault_poll_secs))
+        .with_warn_txns(command.fee_vault_warn_txns);
+        std::mem::forget(monitor.spawn());
+        tracing::info!("FeeVaultMonitor spawned");
     }
 
     // (Metrics recorder + `init_metrics` are installed at the very top of

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -569,6 +569,13 @@ pub fn init_metrics() {
          >0.95×cap for 2 min → page."
     );
     describe_gauge!(
+        "agglayer_writer_jobs_parked",
+        "#201: WriteJobs held because their signer's fee vault could not pay \
+         the Miden fee; each is re-dispatched every 30s and lands once the \
+         account is topped up. Non-zero means an account is dry — see \
+         bridge_fee_vault_txns_left."
+    );
+    describe_gauge!(
         "agglayer_writer_inflight_jobs",
         "RD-940: WriteJobs in the in-flight DashMap (Queued + Submitting + \
          not-yet-TTL'd terminal entries). Informational — NOT a drain signal: \

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -163,6 +163,24 @@ pub fn init_metrics() {
          zkevm-bridge-service claimtxman) is rejected at that nonce forever."
     );
     describe_counter!("ger_injections_total", "Total GER injections");
+    // #201 fee vaults: every account pays its own tx fees; an empty vault stalls it.
+    describe_gauge!(
+        "bridge_fee_vault_balance",
+        "#201: units of the chain's native fee asset in the vault of the labelled \
+         account (service, ger_manager, bridge, faucet:<SYMBOL>). Every transaction \
+         the account executes pays from it; at 0 the account stalls."
+    );
+    describe_gauge!(
+        "bridge_fee_vault_txns_left",
+        "#201: bridge_fee_vault_balance / bridge_fee_max_per_txn — a conservative \
+         count of transactions the account can still pay for. ALERT on this: e.g. \
+         `bridge_fee_vault_txns_left < 32` (the proxy logs a warning there and an error at 0)."
+    );
+    describe_gauge!(
+        "bridge_fee_max_per_txn",
+        "#201: the per-transaction fee cap, verification_base_fee × \
+         (ilog2(MAX_TX_EXECUTION_CYCLES)+1). 0 means a zero-fee chain."
+    );
     describe_gauge!(
         "last_ger_injection_timestamp_seconds",
         "Unix time (seconds) of the most recent GER injection (new insert or a \

--- a/src/network_accounts.rs
+++ b/src/network_accounts.rs
@@ -40,9 +40,7 @@ use miden_base_agglayer::{
     AggLayerBridge, AggLayerFaucet, AgglayerBridgeError, AgglayerFaucetError, BridgeRoles, ExitRoot,
 };
 use miden_client::note::NoteScriptRoot;
-use miden_protocol::account::{
-    Account, AccountBuilder, AccountId, AssetCallbackFlag, StorageMapKey,
-};
+use miden_protocol::account::{Account, AccountBuilder, AccountId, StorageMapKey};
 use miden_protocol::asset::TokenSymbol;
 use miden_protocol::crypto::hash::poseidon2::Poseidon2;
 use miden_protocol::{Felt, Word};
@@ -127,17 +125,8 @@ pub fn faucet_account_builder(
         .active_send_policy(TransferPolicy::allow_all())
         .active_receive_policy(TransferPolicy::allow_all())
         .build();
-    // A faucet that configures a transfer policy MUST carry AssetCallbackFlag::
-    // Enabled (miden-protocol AccountBuilder doc; the flag is immutable, baked
-    // into the id). The upstream AggLayerFaucet::account_builder omits it, so it
-    // builds a Disabled faucet — which the proxy's own Cantina #4 detector
-    // rejects (a legit wrapped-faucet MINT must have Enabled callbacks; live at
-    // base fee 7, the deposit's MINT tripped "asset_callbacks: expected Enabled,
-    // observed Disabled"). Derive it the way miden-standards' faucet helper does.
-    let asset_callbacks = AssetCallbackFlag::from(token_policy_manager.has_transfer_policy());
     let builder = NetworkAccount::builder(seed.into(), allowed, fee_policy_manager)
         .map_err(|e| anyhow!("faucet note allowlist: {e:?}"))?
-        .with_asset_callbacks(asset_callbacks)
         .with_component(faucet)
         .with_component(Ownable2Step::new(bridge_account_id))
         .with_component(rbac)
@@ -222,32 +211,5 @@ mod tests {
         let faucet = p2id_fundable(AggLayerFaucet::allowed_notes());
         assert!(faucet.contains(&P2idNote::script_root()));
         assert!(faucet.is_superset(&AggLayerFaucet::allowed_notes()));
-    }
-
-    #[test]
-    fn faucet_is_asset_callback_enabled() {
-        use miden_protocol::account::{AccountId, AssetCallbackFlag};
-        use miden_protocol::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE as X;
-        let id = AccountId::try_from(X).unwrap();
-        let faucet = faucet_account_builder(
-            [7u8; 32],
-            "ETH",
-            8,
-            Felt::new(1_000_000).unwrap(),
-            Felt::new(0).unwrap(),
-            id,
-            id,
-            id,
-        )
-        .unwrap()
-        .build()
-        .unwrap();
-        // The wrapped faucet configures a transfer policy, so its immutable
-        // AssetCallbackFlag must be Enabled — the invariant the proxy's Cantina
-        // #4 MINT detector enforces (upstream's builder leaves it Disabled).
-        assert_eq!(
-            faucet.id().asset_callback_flag(),
-            AssetCallbackFlag::Enabled
-        );
     }
 }

--- a/src/network_accounts.rs
+++ b/src/network_accounts.rs
@@ -36,15 +36,19 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::anyhow;
-use miden_base_agglayer::{AggLayerBridge, AggLayerFaucet, BridgeRoles};
-use miden_client::Felt;
+use miden_base_agglayer::{
+    AggLayerBridge, AggLayerFaucet, AgglayerBridgeError, AgglayerFaucetError, BridgeRoles, ExitRoot,
+};
 use miden_client::note::NoteScriptRoot;
-use miden_protocol::account::{AccountBuilder, AccountId};
+use miden_protocol::account::{Account, AccountBuilder, AccountId, StorageMapKey};
 use miden_protocol::asset::TokenSymbol;
+use miden_protocol::crypto::hash::poseidon2::Poseidon2;
+use miden_protocol::{Felt, Word};
 use miden_standards::account::access::{
     Authority, Ownable2Step, Pausable, PausableManager, RoleBasedAccessControl, RoleConfig,
 };
 use miden_standards::account::auth::NetworkAccount;
+use miden_standards::account::faucets::FungibleFaucet;
 use miden_standards::account::fees::ConstantFeeManager;
 use miden_standards::account::policies::{
     BurnPolicy, MintPolicy, TokenPolicyManager, TransferPolicy,
@@ -133,6 +137,66 @@ pub fn faucet_account_builder(
         .with_component(ConstantFeeManager::for_basic_constant_fee_policy())
         .with_component(BasicWallet);
     Ok(builder)
+}
+
+// ── Readers that do not gate on the code commitment ────────────────────────────
+//
+// Upstream's `AggLayerBridge::is_ger_registered`, `AggLayerFaucet::
+// try_faucet_from_account` and `AggLayerFaucet::owner_account_id` first assert
+// `BRIDGE_CODE_COMMITMENT == account.code().commitment()` (resp. the faucet's).
+// The P2ID-fundable variants carry one more code component, so that assertion
+// fails ("the code commitment of the provided account does not match …") and
+// the proxy could no longer read its own bridge's GER map — the live deposit
+// stalled on exactly that. Storage is identical (`BasicWallet` has none), so
+// these replicas keep upstream's STORAGE checks and formulas and drop only the
+// code gate. They return upstream's error types so call sites are unchanged.
+
+/// `AggLayerBridge::is_ger_registered` without the code-commitment gate.
+pub fn is_ger_registered(
+    ger: ExitRoot,
+    bridge_account: &Account,
+) -> Result<bool, AgglayerBridgeError> {
+    // Same key derivation as upstream: poseidon2::merge(GER_LOWER, GER_UPPER).
+    let elements = ger.to_elements();
+    let ger_lower: Word = elements[0..4]
+        .try_into()
+        .expect("an exit root is eight field elements");
+    let ger_upper: Word = elements[4..8]
+        .try_into()
+        .expect("an exit root is eight field elements");
+    let ger_hash = Poseidon2::merge(&[ger_lower, ger_upper]);
+    let stored = bridge_account
+        .storage()
+        .get_map_item(
+            AggLayerBridge::ger_map_slot_name(),
+            StorageMapKey::from_raw(ger_hash),
+        )
+        .map_err(|_| AgglayerBridgeError::StorageSlotsMismatch)?;
+    let registered: Word = [Felt::ONE, Felt::ZERO, Felt::ZERO, Felt::ZERO].into();
+    Ok(stored == registered)
+}
+
+/// `AggLayerFaucet::owner_account_id` without the code-commitment gate: the
+/// AggLayer-owned faucet's `Ownable2Step` slot IS the discriminator — a
+/// Miden-native operator faucet has none and fails here, as upstream's does.
+pub fn owner_account_id(faucet_account: &Account) -> Result<AccountId, AgglayerFaucetError> {
+    let ownership = Ownable2Step::try_from_storage(faucet_account.storage())
+        .map_err(AgglayerFaucetError::Ownable2StepError)?;
+    ownership
+        .owner()
+        .ok_or(AgglayerFaucetError::OwnershipRenounced)
+}
+
+/// `AggLayerFaucet::try_faucet_from_account` without the code-commitment gate:
+/// requires the AggLayer ownership slot (see [`owner_account_id`]) and decodes
+/// the standard fungible-faucet metadata.
+pub fn try_faucet_from_account(
+    faucet_account: &Account,
+) -> Result<FungibleFaucet, AgglayerFaucetError> {
+    Ownable2Step::try_from_storage(faucet_account.storage())
+        .map_err(|_| AgglayerFaucetError::StorageSlotsMismatch)?;
+    FungibleFaucet::try_from(faucet_account.storage())
+        .map_err(AgglayerFaucetError::FungibleFaucetError)
 }
 
 #[cfg(test)]

--- a/src/network_accounts.rs
+++ b/src/network_accounts.rs
@@ -40,7 +40,9 @@ use miden_base_agglayer::{
     AggLayerBridge, AggLayerFaucet, AgglayerBridgeError, AgglayerFaucetError, BridgeRoles, ExitRoot,
 };
 use miden_client::note::NoteScriptRoot;
-use miden_protocol::account::{Account, AccountBuilder, AccountId, StorageMapKey};
+use miden_protocol::account::{
+    Account, AccountBuilder, AccountId, AssetCallbackFlag, StorageMapKey,
+};
 use miden_protocol::asset::TokenSymbol;
 use miden_protocol::crypto::hash::poseidon2::Poseidon2;
 use miden_protocol::{Felt, Word};
@@ -125,8 +127,17 @@ pub fn faucet_account_builder(
         .active_send_policy(TransferPolicy::allow_all())
         .active_receive_policy(TransferPolicy::allow_all())
         .build();
+    // A faucet that configures a transfer policy MUST carry AssetCallbackFlag::
+    // Enabled (miden-protocol AccountBuilder doc; the flag is immutable, baked
+    // into the id). The upstream AggLayerFaucet::account_builder omits it, so it
+    // builds a Disabled faucet — which the proxy's own Cantina #4 detector
+    // rejects (a legit wrapped-faucet MINT must have Enabled callbacks; live at
+    // base fee 7, the deposit's MINT tripped "asset_callbacks: expected Enabled,
+    // observed Disabled"). Derive it the way miden-standards' faucet helper does.
+    let asset_callbacks = AssetCallbackFlag::from(token_policy_manager.has_transfer_policy());
     let builder = NetworkAccount::builder(seed.into(), allowed, fee_policy_manager)
         .map_err(|e| anyhow!("faucet note allowlist: {e:?}"))?
+        .with_asset_callbacks(asset_callbacks)
         .with_component(faucet)
         .with_component(Ownable2Step::new(bridge_account_id))
         .with_component(rbac)
@@ -211,5 +222,32 @@ mod tests {
         let faucet = p2id_fundable(AggLayerFaucet::allowed_notes());
         assert!(faucet.contains(&P2idNote::script_root()));
         assert!(faucet.is_superset(&AggLayerFaucet::allowed_notes()));
+    }
+
+    #[test]
+    fn faucet_is_asset_callback_enabled() {
+        use miden_protocol::account::{AccountId, AssetCallbackFlag};
+        use miden_protocol::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE as X;
+        let id = AccountId::try_from(X).unwrap();
+        let faucet = faucet_account_builder(
+            [7u8; 32],
+            "ETH",
+            8,
+            Felt::new(1_000_000).unwrap(),
+            Felt::new(0).unwrap(),
+            id,
+            id,
+            id,
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        // The wrapped faucet configures a transfer policy, so its immutable
+        // AssetCallbackFlag must be Enabled — the invariant the proxy's Cantina
+        // #4 MINT detector enforces (upstream's builder leaves it Disabled).
+        assert_eq!(
+            faucet.id().asset_callback_flag(),
+            AssetCallbackFlag::Enabled
+        );
     }
 }

--- a/src/network_accounts.rs
+++ b/src/network_accounts.rs
@@ -1,0 +1,151 @@
+//! P2ID-fundable network accounts (#201).
+//!
+//! On a fee-charging chain every account pays its own transaction fees from
+//! its vault — including the bridge and the faucets, which are network
+//! accounts (`AuthNetworkAccount`, executed by the ntx-builder). A brand-new
+//! account can only fill its vault by CONSUMING a note in its first
+//! transaction, and a network account only accepts allowlisted note scripts.
+//! The upstream `AggLayerBridge` / `AggLayerFaucet` builders allowlist just
+//! their own feature notes — every one of which carries a `NetworkAccountTarget`
+//! and therefore cannot be created until the target is on-chain (the sender
+//! FPIs into it) — and they carry no `receive_asset`, so a plain P2ID aborts
+//! in the kernel. That left no way to bring such an account to life after
+//! genesis (proven live: `procedure root … not in the account procedure index
+//! map`, then `before_foreign_load … account not found at block N`).
+//!
+//! Miden's own post-genesis network account (the testnet network-monitor's
+//! counter) shows the intended recipe: build the network account WITH a
+//! [`BasicWallet`] component and allowlist the P2ID script at zero fee. A P2ID
+//! carries no attachment, so anyone can create one for a not-yet-created
+//! target, and the account's creation transaction consumes it — funding the
+//! vault, paying the kernel fee from it, and deploying the account in one go.
+//! Afterwards the zero per-note policy means ordinary notes (CLAIM, B2AGG,
+//! UpdateGer, MINT) need no sponsorship: the vault pays, and top-ups are just
+//! more P2IDs from `service`.
+//!
+//! Safety: adding `BasicWallet` also adds its send procedures, but a network
+//! account only runs allowlisted note scripts and the default tx-script
+//! allowlist holds nothing but the network builder's expiration script — so
+//! the only path into those procedures is a note script, and the P2ID script
+//! calls `receive_asset` alone. The agglayer note scripts are unchanged.
+//!
+//! These builders mirror the upstream ones component-for-component; the only
+//! differences are the extended allowlist (+P2ID, scheduled at zero fee) and
+//! the trailing `BasicWallet`.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::anyhow;
+use miden_base_agglayer::{AggLayerBridge, AggLayerFaucet, BridgeRoles};
+use miden_client::Felt;
+use miden_client::note::NoteScriptRoot;
+use miden_protocol::account::{AccountBuilder, AccountId};
+use miden_protocol::asset::TokenSymbol;
+use miden_standards::account::access::{
+    Authority, Ownable2Step, Pausable, PausableManager, RoleBasedAccessControl, RoleConfig,
+};
+use miden_standards::account::auth::NetworkAccount;
+use miden_standards::account::fees::ConstantFeeManager;
+use miden_standards::account::policies::{
+    BurnPolicy, MintPolicy, TokenPolicyManager, TransferPolicy,
+};
+use miden_standards::account::wallets::BasicWallet;
+use miden_standards::note::P2idNote;
+
+use crate::fee_policy::zero_fee_policy_manager_for;
+
+/// The upstream allowlist plus the P2ID script, so the account can be funded
+/// (and later topped up) with a plain P2ID of the fee asset.
+pub fn p2id_fundable(allowed: BTreeSet<NoteScriptRoot>) -> BTreeSet<NoteScriptRoot> {
+    let mut allowed = allowed;
+    allowed.insert(P2idNote::script_root());
+    allowed
+}
+
+/// `AggLayerBridge::account_builder`, P2ID-fundable. Component-for-component
+/// the upstream builder, with the extended allowlist and a trailing
+/// `BasicWallet`.
+pub fn bridge_account_builder(
+    seed: impl Into<[u8; 32]>,
+    bridge_admin: AccountId,
+    roles: BridgeRoles,
+    network_id: u32,
+    fee_faucet_id: AccountId,
+) -> anyhow::Result<AccountBuilder> {
+    let allowed = p2id_fundable(AggLayerBridge::allowed_notes());
+    let fee_policy_manager = zero_fee_policy_manager_for(allowed.clone(), fee_faucet_id);
+    let rbac = RoleBasedAccessControl::builder()
+        .role(RoleConfig::new(RoleBasedAccessControl::admin_role()).with_member(bridge_admin))
+        .roles(roles)
+        .build()
+        .map_err(|e| anyhow!("bridge RBAC roles: {e:?}"))?;
+    let builder = NetworkAccount::builder(seed.into(), allowed, fee_policy_manager)
+        .map_err(|e| anyhow!("bridge note allowlist: {e:?}"))?
+        .with_component(AggLayerBridge::new(network_id))
+        .with_component(rbac)
+        .with_component(Authority::RbacControlled {
+            procedure_roles: AggLayerBridge::procedure_roles(),
+        })
+        .with_component(Pausable::unpaused())
+        .with_component(PausableManager)
+        .with_component(ConstantFeeManager::for_basic_constant_fee_policy())
+        .with_component(BasicWallet);
+    Ok(builder)
+}
+
+/// `AggLayerFaucet::account_builder`, P2ID-fundable. Component-for-component
+/// the upstream builder, with the extended allowlist and a trailing
+/// `BasicWallet`.
+#[allow(clippy::too_many_arguments)]
+pub fn faucet_account_builder(
+    seed: impl Into<[u8; 32]>,
+    token_symbol: &str,
+    decimals: u8,
+    max_supply: Felt,
+    initial_supply: Felt,
+    faucet_admin: AccountId,
+    bridge_account_id: AccountId,
+    fee_faucet_id: AccountId,
+) -> anyhow::Result<AccountBuilder> {
+    let allowed = p2id_fundable(AggLayerFaucet::allowed_notes());
+    let fee_policy_manager = zero_fee_policy_manager_for(allowed.clone(), fee_faucet_id);
+    let symbol = TokenSymbol::new(token_symbol)
+        .map_err(|e| anyhow!("faucet token symbol {token_symbol:?}: {e:?}"))?;
+    let faucet = AggLayerFaucet::new(symbol, decimals, max_supply, initial_supply)
+        .map_err(|e| anyhow!("faucet metadata for {token_symbol}: {e:?}"))?;
+    let rbac = RoleBasedAccessControl::with_admins([faucet_admin])
+        .map_err(|e| anyhow!("faucet RBAC admin: {e:?}"))?;
+    let token_policy_manager = TokenPolicyManager::builder()
+        .active_mint_policy(MintPolicy::owner_only())
+        .active_burn_policy(BurnPolicy::owner_only())
+        .active_send_policy(TransferPolicy::allow_all())
+        .active_receive_policy(TransferPolicy::allow_all())
+        .build();
+    let builder = NetworkAccount::builder(seed.into(), allowed, fee_policy_manager)
+        .map_err(|e| anyhow!("faucet note allowlist: {e:?}"))?
+        .with_component(faucet)
+        .with_component(Ownable2Step::new(bridge_account_id))
+        .with_component(rbac)
+        .with_component(Authority::RbacControlled {
+            procedure_roles: BTreeMap::new(),
+        })
+        .with_components(token_policy_manager)
+        .with_component(ConstantFeeManager::for_basic_constant_fee_policy())
+        .with_component(BasicWallet);
+    Ok(builder)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn p2id_is_added_to_the_allowlists() {
+        let bridge = p2id_fundable(AggLayerBridge::allowed_notes());
+        assert!(bridge.contains(&P2idNote::script_root()));
+        assert!(bridge.is_superset(&AggLayerBridge::allowed_notes()));
+        let faucet = p2id_fundable(AggLayerFaucet::allowed_notes());
+        assert!(faucet.contains(&P2idNote::script_root()));
+        assert!(faucet.is_superset(&AggLayerFaucet::allowed_notes()));
+    }
+}

--- a/src/writer_worker.rs
+++ b/src/writer_worker.rs
@@ -768,6 +768,9 @@ impl WriterWorker {
             "writer worker starting"
         );
         let mut parked_retry = tokio::time::interval(PARKED_RETRY_INTERVAL);
+        // Ticks skipped while nothing was parked must not fire as a burst the
+        // moment a job is parked (seen live: eight retries in half a second).
+        parked_retry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             tokio::select! {
                 biased;

--- a/src/writer_worker.rs
+++ b/src/writer_worker.rs
@@ -49,6 +49,7 @@ use crate::service_state::ServiceState;
 use alloy::consensus::TxEnvelope;
 use alloy::primitives::{Address, TxHash};
 use dashmap::DashMap;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
@@ -555,6 +556,29 @@ pub struct WriterWorker {
     inflight: Arc<DashMap<TxHash, InFlightEntry>>,
     service: ServiceState,
     tx_ttl: Duration,
+    /// Jobs whose signer could not pay the Miden fee (#201), kept for retry
+    /// instead of a failure receipt — see [`is_fee_vault_empty`].
+    parked: VecDeque<WriteJob>,
+}
+
+/// How often parked jobs are re-dispatched. A top-up lands within one
+/// fee-vault monitor tick, so this only bounds how long recovery lags it.
+const PARKED_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
+/// The kernel abort a signing account hits when its fee vault cannot cover the
+/// transaction fee (#201). It reaches us as executor error text, so match the
+/// wording the way `is_recoverable_account_error` matches the node's.
+///
+/// Why this must not become a failure receipt: the claim sponsor
+/// (bridge-service's ClaimTxManager) resends a reverted claim every ~2 s and
+/// marks the deposit permanently FAILED after ten mined-and-failed attempts —
+/// a hard-coded history limit, not config — so an empty vault would strand
+/// every deposit it touched even after the operator tops the account up.
+/// Left pending (receipt `null`) the sponsor simply waits, and the parked job
+/// lands on the first retry after the top-up.
+pub(crate) fn is_fee_vault_empty(err: &anyhow::Error) -> bool {
+    format!("{err:#}")
+        .contains("amount of the asset in the vault is less than the amount to remove")
 }
 
 impl WriterWorker {
@@ -641,6 +665,7 @@ impl WriterWorker {
             inflight: inflight.clone(),
             service: service.clone(),
             tx_ttl,
+            parked: VecDeque::new(),
         };
 
         tokio::spawn(async move {
@@ -742,12 +767,20 @@ impl WriterWorker {
             tx_ttl_secs = self.tx_ttl.as_secs(),
             "writer worker starting"
         );
+        let mut parked_retry = tokio::time::interval(PARKED_RETRY_INTERVAL);
         loop {
             tokio::select! {
                 biased;
                 _ = &mut *shutdown_rx => {
                     tracing::info!(target: "writer_worker", "shutdown signal received");
                     break;
+                }
+                _ = parked_retry.tick(), if !self.parked.is_empty() => {
+                    // Oldest first, so a signer's held nonces land in admission order.
+                    let retry: Vec<WriteJob> = self.parked.drain(..).collect();
+                    for job in retry {
+                        self.process(job).await;
+                    }
                 }
                 maybe_job = self.receiver.recv() => {
                     let Some(job) = maybe_job else {
@@ -782,7 +815,7 @@ impl WriterWorker {
         tracing::info!(target: "writer_worker", "writer worker stopped");
     }
 
-    async fn process(&self, job: WriteJob) {
+    async fn process(&mut self, job: WriteJob) {
         let hash = job.eth_tx_hash();
         let kind = job.kind();
         let job_id = job.job_id();
@@ -880,6 +913,8 @@ impl WriterWorker {
 
         let outcome_label;
         let dispatch_service = self.service.clone();
+        // Kept so a fee-starved job can be parked and re-dispatched verbatim.
+        let retry_copy = job.clone();
         let result =
             supervise_dispatch(async move { dispatch_job(&dispatch_service, job).await }).await;
         match result {
@@ -916,7 +951,24 @@ impl WriterWorker {
                 );
             }
             Err(err) => {
-                if preserve_pending_after_handoff(&self.service.store, hash).await {
+                if is_fee_vault_empty(&err) {
+                    if let Some(mut entry) = self.inflight.get_mut(&hash) {
+                        entry.state = JobState::Queued;
+                        // Restart the TTL clock: the wait for a top-up is the
+                        // operator's, not queue congestion.
+                        entry.created_at = Instant::now();
+                    }
+                    self.parked.push_back(retry_copy);
+                    outcome_label = "parked";
+                    tracing::error!(
+                        target: "writer_worker",
+                        %hash, kind = kind.as_str(), %job_id, signer = %signer,
+                        parked = self.parked.len(),
+                        "fee vault EMPTY — holding the transaction pending and retrying every {}s until the account is topped up (#201)",
+                        PARKED_RETRY_INTERVAL.as_secs()
+                    );
+                    ::metrics::gauge!("agglayer_writer_jobs_parked").set(self.parked.len() as f64);
+                } else if preserve_pending_after_handoff(&self.service.store, hash).await {
                     self.inflight.remove(&hash);
                     outcome_label = "pending";
                     tracing::warn!(
@@ -1083,6 +1135,21 @@ async fn preserve_pending_after_handoff(
 mod tests {
     use super::*;
     use alloy::consensus::{SignableTransaction, TxLegacy};
+
+    #[test]
+    fn fee_vault_empty_is_recognised_through_the_error_chain() {
+        // The kernel assertion text as the executor surfaces it (repro 2026-09-12).
+        let inner = anyhow::anyhow!(
+            "failed to execute transaction kernel program:\n  x assertion failed with error \
+             message: failed to remove the fungible asset from the vault since the amount of \
+             the asset in the vault is less than the amount to remove"
+        );
+        let err = inner.context("transaction execution failed");
+        assert!(is_fee_vault_empty(&err));
+        assert!(!is_fee_vault_empty(&anyhow::anyhow!(
+            "GER is already registered in storage"
+        )));
+    }
     use alloy::primitives::U256;
     use alloy::signers::SignerSync;
     use alloy::signers::local::PrivateKeySigner;
@@ -1188,11 +1255,12 @@ mod tests {
         let mut entry = InFlightEntry::from_job(&job);
         entry.created_at = Instant::now() - Duration::from_secs(2);
         inflight.insert(hash, entry);
-        let worker = WriterWorker {
+        let mut worker = WriterWorker {
             receiver,
             inflight: inflight.clone(),
             service,
             tx_ttl: Duration::from_secs(1),
+            parked: VecDeque::new(),
         };
 
         worker.process(job).await;


### PR DESCRIPTION
Fixes #201.

## Problem
Protocol 0.16 charges `verification_base_fee × (ilog2(cycles)+1)` on **every** transaction, paid by the **executing account from its own vault** in the native fee asset (the live testnet runs base fee 7). A key only authorizes; the account pays. So `--init` on a real chain failed at the first deploy ("amount in the vault is less than the amount to remove"), and nothing told the operator what to fund. Our dev genesis hid it with base fee 0.

## Design — fund only the two KMS accounts; the proxy cascades the rest
1. **`--print-funding`** builds and *persists* `service`/`ger_manager` (random-seeded ids exist only once persisted), reads the chain's fee parameters, writes **`funding.toml`** (addresses, fee asset, `max_fee_per_txn`, recommended `fund_service` / `fund_ger_manager`) and exits without deploying. Re-running re-prints, never rebuilds.
2. The operator sends **two P2IDs** of the fee asset (treasury / faucet operator). `--init` resumes the recorded accounts, waits for the notes (`--funding-wait-secs`), and **deploys each account by consuming its note** — the vault fills before the fee is charged, so the deploy pays for itself. Already-deployed accounts are skipped on restart.
3. **Keyless network accounts (bridge, every faucet)** are built **P2ID-fundable** the way Miden builds its own post-genesis network accounts (the testnet network-monitor's counter): the upstream component set **plus `BasicWallet`**, with `P2idNote` allowlisted at zero fee (`src/network_accounts.rs`, via the public `NetworkAccount::builder`). `service` cascade-sends each a P2ID; its creation tx consumes it. Ongoing notes need no sponsorship (zero per-note policy: the vault pays); top-ups are more P2IDs. Upstream's builders cannot be created post-genesis on a fee-charging chain at all (no `receive_asset`; every accepted note carries a `NetworkAccountTarget` whose creation FPIs into a not-yet-existing target) — proven live, see the comment trail.
4. Upstream's `is_ger_registered` / `try_faucet_from_account` / `owner_account_id` gate on the canonical **code commitment**, which the extra component changes; replicas keep the storage checks and formulas and drop only that gate. MA#4 treats the P2ID root as canonical.
5. **Recipients pay to consume their mint.** The e2e's isolated wallet is funded with the fee asset from the genesis faucet operator when the chain charges fees (`lib-isolated-wallet.sh`); the runbook says the same for real claimants.
6. **Fee-vault monitor** (`FeeVaultMonitor`, `--fee-vault-poll-secs` 60 / `--fee-vault-warn-txns` 32): exports `bridge_fee_vault_balance{account}` and `bridge_fee_vault_txns_left{account}` for `service`, `ger_manager`, the bridge and every faucet (+ `bridge_fee_max_per_txn`), WARNs below the threshold, ERRORs at 0, and logs every "spent since last check" delta. `bridge-out-tool --vault-balance <id>…` gives the same read-only view from the CLI. Measured at base fee 7: network transactions ~40–50 units, signed client transactions the 210 cap; the bridge ran 27 network txs in ten minutes — alert on `bridge_fee_vault_txns_left < 32`, top up from the metric.
7. **Top-ups apply themselves.** A P2ID to `service` / `ger_manager` is consumed by the proxy on its next monitor tick; one to the bridge or a faucet by the **ntx-builder** — the node refuses user-submitted transactions for a deployed network account, and the ntx-builder only sees notes carrying a `NetworkAccountTarget`, so `bridge-out-tool --fund-fee-asset` attaches it when the target is already on chain (a plain P2ID only works pre-deploy, consumed by the creation transaction). Either way the note pays for its own consume: an empty vault recovers without a restart.
8. **Fee-starved work is held, not failed.** With an empty vault the proxy used to fail each claim cleanly (status-0 receipt), and bridge-service's ClaimTxManager resent a new claim every ~2 s until its **hard-coded ten-entry history** was spent, then marked the deposit permanently FAILED (`claimtxman/monitortxs.go`, `maxHistorySize = 10` — not config): a top-up minutes later recovered nothing. The writer worker now recognises the fee-vault abort, keeps the accepted transaction **pending** (the sponsor just waits on "not mined yet"), parks the job and re-dispatches it every 30 s; the first retry after the top-up lands it. Same path for `ger_manager`'s GER inserts. ERROR log + gauge `agglayer_writer_jobs_parked`.
9. **`e2e-fee-exhaustion` (`service` | `ger_manager` | `bridge`)**, in the battery: each scenario starts one account with a tiny budget (`FEE_TXN_BUDGET_*`), runs deposits until it is dry, asserts the stall is visible (`bridge_fee_vault_txns_left{account}=0`, the monitor's ERROR, the flow stuck), tops the account up the runbook's way, and asserts a new deposit completes **and the deposits stuck while dry land too**. All three pass end to end on the shared box (service, ger_manager at `cef69d4`; bridge at `b08f05a`). The target hands back a default-budget stack so later battery targets never inherit a starved chain.
10. Fee-charging fixes for the test tooling: `fee-funder` stays alive (compose `--wait` treated its clean exit as failure, breaking `make e2e-up`) and re-funds a new manifest; native-faucet / foreign-bridge deployments (permissionless-faucet, claim-provenance, chaos-garbo) pay their fees via the shared deploy path; the e2e's isolated recipient wallet is fee-funded.
11. e2e genesis now runs **base fee 7** (mirrors the testnet); a `fee-funder` sidecar plays the operator with `bridge-out-tool --fund-fee-asset`.

Sizing (measured on the box): a bridge network transaction costs **~112 units** (120 of them burned a 13,440-unit cascade in 2.5 h), faucet mints ~105, signed client transactions the 210 cap. Production cascade default is therefore 256 (53,760 ≈ 480 bridge transactions), `fund_service` 698,880 at base fee 7; the e2e battery — one unattended half-day chain, ~9 new tokens per `test-e2e` — reserves 4096/4096/1024 and 64 cascades, well inside the operator's 1e9.

Safety: a network account runs only allowlisted note scripts and its tx-script allowlist holds only the expiration script, so `BasicWallet`'s send procedures are unreachable; the P2ID script calls `receive_asset` alone; the node store classifies network notes by the `NetworkAccountTarget` attachment only, so stranger P2IDs are invisible to the ntx-builder (no fee-drain).

## Evidence (live on the shared box, web3signer → real AWS-KMS keys)
- **Base fee 7: `e2e-web3signer.sh` 13/13 PASS** — bound service key adopted, no local secret, L1→L2 deposit completes, signer served the signatures, signing fails with the signer down.
- **Full battery at base fee 7, run `final6` (`e608a20`): 22 PASS** — both drills, `test-e2e` 286/0 with every tier (L2↔L2, Miden-origin ×3, permissionless), l1-to-l2, claim-provenance, claim-watcher ×2, b2agg, autoclaim, restore, cantina 6/10/12/13, GER-decomposition, security, fuzz, rd913, rd940, reconciler-cursor. The one non-fee failure, `e2e-reconciler-private-note`, is a pre-existing flake (identical on fee-0 batteries since 2026-09-05) → #205.
- **`e2e-fee-exhaustion`: all three scenarios PASS standalone** with full self-recovery of the stuck deposits (service, ger_manager `cef69d4`; bridge `b08f05a`).
- **Full battery `final7` (`93c8fc5`, everything above): 30 PASS / 2 FAIL of 32, 08:18–15:27Z, no mid-run top-up** — drills, `test-e2e` 283/0, l1-to-l2, claim-provenance, claim-watchers, b2agg, autoclaim, restore, cantina 6/10/12/13, GER-decomposition, security, fuzz, both reconciler tests, **`e2e-fee-exhaustion` (all three accounts recovered in-battery)**, rd940, L2↔L2, Miden-origin ×3, recovery-readiness, fixture bridge-out, DB-loss, loadtest N=30, event-completeness, post-chaos DB-loss. The two FAILs are harness: `rd913` (#206, counts drift across its restart window; 5 of the last 8 batteries incl. pre-fee-7) and `chaos-soak`, whose product verdicts — legit completeness, garbo containment, post-chaos liveness (self-recovered) — all PASS; only its "chaos actually fired" gate failed because the garbo's foreign-claim injector could not create its foreign bridge (it passed the creator wallet of another store) — fixed in `5101416`/`1c81d70`; **standalone chaos soak on a fresh stack at `0af9c22`: all four verdicts PASS** (completeness, garbo containment, chaos fired with 7 faults incl. the foreign injection, post-chaos liveness). The rd913 and private-note harness fixes (`5692089`) were verified standalone too (#205, #206). Live board: https://claude.ai/code/artifact/cf09b77c-3eaf-4882-87ad-3e8e7e2ac303
- A mid-run runbook top-up on the live chain (operator P2ID → `service`, 2,580,480 units) was swept on the next tick, no restart.

## Operator runbook
`docs/operations/provisioning.md` → "Funding the accounts on a fee-charging chain" (manual procedure, `funding.toml` fields, top-ups, recipients).

## Follow-ups
- #205 — `e2e-reconciler-private-note` Phase 0 funding timeout, pre-existing on fee-0 batteries too.
- #206 — `e2e-rd913-restart-burn-collision` counts monitor rows across a restart without waiting for the chain to settle; FAIL in 5 of the last 8 batteries incl. pre-fee-7 runs. Harness fixes for #205/#206 are on this branch (`5692089`), standalone verification in progress.
- #208 — chaos soak: the mixed loadtest's aggkit readiness gate waited for a settled certificate after a mid-run recreate while aggsender correctly had nothing to certify yet (the exits come from the back-ops after the gate); fixed on this branch (`0af9c22`, readiness also accepts an evaluated range) and verified by the green soak above. What recreates aggkit at that point is still open. Not fee-related.
- #207 — LET cardinality gate halted permanently on an on-chain read of 0 leaves (vs 44 local) after a chaos run was killed mid-storm; not fee-related.
- #203 — Cantina #4 `asset_callbacks` alert is a pre-existing false positive (fires on `main` at fee 0 too; never blocks).
- Upstream `miden-agglayer`: a P2ID-fundable option on the bridge/faucet builders (and non-code-gated readers) so the replicas can go away.
- A restarted `--init` currently rolls a fresh bridge id until it deploys — pin bridge/faucet ids in the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGoAzmPkjYq85iADpZodwm







